### PR TITLE
Improve substring rope creation

### DIFF
--- a/src/main/java/org/truffleruby/cext/CExtNodes.java
+++ b/src/main/java/org/truffleruby/cext/CExtNodes.java
@@ -391,10 +391,11 @@ public class CExtNodes {
 
         @Specialization
         public DynamicObject rbEncCodePointLen(DynamicObject string, DynamicObject encoding,
-                @Cached("create()") RopeNodes.BytesNode bytesNode) {
+                @Cached("create()") RopeNodes.BytesNode bytesNode,
+                @Cached("create()") RopeNodes.PreciseLengthNode preciseLengthNode) {
             final byte[] bytes = bytesNode.execute(StringOperations.rope(string));
             final Encoding enc = Layouts.ENCODING.getEncoding(encoding);
-            final int r = StringSupport.preciseLength(enc, bytes, 0, bytes.length);
+            final int r = preciseLengthNode.executeLength(enc, bytes, 0, bytes.length);
             if (!StringSupport.MBCLEN_CHARFOUND_P(r)) {
                 throw new RaiseException(coreExceptions().argumentError("invalid byte sequence in " + enc, this));
             }
@@ -1078,8 +1079,9 @@ public class CExtNodes {
     public abstract static class RbEncPreciseMbclenNode extends CoreMethodArrayArgumentsNode {
 
         @Specialization(guards = { "isRubyEncoding(enc)", "isRubyString(str)" })
-        public Object rbEncPreciseMbclen(DynamicObject enc, DynamicObject str, int p, int end) {
-            return StringSupport.preciseLength(
+        public Object rbEncPreciseMbclen(DynamicObject enc, DynamicObject str, int p, int end,
+                @Cached("create()") RopeNodes.PreciseLengthNode preciseLengthNode) {
+            return preciseLengthNode.executeLength(
                     EncodingOperations.getEncoding(enc), StringOperations.rope(str).getBytes(), p, end);
         }
 

--- a/src/main/java/org/truffleruby/cext/CExtNodes.java
+++ b/src/main/java/org/truffleruby/cext/CExtNodes.java
@@ -426,7 +426,7 @@ public class CExtNodes {
         public DynamicObject rbStrResizeGrow(DynamicObject string, int len,
                                              @Cached("create()") RopeNodes.SubstringNode substringNode,
                                              @Cached("create()") RopeNodes.ConcatNode concatNode,
-                                             @Cached("create()") RopeNodes.MakeRepeatingNode makeRepeatingNode) {
+                                             @Cached("create()") RopeNodes.RepeatNode repeatNode) {
             final Rope rope = rope(string);
 
             if (rope instanceof SubstringRope) {
@@ -445,12 +445,12 @@ public class CExtNodes {
                     if (withBase.byteLength() == len) {
                         StringOperations.setRope(string, withBase);
                     } else {
-                        final Rope filler = makeRepeatingNode.executeMake(RopeConstants.UTF8_SINGLE_BYTE_ROPES[0], len - withBase.byteLength());
+                        final Rope filler = repeatNode.executeRepeat(RopeConstants.UTF8_SINGLE_BYTE_ROPES[0], len - withBase.byteLength());
                         StringOperations.setRope(string, concatNode.executeConcat(withBase, filler, rope.getEncoding()));
                     }
                 }
             } else {
-                final Rope filler = makeRepeatingNode.executeMake(RopeConstants.UTF8_SINGLE_BYTE_ROPES[0], len - rope.byteLength());
+                final Rope filler = repeatNode.executeRepeat(RopeConstants.UTF8_SINGLE_BYTE_ROPES[0], len - rope.byteLength());
                 StringOperations.setRope(string, concatNode.executeConcat(rope, filler, rope.getEncoding()));
             }
 

--- a/src/main/java/org/truffleruby/cext/CExtNodes.java
+++ b/src/main/java/org/truffleruby/cext/CExtNodes.java
@@ -416,15 +416,15 @@ public class CExtNodes {
 
         @Specialization(guards = "shouldShrink(string, len)")
         public DynamicObject rbStrResizeShrink(DynamicObject string, int len,
-                                               @Cached("create()") RopeNodes.MakeSubstringNode makeSubstringNode) {
-            StringOperations.setRope(string, makeSubstringNode.executeMake(rope(string), 0, len));
+                                               @Cached("create()") RopeNodes.SubstringNode substringNode) {
+            StringOperations.setRope(string, substringNode.executeSubstring(rope(string), 0, len));
             return string;
         }
 
         @TruffleBoundary
         @Specialization(guards = { "!shouldNoop(string, len)", "!shouldShrink(string, len)" })
         public DynamicObject rbStrResizeGrow(DynamicObject string, int len,
-                                             @Cached("create()") RopeNodes.MakeSubstringNode makeSubstringNode,
+                                             @Cached("create()") RopeNodes.SubstringNode substringNode,
                                              @Cached("create()") RopeNodes.MakeConcatNode makeConcatNode,
                                              @Cached("create()") RopeNodes.MakeRepeatingNode makeRepeatingNode) {
             final Rope rope = rope(string);
@@ -439,7 +439,7 @@ public class CExtNodes {
                     final Rope base = substringRope.getChild();
 
                     final int lenFromBase = base.byteLength() <= len ? len - base.byteLength() : len - nullAppended.byteLength();
-                    final Rope fromBase = makeSubstringNode.executeMake(base, nullAppended.byteLength(), lenFromBase);
+                    final Rope fromBase = substringNode.executeSubstring(base, nullAppended.byteLength(), lenFromBase);
                     final Rope withBase = makeConcatNode.executeMake(nullAppended, fromBase, nullAppended.getEncoding());
 
                     if (withBase.byteLength() == len) {

--- a/src/main/java/org/truffleruby/cext/CExtNodes.java
+++ b/src/main/java/org/truffleruby/cext/CExtNodes.java
@@ -425,12 +425,12 @@ public class CExtNodes {
         @Specialization(guards = { "!shouldNoop(string, len)", "!shouldShrink(string, len)" })
         public DynamicObject rbStrResizeGrow(DynamicObject string, int len,
                                              @Cached("create()") RopeNodes.SubstringNode substringNode,
-                                             @Cached("create()") RopeNodes.MakeConcatNode makeConcatNode,
+                                             @Cached("create()") RopeNodes.ConcatNode concatNode,
                                              @Cached("create()") RopeNodes.MakeRepeatingNode makeRepeatingNode) {
             final Rope rope = rope(string);
 
             if (rope instanceof SubstringRope) {
-                final Rope nullAppended = makeConcatNode.executeMake(rope, RopeConstants.UTF8_SINGLE_BYTE_ROPES[0], rope.getEncoding());
+                final Rope nullAppended = concatNode.executeConcat(rope, RopeConstants.UTF8_SINGLE_BYTE_ROPES[0], rope.getEncoding());
 
                 if (nullAppended.byteLength() == len) {
                     StringOperations.setRope(string, nullAppended);
@@ -440,18 +440,18 @@ public class CExtNodes {
 
                     final int lenFromBase = base.byteLength() <= len ? len - base.byteLength() : len - nullAppended.byteLength();
                     final Rope fromBase = substringNode.executeSubstring(base, nullAppended.byteLength(), lenFromBase);
-                    final Rope withBase = makeConcatNode.executeMake(nullAppended, fromBase, nullAppended.getEncoding());
+                    final Rope withBase = concatNode.executeConcat(nullAppended, fromBase, nullAppended.getEncoding());
 
                     if (withBase.byteLength() == len) {
                         StringOperations.setRope(string, withBase);
                     } else {
                         final Rope filler = makeRepeatingNode.executeMake(RopeConstants.UTF8_SINGLE_BYTE_ROPES[0], len - withBase.byteLength());
-                        StringOperations.setRope(string, makeConcatNode.executeMake(withBase, filler, rope.getEncoding()));
+                        StringOperations.setRope(string, concatNode.executeConcat(withBase, filler, rope.getEncoding()));
                     }
                 }
             } else {
                 final Rope filler = makeRepeatingNode.executeMake(RopeConstants.UTF8_SINGLE_BYTE_ROPES[0], len - rope.byteLength());
-                StringOperations.setRope(string, makeConcatNode.executeMake(rope, filler, rope.getEncoding()));
+                StringOperations.setRope(string, concatNode.executeConcat(rope, filler, rope.getEncoding()));
             }
 
             return string;

--- a/src/main/java/org/truffleruby/core/encoding/EncodingConverterNodes.java
+++ b/src/main/java/org/truffleruby/core/encoding/EncodingConverterNodes.java
@@ -191,7 +191,7 @@ public abstract class EncodingConverterNodes {
     @Primitive(name = "encoding_converter_primitive_convert", lowerFixnum = { 3, 4, 5 })
     public static abstract class PrimitiveConvertNode extends PrimitiveArrayArgumentsNode {
 
-        @Child private RopeNodes.MakeSubstringNode makeSubstringNode = RopeNodes.MakeSubstringNode.create();
+        @Child private RopeNodes.SubstringNode substringNode = RopeNodes.SubstringNode.create();
 
         @Specialization(guards = {"isRubyString(source)", "isRubyString(target)", "isRubyHash(options)"})
         public Object encodingConverterPrimitiveConvert(DynamicObject encodingConverter, DynamicObject source,
@@ -273,7 +273,7 @@ public abstract class EncodingConverterNodes {
                 outBytes.setLength(outPtr.p);
 
                 if (nonNullSource) {
-                    sourceRope = makeSubstringNode.executeMake(sourceRope, inPtr.p, sourceRope.byteLength() - inPtr.p);
+                    sourceRope = substringNode.executeSubstring(sourceRope, inPtr.p, sourceRope.byteLength() - inPtr.p);
                     StringOperations.setRope(source, sourceRope);
                 }
 

--- a/src/main/java/org/truffleruby/core/regexp/MatchDataNodes.java
+++ b/src/main/java/org/truffleruby/core/regexp/MatchDataNodes.java
@@ -176,7 +176,7 @@ public abstract class MatchDataNodes {
 
         @Child private ToIntNode toIntNode;
         @Child private ValuesNode getValuesNode = ValuesNode.create();
-        @Child private RopeNodes.MakeSubstringNode makeSubstringNode = RopeNodes.MakeSubstringNode.create();
+        @Child private RopeNodes.SubstringNode substringNode = RopeNodes.SubstringNode.create();
         @Child private AllocateObjectNode allocateNode = AllocateObjectNode.create();
 
         public static GetIndexNode create() {
@@ -205,7 +205,7 @@ public abstract class MatchDataNodes {
                 final int start = region.beg[normalizedIndex];
                 final int end = region.end[normalizedIndex];
                 if (hasValueProfile.profile(start > -1 && end > -1)) {
-                    Rope rope = makeSubstringNode.executeMake(sourceRope, start, end - start);
+                    Rope rope = substringNode.executeSubstring(sourceRope, start, end - start);
                     return allocateNode.allocate(Layouts.BASIC_OBJECT.getLogicalClass(source), Layouts.STRING.build(false, false, rope, null));
                 } else {
                     return nil();
@@ -363,7 +363,7 @@ public abstract class MatchDataNodes {
 
     public abstract static class ValuesNode extends CoreMethodArrayArgumentsNode {
 
-        @Child private RopeNodes.MakeSubstringNode makeSubstringNode = RopeNodes.MakeSubstringNode.create();
+        @Child private RopeNodes.SubstringNode substringNode = RopeNodes.SubstringNode.create();
         @Child private AllocateObjectNode allocateNode = AllocateObjectNode.create();
         @Child private IsTaintedNode isTaintedNode = IsTaintedNode.create();
 
@@ -387,7 +387,7 @@ public abstract class MatchDataNodes {
                 final int end = region.end[n];
 
                 if (start > -1 && end > -1) {
-                    Rope rope = makeSubstringNode.executeMake(sourceRope, start, end - start);
+                    Rope rope = substringNode.executeSubstring(sourceRope, start, end - start);
                     DynamicObject string = allocateNode.allocate(Layouts.BASIC_OBJECT.getLogicalClass(source), Layouts.STRING.build(false, isTainted, rope, null));
                     values[n] = string;
                 } else {
@@ -489,7 +489,7 @@ public abstract class MatchDataNodes {
     @CoreMethod(names = "pre_match", taintFrom = 0)
     public abstract static class PreMatchNode extends CoreMethodArrayArgumentsNode {
 
-        @Child private RopeNodes.MakeSubstringNode makeSubstringNode = RopeNodes.MakeSubstringNode.create();
+        @Child private RopeNodes.SubstringNode substringNode = RopeNodes.SubstringNode.create();
         @Child private AllocateObjectNode allocateNode = AllocateObjectNode.create();
 
         public static PreMatchNode create() {
@@ -505,7 +505,7 @@ public abstract class MatchDataNodes {
             Region region = Layouts.MATCH_DATA.getRegion(matchData);
             int start = 0;
             int length = region.beg[0];
-            Rope rope = makeSubstringNode.executeMake(sourceRope, start, length);
+            Rope rope = substringNode.executeSubstring(sourceRope, start, length);
             DynamicObject string = allocateNode.allocate(Layouts.BASIC_OBJECT.getLogicalClass(source), Layouts.STRING.build(false, false, rope, null));
             return string;
         }
@@ -514,7 +514,7 @@ public abstract class MatchDataNodes {
     @CoreMethod(names = "post_match", taintFrom = 0)
     public abstract static class PostMatchNode extends CoreMethodArrayArgumentsNode {
 
-        @Child private RopeNodes.MakeSubstringNode makeSubstringNode = RopeNodes.MakeSubstringNode.create();
+        @Child private RopeNodes.SubstringNode substringNode = RopeNodes.SubstringNode.create();
         @Child private AllocateObjectNode allocateNode = AllocateObjectNode.create();
 
         public static PostMatchNode create() {
@@ -530,7 +530,7 @@ public abstract class MatchDataNodes {
             Region region = Layouts.MATCH_DATA.getRegion(matchData);
             int start = region.end[0];
             int length = sourceRope.byteLength() - region.end[0];
-            Rope rope = makeSubstringNode.executeMake(sourceRope, start, length);
+            Rope rope = substringNode.executeSubstring(sourceRope, start, length);
             DynamicObject string = allocateNode.allocate(Layouts.BASIC_OBJECT.getLogicalClass(source), Layouts.STRING.build(false, false, rope, null));
             return string;
         }

--- a/src/main/java/org/truffleruby/core/rope/RopeGuards.java
+++ b/src/main/java/org/truffleruby/core/rope/RopeGuards.java
@@ -11,6 +11,9 @@
 
 package org.truffleruby.core.rope;
 
+import org.jcodings.Encoding;
+import org.jcodings.specific.ASCIIEncoding;
+
 public class RopeGuards {
 
     public static boolean isSingleByteString(Rope rope) {
@@ -19,6 +22,18 @@ public class RopeGuards {
 
     public static boolean isLeafRope(Rope rope) {
         return rope instanceof LeafRope;
+    }
+
+    public static boolean isEmpty(byte[] bytes) {
+        return bytes.length == 0;
+    }
+
+    public static boolean isBinaryString(Encoding encoding) {
+        return encoding == ASCIIEncoding.INSTANCE;
+    }
+
+    public static boolean isAsciiCompatible(Encoding encoding) {
+        return encoding.isAsciiCompatible();
     }
 
 }

--- a/src/main/java/org/truffleruby/core/rope/RopeNodes.java
+++ b/src/main/java/org/truffleruby/core/rope/RopeNodes.java
@@ -53,15 +53,15 @@ public abstract class RopeNodes {
             @NodeChild(type = RubyNode.class, value = "byteOffset"),
             @NodeChild(type = RubyNode.class, value = "byteLength")
     })
-    public abstract static class MakeSubstringNode extends RubyNode {
+    public abstract static class SubstringNode extends RubyNode {
 
         @Child private MakeLeafRopeNode makeLeafRopeNode;
 
-        public static MakeSubstringNode create() {
-            return RopeNodesFactory.MakeSubstringNodeGen.create(null, null, null);
+        public static SubstringNode create() {
+            return RopeNodesFactory.SubstringNodeGen.create(null, null, null);
         }
 
-        public abstract Rope executeMake(Rope base, int byteOffset, int byteLength);
+        public abstract Rope executeSubstring(Rope base, int byteOffset, int byteLength);
 
         @Specialization(guards = "byteLength == 0")
         public Rope substringZeroBytes(Rope base, int byteOffset, int byteLength,

--- a/src/main/java/org/truffleruby/core/rope/RopeNodes.java
+++ b/src/main/java/org/truffleruby/core/rope/RopeNodes.java
@@ -65,26 +65,8 @@ public abstract class RopeNodes {
 
         @Specialization(guards = "byteLength == 0")
         public Rope substringZeroBytes(Rope base, int byteOffset, int byteLength,
-                                       @Cached("createBinaryProfile()") ConditionProfile isUTF8,
-                                       @Cached("createBinaryProfile()") ConditionProfile isUSAscii,
-                                       @Cached("createBinaryProfile()") ConditionProfile isAscii8Bit,
-                                       @Cached("createBinaryProfile()") ConditionProfile isAsciiCompatible,
                                        @Cached("create()") MakeLeafRopeNode makeLeafRopeNode) {
-            if (isUTF8.profile(base.getEncoding() == UTF8Encoding.INSTANCE)) {
-                return RopeConstants.EMPTY_UTF8_ROPE;
-            }
-
-            if (isUSAscii.profile(base.getEncoding() == USASCIIEncoding.INSTANCE)) {
-                return RopeConstants.EMPTY_US_ASCII_ROPE;
-            }
-
-            if (isAscii8Bit.profile(base.getEncoding() == ASCIIEncoding.INSTANCE)) {
-                return RopeConstants.EMPTY_ASCII_8BIT_ROPE;
-            }
-
-            final CodeRange codeRange = isAsciiCompatible.profile(base.getEncoding().isAsciiCompatible()) ? CR_7BIT : CR_VALID;
-
-            return makeLeafRopeNode.executeMake(RopeConstants.EMPTY_BYTES, base.getEncoding(), codeRange, 0);
+            return makeLeafRopeNode.executeMake(RopeConstants.EMPTY_BYTES, base.getEncoding(), CR_UNKNOWN, 0);
         }
 
         @Specialization(guards = "byteLength == 1")

--- a/src/main/java/org/truffleruby/core/rope/RopeNodes.java
+++ b/src/main/java/org/truffleruby/core/rope/RopeNodes.java
@@ -702,13 +702,13 @@ public abstract class RopeNodes {
             @NodeChild(type = RubyNode.class, value = "times")
     })
     @ImportStatic(RopeGuards.class)
-    public abstract static class MakeRepeatingNode extends RubyNode {
+    public abstract static class RepeatNode extends RubyNode {
 
-        public static MakeRepeatingNode create() {
-            return RopeNodesFactory.MakeRepeatingNodeGen.create(null, null);
+        public static RepeatNode create() {
+            return RopeNodesFactory.RepeatNodeGen.create(null, null);
         }
 
-        public abstract Rope executeMake(Rope base, int times);
+        public abstract Rope executeRepeat(Rope base, int times);
 
         @Specialization(guards = "times == 0")
         public Rope repeatZero(Rope base, int times,

--- a/src/main/java/org/truffleruby/core/rope/RopeNodes.java
+++ b/src/main/java/org/truffleruby/core/rope/RopeNodes.java
@@ -297,6 +297,8 @@ public abstract class RopeNodes {
         @Specialization(replaces = "calculateAttributesAsciiCompatible",
                 guards = { "!isEmpty(bytes)", "!isBinaryString(encoding)", "isAsciiCompatible(encoding)" })
         StringAttributes calculateAttributesAsciiCompatibleGeneric(Encoding encoding, byte[] bytes,
+                                                                   @Cached("create()") PreciseLengthNode preciseLengthNode,
+                                                                   @Cached("createBinaryProfile()") ConditionProfile utf8Profile,
                                                                    @Cached("create()") BranchProfile multiByteCharacterProfile,
                                                                    @Cached("create()") BranchProfile brokenCodeRangeProfile) {
             // Taken from StringSupport.strLengthWithCodeRangeAsciiCompatible.
@@ -317,7 +319,7 @@ public abstract class RopeNodes {
                     p = multiByteCharacterPosition;
                 }
 
-                final int lengthOfCurrentCharacter = StringSupport.preciseLength(encoding, bytes, p, end);
+                final int lengthOfCurrentCharacter = preciseLengthNode.executeLength(encoding, bytes, p, end);
 
                 if (lengthOfCurrentCharacter > 0) {
                     multiByteCharacterProfile.enter();
@@ -341,6 +343,7 @@ public abstract class RopeNodes {
 
         @Specialization(guards = { "!isEmpty(bytes)", "!isBinaryString(encoding)", "!isAsciiCompatible(encoding)" })
         StringAttributes calculateAttributesGeneric(Encoding encoding, byte[] bytes,
+                                                    @Cached("create()") PreciseLengthNode preciseLengthNode,
                                                     @Cached("createBinaryProfile()") ConditionProfile asciiCompatibleProfile,
                                                     @Cached("create()") BranchProfile multiByteCharacterProfile,
                                                     @Cached("create()") BranchProfile brokenCodeRangeProfile) {
@@ -352,7 +355,7 @@ public abstract class RopeNodes {
             final int end = bytes.length;
 
             for (characters = 0; p < end; characters++) {
-                final int lengthOfCurrentCharacter = StringSupport.preciseLength(encoding, bytes, p, end);
+                final int lengthOfCurrentCharacter = preciseLengthNode.executeLength(encoding, bytes, p, end);
 
                 if (lengthOfCurrentCharacter > 0) {
                     multiByteCharacterProfile.enter();
@@ -645,7 +648,8 @@ public abstract class RopeNodes {
 
         @Specialization(guards = { "isValid(codeRange)", "!isFixedWidth(encoding)", "isAsciiCompatible(encoding)" })
         public LeafRope makeValidLeafRopeAsciiCompat(byte[] bytes, Encoding encoding, CodeRange codeRange, NotProvided characterLength,
-                                                     @Cached("create()") BranchProfile errorProfile) {
+                @Cached("create()") BranchProfile errorProfile,
+                @Cached("create()") EncodingLengthNode encodingLengthNode) {
             // Extracted from StringSupport.strLength.
 
             int calculatedCharacterLength = 0;
@@ -662,7 +666,7 @@ public abstract class RopeNodes {
                     calculatedCharacterLength += q - p;
                     p = q;
                 }
-                int delta = StringSupport.encLength(encoding, bytes, p, e);
+                int delta = encodingLengthNode.executeLength(encoding, bytes, p, e);
 
                 if (delta < 0) {
                     errorProfile.enter();
@@ -1112,6 +1116,8 @@ public abstract class RopeNodes {
     })
     public abstract static class GetCodePointNode extends RubyNode {
 
+        @Child private PreciseLengthNode preciseLengthNode;
+
         public static GetCodePointNode create() {
             return RopeNodesFactory.GetCodePointNodeGen.create(null, null);
         }
@@ -1126,10 +1132,10 @@ public abstract class RopeNodes {
 
         @Specialization(guards = { "!rope.isSingleByteOptimizable()", "rope.getEncoding().isUTF8()" })
         public int getCodePointUTF8(Rope rope, int index,
-                                    @Cached("create()") GetByteNode getByteNode,
-                                    @Cached("createBinaryProfile()") ConditionProfile singleByteCharProfile,
-                @Cached("create()") BranchProfile errorProfile,
-                @Cached("create()") BytesNode bytesNode) {
+                @Cached("create()") GetByteNode getByteNode,
+                @Cached("create()") BytesNode bytesNode,
+                @Cached("createBinaryProfile()") ConditionProfile singleByteCharProfile,
+                @Cached("create()") BranchProfile errorProfile) {
             final int firstByte = getByteNode.executeGetByte(rope, index);
             if (singleByteCharProfile.profile(firstByte < 128)) {
                 return firstByte;
@@ -1145,7 +1151,7 @@ public abstract class RopeNodes {
             final byte[] bytes = bytesNode.execute(rope);
             final Encoding encoding = rope.getEncoding();
 
-            final int characterLength = preciseCharacterLength(encoding, bytes, index, rope.byteLength());
+            final int characterLength = preciseLength(encoding, bytes, index, rope.byteLength());
             if (characterLength <= 0) {
                 errorProfile.enter();
                 throw new RaiseException(getContext().getCoreExceptions().argumentError("invalid byte sequence in " + encoding, null));
@@ -1155,13 +1161,17 @@ public abstract class RopeNodes {
         }
 
         @TruffleBoundary
-        private int preciseCharacterLength(Encoding encoding, byte[] bytes, int start, int end) {
-            return StringSupport.preciseLength(encoding, bytes, start, end);
-        }
-
-        @TruffleBoundary
         private int mbcToCode(Encoding encoding, byte[] bytes, int start, int end) {
             return encoding.mbcToCode(bytes, start, end);
+        }
+
+        private int preciseLength(Encoding encoding, byte[] bytes, int start, int end) {
+            if (preciseLengthNode == null) {
+                CompilerDirectives.transferToInterpreterAndInvalidate();
+                preciseLengthNode = insert(PreciseLengthNode.create());
+            }
+
+            return preciseLengthNode.executeLength(encoding, bytes, start, end);
         }
 
     }
@@ -1432,6 +1442,69 @@ public abstract class RopeNodes {
         public int executeHashNotCalculated(Rope rope) {
             return rope.hashCode();
         }
+    }
+
+    @NodeChildren({
+            @NodeChild(type = RubyNode.class, value = "encoding"),
+            @NodeChild(type = RubyNode.class, value = "bytes"),
+            @NodeChild(type = RubyNode.class, value = "start"),
+            @NodeChild(type = RubyNode.class, value = "end")
+    })
+    public abstract static class EncodingLengthNode extends RubyNode {
+
+        public static EncodingLengthNode create() {
+            return RopeNodesFactory.EncodingLengthNodeGen.create(null, null, null, null);
+        }
+
+        public abstract int executeLength(Encoding encoding, byte[] bytes, int start, int end);
+
+        @Specialization(guards = "encoding.isUTF8()")
+        int utf8Length(Encoding encoding, byte[] bytes, int start, int end) {
+            return UTF8Encoding.class.cast(encoding).length(bytes, start, end);
+        }
+
+        @TruffleBoundary
+        @Specialization(guards = "!encoding.isUTF8()")
+        int genericLength(Encoding encoding, byte[] bytes, int start, int end) {
+            return encoding.length(bytes, start, end);
+        }
+
+    }
+
+    @NodeChildren({
+            @NodeChild(type = RubyNode.class, value = "encoding"),
+            @NodeChild(type = RubyNode.class, value = "bytes"),
+            @NodeChild(type = RubyNode.class, value = "start"),
+            @NodeChild(type = RubyNode.class, value = "end")
+    })
+    public abstract static class PreciseLengthNode extends RubyNode {
+
+        public static PreciseLengthNode create() {
+            return RopeNodesFactory.PreciseLengthNodeGen.create(null, null, null, null);
+        }
+
+        public abstract int executeLength(Encoding encoding, byte[] bytes, int start, int end);
+
+        @Specialization
+        int preciseLength(Encoding encoding, byte[] bytes, int start, int end,
+                          @Cached("create()") EncodingLengthNode encodingLengthNode,
+                          @Cached("create()") BranchProfile startTooLargeProfile,
+                          @Cached("create()") BranchProfile characterTooLargeProfile) {
+            if (start >= end) {
+                startTooLargeProfile.enter();
+                return -1 - (1);
+            }
+
+            int n = encodingLengthNode.executeLength(encoding, bytes, start, end);
+
+            if (n > end - start) {
+                characterTooLargeProfile.enter();
+                return StringSupport.MBCLEN_NEEDMORE(n - (end - start));
+            }
+
+            return n;
+        }
+
     }
 
     public static final class StringAttributes {

--- a/src/main/java/org/truffleruby/core/rope/RopeNodes.java
+++ b/src/main/java/org/truffleruby/core/rope/RopeNodes.java
@@ -214,12 +214,14 @@ public abstract class RopeNodes {
             }
         }
 
-        @TruffleBoundary
         @Specialization(guards = "!is7Bit(base.getCodeRange())")
-        protected Rope makeSubstringNon7Bit(Encoding encoding, Rope base, int byteOffset, int byteLength) {
-            final long packedLengthAndCodeRange = RopeOperations.calculateCodeRangeAndLength(encoding, base.getBytes(), byteOffset, byteOffset + byteLength);
-            final CodeRange codeRange = CodeRange.fromInt(StringSupport.unpackArg(packedLengthAndCodeRange));
-            final int characterLength = StringSupport.unpackResult(packedLengthAndCodeRange);
+        protected Rope makeSubstringNon7Bit(Encoding encoding, Rope base, int byteOffset, int byteLength,
+                                            @Cached("create()") CalculateAttributesNode calculateAttributesNode) {
+
+            final StringAttributes attributes = calculateAttributesNode.executeCalculateAttributes(encoding, RopeOperations.extractRange(base, byteOffset, byteLength));
+
+            final CodeRange codeRange = attributes.codeRange;
+            final int characterLength = attributes.characterLength;
             final boolean singleByteOptimizable = base.isSingleByteOptimizable() || (codeRange == CR_7BIT);
 
             if (getContext().getOptions().ROPE_LAZY_SUBSTRINGS) {
@@ -238,6 +240,140 @@ public abstract class RopeNodes {
 
         protected static boolean is7Bit(CodeRange codeRange) {
             return codeRange == CR_7BIT;
+        }
+
+    }
+
+    @NodeChildren({
+            @NodeChild(type = RubyNode.class, value = "encoding"),
+            @NodeChild(type = RubyNode.class, value = "bytes")
+    })
+    @ImportStatic(RopeGuards.class)
+    public abstract static class CalculateAttributesNode extends RubyNode {
+
+        public static CalculateAttributesNode create() {
+            return RopeNodesFactory.CalculateAttributesNodeGen.create(null, null);
+        }
+
+        abstract StringAttributes executeCalculateAttributes(Encoding encoding, byte[] bytes);
+
+        @Specialization(guards = "isEmpty(bytes)")
+        StringAttributes calculateAttributesEmpty(Encoding encoding, byte[] bytes,
+                                                  @Cached("createBinaryProfile()") ConditionProfile isAsciiCompatible) {
+            return new StringAttributes(0,
+                    isAsciiCompatible.profile(encoding.isAsciiCompatible()) ? CR_7BIT : CR_VALID);
+        }
+
+        @Specialization(guards = { "!isEmpty(bytes)", "isBinaryString(encoding)" })
+        StringAttributes calculateAttributesBinaryString(Encoding encoding, byte[] bytes,
+                                                         @Cached("create()") BranchProfile nonAsciiStringProfile) {
+            CodeRange codeRange = CR_7BIT;
+
+            for (int i = 0; i < bytes.length; i++) {
+                if (bytes[i] < 0) {
+                    nonAsciiStringProfile.enter();
+                    codeRange = CR_VALID;
+                    break;
+                }
+            }
+
+            return new StringAttributes(bytes.length, codeRange);
+        }
+
+        @Specialization(rewriteOn = NonAsciiCharException.class,
+                guards = { "!isEmpty(bytes)", "!isBinaryString(encoding)", "isAsciiCompatible(encoding)" })
+        StringAttributes calculateAttributesAsciiCompatible(Encoding encoding, byte[] bytes) throws NonAsciiCharException {
+            // Optimistically assume this string consists only of ASCII characters. If a non-ASCII character is found,
+            // fail over to a more generalized search.
+            for (int i = 0; i < bytes.length; i++) {
+                if (bytes[i] < 0) {
+                    throw new NonAsciiCharException();
+                }
+            }
+
+            return new StringAttributes(bytes.length, CR_7BIT);
+        }
+
+        @Specialization(replaces = "calculateAttributesAsciiCompatible",
+                guards = { "!isEmpty(bytes)", "!isBinaryString(encoding)", "isAsciiCompatible(encoding)" })
+        StringAttributes calculateAttributesAsciiCompatibleGeneric(Encoding encoding, byte[] bytes,
+                                                                   @Cached("create()") BranchProfile multiByteCharacterProfile,
+                                                                   @Cached("create()") BranchProfile brokenCodeRangeProfile) {
+            // Taken from StringSupport.strLengthWithCodeRangeAsciiCompatible.
+
+            CodeRange codeRange = CR_7BIT;
+            int characters = 0;
+            int p = 0;
+            final int end = bytes.length;
+
+            while (p < end) {
+                if (Encoding.isAscii(bytes[p])) {
+                    final int multiByteCharacterPosition = StringSupport.searchNonAscii(bytes, p, end);
+                    if (multiByteCharacterPosition == -1) {
+                        return new StringAttributes(characters + (end - p), codeRange);
+                    }
+
+                    characters += multiByteCharacterPosition - p;
+                    p = multiByteCharacterPosition;
+                }
+
+                final int lengthOfCurrentCharacter = StringSupport.preciseLength(encoding, bytes, p, end);
+
+                if (lengthOfCurrentCharacter > 0) {
+                    multiByteCharacterProfile.enter();
+
+                    if (codeRange != CR_BROKEN) {
+                        codeRange = CR_VALID;
+                    }
+
+                    p += lengthOfCurrentCharacter;
+                } else {
+                    brokenCodeRangeProfile.enter();
+                    codeRange = CR_BROKEN;
+                    p++;
+                }
+
+                characters++;
+            }
+
+            return new StringAttributes(characters, codeRange);
+        }
+
+        @Specialization(guards = { "!isEmpty(bytes)", "!isBinaryString(encoding)", "!isAsciiCompatible(encoding)" })
+        StringAttributes calculateAttributesGeneric(Encoding encoding, byte[] bytes,
+                                                    @Cached("createBinaryProfile()") ConditionProfile asciiCompatibleProfile,
+                                                    @Cached("create()") BranchProfile multiByteCharacterProfile,
+                                                    @Cached("create()") BranchProfile brokenCodeRangeProfile) {
+            // Taken from StringSupport.strLengthWithCodeRangeNonAsciiCompatible.
+
+            CodeRange codeRange = asciiCompatibleProfile.profile(encoding.isAsciiCompatible()) ? CR_7BIT : CR_VALID;
+            int characters;
+            int p = 0;
+            final int end = bytes.length;
+
+            for (characters = 0; p < end; characters++) {
+                final int lengthOfCurrentCharacter = StringSupport.preciseLength(encoding, bytes, p, end);
+
+                if (lengthOfCurrentCharacter > 0) {
+                    multiByteCharacterProfile.enter();
+
+                    if (codeRange != CR_BROKEN) {
+                        codeRange = CR_VALID;
+                    }
+
+                    p += lengthOfCurrentCharacter;
+                } else {
+                    brokenCodeRangeProfile.enter();
+                    codeRange = CR_BROKEN;
+                    p++;
+                }
+            }
+
+            return new StringAttributes(characters, codeRange);
+        }
+
+        protected static final class NonAsciiCharException extends SlowPathException {
+            private static final long serialVersionUID = 5550642254188358382L;
         }
 
     }
@@ -481,6 +617,7 @@ public abstract class RopeNodes {
             @NodeChild(type = RubyNode.class, value = "codeRange"),
             @NodeChild(type = RubyNode.class, value = "characterLength")
     })
+    @ImportStatic(RopeGuards.class)
     public abstract static class MakeLeafRopeNode extends RubyNode {
 
         public static MakeLeafRopeNode create() {
@@ -669,18 +806,6 @@ public abstract class RopeNodes {
 
         protected static boolean isUnknown(CodeRange codeRange) {
             return codeRange == CodeRange.CR_UNKNOWN;
-        }
-
-        protected static boolean isBinaryString(Encoding encoding) {
-            return encoding == ASCIIEncoding.INSTANCE;
-        }
-
-        protected static boolean isEmpty(byte[] bytes) {
-            return bytes.length == 0;
-        }
-
-        protected static boolean isAsciiCompatible(Encoding encoding) {
-            return encoding.isAsciiCompatible();
         }
 
         protected static boolean isFixedWidth(Encoding encoding) {
@@ -1351,4 +1476,15 @@ public abstract class RopeNodes {
             return rope.hashCode();
         }
     }
+
+    public static final class StringAttributes {
+        final int characterLength;
+        final CodeRange codeRange;
+
+        StringAttributes(int characterLength, CodeRange codeRange) {
+            this.characterLength = characterLength;
+            this.codeRange = codeRange;
+        }
+    }
+
 }

--- a/src/main/java/org/truffleruby/core/rope/RopeNodes.java
+++ b/src/main/java/org/truffleruby/core/rope/RopeNodes.java
@@ -246,26 +246,26 @@ public abstract class RopeNodes {
             @NodeChild(type = RubyNode.class, value = "right"),
             @NodeChild(type = RubyNode.class, value = "encoding")
     })
-    public abstract static class MakeConcatNode extends RubyNode {
+    public abstract static class ConcatNode extends RubyNode {
 
-        public static MakeConcatNode create() {
-            return RopeNodesFactory.MakeConcatNodeGen.create(null, null, null);
+        public static ConcatNode create() {
+            return RopeNodesFactory.ConcatNodeGen.create(null, null, null);
         }
 
         @Child private FlattenNode flattenNode;
 
-        public abstract Rope executeMake(Rope left, Rope right, Encoding encoding);
+        public abstract Rope executeConcat(Rope left, Rope right, Encoding encoding);
 
         @TruffleBoundary
         @Specialization
         public Rope concatNativeRopeLeft(NativeRope left, Rope right, Encoding encoding) {
-            return executeMake(left.toLeafRope(), right, encoding);
+            return executeConcat(left.toLeafRope(), right, encoding);
         }
 
         @TruffleBoundary
         @Specialization
         public Rope concatNativeRopeRight(Rope left, NativeRope right, Encoding encoding) {
-            return executeMake(left, right.toLeafRope(), encoding);
+            return executeConcat(left, right.toLeafRope(), encoding);
         }
 
         @Specialization(guards = { "!isNativeRope(left)", "!isNativeRope(right)", "!isCodeRangeBroken(left, right)" })

--- a/src/main/java/org/truffleruby/core/string/StringNodes.java
+++ b/src/main/java/org/truffleruby/core/string/StringNodes.java
@@ -1134,7 +1134,7 @@ public abstract class StringNodes {
     public abstract static class EachCharNode extends YieldingCoreMethodNode {
 
         @Child private AllocateObjectNode allocateObjectNode = AllocateObjectNode.create();
-        @Child private RopeNodes.MakeSubstringNode makeSubstringNode = RopeNodes.MakeSubstringNode.create();
+        @Child private RopeNodes.SubstringNode substringNode = RopeNodes.SubstringNode.create();
         @Child private TaintResultNode taintResultNode;
         @Child private RopeNodes.BytesNode bytesNode = RopeNodes.BytesNode.create();
 
@@ -1193,7 +1193,7 @@ public abstract class StringNodes {
 
             int end = Math.min(length, beg + len);
 
-            final Rope substringRope = makeSubstringNode.executeMake(rope, beg, end - beg);
+            final Rope substringRope = substringNode.executeSubstring(rope, beg, end - beg);
 
             if (taintResultNode == null) {
                 CompilerDirectives.transferToInterpreterAndInvalidate();
@@ -1382,7 +1382,7 @@ public abstract class StringNodes {
     public abstract static class LstripBangNode extends CoreMethodArrayArgumentsNode {
 
         @Child private RopeNodes.GetCodePointNode getCodePointNode = RopeNodes.GetCodePointNode.create();
-        @Child private RopeNodes.MakeSubstringNode makeSubstringNode = RopeNodes.MakeSubstringNode.create();
+        @Child private RopeNodes.SubstringNode substringNode = RopeNodes.SubstringNode.create();
 
         @Specialization(guards = "isEmpty(string)")
         public DynamicObject lstripBangEmptyString(DynamicObject string) {
@@ -1413,7 +1413,7 @@ public abstract class StringNodes {
                 p++;
             }
 
-            StringOperations.setRope(string, makeSubstringNode.executeMake(rope, p, end - p));
+            StringOperations.setRope(string, substringNode.executeSubstring(rope, p, end - p));
 
             return string;
         }
@@ -1438,7 +1438,7 @@ public abstract class StringNodes {
             }
 
             if (p > s) {
-                StringOperations.setRope(string, makeSubstringNode.executeMake(rope, p - s, end - p));
+                StringOperations.setRope(string, substringNode.executeSubstring(rope, p - s, end - p));
 
                 return string;
             }
@@ -1495,7 +1495,7 @@ public abstract class StringNodes {
     public abstract static class RstripBangNode extends CoreMethodArrayArgumentsNode {
 
         @Child private RopeNodes.GetCodePointNode getCodePointNode = RopeNodes.GetCodePointNode.create();
-        @Child private RopeNodes.MakeSubstringNode makeSubstringNode = RopeNodes.MakeSubstringNode.create();
+        @Child private RopeNodes.SubstringNode substringNode = RopeNodes.SubstringNode.create();
 
         @Specialization(guards = "isEmpty(string)")
         public DynamicObject rstripBangEmptyString(DynamicObject string) {
@@ -1527,7 +1527,7 @@ public abstract class StringNodes {
                 endp--;
             }
 
-            StringOperations.setRope(string, makeSubstringNode.executeMake(rope, 0, endp + 1));
+            StringOperations.setRope(string, substringNode.executeSubstring(rope, 0, endp + 1));
 
             return string;
         }
@@ -1560,7 +1560,7 @@ public abstract class StringNodes {
             }
 
             if (endp < end) {
-                StringOperations.setRope(string, makeSubstringNode.executeMake(rope, 0, endp - start));
+                StringOperations.setRope(string, substringNode.executeSubstring(rope, 0, endp - start));
 
                 return string;
             }
@@ -1579,7 +1579,7 @@ public abstract class StringNodes {
 
         @Child private YieldNode yieldNode = new YieldNode();
         @Child private RopeNodes.MakeConcatNode makeConcatNode = RopeNodes.MakeConcatNode.create();
-        @Child private RopeNodes.MakeSubstringNode makeSubstringNode = RopeNodes.MakeSubstringNode.create();
+        @Child private RopeNodes.SubstringNode substringNode = RopeNodes.SubstringNode.create();
         @Child private MakeStringNode makeStringNode = StringNodes.MakeStringNode.create();
         private final RopeNodes.BytesNode bytesNode = RopeNodes.BytesNode.create();
 
@@ -1610,7 +1610,7 @@ public abstract class StringNodes {
                     // p ~e: invalid bytes + unknown bytes
                     int clen = enc.maxLength();
                     if (p1 < p) {
-                        buf = makeConcatNode.executeMake(buf, makeSubstringNode.executeMake(rope, p1, p - p1), enc);
+                        buf = makeConcatNode.executeMake(buf, substringNode.executeSubstring(rope, p1, p - p1), enc);
                     }
 
                     if (e - p < clen) {
@@ -1630,7 +1630,7 @@ public abstract class StringNodes {
                             }
                         }
                     }
-                    DynamicObject repl = (DynamicObject) yield(block, makeStringNode.fromRope(makeSubstringNode.executeMake(rope, p, clen)));
+                    DynamicObject repl = (DynamicObject) yield(block, makeStringNode.fromRope(substringNode.executeSubstring(rope, p, clen)));
                     buf = makeConcatNode.executeMake(buf, rope(repl), enc);
                     p += clen;
                     p1 = p;
@@ -1642,10 +1642,10 @@ public abstract class StringNodes {
                 }
             }
             if (p1 < p) {
-                buf = makeConcatNode.executeMake(buf, makeSubstringNode.executeMake(rope, p1, p - p1), enc);
+                buf = makeConcatNode.executeMake(buf, substringNode.executeSubstring(rope, p1, p - p1), enc);
             }
             if (p < e) {
-                DynamicObject repl = (DynamicObject) yield(block, makeStringNode.fromRope(makeSubstringNode.executeMake(rope, p, e - p)));
+                DynamicObject repl = (DynamicObject) yield(block, makeStringNode.fromRope(substringNode.executeSubstring(rope, p, e - p)));
                 buf = makeConcatNode.executeMake(buf, rope(repl), enc);
             }
 
@@ -1676,7 +1676,7 @@ public abstract class StringNodes {
                     int clen = enc.maxLength();
 
                     if (p1 < p) {
-                        buf = makeConcatNode.executeMake(buf, makeSubstringNode.executeMake(rope, p1, p - p1), enc);
+                        buf = makeConcatNode.executeMake(buf, substringNode.executeSubstring(rope, p1, p - p1), enc);
                     }
 
                     if (e - p < clen) {
@@ -1694,17 +1694,17 @@ public abstract class StringNodes {
                         }
                     }
 
-                    DynamicObject repl = (DynamicObject) yield(block, makeStringNode.fromRope(makeSubstringNode.executeMake(rope, p, clen)));
+                    DynamicObject repl = (DynamicObject) yield(block, makeStringNode.fromRope(substringNode.executeSubstring(rope, p, clen)));
                     buf = makeConcatNode.executeMake(buf, rope(repl), enc);
                     p += clen;
                     p1 = p;
                 }
             }
             if (p1 < p) {
-                buf = makeConcatNode.executeMake(buf, makeSubstringNode.executeMake(rope, p1, p - p1), enc);
+                buf = makeConcatNode.executeMake(buf, substringNode.executeSubstring(rope, p1, p - p1), enc);
             }
             if (p < e) {
-                DynamicObject repl = (DynamicObject) yield(block, makeStringNode.fromRope(makeSubstringNode.executeMake(rope, p, e - p)));
+                DynamicObject repl = (DynamicObject) yield(block, makeStringNode.fromRope(substringNode.executeSubstring(rope, p, e - p)));
                 buf = makeConcatNode.executeMake(buf, rope(repl), enc);
             }
 
@@ -1956,8 +1956,8 @@ public abstract class StringNodes {
         @Child private RopeNodes.MakeConcatNode composedMakeConcatNode = RopeNodes.MakeConcatNode.create();
         @Child private RopeNodes.MakeConcatNode middleMakeConcatNode = RopeNodes.MakeConcatNode.create();
         @Child private RopeNodes.MakeLeafRopeNode makeLeafRopeNode = RopeNodes.MakeLeafRopeNode.create();
-        @Child private RopeNodes.MakeSubstringNode leftMakeSubstringNode = RopeNodes.MakeSubstringNode.create();
-        @Child private RopeNodes.MakeSubstringNode rightMakeSubstringNode = RopeNodes.MakeSubstringNode.create();
+        @Child private RopeNodes.SubstringNode leftSubstringNode = RopeNodes.SubstringNode.create();
+        @Child private RopeNodes.SubstringNode rightSubstringNode = RopeNodes.SubstringNode.create();
 
         @CreateCast("index") public RubyNode coerceIndexToInt(RubyNode index) {
             return FixnumLowerNodeGen.create(ToIntNodeGen.create(index));
@@ -1974,8 +1974,8 @@ public abstract class StringNodes {
             final Rope rope = rope(string);
             final int normalizedIndex = checkIndexNode.executeCheck(index, rope.byteLength());
 
-            final Rope left = leftMakeSubstringNode.executeMake(rope, 0, normalizedIndex);
-            final Rope right = rightMakeSubstringNode.executeMake(rope, normalizedIndex + 1, rope.byteLength() - normalizedIndex - 1);
+            final Rope left = leftSubstringNode.executeSubstring(rope, 0, normalizedIndex);
+            final Rope right = rightSubstringNode.executeSubstring(rope, normalizedIndex + 1, rope.byteLength() - normalizedIndex - 1);
             final Rope middle = makeLeafRopeNode.executeMake(new byte[] { (byte) value }, rope.getEncoding(), CodeRange.CR_UNKNOWN, NotProvided.INSTANCE);
             final Rope composed = composedMakeConcatNode.executeMake(middleMakeConcatNode.executeMake(left, middle, rope.getEncoding()), right, rope.getEncoding());
 
@@ -2820,11 +2820,11 @@ public abstract class StringNodes {
     @CoreMethod(names = "clear", raiseIfFrozenSelf = true)
     public abstract static class ClearNode extends CoreMethodArrayArgumentsNode {
 
-        @Child private RopeNodes.MakeSubstringNode makeSubstringNode = RopeNodes.MakeSubstringNode.create();
+        @Child private RopeNodes.SubstringNode substringNode = RopeNodes.SubstringNode.create();
 
         @Specialization
         public DynamicObject clear(DynamicObject string) {
-            StringOperations.setRope(string, makeSubstringNode.executeMake(rope(string), 0, 0));
+            StringOperations.setRope(string, substringNode.executeSubstring(rope(string), 0, 0));
 
             return string;
         }
@@ -2905,7 +2905,7 @@ public abstract class StringNodes {
     public static abstract class StringAwkSplitPrimitiveNode extends PrimitiveArrayArgumentsNode {
 
         @Child private RopeNodes.GetCodePointNode getCodePointNode = RopeNodes.GetCodePointNode.create();
-        @Child private RopeNodes.MakeSubstringNode makeSubstringNode = RopeNodes.MakeSubstringNode.create();
+        @Child private RopeNodes.SubstringNode substringNode = RopeNodes.SubstringNode.create();
         @Child private TaintResultNode taintResultNode = new TaintResultNode();
 
         @TruffleBoundary
@@ -2972,7 +2972,7 @@ public abstract class StringNodes {
         private DynamicObject makeString(DynamicObject source, int index, int length) {
             assert RubyGuards.isRubyString(source);
 
-            final Rope rope = makeSubstringNode.executeMake(rope(source), index, length);
+            final Rope rope = substringNode.executeSubstring(rope(source), index, length);
 
             final DynamicObject ret = Layouts.CLASS.getInstanceFactory(Layouts.BASIC_OBJECT.getLogicalClass(source)).newInstance(Layouts.STRING.build(false, false, rope, null));
             taintResultNode.maybeTaint(source, ret);
@@ -2991,7 +2991,7 @@ public abstract class StringNodes {
 
         @Child private AllocateObjectNode allocateObjectNode = AllocateObjectNode.create();
         @Child private NormalizeIndexNode normalizeIndexNode = StringNodesFactory.NormalizeIndexNodeGen.create(null, null);
-        @Child private RopeNodes.MakeSubstringNode makeSubstringNode = RopeNodes.MakeSubstringNode.create();
+        @Child private RopeNodes.SubstringNode substringNode = RopeNodes.SubstringNode.create();
         @Child private TaintResultNode taintResultNode = new TaintResultNode();
 
         public static StringByteSubstringPrimitiveNode create() {
@@ -3043,7 +3043,7 @@ public abstract class StringNodes {
                 length = rope.byteLength() - normalizedIndex;
             }
 
-            final Rope substringRope = makeSubstringNode.executeMake(rope, normalizedIndex, length);
+            final Rope substringRope = substringNode.executeSubstring(rope, normalizedIndex, length);
             final DynamicObject result = allocateObjectNode.allocate(Layouts.BASIC_OBJECT.getLogicalClass(string), Layouts.STRING.build(false, false, substringRope, null));
 
             return taintResultNode.maybeTaint(string, result);
@@ -3313,7 +3313,7 @@ public abstract class StringNodes {
     public static abstract class StringFindCharacterNode extends CoreMethodArrayArgumentsNode {
 
         @Child private AllocateObjectNode allocateObjectNode = AllocateObjectNode.create();
-        @Child private RopeNodes.MakeSubstringNode makeSubstringNode = RopeNodes.MakeSubstringNode.create();
+        @Child private RopeNodes.SubstringNode substringNode = RopeNodes.SubstringNode.create();
         @Child private TaintResultNode taintResultNode;
 
         @Specialization(guards = "offset < 0")
@@ -3332,7 +3332,7 @@ public abstract class StringNodes {
 
             final Rope rope = rope(string);
 
-            final DynamicObject ret = allocateObjectNode.allocate(Layouts.BASIC_OBJECT.getLogicalClass(string), Layouts.STRING.build(false, false, makeSubstringNode.executeMake(rope, offset, 1), null));
+            final DynamicObject ret = allocateObjectNode.allocate(Layouts.BASIC_OBJECT.getLogicalClass(string), Layouts.STRING.build(false, false, substringNode.executeSubstring(rope, offset, 1), null));
 
             return propagate(string, ret);
         }
@@ -3349,9 +3349,9 @@ public abstract class StringNodes {
 
             final DynamicObject ret;
             if (StringSupport.MBCLEN_CHARFOUND_P(clen)) {
-                ret = allocateObjectNode.allocate(Layouts.BASIC_OBJECT.getLogicalClass(string), Layouts.STRING.build(false, false, makeSubstringNode.executeMake(rope, offset, clen), null));
+                ret = allocateObjectNode.allocate(Layouts.BASIC_OBJECT.getLogicalClass(string), Layouts.STRING.build(false, false, substringNode.executeSubstring(rope, offset, clen), null));
             } else {
-                ret = allocateObjectNode.allocate(Layouts.BASIC_OBJECT.getLogicalClass(string), Layouts.STRING.build(false, false, makeSubstringNode.executeMake(rope, offset, 1), null));
+                ret = allocateObjectNode.allocate(Layouts.BASIC_OBJECT.getLogicalClass(string), Layouts.STRING.build(false, false, substringNode.executeSubstring(rope, offset, 1), null));
             }
 
             return propagate(string, ret);
@@ -4051,13 +4051,13 @@ public abstract class StringNodes {
 
         @Specialization(guards = { "indexAtStartBound(spliceByteIndex)", "isRubyString(other)", "isRubyEncoding(rubyEncoding)" })
         public Object splicePrepend(DynamicObject string, DynamicObject other, int spliceByteIndex, int byteCountToReplace, DynamicObject rubyEncoding,
-                @Cached("create()") RopeNodes.MakeSubstringNode prependMakeSubstringNode,
+                @Cached("create()") RopeNodes.SubstringNode prependSubstringNode,
                 @Cached("create()") RopeNodes.MakeConcatNode prependMakeConcatNode) {
 
             final Encoding encoding = EncodingOperations.getEncoding(rubyEncoding);
             final Rope original = rope(string);
             final Rope left = rope(other);
-            final Rope right = prependMakeSubstringNode.executeMake(original, byteCountToReplace, original.byteLength() - byteCountToReplace);
+            final Rope right = prependSubstringNode.executeSubstring(original, byteCountToReplace, original.byteLength() - byteCountToReplace);
 
             StringOperations.setRope(string, prependMakeConcatNode.executeMake(left, right, encoding));
 
@@ -4080,8 +4080,8 @@ public abstract class StringNodes {
         public DynamicObject splice(DynamicObject string, DynamicObject other, int spliceByteIndex, int byteCountToReplace, DynamicObject rubyEncoding,
                 @Cached("createBinaryProfile()") ConditionProfile insertStringIsEmptyProfile,
                 @Cached("createBinaryProfile()") ConditionProfile splitRightIsEmptyProfile,
-                @Cached("create()") RopeNodes.MakeSubstringNode leftMakeSubstringNode,
-                @Cached("create()") RopeNodes.MakeSubstringNode rightMakeSubstringNode,
+                @Cached("create()") RopeNodes.SubstringNode leftSubstringNode,
+                @Cached("create()") RopeNodes.SubstringNode rightSubstringNode,
                 @Cached("create()") RopeNodes.MakeConcatNode leftMakeConcatNode,
                 @Cached("create()") RopeNodes.MakeConcatNode rightMakeConcatNode) {
 
@@ -4090,8 +4090,8 @@ public abstract class StringNodes {
             final Rope insert = rope(other);
             final int rightSideStartingIndex = spliceByteIndex + byteCountToReplace;
 
-            final Rope splitLeft = leftMakeSubstringNode.executeMake(source, 0, spliceByteIndex);
-            final Rope splitRight = rightMakeSubstringNode.executeMake(source, rightSideStartingIndex, source.byteLength() - rightSideStartingIndex);
+            final Rope splitLeft = leftSubstringNode.executeSubstring(source, 0, spliceByteIndex);
+            final Rope splitRight = rightSubstringNode.executeSubstring(source, rightSideStartingIndex, source.byteLength() - rightSideStartingIndex);
 
             final Rope joinedLeft;
             if (insertStringIsEmptyProfile.profile(insert.isEmpty())) {
@@ -4180,7 +4180,7 @@ public abstract class StringNodes {
 
         @Child private AllocateObjectNode allocateNode;
         @Child private NormalizeIndexNode normalizeIndexNode = StringNodesFactory.NormalizeIndexNodeGen.create(null, null);
-        @Child private RopeNodes.MakeSubstringNode makeSubstringNode;
+        @Child private RopeNodes.SubstringNode substringNode;
         @Child private TaintResultNode taintResultNode;
 
         public abstract Object execute(VirtualFrame frame, DynamicObject string, int index, int characterLength);
@@ -4352,9 +4352,9 @@ public abstract class StringNodes {
                 allocateNode = insert(AllocateObjectNode.create());
             }
 
-            if (makeSubstringNode == null) {
+            if (substringNode == null) {
                 CompilerDirectives.transferToInterpreterAndInvalidate();
-                makeSubstringNode = insert(RopeNodes.MakeSubstringNode.create());
+                substringNode = insert(RopeNodes.SubstringNode.create());
             }
 
             if (taintResultNode == null) {
@@ -4364,7 +4364,7 @@ public abstract class StringNodes {
 
             final DynamicObject ret = allocateNode.allocate(
                     Layouts.BASIC_OBJECT.getLogicalClass(string),
-                    Layouts.STRING.build(false, false, makeSubstringNode.executeMake(rope, beg, byteLength), null));
+                    Layouts.STRING.build(false, false, substringNode.executeSubstring(rope, beg, byteLength), null));
 
             taintResultNode.maybeTaint(string, ret);
 

--- a/src/main/java/org/truffleruby/core/string/StringNodes.java
+++ b/src/main/java/org/truffleruby/core/string/StringNodes.java
@@ -124,7 +124,7 @@ import org.truffleruby.core.rope.RopeBuilder;
 import org.truffleruby.core.rope.RopeConstants;
 import org.truffleruby.core.rope.RopeGuards;
 import org.truffleruby.core.rope.RopeNodes;
-import org.truffleruby.core.rope.RopeNodes.MakeRepeatingNode;
+import org.truffleruby.core.rope.RopeNodes.RepeatNode;
 import org.truffleruby.core.rope.RopeNodesFactory;
 import org.truffleruby.core.rope.RopeOperations;
 import org.truffleruby.core.rope.SubstringRope;
@@ -307,8 +307,8 @@ public abstract class StringNodes {
 
         @Specialization(guards = { "times >= 0", "!isEmpty(string)" })
         public DynamicObject multiply(DynamicObject string, int times,
-                                      @Cached("create()") MakeRepeatingNode makeRepeatingNode) {
-            final Rope repeated = makeRepeatingNode.executeMake(rope(string), times);
+                                      @Cached("create()") RepeatNode repeatNode) {
+            final Rope repeated = repeatNode.executeRepeat(rope(string), times);
 
             return allocateObjectNode.allocate(Layouts.BASIC_OBJECT.getLogicalClass(string), Layouts.STRING.build(false, false, repeated, null));
         }
@@ -320,8 +320,8 @@ public abstract class StringNodes {
 
         @Specialization(guards = { "times >= 0", "isEmpty(string)" })
         public DynamicObject multiplyEmpty(DynamicObject string, long times,
-                @Cached("create()") MakeRepeatingNode makeRepeatingNode) {
-            final Rope repeated = makeRepeatingNode.executeMake(rope(string), 0);
+                @Cached("create()") RopeNodes.RepeatNode repeatNode) {
+            final Rope repeated = repeatNode.executeRepeat(rope(string), 0);
 
             return allocateObjectNode.allocate(Layouts.BASIC_OBJECT.getLogicalClass(string), Layouts.STRING.build(false, false, repeated, null));
         }
@@ -3996,11 +3996,11 @@ public abstract class StringNodes {
 
         @Child private AllocateObjectNode allocateObjectNode = AllocateObjectNode.create();
         @Child private RopeNodes.MakeLeafRopeNode makeLeafRopeNode = RopeNodes.MakeLeafRopeNode.create();
-        @Child private RopeNodes.MakeRepeatingNode makeRepeatingNode = RopeNodes.MakeRepeatingNode.create();
+        @Child private RopeNodes.RepeatNode repeatNode = RopeNodes.RepeatNode.create();
 
         @Specialization(guards = "value >= 0")
         public DynamicObject stringPatternZero(DynamicObject stringClass, int size, int value) {
-            final Rope repeatingRope = makeRepeatingNode.executeMake(RopeConstants.ASCII_8BIT_SINGLE_BYTE_ROPES[value], size);
+            final Rope repeatingRope = repeatNode.executeRepeat(RopeConstants.ASCII_8BIT_SINGLE_BYTE_ROPES[value], size);
 
             return allocateObjectNode.allocate(stringClass, Layouts.STRING.build(false, false, repeatingRope, null));
         }
@@ -4008,7 +4008,7 @@ public abstract class StringNodes {
         @Specialization(guards = { "isRubyString(string)", "patternFitsEvenly(string, size)" })
         public DynamicObject stringPatternFitsEvenly(DynamicObject stringClass, int size, DynamicObject string) {
             final Rope rope = rope(string);
-            final Rope repeatingRope = makeRepeatingNode.executeMake(rope, size / rope.byteLength());
+            final Rope repeatingRope = repeatNode.executeRepeat(rope, size / rope.byteLength());
 
             return allocateObjectNode.allocate(stringClass, Layouts.STRING.build(false, false, repeatingRope, null));
         }

--- a/src/main/java/org/truffleruby/core/string/StringNodes.java
+++ b/src/main/java/org/truffleruby/core/string/StringNodes.java
@@ -1139,7 +1139,8 @@ public abstract class StringNodes {
         @Child private RopeNodes.BytesNode bytesNode = RopeNodes.BytesNode.create();
 
         @Specialization(guards = "!isBrokenCodeRange(string)")
-        public DynamicObject eachChar(DynamicObject string, DynamicObject block) {
+        public DynamicObject eachChar(DynamicObject string, DynamicObject block,
+                @Cached("create()") RopeNodes.EncodingLengthNode encodingLengthNode) {
             final Rope rope = rope(string);
             final byte[] ptrBytes = bytesNode.execute(rope);
             final int len = ptrBytes.length;
@@ -1148,7 +1149,7 @@ public abstract class StringNodes {
             int n;
 
             for (int i = 0; i < len; i += n) {
-                n = StringSupport.encLength(enc, ptrBytes, i, len);
+                n = encodingLengthNode.executeLength(enc, ptrBytes, i, len);
 
                 yield(block, substr(rope, string, i, n));
             }
@@ -1581,6 +1582,7 @@ public abstract class StringNodes {
         @Child private RopeNodes.ConcatNode concatNode = RopeNodes.ConcatNode.create();
         @Child private RopeNodes.SubstringNode substringNode = RopeNodes.SubstringNode.create();
         @Child private MakeStringNode makeStringNode = StringNodes.MakeStringNode.create();
+        @Child private RopeNodes.EncodingLengthNode encodingLengthNode = RopeNodes.EncodingLengthNode.create();
         private final RopeNodes.BytesNode bytesNode = RopeNodes.BytesNode.create();
 
         @Specialization(guards = { "isBrokenCodeRange(string)", "isAsciiCompatible(string)" })
@@ -1600,7 +1602,7 @@ public abstract class StringNodes {
                 p = e;
             }
             while (p < e) {
-                int ret = StringSupport.encLength(enc, pBytes, p, e);
+                int ret = encodingLengthNode.executeLength(enc, pBytes, p, e);
                 if (MBCLEN_NEEDMORE_P(ret)) {
                     break;
                 } else if (MBCLEN_CHARFOUND_P(ret)) {
@@ -1653,7 +1655,8 @@ public abstract class StringNodes {
         }
 
         @Specialization(guards = { "isBrokenCodeRange(string)", "!isAsciiCompatible(string)" })
-        public DynamicObject scrubAsciiIncompatible(DynamicObject string, DynamicObject block) {
+        public DynamicObject scrubAsciiIncompatible(DynamicObject string, DynamicObject block,
+                @Cached("create()") RopeNodes.PreciseLengthNode preciseLengthNode) {
             final Rope rope = rope(string);
             final Encoding enc = rope.getEncoding();
             Rope buf = RopeConstants.EMPTY_ASCII_8BIT_ROPE;
@@ -1666,7 +1669,7 @@ public abstract class StringNodes {
             final int mbminlen = enc.minLength();
 
             while (p < e) {
-                int ret = StringSupport.preciseLength(enc, pBytes, p, e);
+                int ret = preciseLengthNode.executeLength(enc, pBytes, p, e);
                 if (MBCLEN_NEEDMORE_P(ret)) {
                     break;
                 } else if (MBCLEN_CHARFOUND_P(ret)) {
@@ -1687,7 +1690,7 @@ public abstract class StringNodes {
                     } else {
                         clen -= mbminlen;
                         for (; clen > mbminlen; clen -= mbminlen) {
-                            ret = StringSupport.encLength(enc, pBytes, q, q + clen);
+                            ret = encodingLengthNode.executeLength(enc, pBytes, q, q + clen);
                             if (MBCLEN_NEEDMORE_P(ret)) {
                                 break;
                             }
@@ -3075,12 +3078,13 @@ public abstract class StringNodes {
 
         @Specialization(guards = { "!indexOutOfBounds(string, byteIndex)", "!isSingleByteOptimizable(string)" })
         public Object stringChrAt(DynamicObject string, int byteIndex,
-                @Cached("create()") RopeNodes.BytesNode bytesNode) {
+                @Cached("create()") RopeNodes.BytesNode bytesNode,
+                @Cached("create()") RopeNodes.PreciseLengthNode preciseLengthNode) {
             // Taken from Rubinius's Character::create_from.
 
             final Rope rope = rope(string);
             final int end = rope.byteLength();
-            final int c = StringSupport.preciseLength(rope.getEncoding(), bytesNode.execute(rope), byteIndex, end);
+            final int c = preciseLengthNode.executeLength(rope.getEncoding(), bytesNode.execute(rope), byteIndex, end);
 
             if (!StringSupport.MBCLEN_CHARFOUND_P(c)) {
                 return nil();
@@ -3337,22 +3341,18 @@ public abstract class StringNodes {
             return propagate(string, ret);
         }
 
-        @TruffleBoundary
         @Specialization(guards = { "offset >= 0", "!offsetTooLarge(string, offset)", "!isSingleByteOptimizable(string)" })
-        public Object stringFindCharacter(DynamicObject string, int offset) {
+        public Object stringFindCharacter(DynamicObject string, int offset,
+                @Cached("create()") RopeNodes.PreciseLengthNode preciseLengthNode) {
             // Taken from Rubinius's String::find_character.
 
             final Rope rope = rope(string);
 
             final Encoding enc = rope.getEncoding();
-            final int clen = StringSupport.preciseLength(enc, rope.getBytes(), offset, offset + enc.maxLength());
+            final int clen = preciseLengthNode.executeLength(enc, rope.getBytes(), offset, offset + enc.maxLength());
 
-            final DynamicObject ret;
-            if (StringSupport.MBCLEN_CHARFOUND_P(clen)) {
-                ret = allocateObjectNode.allocate(Layouts.BASIC_OBJECT.getLogicalClass(string), Layouts.STRING.build(false, false, substringNode.executeSubstring(rope, offset, clen), null));
-            } else {
-                ret = allocateObjectNode.allocate(Layouts.BASIC_OBJECT.getLogicalClass(string), Layouts.STRING.build(false, false, substringNode.executeSubstring(rope, offset, 1), null));
-            }
+            final DynamicObject ret = allocateObjectNode.allocate(Layouts.BASIC_OBJECT.getLogicalClass(string),
+                    Layouts.STRING.build(false, false, substringNode.executeSubstring(rope, offset, clen), null));
 
             return propagate(string, ret);
         }
@@ -3408,7 +3408,8 @@ public abstract class StringNodes {
 
         @TruffleBoundary(transferToInterpreterOnException = false)
         @Specialization(guards = { "isRubyEncoding(rubyEncoding)", "!isSimple(code, rubyEncoding)", "isCodepoint(code)" })
-        public DynamicObject stringFromCodepoint(long code, DynamicObject rubyEncoding) {
+        public DynamicObject stringFromCodepoint(long code, DynamicObject rubyEncoding,
+                @Cached("create()") RopeNodes.PreciseLengthNode preciseLengthNode) {
             final Encoding encoding = EncodingOperations.getEncoding(rubyEncoding);
             final int length;
 
@@ -3429,7 +3430,7 @@ public abstract class StringNodes {
                 throw new RaiseException(coreExceptions().rangeError(code, rubyEncoding, this));
             }
 
-            if (StringSupport.preciseLength(encoding, bytes, 0, length) != length) {
+            if (preciseLengthNode.executeLength(encoding, bytes, 0, length) != length) {
                 throw new RaiseException(coreExceptions().rangeError(code, rubyEncoding, this));
             }
 
@@ -3733,7 +3734,8 @@ public abstract class StringNodes {
 
         @TruffleBoundary
         @Specialization(guards = "isRubyString(pattern)")
-        public Object stringCharacterIndex(DynamicObject string, DynamicObject pattern, int offset) {
+        public Object stringCharacterIndex(DynamicObject string, DynamicObject pattern, int offset,
+                @Cached("create()") RopeNodes.PreciseLengthNode preciseLengthNode) {
             if (offset < 0) {
                 return nil();
             }
@@ -3765,7 +3767,7 @@ public abstract class StringNodes {
             int c = 0;
 
             while (p < e && index < offset) {
-                c = StringSupport.preciseLength(enc, stringBytes, p, e);
+                c = preciseLengthNode.executeLength(enc, stringBytes, p, e);
 
                 if (StringSupport.MBCLEN_CHARFOUND_P(c)) {
                     p += c;
@@ -3776,7 +3778,7 @@ public abstract class StringNodes {
             }
 
             for (; p < l; p += c, ++index) {
-                c = StringSupport.preciseLength(enc, stringBytes, p, e);
+                c = preciseLengthNode.executeLength(enc, stringBytes, p, e);
                 if (!StringSupport.MBCLEN_CHARFOUND_P(c)) {
                     return nil();
                 }
@@ -3818,9 +3820,10 @@ public abstract class StringNodes {
 
         @Specialization(guards = { "characterIndexInBounds(string, characterIndex)", "!isSingleByteOptimizable(string)" })
         protected Object multiBytes(DynamicObject string, int characterIndex,
-                                    @Cached("createBinaryProfile()") ConditionProfile indexTooLargeProfile,
-                                    @Cached("createBinaryProfile()") ConditionProfile invalidByteProfile,
-                @Cached("create()") RopeNodes.BytesNode bytesNode) {
+                @Cached("createBinaryProfile()") ConditionProfile indexTooLargeProfile,
+                @Cached("createBinaryProfile()") ConditionProfile invalidByteProfile,
+                @Cached("create()") RopeNodes.BytesNode bytesNode,
+                @Cached("create()") RopeNodes.PreciseLengthNode preciseLengthNode) {
             // Taken from Rubinius's String::byte_index.
 
             final Rope rope = rope(string);
@@ -3831,7 +3834,7 @@ public abstract class StringNodes {
             int i, k = characterIndex;
 
             for (i = 0; i < k && p < e; i++) {
-                final int c = StringSupport.preciseLength(enc, bytesNode.execute(rope), p, e);
+                final int c = preciseLengthNode.executeLength(enc, bytesNode.execute(rope), p, e);
 
                 // TODO (nirvdrum 22-Dec-16): Consider having a specialized version for CR_BROKEN strings to avoid these checks.
                 // If it's an invalid byte, just treat it as a single byte

--- a/src/main/java/org/truffleruby/core/string/StringNodes.java
+++ b/src/main/java/org/truffleruby/core/string/StringNodes.java
@@ -65,6 +65,7 @@ package org.truffleruby.core.string;
 
 import static org.truffleruby.core.rope.CodeRange.CR_7BIT;
 import static org.truffleruby.core.rope.CodeRange.CR_UNKNOWN;
+import static org.truffleruby.core.rope.CodeRange.CR_VALID;
 import static org.truffleruby.core.rope.RopeConstants.EMPTY_ASCII_8BIT_ROPE;
 import static org.truffleruby.core.string.StringOperations.encoding;
 import static org.truffleruby.core.string.StringOperations.rope;
@@ -4188,15 +4189,12 @@ public abstract class StringNodes {
 
         public abstract Object execute(VirtualFrame frame, DynamicObject string, int index, int characterLength);
 
-        @Specialization(guards = "!indexTriviallyOutOfBounds(string, beg, characterLen)")
-        public Object stringSubstring(DynamicObject string, int beg, int characterLen,
-                                      @Cached("createBinaryProfile()") ConditionProfile negativeIndexProfile,
-                                      @Cached("createBinaryProfile()") ConditionProfile tooLargeTotalProfile,
-                                      @Cached("createBinaryProfile()") ConditionProfile singleByteOptimizableProfile,
-                                      @Cached("createBinaryProfile()") ConditionProfile foundSingleByteOptimizableDescendentProfile) {
+        @Specialization(guards = { "!indexTriviallyOutOfBounds(string, beg, characterLen)", "noCharacterSearch(string)" })
+        public Object stringSubstringSingleByte(DynamicObject string, int beg, int characterLen,
+                @Cached("createBinaryProfile()") ConditionProfile negativeIndexProfile,
+                @Cached("createBinaryProfile()") ConditionProfile tooLargeTotalProfile) {
             final Rope rope = rope(string);
-
-            int index = normalizeIndexNode.executeNormalize(beg, rope.characterLength());
+            final int index = normalizeIndexNode.executeNormalize(beg, rope.characterLength());
             int characterLength = characterLen;
 
             if (negativeIndexProfile.profile(index < 0)) {
@@ -4207,21 +4205,69 @@ public abstract class StringNodes {
                 characterLength = rope.characterLength() - index;
             }
 
-            if (singleByteOptimizableProfile.profile((characterLength == 0) || rope.isSingleByteOptimizable())) {
-                return makeRope(string, rope, index, characterLength);
-            } else {
-                final SearchResult searchResult = searchForSingleByteOptimizableDescendant(rope, index, characterLength);
+            return makeRope(string, rope, index, characterLength);
+        }
 
-                if (foundSingleByteOptimizableDescendentProfile.profile(searchResult.rope.isSingleByteOptimizable())) {
-                    return makeRope(string, searchResult.rope, searchResult.index, characterLength);
-                }
+        @Specialization(guards = { "!indexTriviallyOutOfBounds(string, beg, characterLen)", "!noCharacterSearch(string)" })
+        public Object stringSubstringGeneric(DynamicObject string, int beg, int characterLen,
+                @Cached("createBinaryProfile()") ConditionProfile negativeIndexProfile,
+                @Cached("createBinaryProfile()") ConditionProfile tooLargeTotalProfile,
+                @Cached("createBinaryProfile()") ConditionProfile foundSingleByteOptimizableDescendentProfile,
+                @Cached("create()") BranchProfile singleByteOptimizableBaseProfile,
+                @Cached("create()") BranchProfile leafBaseProfile,
+                @Cached("create()") BranchProfile slowSearchProfile,
+                @Cached("create()") BranchProfile utf8Profile,
+                @Cached("create()") BranchProfile fixedWidthProfile,
+                @Cached("create()") BranchProfile fallbackProfile,
+                @Cached("create()") RopeNodes.BytesNode bytesNode) {
+            final Rope rope = rope(string);
+            final int index = normalizeIndexNode.executeNormalize(beg, rope.characterLength());
+            int characterLength = characterLen;
 
-                return stringSubstringMultiByte(string, index, characterLength);
+            if (negativeIndexProfile.profile(index < 0)) {
+                return nil();
             }
+
+            if (tooLargeTotalProfile.profile(index + characterLength > rope.characterLength())) {
+                characterLength = rope.characterLength() - index;
+            }
+
+            final SearchResult searchResult = searchForSingleByteOptimizableDescendant(rope, index, characterLength,
+                    singleByteOptimizableBaseProfile , leafBaseProfile, slowSearchProfile);
+
+            if (foundSingleByteOptimizableDescendentProfile.profile(searchResult.rope.isSingleByteOptimizable())) {
+                return makeRope(string, searchResult.rope, searchResult.index, characterLength);
+            }
+
+            return stringSubstringMultiByte(string, index, characterLength, bytesNode, utf8Profile, fixedWidthProfile, fallbackProfile);
+        }
+
+        @Specialization(guards = "indexTriviallyOutOfBounds(string, beg, len)")
+        public Object stringSubstringNegativeLength(DynamicObject string, int beg, int len) {
+            return nil();
+        }
+
+        private SearchResult searchForSingleByteOptimizableDescendant(Rope base, int index, int characterLength,
+                BranchProfile singleByteOptimizableBaseProfile,
+                BranchProfile leafBaseProfile,
+                BranchProfile slowSearchProfile) {
+
+            if (base.isSingleByteOptimizable()) {
+                singleByteOptimizableBaseProfile.enter();
+                return new SearchResult(index, base);
+            }
+
+            if (base instanceof LeafRope) {
+                leafBaseProfile.enter();
+                return new SearchResult(index, base);
+            }
+
+            slowSearchProfile.enter();
+            return searchForSingleByteOptimizableDescendantSlow(base, index, characterLength);
         }
 
         @TruffleBoundary
-        private SearchResult searchForSingleByteOptimizableDescendant(Rope base, int index, int characterLength) {
+        private SearchResult searchForSingleByteOptimizableDescendantSlow(Rope base, int index, int characterLength) {
             // If we've found something that's single-byte optimizable, we can halt the search. Taking a substring of
             // a single byte optimizable rope is a fast operation.
             if (base.isSingleByteOptimizable()) {
@@ -4234,7 +4280,7 @@ public abstract class StringNodes {
                 final SubstringRope substringRope = (SubstringRope) base;
                 if (substringRope.isSingleByteOptimizable()) {
                     // the substring byte offset is also a character offset
-                    return searchForSingleByteOptimizableDescendant(substringRope.getChild(), index + substringRope.getByteOffset(), characterLength);
+                    return searchForSingleByteOptimizableDescendantSlow(substringRope.getChild(), index + substringRope.getByteOffset(), characterLength);
                 } else {
                     return new SearchResult(index, substringRope);
                 }
@@ -4244,9 +4290,9 @@ public abstract class StringNodes {
                 final Rope right = concatRope.getRight();
 
                 if (index + characterLength <= left.characterLength()) {
-                    return searchForSingleByteOptimizableDescendant(left, index, characterLength);
+                    return searchForSingleByteOptimizableDescendantSlow(left, index, characterLength);
                 } else if (index >= left.characterLength()) {
-                    return searchForSingleByteOptimizableDescendant(right, index - left.characterLength(), characterLength);
+                    return searchForSingleByteOptimizableDescendantSlow(right, index - left.characterLength(), characterLength);
                 } else {
                     return new SearchResult(index, concatRope);
                 }
@@ -4254,7 +4300,7 @@ public abstract class StringNodes {
                 final RepeatingRope repeatingRope = (RepeatingRope) base;
 
                 if (index + characterLength <= repeatingRope.getChild().characterLength()) {
-                    return searchForSingleByteOptimizableDescendant(repeatingRope.getChild(), index, characterLength);
+                    return searchForSingleByteOptimizableDescendantSlow(repeatingRope.getChild(), index, characterLength);
                 } else {
                     return new SearchResult(index, repeatingRope);
                 }
@@ -4266,8 +4312,11 @@ public abstract class StringNodes {
             }
         }
 
-        @TruffleBoundary
-        private Object stringSubstringMultiByte(DynamicObject string, int beg, int characterLen) {
+        private Object stringSubstringMultiByte(DynamicObject string, int beg, int characterLen,
+                RopeNodes.BytesNode bytesNode,
+                BranchProfile utf8Profile,
+                BranchProfile fixedWidthProfile,
+                BranchProfile fallbackProfile) {
             // Taken from org.jruby.RubyString#substr19 & org.jruby.RubyString#multibyteSubstr19.
 
             final Rope rope = rope(string);
@@ -4277,46 +4326,17 @@ public abstract class StringNodes {
             int p;
             int s = 0;
             int end = s + length;
-            byte[] bytes = rope.getBytes();
+            byte[] bytes = bytesNode.execute(rope);
             int substringByteLength = characterLen;
 
-            if (beg < 0) {
-                if (characterLen > -beg) {
-                    characterLen = -beg;
-                }
-                if (-beg * enc.maxLength() < length >>> 3) {
-                    beg = -beg;
-                    int e = end;
-                    while (beg-- > characterLen && (e = enc.prevCharHead(bytes, s, e, e)) != -1) {
-                        // nothing
-                    }
-                    p = e;
-                    if (p == -1) {
-                        return nil();
-                    }
-                    while (characterLen-- > 0 && (p = enc.prevCharHead(bytes, s, p, e)) != -1) {
-                        // nothing
-                    }
-                    if (p == -1) {
-                        return nil();
-                    }
+            if (rope.getCodeRange() == CR_VALID && enc.isUTF8()) {
+                utf8Profile.enter();
 
-                    return makeRope(string, rope, p - s, e - p);
-                } else {
-                    beg += rope.characterLength();
-                    if (beg < 0) {
-                        return nil();
-                    }
-                }
-            } else if (beg > 0 && beg > rope.characterLength()) {
-                return nil();
-            }
-            if (characterLen == 0) {
-                p = 0;
-            } else if (StringGuards.isValidCodeRange(string) && enc instanceof UTF8Encoding) {
                 p = StringSupport.utf8Nth(bytes, s, end, beg);
                 substringByteLength = StringSupport.utf8Offset(bytes, p, end, characterLen);
             } else if (enc.isFixedWidth()) {
+                fixedWidthProfile.enter();
+
                 int w = enc.maxLength();
                 p = s + beg * w;
                 if (p > end) {
@@ -4327,24 +4347,17 @@ public abstract class StringNodes {
                 } else {
                     substringByteLength *= w;
                 }
-            } else if ((p = StringSupport.nth(enc, bytes, s, end, beg)) == end) {
-                substringByteLength = 0;
             } else {
-                substringByteLength = StringSupport.offset(enc, bytes, p, end, characterLen);
+                fallbackProfile.enter();
+
+                if ((p = StringSupport.nth(enc, bytes, s, end, beg)) == end) {
+                    substringByteLength = 0;
+                } else {
+                    substringByteLength = StringSupport.offset(enc, bytes, p, end, characterLen);
+                }
             }
 
             return makeRope(string, rope, p - s, substringByteLength);
-        }
-
-        @Specialization(guards = "indexTriviallyOutOfBounds(string, beg, len)")
-        public Object stringSubstringNegativeLength(DynamicObject string, int beg, int len) {
-            return nil();
-        }
-
-        protected static boolean indexTriviallyOutOfBounds(DynamicObject string, int index, int length) {
-            assert RubyGuards.isRubyString(string);
-
-            return (length < 0) || (index > rope(string).characterLength());
         }
 
         private DynamicObject makeRope(DynamicObject string, Rope rope, int beg, int byteLength) {
@@ -4372,6 +4385,17 @@ public abstract class StringNodes {
             taintResultNode.maybeTaint(string, ret);
 
             return ret;
+        }
+
+        protected static boolean indexTriviallyOutOfBounds(DynamicObject string, int index, int length) {
+            assert RubyGuards.isRubyString(string);
+
+            return (length < 0) || (index > rope(string).characterLength());
+        }
+
+        protected static boolean noCharacterSearch(DynamicObject string) {
+            final Rope rope = rope(string);
+            return rope.isEmpty() || rope.isSingleByteOptimizable();
         }
 
         private static final class SearchResult {

--- a/src/main/java/org/truffleruby/core/string/StringSupport.java
+++ b/src/main/java/org/truffleruby/core/string/StringSupport.java
@@ -68,12 +68,11 @@ public final class StringSupport {
     }
 
     // rb_enc_precise_mbclen
-    @TruffleBoundary
     public static int preciseLength(Encoding enc, byte[]bytes, int p, int end) {
         if (p >= end) {
             return -1 - (1);
         }
-        int n = enc.length(bytes, p, end);
+        int n = encLength(enc, bytes, p, end);
         if (n > end - p) {
             return MBCLEN_NEEDMORE(n - (end - p));
         }

--- a/src/main/java/org/truffleruby/core/string/StringSupport.java
+++ b/src/main/java/org/truffleruby/core/string/StringSupport.java
@@ -57,9 +57,8 @@ public final class StringSupport {
     }
 
     // rb_enc_mbclen
-    @TruffleBoundary
     public static int length(Encoding enc, byte[]bytes, int p, int end) {
-        int n = enc.length(bytes, p, end);
+        int n = encLength(enc, bytes, p, end);
         if (MBCLEN_CHARFOUND_P(n) && MBCLEN_CHARFOUND_LEN(n) <= end - p) {
             return MBCLEN_CHARFOUND_LEN(n);
         }

--- a/src/main/java/org/truffleruby/core/string/TruffleStringNodes.java
+++ b/src/main/java/org/truffleruby/core/string/TruffleStringNodes.java
@@ -45,9 +45,9 @@ public class TruffleStringNodes {
 
         @Specialization(guards = { "newByteLength >= 0", "isRubyString(string)", "!isNewLengthTooLarge(string, newByteLength)" })
         public DynamicObject stealStorage(DynamicObject string, int newByteLength,
-                @Cached("create()") RopeNodes.MakeSubstringNode makeSubstringNode) {
+                @Cached("create()") RopeNodes.SubstringNode substringNode) {
 
-            StringOperations.setRope(string, makeSubstringNode.executeMake(rope(string), 0, newByteLength));
+            StringOperations.setRope(string, substringNode.executeSubstring(rope(string), 0, newByteLength));
 
             return string;
         }

--- a/src/main/java/org/truffleruby/parser/parser/ParserRopeOperations.java
+++ b/src/main/java/org/truffleruby/parser/parser/ParserRopeOperations.java
@@ -44,7 +44,7 @@ public class ParserRopeOperations {
 
             return RopeOperations.create(Arrays.copyOfRange(rope.getBytes(), sharedStart, sharedStart + sharedLength), rope.getEncoding(), rope.getCodeRange() == CR_7BIT ? CR_7BIT : CR_UNKNOWN);
         } else {
-            return ropeNode.getMakeSubstringNode().executeMake(rope, sharedStart, sharedLength);
+            return ropeNode.getSubstringNode().executeSubstring(rope, sharedStart, sharedLength);
         }
     }
 
@@ -57,16 +57,16 @@ public class ParserRopeOperations {
 
     private static class RopeNode extends RubyNode {
 
-        @Child RopeNodes.MakeSubstringNode makeSubstringNode;
+        @Child RopeNodes.SubstringNode substringNode;
         @Child RopeNodes.WithEncodingNode withEncodingNode;
 
-        public RopeNodes.MakeSubstringNode getMakeSubstringNode() {
-            if (makeSubstringNode == null) {
+        public RopeNodes.SubstringNode getSubstringNode() {
+            if (substringNode == null) {
                 CompilerDirectives.transferToInterpreterAndInvalidate();
-                makeSubstringNode = insert(RopeNodes.MakeSubstringNode.create());
+                substringNode = insert(RopeNodes.SubstringNode.create());
             }
 
-            return makeSubstringNode;
+            return substringNode;
         }
 
         public RopeNodes.WithEncodingNode getWithEncodingNode() {


### PR DESCRIPTION
This one blew up in scope a bit. It turned into a general cleanup of `RopeNodes` while I tried to make substring operations faster on non-ASCII UTF-8 strings. I recommend going commit-by-commit.