### PR TITLE
Cleanup IO::InternalBuffer

### DIFF
--- a/spec/ruby/core/io/ungetc_spec.rb
+++ b/spec/ruby/core/io/ungetc_spec.rb
@@ -31,6 +31,22 @@ describe "IO#ungetc" do
     @io.getc.should == ?c
   end
 
+  it "interprets the codepoint in the external encoding" do
+    @io.set_encoding(Encoding::UTF_8)
+    @io.ungetc(233)
+    c = @io.getc
+    c.encoding.should == Encoding::UTF_8
+    c.should == "é"
+    c.bytes.should == [195, 169]
+
+    @io.set_encoding(Encoding::IBM437)
+    @io.ungetc(130)
+    c = @io.getc
+    c.encoding.should == Encoding::IBM437
+    c.bytes.should == [130]
+    c.encode(Encoding::UTF_8).should == "é"
+  end
+
   it "pushes back one character when invoked at the end of the stream" do
     # read entire content
     @io.read

--- a/spec/tags/core/io/external_encoding_tags.txt
+++ b/spec/tags/core/io/external_encoding_tags.txt
@@ -1,2 +1,0 @@
-fails:IO#external_encoding with 'r' mode when Encoding.default_internal is nil returns Encoding.default_external if the external encoding is not set
-fails:IO#external_encoding with 'r' mode when Encoding.default_internal is nil returns Encoding.default_external when that encoding is changed after the instance is created

--- a/src/main/java/org/truffleruby/core/support/ByteArrayNodes.java
+++ b/src/main/java/org/truffleruby/core/support/ByteArrayNodes.java
@@ -61,7 +61,7 @@ public abstract class ByteArrayNodes {
 
     }
 
-    @CoreMethod(names = {"get_byte", "[]"}, required = 1, lowerFixnum = 1)
+    @CoreMethod(names = "[]", required = 1, lowerFixnum = 1)
     public abstract static class GetByteNode extends CoreMethodArrayArgumentsNode {
 
         @Specialization
@@ -102,7 +102,7 @@ public abstract class ByteArrayNodes {
 
     }
 
-    @CoreMethod(names = {"set_byte", "[]="}, required = 2, lowerFixnum = { 1, 2 })
+    @CoreMethod(names = "[]=", required = 2, lowerFixnum = { 1, 2 })
     public abstract static class SetByteNode extends CoreMethodArrayArgumentsNode {
 
         @Specialization

--- a/src/main/ruby/core/io.rb
+++ b/src/main/ruby/core/io.rb
@@ -140,7 +140,7 @@ class IO
 
     # Returns +true+ if the buffer is filled to capacity.
     def full?
-      @total == @used
+      @used == @total
     end
 
     # Returns +true+ if the buffer is empty and cannot be filled further.

--- a/src/main/ruby/core/io.rb
+++ b/src/main/ruby/core/io.rb
@@ -165,10 +165,10 @@ class IO
     # the IO, and +unshift+ again beginning at +start_pos+.
     def unshift(str, start_pos)
       @write_synced = false
-      available = SIZE - @used
+      free = unused
       written = str.bytesize - start_pos
-      if written > available
-        written = available
+      if written > free
+        written = free
       end
       @storage.fill(@used, str, start_pos, written)
       @used += written

--- a/src/main/ruby/core/io.rb
+++ b/src/main/ruby/core/io.rb
@@ -212,9 +212,7 @@ class IO
         return size unless empty?
 
         reset!
-        fill(io)
-
-        if @used == 0
+        if fill(io) == 0
           io.eof!
           @eof = true
         end

--- a/src/main/ruby/core/io.rb
+++ b/src/main/ruby/core/io.rb
@@ -121,14 +121,43 @@ class IO
       @eof = false
     end
 
+    # Returns the number of bytes available in the buffer.
+    def size
+      @used - @start
+    end
+
     # Returns +true+ if the buffer can be filled.
     def empty?
       @start == @used
     end
 
+    # Returns the number of bytes of capacity remaining in the buffer.
+    # This is the number of additional bytes that can be added to the
+    # buffer before it is full.
+    def unused
+      @total - @used
+    end
+
+    # Returns +true+ if the buffer is filled to capacity.
+    def full?
+      @total == @used
+    end
+
     # Returns +true+ if the buffer is empty and cannot be filled further.
     def exhausted?
       @eof and empty?
+    end
+
+    # Resets the buffer state so the buffer can be filled again.
+    def reset!
+      @start = 0
+      @used = 0
+      @eof = false
+      @write_synced = true
+    end
+
+    def write_synced?
+      @write_synced
     end
 
     # Returns the number of bytes that could be written to the buffer.
@@ -227,29 +256,6 @@ class IO
       end
     end
 
-    # Returns +true+ if the buffer is filled to capacity.
-    def full?
-      @total == @used
-    end
-
-    def inspect # :nodoc:
-      content = (@start..@used).map { |i| @storage[i].chr }.join.inspect
-      format '#<IO::InternalBuffer:0x%x total=%p start=%p used=%p data=%p %s>',
-             object_id, @total, @start, @used, @storage, content
-    end
-
-    # Resets the buffer state so the buffer can be filled again.
-    def reset!
-      @start = 0
-      @used = 0
-      @eof = false
-      @write_synced = true
-    end
-
-    def write_synced?
-      @write_synced
-    end
-
     def unseek!(io)
       Truffle.synchronize(self) do
         # Unseek the still buffered amount
@@ -344,16 +350,10 @@ class IO
       end
     end
 
-    # Returns the number of bytes available in the buffer.
-    def size
-      @used - @start
-    end
-
-    # Returns the number of bytes of capacity remaining in the buffer.
-    # This is the number of additional bytes that can be added to the
-    # buffer before it is full.
-    def unused
-      @total - @used
+    def inspect # :nodoc:
+      content = (@start..@used).map { |i| @storage[i].chr }.join.inspect
+      format '#<IO::InternalBuffer:0x%x total=%p start=%p used=%p data=%p %s>',
+             object_id, @total, @start, @used, @storage, content
     end
   end
 

--- a/src/main/ruby/core/io.rb
+++ b/src/main/ruby/core/io.rb
@@ -89,6 +89,8 @@ class IO
   # the number of bytes taken. Once +start+ == +used+, the
   # buffer is +empty?+ and needs to be refilled.
   #
+  # 0 <= @start <= @used <= @total
+  #
   # This description should be independent of the "direction"
   # in which the buffer is used. As a read buffer, +fill_from+
   # appends at +used+, but not exceeding +total+. When +used+
@@ -112,10 +114,10 @@ class IO
 
     def initialize
       @storage = Truffle::ByteArray.new(SIZE)
+      @start = 0
       @used = 0
       @total = SIZE
       @write_synced = true
-      @start = 0
       @eof = false
     end
 

--- a/src/main/ruby/core/io.rb
+++ b/src/main/ruby/core/io.rb
@@ -121,19 +121,16 @@ class IO
       @eof = false
     end
 
-    ##
     # Returns +true+ if the buffer can be filled.
     def empty?
       @start == @used
     end
 
-    ##
     # Returns +true+ if the buffer is empty and cannot be filled further.
     def exhausted?
       @eof and empty?
     end
 
-    ##
     # Returns the number of bytes that could be written to the buffer.
     # If the number is less then the expected, then we need to +empty_to+
     # the IO, and +unshift+ again beginning at +start_pos+.
@@ -173,7 +170,6 @@ class IO
       bytes_read
     end
 
-    ##
     # A request to the buffer to have data. The buffer decides whether
     # existing data is sufficient, or whether to read more data from the
     # +IO+ instance. Any new data causes this method to return.
@@ -212,7 +208,6 @@ class IO
       size
     end
 
-    ##
     # Advances the beginning-of-buffer marker past any number
     # of contiguous characters == +skip+. For example, if +skip+
     # is ?\n and the buffer contents are "\n\n\nAbc...", the
@@ -224,7 +219,6 @@ class IO
       end
     end
 
-    ##
     # Returns the number of bytes to fetch from the buffer up-to-
     # and-including +pattern+. Returns +nil+ if pattern is not found.
     def find(pattern, discard = nil)
@@ -233,7 +227,6 @@ class IO
       end
     end
 
-    ##
     # Returns +true+ if the buffer is filled to capacity.
     def full?
       @total == @used
@@ -245,7 +238,6 @@ class IO
              object_id, @total, @start, @used, @storage, content
     end
 
-    ##
     # Resets the buffer state so the buffer can be filled again.
     def reset!
       @start = 0
@@ -271,7 +263,6 @@ class IO
       end
     end
 
-    ##
     # Returns +count+ bytes from the +start+ of the buffer as a new String.
     # If +count+ is +nil+, returns all available bytes in the buffer.
     def shift(count=nil, encoding=Encoding::ASCII_8BIT)
@@ -308,7 +299,6 @@ class IO
       IO.read_encode io, str
     end
 
-    ##
     # Returns one Fixnum as the start byte.
     def getbyte(io)
       return if size == 0 and fill_from(io) == 0
@@ -339,7 +329,6 @@ class IO
       end
     end
 
-    ##
     # Prepends the byte +chr+ to the internal buffer, so that future
     # reads will return it.
     def put_back(chr)
@@ -355,13 +344,11 @@ class IO
       end
     end
 
-    ##
     # Returns the number of bytes available in the buffer.
     def size
       @used - @start
     end
 
-    ##
     # Returns the number of bytes of capacity remaining in the buffer.
     # This is the number of additional bytes that can be added to the
     # buffer before it is full.

--- a/src/main/ruby/core/io.rb
+++ b/src/main/ruby/core/io.rb
@@ -212,10 +212,7 @@ class IO
         return size unless empty?
 
         reset!
-
-        if fill(io) < 0
-          raise IOError, "error occurred while filling buffer (#{obj})"
-        end
+        fill(io)
 
         if @used == 0
           io.eof!

--- a/src/main/ruby/core/io.rb
+++ b/src/main/ruby/core/io.rb
@@ -1660,7 +1660,11 @@ class IO
   end
 
   def external_encoding
-    @external
+    if @mode & ACCMODE == RDONLY
+      @external || Encoding.default_external
+    else
+      @external
+    end
   end
 
   ##


### PR DESCRIPTION
Some cleanup of IO::InternalBuffer along with a fix for `ungetc`.
Review commit-by-commit.