### PR TITLE
[MatchData] inspect to handle named captures

### DIFF
--- a/spec/ruby/core/matchdata/inspect_spec.rb
+++ b/spec/ruby/core/matchdata/inspect_spec.rb
@@ -14,4 +14,10 @@ describe "MatchData#inspect" do
     # it makes perfect sense. See JRUBY-4558 for example.
     @match_data.inspect.should == '#<MatchData "HX1138" 1:"H" 2:"X" 3:"113" 4:"8">'
   end
+
+  it "returns a human readable representation of named captures" do
+    match_data = "abc def ghi".match(/(?<first>\w+)\s+(?<last>\w+)\s+(\w+)/)
+
+    match_data.inspect.should == '#<MatchData "abc def ghi" first:"abc" last:"def">'
+  end
 end

--- a/src/main/ruby/core/regexp.rb
+++ b/src/main/ruby/core/regexp.rb
@@ -379,14 +379,13 @@ class MatchData
   end
 
   def inspect
-    capts = captures
-    if capts.empty?
-      "#<MatchData \"#{self[0]}\">"
-    else
-      idx = 0
-      capts.map! { |capture| "#{idx += 1}:#{capture.inspect}" }
-      "#<MatchData \"#{self[0]}\" #{capts.join(" ")}>"
+    str = "#<MatchData \"#{self[0]}\""
+    idx = 0
+    captures.zip(names) do |capture, name|
+      idx += 1
+      str << " #{name || idx}:#{capture.inspect}"
     end
+    "#{str}>"
   end
 
   def values_at(*indexes)


### PR DESCRIPTION
MatchData inspect behaviour differs

Experiment:
```ruby
puts <<STATS
RUBY_ENGINE: #{RUBY_ENGINE}
RUBY_VERSION: #{RUBY_VERSION}
RUBY_REVISION: #{RUBY_REVISION}
RUBY_PATCHLEVEL: #{RUBY_PATCHLEVEL}
RUBY_RELEASE_DATE: #{RUBY_RELEASE_DATE}
RUBY_ENGINE_VERSION: #{RUBY_ENGINE_VERSION}

STATS

match = "abc def".match(/(?<first>\w+)\s+(?<last>\w+)/)

puts match.inspect
puts match[1].inspect
puts match[:first].inspect
```

Results:
```
RUBY_ENGINE: ruby
RUBY_VERSION: 2.3.3
RUBY_REVISION: 56859
RUBY_PATCHLEVEL: 222
RUBY_RELEASE_DATE: 2016-11-21
RUBY_ENGINE_VERSION: 2.3.3

#<MatchData "abc def" first:"abc" last:"def">
"abc"
"abc"
```

```
RUBY_ENGINE: truffleruby
RUBY_VERSION: 2.3.5
RUBY_REVISION: 59905
RUBY_PATCHLEVEL: 0
RUBY_RELEASE_DATE: 2018-01-29
RUBY_ENGINE_VERSION: 0.0-e8fc582e5f

#<MatchData "abc def" 1:"abc" 2:"def">
"abc"
"abc"
```

I can only presume the spec shouldn't be edited directly as these would have come from ruby/ruby at an earlier point in time, but then I'm not sure if it makes this change undesired as the spec was already passing.