### PR TITLE
Unroll loop for Array#each where the array only contains a single element.

### DIFF
--- a/src/main/java/org/truffleruby/core/array/ArrayNodes.java
+++ b/src/main/java/org/truffleruby/core/array/ArrayNodes.java
@@ -733,7 +733,17 @@ public abstract class ArrayNodes {
     @ImportStatic(ArrayGuards.class)
     public abstract static class EachNode extends YieldingCoreMethodNode {
 
-        @Specialization(guards = "strategy.matches(array)", limit = "ARRAY_STRATEGIES")
+        @Specialization(guards = { "strategy.matches(array)", "strategy.getSize(array) == 1" }, limit = "ARRAY_STRATEGIES")
+        public Object eachOne(DynamicObject array, DynamicObject block,
+                              @Cached("of(array)") ArrayStrategy strategy) {
+            final ArrayMirror store = strategy.newMirror(array);
+
+            yield(block, store.get(0));
+
+            return array;
+        }
+
+        @Specialization(guards = { "strategy.matches(array)", "strategy.getSize(array) != 1" }, limit = "ARRAY_STRATEGIES")
         public Object eachOther(DynamicObject array, DynamicObject block,
                 @Cached("of(array)") ArrayStrategy strategy) {
             final ArrayMirror store = strategy.newMirror(array);


### PR DESCRIPTION
It's a common pattern to have a method accept varargs and iterate over them. In many cases, these methods are called with a single element that is wrapped into an array. Manually unrolling for this case can yield significant savings. The generated code for a no-op iteration is reduced by 2/3.