### PR TITLE
Document TRUFFLERUBY_RESILIENT_GEM_HOME

### DIFF
--- a/doc/user/ruby-managers.md
+++ b/doc/user/ruby-managers.md
@@ -64,8 +64,16 @@ environment variables `GEM_HOME`, `GEM_PATH`, and `GEM_ROOT`. The variables
 are picked up by truffleruby (as any other Ruby implementation would do)
 causing truffleruby to pickup the wrong gem-home directory instead of its own.
 
-It can be easily fixed by clearing the environment with one of the following 
-commands:
+One way to fix this for all sessions is to tell TruffleRuby to ignore `GEM_*`
+variables and always use its own Gem home under `truffleruby/lib/ruby/gems`:
+
+```bash
+# In ~/.bashrc or ~/.zshenv
+export TRUFFLERUBY_RESILIENT_GEM_HOME=true
+```
+
+It can also be fixed just for the current terminal by clearing
+the environment with one of the following commands:
 
 ```bash
 rvm use system
@@ -73,7 +81,7 @@ rbenv system
 chruby system
 ```
 
-Otherwise, unset the variables with:
+Otherwise, unset the variables manually with:
 
 ```bash
 unset GEM_HOME GEM_PATH GEM_ROOT

--- a/doc/user/ruby-managers.md
+++ b/doc/user/ruby-managers.md
@@ -79,11 +79,7 @@ the environment with one of the following commands:
 rvm use system
 rbenv system
 chruby system
-```
-
-Otherwise, unset the variables manually with:
-
-```bash
+# Or manually:
 unset GEM_HOME GEM_PATH GEM_ROOT
 ```
 

--- a/doc/user/ruby-managers.md
+++ b/doc/user/ruby-managers.md
@@ -62,7 +62,7 @@ If you are using a Ruby manager like `rvm`, `rbenv`, or `chruby` and wish not to
 add TruffleRuby to one of them make sure that the manager does not set
 environment variables `GEM_HOME`, `GEM_PATH`, and `GEM_ROOT`. The variables
 are picked up by truffleruby (as any other Ruby implementation would do)
-causing truffleruby to pickup the wrong gem-home directory instead of its own.
+causing truffleruby to pickup the wrong Gem home instead of its own.
 
 One way to fix this for all sessions is to tell TruffleRuby to ignore `GEM_*`
 variables and always use its own Gem home under `truffleruby/lib/ruby/gems`:


### PR DESCRIPTION
* It is a convenient way to not pick the wrong GEM_HOME for TruffleRuby.