### PR TITLE
Context pre-initialization (first steps)

### DIFF
--- a/mx.truffleruby/native-image.properties
+++ b/mx.truffleruby/native-image.properties
@@ -15,3 +15,8 @@ Args = -H:MaxRuntimeCompileMethods=11000 \
        -H:SubstitutionResources=org/truffleruby/aot/substitutions.json \
        -H:+AddAllCharsets \
        -H:Class=org.truffleruby.Main
+
+# Pass the home for context pre-initialization
+# ${.} expands to the destination Ruby home created by mx fetch-languages,
+# such as substratevm/svmbuild/native-image-root/languages/ruby.
+JavaArgs = -Dpolyglot.ruby.home=${.}

--- a/mx.truffleruby/suite.py
+++ b/mx.truffleruby/suite.py
@@ -7,7 +7,7 @@ suite = {
             {
                 "name": "truffle",
                 "subdir": True,
-                "version": "b47953d178018b18a4b16529b2495da69544427a",
+                "version": "c5d96fb90fd7a2b0bfc6a7bfd34abf5b81d7eb20",
                 "urls": [
                     {"url": "https://github.com/graalvm/graal.git", "kind": "git"},
                     {"url": "https://curio.ssw.jku.at/nexus/content/repositories/snapshots", "kind": "binary"},

--- a/src/launcher/java/org/truffleruby/launcher/Launcher.java
+++ b/src/launcher/java/org/truffleruby/launcher/Launcher.java
@@ -71,9 +71,9 @@ public class Launcher {
     public static final String BOOT_SOURCE_NAME = "main_boot_source";
     public static final String RUBY_COPYRIGHT = "truffleruby - Copyright (c) 2013-2017 Oracle and/or its affiliates";
 
+    // Properties set directly on the java command-line with -D for image building
     private static final String LIBSULONG_DIR = IS_NATIVE ? System.getProperty("truffleruby.native.libsulong_dir") : null;
-
-    private static final boolean DEBUG_PRE_INIT_CONTEXT = !IS_NATIVE && System.getProperty("polyglot.engine.PreinitializeContexts") != null;
+    public static final boolean PRE_INITIALIZE_CONTEXTS = System.getProperty("polyglot.engine.PreinitializeContexts") != null;
 
     // These system properties are used before outside the SDK option system
 
@@ -126,7 +126,7 @@ public class Launcher {
     }
 
     private static void debugPreInitialization() {
-        if (DEBUG_PRE_INIT_CONTEXT) {
+        if (!IS_NATIVE && PRE_INITIALIZE_CONTEXTS) {
             try {
                 final Class<?> holderClz = Class.forName("org.graalvm.polyglot.Engine$ImplHolder");
                 final Method preInitMethod = holderClz.getDeclaredMethod("preInitializeEngine");

--- a/src/main/java/org/truffleruby/RubyContext.java
+++ b/src/main/java/org/truffleruby/RubyContext.java
@@ -333,10 +333,6 @@ public class RubyContext {
             Log.LOGGER.fine(notReusingContext + "-Xplatform.native is " + newOptions.NATIVE_PLATFORM);
             return false;
         }
-        if (newOptions.POLYGLOT_STDIO != oldOptions.POLYGLOT_STDIO) {
-            Log.LOGGER.fine(notReusingContext + "-Xpolyglot.stdio is " + newOptions.POLYGLOT_STDIO);
-            return false;
-        }
         if (newOptions.VERBOSITY != oldOptions.VERBOSITY) {
             Log.LOGGER.fine(notReusingContext + "$VERBOSE is " + newOptions.VERBOSITY + " (was " + oldOptions.VERBOSITY + ")");
             return false;

--- a/src/main/java/org/truffleruby/RubyContext.java
+++ b/src/main/java/org/truffleruby/RubyContext.java
@@ -125,7 +125,7 @@ public class RubyContext {
     private boolean initialized;
     private volatile boolean finalizing;
 
-    private static boolean preInitializeContexts = System.getProperty("polyglot.engine.PreinitializeContexts") != null;
+    private static boolean preInitializeContexts = Launcher.PRE_INITIALIZE_CONTEXTS;
 
     public boolean isPreInitializing() {
         return preInitializing;

--- a/src/main/java/org/truffleruby/RubyContext.java
+++ b/src/main/java/org/truffleruby/RubyContext.java
@@ -499,6 +499,17 @@ public class RubyContext {
             return home.getCanonicalPath();
         }
 
+        // We need a home for context pre-initialization but the Context is built without arguments.
+        // Therefore we use a system property set in native-image.properties.
+        final String fromProperty = System.getProperty("polyglot.ruby.home");
+        if (fromProperty != null && !fromProperty.isEmpty()) {
+            final File home = new File(fromProperty);
+            if (!isRubyHome(home)) {
+                Log.LOGGER.warning(home + " does not look like truffleruby's home");
+            }
+            return home.getCanonicalPath();
+        }
+
         StringBuilder warning = new StringBuilder("TruffleRuby's home was not explicitly set.\n");
 
         if (!options.LAUNCHER.isEmpty()) {

--- a/src/main/java/org/truffleruby/RubyContext.java
+++ b/src/main/java/org/truffleruby/RubyContext.java
@@ -330,10 +330,12 @@ public class RubyContext {
         }
 
         // The core library captures the value of these options (via Truffle::Boot.get_option).
+
         if (newOptions.NATIVE_PLATFORM != oldOptions.NATIVE_PLATFORM) {
             Log.LOGGER.fine(notReusingContext + "-Xplatform.native is " + newOptions.NATIVE_PLATFORM);
             return false;
         }
+
         if (newOptions.VERBOSITY != oldOptions.VERBOSITY) {
             Log.LOGGER.fine(notReusingContext + "$VERBOSE is " + newOptions.VERBOSITY + " (was " + oldOptions.VERBOSITY + ")");
             return false;

--- a/src/main/java/org/truffleruby/RubyContext.java
+++ b/src/main/java/org/truffleruby/RubyContext.java
@@ -122,6 +122,7 @@ public class RubyContext {
     private final Object classVariableDefinitionLock = new Object();
 
     private boolean preInitializing;
+    private boolean reInitialized = false;
     private boolean initialized;
     private volatile boolean finalizing;
 
@@ -282,7 +283,7 @@ public class RubyContext {
 
     /** Re-initialize parts of the RubyContext depending on the current process */
     private void reInitialize() {
-        if (random != null) {
+        if (reInitialized) {
             throw new UnsupportedOperationException("re-initialization was already performed");
         }
 
@@ -293,6 +294,8 @@ public class RubyContext {
 
         threadManager.restartMainThread(Thread.currentThread());
         threadManager.initialize(truffleNFIPlatform, nativeConfiguration);
+
+        this.reInitialized = true;
     }
 
     protected boolean patch(Env newEnv) {

--- a/src/main/java/org/truffleruby/RubyContext.java
+++ b/src/main/java/org/truffleruby/RubyContext.java
@@ -204,20 +204,18 @@ public class RubyContext {
 
         // Create objects that need core classes
 
-        Launcher.printTruffleTimeMetric("before-create-native-platform");
-        truffleNFIPlatform = options.NATIVE_PLATFORM ? new TruffleNFIPlatform(this) : null;
-        featureLoader.initialize(nativeConfiguration, truffleNFIPlatform);
-        Launcher.printTruffleTimeMetric("after-create-native-platform");
+        truffleNFIPlatform = createNativePlatform();
 
         // The encoding manager relies on POSIX having been initialized, so we can't process it during
         // normal core library initialization.
         Launcher.printTruffleTimeMetric("before-initialize-encodings");
-        coreLibrary.initializeEncodingManager();
+        coreLibrary.defineEncodings();
+        coreLibrary.initializeDefaultEncodings(truffleNFIPlatform, nativeConfiguration);
         Launcher.printTruffleTimeMetric("after-initialize-encodings");
 
         Launcher.printTruffleTimeMetric("before-thread-manager");
         threadManager = new ThreadManager(this);
-        threadManager.initialize();
+        threadManager.initialize(truffleNFIPlatform, nativeConfiguration);
         Launcher.printTruffleTimeMetric("after-thread-manager");
 
         Launcher.printTruffleTimeMetric("before-instruments");
@@ -258,6 +256,14 @@ public class RubyContext {
         }
 
         initialized = true;
+    }
+
+    private TruffleNFIPlatform createNativePlatform() {
+        Launcher.printTruffleTimeMetric("before-create-native-platform");
+        final TruffleNFIPlatform truffleNFIPlatform = options.NATIVE_PLATFORM ? new TruffleNFIPlatform(this) : null;
+        featureLoader.initialize(nativeConfiguration, truffleNFIPlatform);
+        Launcher.printTruffleTimeMetric("after-create-native-platform");
+        return truffleNFIPlatform;
     }
 
     private NativeConfiguration loadNativeConfiguration() {

--- a/src/main/java/org/truffleruby/RubyContext.java
+++ b/src/main/java/org/truffleruby/RubyContext.java
@@ -270,8 +270,6 @@ public class RubyContext {
         if (isPreInitializing()) {
             // Cannot save the FileDescriptor in the image, referenced by the SecureRandom instance
             random = null;
-            // Cannot save native functions in the image
-            truffleNFIPlatform = null;
             // Cannot save the root Java Thread instance in the image
             threadManager.resetMainThread();
         } else {

--- a/src/main/java/org/truffleruby/RubyLanguage.java
+++ b/src/main/java/org/truffleruby/RubyLanguage.java
@@ -227,7 +227,7 @@ public class RubyLanguage extends TruffleLanguage<RubyContext> {
 
     @Override
     protected void initializeThread(RubyContext context, Thread thread) {
-        if (thread == context.getThreadManager().getRootJavaThread()) {
+        if (thread == context.getThreadManager().getOrInitializeRootJavaThread()) {
             // Already initialized when creating the context
             return;
         }

--- a/src/main/java/org/truffleruby/RubyLanguage.java
+++ b/src/main/java/org/truffleruby/RubyLanguage.java
@@ -108,6 +108,7 @@ public class RubyLanguage extends TruffleLanguage<RubyContext> {
 
     @Override
     public RubyContext createContext(Env env) {
+        Log.LOGGER.fine("createContext()");
         Launcher.printTruffleTimeMetric("before-create-context");
         // TODO CS 3-Dec-16 need to parse RUBYOPT here if it hasn't been already?
         final RubyContext context = new RubyContext(this, env);
@@ -117,6 +118,7 @@ public class RubyLanguage extends TruffleLanguage<RubyContext> {
 
     @Override
     protected void initializeContext(RubyContext context) throws Exception {
+        Log.LOGGER.fine("initializeContext()");
         Launcher.printTruffleTimeMetric("before-initialize-context");
         context.initialize();
         Launcher.printTruffleTimeMetric("after-initialize-context");
@@ -124,11 +126,13 @@ public class RubyLanguage extends TruffleLanguage<RubyContext> {
 
     @Override
     protected void finalizeContext(RubyContext context) {
+        Log.LOGGER.fine("finalizeContext()");
         context.finalizeContext();
     }
 
     @Override
     protected void disposeContext(RubyContext context) {
+        Log.LOGGER.fine("disposeContext()");
         context.disposeContext();
     }
 

--- a/src/main/java/org/truffleruby/RubyLanguage.java
+++ b/src/main/java/org/truffleruby/RubyLanguage.java
@@ -125,6 +125,15 @@ public class RubyLanguage extends TruffleLanguage<RubyContext> {
     }
 
     @Override
+    protected boolean patchContext(RubyContext context, Env newEnv) {
+        Log.LOGGER.fine("patchContext()");
+        Launcher.printTruffleTimeMetric("before-patch-context");
+        boolean patched = context.patch(newEnv);
+        Launcher.printTruffleTimeMetric("after-patch-context");
+        return patched;
+    }
+
+    @Override
     protected void finalizeContext(RubyContext context) {
         Log.LOGGER.fine("finalizeContext()");
         context.finalizeContext();

--- a/src/main/java/org/truffleruby/core/CoreLibrary.java
+++ b/src/main/java/org/truffleruby/core/CoreLibrary.java
@@ -60,6 +60,7 @@ import org.truffleruby.parser.ParserContext;
 import org.truffleruby.parser.TranslatorDriver;
 import org.truffleruby.platform.NativeTypes;
 import org.truffleruby.platform.Platform;
+import org.truffleruby.platform.TruffleNFIPlatform;
 import org.truffleruby.platform.NativeConfiguration;
 import org.truffleruby.stdlib.psych.YAMLEncoding;
 
@@ -872,12 +873,15 @@ public class CoreLibrary {
         }
     }
 
-    public void initializeEncodingManager() {
-        final EncodingManager encodingManager = getContext().getEncodingManager();
-
+    public void defineEncodings() {
         initializeEncodings();
         initializeEncodingAliases();
-        encodingManager.initializeLocaleEncoding(getContext().getTruffleNFI(), getContext().getNativeConfiguration());
+    }
+
+    public void initializeDefaultEncodings(TruffleNFIPlatform nfi, NativeConfiguration nativeConfiguration) {
+        final EncodingManager encodingManager = getContext().getEncodingManager();
+
+        encodingManager.initializeLocaleEncoding(nfi, nativeConfiguration);
 
         // External should always have a value, but Encoding.external_encoding{,=} will lazily setup
         final String externalEncodingName = getContext().getOptions().EXTERNAL_ENCODING;

--- a/src/main/java/org/truffleruby/core/CoreLibrary.java
+++ b/src/main/java/org/truffleruby/core/CoreLibrary.java
@@ -815,12 +815,12 @@ public class CoreLibrary {
 
         eagainWaitWritable = (DynamicObject) Layouts.MODULE.getFields(ioClass).getConstant("EAGAINWaitWritable").getValue();
         assert Layouts.CLASS.isClass(eagainWaitWritable);
+
+        findGlobalVariableStorage();
     }
 
     public void initializePostBoot() {
         // Load code that can't be run until everything else is boostrapped, such as pre-loaded Ruby stdlib.
-
-        findGlobalVariableStorage();
 
         try {
             final RubyRootNode rootNode = context.getCodeLoader().parse(context.getSourceLoader().load(getCoreLoadPath() + "/post-boot/post-boot.rb"),

--- a/src/main/java/org/truffleruby/core/FinalizationService.java
+++ b/src/main/java/org/truffleruby/core/FinalizationService.java
@@ -125,7 +125,7 @@ public class FinalizationService {
              * leaking a tiny number of bytes if it doesn't hold.
              */
 
-            if (finalizerThread == null && context.isInitialized() && !context.isFinalizing()) {
+            if (finalizerThread == null && !context.isPreInitializing() && context.isInitialized() && !context.isFinalizing()) {
                 createFinalizationThread();
             }
 

--- a/src/main/java/org/truffleruby/core/encoding/EncodingManager.java
+++ b/src/main/java/org/truffleruby/core/encoding/EncodingManager.java
@@ -68,7 +68,7 @@ public class EncodingManager {
     // This must be run after the locale is set for native, see the setLocale() call above
     public void initializeLocaleEncoding(TruffleNFIPlatform nfi, NativeConfiguration nativeConfiguration) {
         final String localeEncodingName;
-        if (context.getOptions().NATIVE_PLATFORM) {
+        if (nfi != null) {
             final int codeset = (int) nativeConfiguration.get("platform.langinfo.CODESET");
 
             // char *nl_langinfo(nl_item item);

--- a/src/main/java/org/truffleruby/core/fiber/FiberLayout.java
+++ b/src/main/java/org/truffleruby/core/fiber/FiberLayout.java
@@ -46,6 +46,7 @@ public interface FiberLayout extends BasicObjectLayout {
     CountDownLatch getInitializedLatch(DynamicObject object);
 
     CountDownLatch getFinishedLatch(DynamicObject object);
+    void setFinishedLatch(DynamicObject object, CountDownLatch value);
 
     BlockingQueue<FiberManager.FiberMessage> getMessageQueue(DynamicObject object);
 

--- a/src/main/java/org/truffleruby/core/thread/GetCurrentRubyThreadNode.java
+++ b/src/main/java/org/truffleruby/core/thread/GetCurrentRubyThreadNode.java
@@ -36,9 +36,11 @@ public abstract class GetCurrentRubyThreadNode extends RubyNode {
      */
     @Specialization(guards = {
             "getCurrentJavaThread(frame) == cachedJavaThread",
-            "hasThread(frame, cachedFiber)"
+            "hasThread(frame, cachedFiber)",
+            "!preInitializing" // Cannot cache a Thread instance when pre-initializing
     }, limit = "getCacheLimit()")
     protected DynamicObject getRubyThreadCached(VirtualFrame frame,
+            @Cached("isPreInitializing()") boolean preInitializing,
             @Cached("getCurrentJavaThread(frame)") Thread cachedJavaThread,
             @Cached("getCurrentRubyThread(frame)") DynamicObject cachedRubyThread,
             @Cached("getCurrentFiber(cachedRubyThread)") DynamicObject cachedFiber) {
@@ -64,6 +66,10 @@ public abstract class GetCurrentRubyThreadNode extends RubyNode {
 
     protected boolean hasThread(VirtualFrame frame, DynamicObject fiber) {
         return Layouts.FIBER.getThread(fiber) != null;
+    }
+
+    protected boolean isPreInitializing() {
+        return getContext().isPreInitializing();
     }
 
     protected int getCacheLimit() {

--- a/src/main/java/org/truffleruby/core/thread/ThreadLayout.java
+++ b/src/main/java/org/truffleruby/core/thread/ThreadLayout.java
@@ -55,6 +55,7 @@ public interface ThreadLayout extends BasicObjectLayout {
     void setFiberManagerUnsafe(DynamicObject object, FiberManager value);
 
     CountDownLatch getFinishedLatch(DynamicObject object);
+    void setFinishedLatch(DynamicObject object, CountDownLatch value);
 
     DynamicObject getThreadLocals(DynamicObject object);
 

--- a/src/main/java/org/truffleruby/core/thread/ThreadManager.java
+++ b/src/main/java/org/truffleruby/core/thread/ThreadManager.java
@@ -20,6 +20,7 @@ import org.truffleruby.Log;
 import org.truffleruby.RubyContext;
 import org.truffleruby.core.InterruptMode;
 import org.truffleruby.core.fiber.FiberManager;
+import org.truffleruby.core.string.StringUtils;
 import org.truffleruby.language.NotProvided;
 import org.truffleruby.language.RubyGuards;
 import org.truffleruby.language.SafepointManager;
@@ -517,7 +518,7 @@ public class ThreadManager {
     private void checkCalledInMainThreadRootFiber() {
         final DynamicObject currentThread = getCurrentThread();
         if (currentThread != rootThread) {
-            throw new UnsupportedOperationException(String.format(
+            throw new UnsupportedOperationException(StringUtils.format(
                     "ThreadManager.shutdown() must be called on the root Ruby Thread (%s) but was called on %s",
                     rootThread, currentThread));
         }

--- a/src/main/java/org/truffleruby/core/thread/ThreadManager.java
+++ b/src/main/java/org/truffleruby/core/thread/ThreadManager.java
@@ -517,9 +517,9 @@ public class ThreadManager {
     private void checkCalledInMainThreadRootFiber() {
         final DynamicObject currentThread = getCurrentThread();
         if (currentThread != rootThread) {
-            throw new UnsupportedOperationException(
-                    "ThreadManager.shutdown() must be called on the root Ruby Thread (" +
-                            rootThread + ") but was called on " + currentThread);
+            throw new UnsupportedOperationException(String.format(
+                    "ThreadManager.shutdown() must be called on the root Ruby Thread (%s) but was called on %s",
+                    rootThread, currentThread));
         }
 
         final FiberManager fiberManager = Layouts.THREAD.getFiberManager(rootThread);

--- a/src/main/java/org/truffleruby/core/thread/ThreadManager.java
+++ b/src/main/java/org/truffleruby/core/thread/ThreadManager.java
@@ -85,10 +85,10 @@ public class ThreadManager {
         this.fiberPool = Executors.newCachedThreadPool(this::createJavaThread);
     }
 
-    public void initialize() {
+    public void initialize(TruffleNFIPlatform nfi, NativeConfiguration nativeConfiguration) {
         if (context.getOptions().NATIVE_INTERRUPT) {
-            setupSignalHandler(context);
-            setupNativeThreadSupport();
+            setupSignalHandler(nfi, nativeConfiguration);
+            setupNativeThreadSupport(nfi, nativeConfiguration);
         }
 
         rubyManagedThreads.add(rootJavaThread);
@@ -172,11 +172,9 @@ public class ThreadManager {
         return threadLocals;
     }
 
-    private void setupSignalHandler(RubyContext context) {
-        final NativeConfiguration config = context.getNativeConfiguration();
+    private void setupSignalHandler(TruffleNFIPlatform nfi, NativeConfiguration config) {
         SIGVTALRM = (int) config.get("platform.signal.SIGVTALRM");
 
-        final TruffleNFIPlatform nfi = context.getTruffleNFI();
         final TruffleObject libC = nfi.getDefaultLibrary();
 
         // We use abs() as a function taking a int and having no side effects
@@ -198,9 +196,8 @@ public class ThreadManager {
         }
     }
 
-    private void setupNativeThreadSupport() {
-        final TruffleNFIPlatform nfi = context.getTruffleNFI();
-        final String pthread_t = nfi.resolveType(context.getNativeConfiguration(), "pthread_t");
+    private void setupNativeThreadSupport(TruffleNFIPlatform nfi, NativeConfiguration nativeConfiguration) {
+        final String pthread_t = nfi.resolveType(nativeConfiguration, "pthread_t");
 
         pthread_self = nfi.getFunction("pthread_self", 0, "():" + pthread_t);
         pthread_kill = nfi.getFunction("pthread_kill", 2, "(" + pthread_t + ",sint32):sint32");

--- a/src/main/java/org/truffleruby/core/thread/ThreadManager.java
+++ b/src/main/java/org/truffleruby/core/thread/ThreadManager.java
@@ -486,7 +486,11 @@ public class ThreadManager {
 
     @TruffleBoundary
     public DynamicObject getCurrentThread() {
-        return currentThread.get();
+        final DynamicObject rubyThread = currentThread.get();
+        if (rubyThread == null) {
+            throw new UnsupportedOperationException("No Ruby Thread is associated with this Java Thread: " + Thread.currentThread());
+        }
+        return rubyThread;
     }
 
     @TruffleBoundary

--- a/src/main/java/org/truffleruby/core/thread/ThreadManager.java
+++ b/src/main/java/org/truffleruby/core/thread/ThreadManager.java
@@ -295,6 +295,15 @@ public class ThreadManager {
         return rootJavaThread;
     }
 
+    public synchronized Thread getOrInitializeRootJavaThread() {
+        // rootJavaThread can be null with a pre-initialized context.
+        // In such a case, the first Thread in is considered the root Thread.
+        if (rootJavaThread == null) {
+            rootJavaThread = Thread.currentThread();
+        }
+        return rootJavaThread;
+    }
+
     public DynamicObject getRootThread() {
         return rootThread;
     }

--- a/src/main/java/org/truffleruby/core/thread/ThreadManager.java
+++ b/src/main/java/org/truffleruby/core/thread/ThreadManager.java
@@ -487,8 +487,11 @@ public class ThreadManager {
     }
 
     private void checkCalledInMainThreadRootFiber() {
-        if (getCurrentThread() != rootThread) {
-            throw new UnsupportedOperationException("ThreadManager.shutdown() must be called on the root Ruby Thread");
+        final DynamicObject currentThread = getCurrentThread();
+        if (currentThread != rootThread) {
+            throw new UnsupportedOperationException(
+                    "ThreadManager.shutdown() must be called on the root Ruby Thread (" +
+                            rootThread + ") but was called on " + currentThread);
         }
 
         final FiberManager fiberManager = Layouts.THREAD.getFiberManager(rootThread);

--- a/src/main/java/org/truffleruby/language/TruffleBootNodes.java
+++ b/src/main/java/org/truffleruby/language/TruffleBootNodes.java
@@ -86,6 +86,15 @@ public abstract class TruffleBootNodes {
         }
     }
 
+    @CoreMethod(names = "preinitializing?", onSingleton = true)
+    public abstract static class IsPreinitializingNode extends CoreMethodArrayArgumentsNode {
+
+        @Specialization
+        protected boolean isPreinitializingContext() {
+            return getContext().isPreInitializing();
+        }
+    }
+
     @CoreMethod(names = "main", onSingleton = true)
     public abstract static class MainNode extends CoreMethodArrayArgumentsNode {
 

--- a/src/main/ruby/core/env.rb
+++ b/src/main/ruby/core/env.rb
@@ -311,7 +311,9 @@ module Truffle
   end
 end
 
-ENV = Truffle::EnvironmentVariables.new
+Truffle::Boot.delay do
+  ENV = Truffle::EnvironmentVariables.new
+end
 
 # JRuby uses this for example to make proxy settings visible to stdlib/uri/common.rb
 

--- a/src/main/ruby/core/main.rb
+++ b/src/main/ruby/core/main.rb
@@ -69,17 +69,19 @@ show_backtraces = -> {
   end
 }
 
-Signal.trap('INT') do
-  if Truffle::Boot.get_option('backtraces.on_interrupt')
-    puts 'Interrupting...'
-    show_backtraces.call
+Truffle::Boot.delay do
+  Signal.trap('INT') do
+    if Truffle::Boot.get_option('backtraces.on_interrupt')
+      puts 'Interrupting...'
+      show_backtraces.call
+    end
+
+    raise Interrupt
   end
 
-  raise Interrupt
-end
-
-if Truffle::Boot.get_option('backtraces.sigalrm')
-  Signal.trap('ALRM') do
-    show_backtraces.call
+  if Truffle::Boot.get_option('backtraces.sigalrm')
+    Signal.trap('ALRM') do
+      show_backtraces.call
+    end
   end
 end

--- a/src/main/ruby/core/posix.rb
+++ b/src/main/ruby/core/posix.rb
@@ -17,6 +17,7 @@ module Truffle::POSIX
       if resolved = @resolved
         resolved
       else
+        raise 'loading library while pre-initializing' if Truffle::Boot.preinitializing?
         Truffle.synchronize(self) do
           @resolved ||= @block.call
         end

--- a/src/main/ruby/core/posix.rb
+++ b/src/main/ruby/core/posix.rb
@@ -378,40 +378,42 @@ module Truffle::POSIX
     written
   end
 
-  if Truffle::Boot.get_option('polyglot.stdio')
-    class << self
-      alias_method :read_string_native, :read_string
-      alias_method :write_string_native, :write_string
-      alias_method :write_string_nonblock_native, :write_string_nonblock
-    end
-
-    def self.read_string(io, length)
-      fd = io.descriptor
-      if fd == 0
-        read = Truffle.invoke_primitive :io_read_polyglot, fd, length
-        [read, 0]
-      else
-        read_string_native(io, length)
+  Truffle::Boot.delay do
+    if Truffle::Boot.get_option('polyglot.stdio')
+      class << self
+        alias_method :read_string_native, :read_string
+        alias_method :write_string_native, :write_string
+        alias_method :write_string_nonblock_native, :write_string_nonblock
       end
-    end
 
-    def self.write_string(io, string, continue_on_eagain)
-      fd = io.descriptor
-      if fd == 1 || fd == 2
-        # Ignore continue_on_eagain for polyglot writes
-        Truffle.invoke_primitive :io_write_polyglot, fd, string
-      else
-        write_string_native(io, string, continue_on_eagain)
+      def self.read_string(io, length)
+        fd = io.descriptor
+        if fd == 0
+          read = Truffle.invoke_primitive :io_read_polyglot, fd, length
+          [read, 0]
+        else
+          read_string_native(io, length)
+        end
       end
-    end
 
-    def self.write_string_nonblock(io, string)
-      fd = io.descriptor
-      if fd == 1 || fd == 2
-        # Ignore non-blocking for polyglot writes
-        Truffle.invoke_primitive :io_write_polyglot, fd, string
-      else
-        write_string_nonblock_native(io, string)
+      def self.write_string(io, string, continue_on_eagain)
+        fd = io.descriptor
+        if fd == 1 || fd == 2
+          # Ignore continue_on_eagain for polyglot writes
+          Truffle.invoke_primitive :io_write_polyglot, fd, string
+        else
+          write_string_native(io, string, continue_on_eagain)
+        end
+      end
+
+      def self.write_string_nonblock(io, string)
+        fd = io.descriptor
+        if fd == 1 || fd == 2
+          # Ignore non-blocking for polyglot writes
+          Truffle.invoke_primitive :io_write_polyglot, fd, string
+        else
+          write_string_nonblock_native(io, string)
+        end
       end
     end
   end

--- a/src/main/ruby/core/post.rb
+++ b/src/main/ruby/core/post.rb
@@ -32,35 +32,37 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-# Set up IO only now as it has lots of dependencies
-STDIN = File.new(0)
-STDOUT = File.new(1)
-STDERR = File.new(2)
+Truffle::Boot.delay do
+  # Set up IO only now as it has lots of dependencies
+  STDIN = File.new(0)
+  STDOUT = File.new(1)
+  STDERR = File.new(2)
 
-$stdin = STDIN
-$stdout = STDOUT
-$stderr = STDERR
+  $stdin = STDIN
+  $stdout = STDOUT
+  $stderr = STDERR
 
-class << STDIN
-  def external_encoding
-    super || Encoding.default_external
+  class << STDIN
+    def external_encoding
+      super || Encoding.default_external
+    end
   end
-end
 
-# stdout is line-buffered if it refers to a terminal
-if Truffle::Boot.get_option('sync.stdio') || STDOUT.tty?
-  STDOUT.sync = true
-end
+  # stdout is line-buffered if it refers to a terminal
+  if Truffle::Boot.get_option('sync.stdio') || STDOUT.tty?
+    STDOUT.sync = true
+  end
 
-# stderr is always unbuffered, see setvbuf(3)
-STDERR.sync = true
+  # stderr is always unbuffered, see setvbuf(3)
+  STDERR.sync = true
 
-# Always flush standard streams on exit
-Truffle::KernelOperations.at_exit true do
-  STDOUT.flush
-end
-Truffle::KernelOperations.at_exit true do
-  STDERR.flush
+  # Always flush standard streams on exit
+  Truffle::KernelOperations.at_exit true do
+    STDOUT.flush
+  end
+  Truffle::KernelOperations.at_exit true do
+    STDERR.flush
+  end
 end
 
 module Truffle
@@ -89,9 +91,11 @@ module Kernel
   module_function :p
 end
 
-$$ = Process.pid if Truffle::Boot.get_option 'platform.native'
+Truffle::Boot.delay do
+  $$ = Process.pid if Truffle::Boot.get_option 'platform.native'
 
-ARGV.concat(Truffle::Boot.original_argv)
+  ARGV.concat(Truffle::Boot.original_argv)
+end
 
 $LOAD_PATH.concat(Truffle::Boot.original_load_path)
 

--- a/src/main/ruby/core/pre.rb
+++ b/src/main/ruby/core/pre.rb
@@ -57,3 +57,16 @@ class Symbol
     self
   end
 end
+
+module Truffle::Boot
+  if preinitializing?
+    TO_RUN_AT_INIT = []
+    def self.delay(&block)
+      TO_RUN_AT_INIT << block
+    end
+  else
+    def self.delay
+      yield
+    end
+  end
+end

--- a/src/main/ruby/post-boot/post-boot.rb
+++ b/src/main/ruby/post-boot/post-boot.rb
@@ -7,83 +7,80 @@
 # GNU Lesser General Public License version 2.1
 
 Truffle::Boot.delay do
-# rubocop:disable Style/IndentationWidth
+  wd = Truffle::Boot.get_option('working_directory')
+  Dir.chdir(wd) unless wd.empty?
 
-wd = Truffle::Boot.get_option('working_directory')
-Dir.chdir(wd) unless wd.empty?
-
-# Always provided features: ruby --disable-gems -e 'puts $"'
-begin
-  require 'enumerator'
-  require 'thread'
-  require 'rational'
-  require 'complex'
-  require 'unicode_normalize'
-  if Truffle::Boot.get_option 'patching'
-    Truffle::Boot.print_time_metric :'before-patching'
-    require 'truffle/patching'
-    Truffle::Patching.insert_patching_dir 'stdlib', "#{Truffle::Boot.ruby_home}/lib/mri"
-    Truffle::Boot.print_time_metric :'after-patching'
-  end
-rescue LoadError => e
-  Truffle::Debug.log_warning "#{File.basename(__FILE__)}:#{__LINE__} #{e.message}"
-end
-
-if Truffle::Boot.get_option 'rubygems'
-  if Truffle::Boot.resilient_gem_home?
-    ENV.delete 'GEM_HOME'
-    ENV.delete 'GEM_PATH'
-    ENV.delete 'GEM_ROOT'
-  end
-
+  # Always provided features: ruby --disable-gems -e 'puts $"'
   begin
-    Truffle::Boot.print_time_metric :'before-rubygems'
-    begin
-      if Truffle::Boot.get_option 'rubygems.lazy'
-        require 'truffle/lazy-rubygems'
-      else
-        require 'rubygems'
-      end
-    ensure
-      Truffle::Boot.print_time_metric :'after-rubygems'
+    require 'enumerator'
+    require 'thread'
+    require 'rational'
+    require 'complex'
+    require 'unicode_normalize'
+    if Truffle::Boot.get_option 'patching'
+      Truffle::Boot.print_time_metric :'before-patching'
+      require 'truffle/patching'
+      Truffle::Patching.insert_patching_dir 'stdlib', "#{Truffle::Boot.ruby_home}/lib/mri"
+      Truffle::Boot.print_time_metric :'after-patching'
     end
   rescue LoadError => e
     Truffle::Debug.log_warning "#{File.basename(__FILE__)}:#{__LINE__} #{e.message}"
-  else
-    # TODO (pitr-ch 17-Feb-2017): remove the warning when we can integrate with ruby managers
-    if gem_home = ENV['GEM_HOME']
-      bad_gem_home = false
+  end
 
-      # rbenv does not set GEM_HOME
-      # rbenv-gemset has to be installed which does set GEM_HOME, it's in the subdir of Truffle::Boot.ruby_home
-      # rbenv/versions/<ruby>/gemsets
-      bad_gem_home ||= gem_home.include?('rbenv/versions') && !gem_home.include?('rbenv/versions/truffleruby')
-
-      # rvm stores gems at .rvm/gems/<ruby>@<gemset-name>
-      bad_gem_home ||= gem_home.include?('rvm/gems') && !gem_home.include?('rvm/gems/truffleruby')
-
-      # chruby stores gem in ~/.gem/<ruby>/<version>
-      bad_gem_home ||= gem_home.include?('.gem') && !gem_home.include?('.gem/truffleruby')
-
-      warn "[ruby] WARN A nonstandard GEM_HOME is set #{gem_home}" if $VERBOSE || bad_gem_home
-      if bad_gem_home
-        warn "[ruby] WARN The bad GEM_HOME may come from a ruby manager, make sure you've called one of: " +
-                 '`rvm use system`, `rbenv system`, or `chruby system` to clear the environment.'
-      end
+  if Truffle::Boot.get_option 'rubygems'
+    if Truffle::Boot.resilient_gem_home?
+      ENV.delete 'GEM_HOME'
+      ENV.delete 'GEM_PATH'
+      ENV.delete 'GEM_ROOT'
     end
 
-    if Truffle::Boot.get_option 'did_you_mean'
-      Truffle::Boot.print_time_metric :'before-did-you-mean'
+    begin
+      Truffle::Boot.print_time_metric :'before-rubygems'
       begin
-        $LOAD_PATH << "#{Truffle::Boot.ruby_home}/lib/ruby/gems/2.3.0/gems/did_you_mean-1.0.0/lib"
-        require 'did_you_mean'
-      rescue LoadError => e
-        Truffle::Debug.log_warning "#{File.basename(__FILE__)}:#{__LINE__} #{e.message}"
+        if Truffle::Boot.get_option 'rubygems.lazy'
+          require 'truffle/lazy-rubygems'
+        else
+          require 'rubygems'
+        end
       ensure
-        Truffle::Boot.print_time_metric :'after-did-you-mean'
+        Truffle::Boot.print_time_metric :'after-rubygems'
+      end
+    rescue LoadError => e
+      Truffle::Debug.log_warning "#{File.basename(__FILE__)}:#{__LINE__} #{e.message}"
+    else
+      # TODO (pitr-ch 17-Feb-2017): remove the warning when we can integrate with ruby managers
+      if gem_home = ENV['GEM_HOME']
+        bad_gem_home = false
+
+        # rbenv does not set GEM_HOME
+        # rbenv-gemset has to be installed which does set GEM_HOME, it's in the subdir of Truffle::Boot.ruby_home
+        # rbenv/versions/<ruby>/gemsets
+        bad_gem_home ||= gem_home.include?('rbenv/versions') && !gem_home.include?('rbenv/versions/truffleruby')
+
+        # rvm stores gems at .rvm/gems/<ruby>@<gemset-name>
+        bad_gem_home ||= gem_home.include?('rvm/gems') && !gem_home.include?('rvm/gems/truffleruby')
+
+        # chruby stores gem in ~/.gem/<ruby>/<version>
+        bad_gem_home ||= gem_home.include?('.gem') && !gem_home.include?('.gem/truffleruby')
+
+        warn "[ruby] WARN A nonstandard GEM_HOME is set #{gem_home}" if $VERBOSE || bad_gem_home
+        if bad_gem_home
+          warn "[ruby] WARN The bad GEM_HOME may come from a ruby manager, make sure you've called one of: " +
+                   '`rvm use system`, `rbenv system`, or `chruby system` to clear the environment.'
+        end
+      end
+
+      if Truffle::Boot.get_option 'did_you_mean'
+        Truffle::Boot.print_time_metric :'before-did-you-mean'
+        begin
+          $LOAD_PATH << "#{Truffle::Boot.ruby_home}/lib/ruby/gems/2.3.0/gems/did_you_mean-1.0.0/lib"
+          require 'did_you_mean'
+        rescue LoadError => e
+          Truffle::Debug.log_warning "#{File.basename(__FILE__)}:#{__LINE__} #{e.message}"
+        ensure
+          Truffle::Boot.print_time_metric :'after-did-you-mean'
+        end
       end
     end
   end
-end
-
 end

--- a/src/main/ruby/post-boot/post-boot.rb
+++ b/src/main/ruby/post-boot/post-boot.rb
@@ -6,6 +6,9 @@
 # GNU General Public License version 2
 # GNU Lesser General Public License version 2.1
 
+Truffle::Boot.delay do
+# rubocop:disable Style/IndentationWidth
+
 wd = Truffle::Boot.get_option('working_directory')
 Dir.chdir(wd) unless wd.empty?
 
@@ -81,4 +84,6 @@ if Truffle::Boot.get_option 'rubygems'
       end
     end
   end
+end
+
 end


### PR DESCRIPTION
This is the first steps to support the new Truffle feature: Context pre-initialization.
So far, it's possible (with latest Truffle) to build a SVM image where a RubyContext is created and on which `initialize()` is called (by using `/native-image -no-server --ruby -Dpolyglot.engine.PreinitializeContexts=ruby` in SVM).
When the image is executed, `RubyLanguage.patchContext()` is called to patch things up with values from the running process.
This feature allows to reduce startup time even further (currently by around 2-3 times less than before).

There are likely some rough edges left (e.g.: how to handle a changing TruffleRuby home).
The startup can also be improved further by reducing delayed initialization.
Of course, this will need to be integrated in CI and probably replace the current SVM image once stable enough.