### PR TITLE
Better C backtraces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,9 @@ test/truffle/cexts/**/*.bc
 test/truffle/cexts/**/*.su
 test/truffle/cexts/**/extconf.h
 test/truffle/cexts/**/mkmf.log
+test/truffle/cexts/**/*.o
+test/truffle/cexts/**/*.so
+test/truffle/cexts/**/*.dylib
 
 test/mri/tests/cext-c/**/Makefile
 test/mri/tests/cext-c/**/*.bc

--- a/spec/tags/truffle/java_exception_tags.txt
+++ b/spec/tags/truffle/java_exception_tags.txt
@@ -1,4 +1,3 @@
 aot:Java exceptions formats to include the source information
-aot:Java exceptions formats to include the source information including causefails:Java exceptions includes the first lines of the Java stacktrace for uncaught Java exceptions
-fails:Java exceptions includes the first lines of the Java stacktrace for uncaught Java exceptions
-fails:Java exceptions formats to include the source information including cause
+aot:Java exceptions formats to include the source information including cause
+aot:Java exceptions includes the first lines of the Java stacktrace for uncaught Java exceptions

--- a/spec/tags/truffle/nfi_tags.txt
+++ b/spec/tags/truffle/nfi_tags.txt
@@ -1,0 +1,1 @@
+aot(crashes, exits with 99):NFI with callbacks to Ruby propagates exceptions from the callback

--- a/spec/truffle/java_exception_spec.rb
+++ b/spec/truffle/java_exception_spec.rb
@@ -13,28 +13,43 @@ describe "Java exceptions" do
   it "formats to include the source information" do
     lambda { Truffle::Debug.throw_java_exception 'message' }.should raise_error { |e|
       message = e.message.gsub(/:\d+/, ':LINE')
-      message.lines[0].should == "message\n"
-      message.lines[1].should == "\tRuntimeException org.truffleruby.debug.TruffleDebugNodes$ThrowJavaExceptionNode.throwingMethod(TruffleDebugNodes.java:LINE)\n"
+      message.lines[0].should == "message (RuntimeException)\n"
+      message.lines[1].should == "\tfrom org.truffleruby.debug.TruffleDebugNodes$ThrowJavaExceptionNode.throwingMethod(TruffleDebugNodes.java:LINE)\n"
     }
   end
 
   it "includes the first lines of the Java stacktrace for uncaught Java exceptions" do
     lambda { Truffle::Debug.throw_java_exception 'message' }.should raise_error { |e|
       message = e.message.gsub(/:\d+/, ':LINE')
-      message.lines[0].should == "message\n"
-      message.lines[1].should == "\tRuntimeException org.truffleruby.debug.TruffleDebugNodes$ThrowJavaExceptionNode.throwingMethod(TruffleDebugNodes.java:LINE)\n"
-      message.lines[2].should == "\torg.truffleruby.debug.TruffleDebugNodes$ThrowJavaExceptionNode.callingMethod(TruffleDebugNodes.java:LINE)\n"
-      message.lines[3].should == "\torg.truffleruby.debug.TruffleDebugNodes$ThrowJavaExceptionNode.throwJavaException(TruffleDebugNodes.java:LINE)\n"
+message.lines[0...4].join.should == <<EOS
+message (RuntimeException)
+\tfrom org.truffleruby.debug.TruffleDebugNodes$ThrowJavaExceptionNode.throwingMethod(TruffleDebugNodes.java:LINE)
+\tfrom org.truffleruby.debug.TruffleDebugNodes$ThrowJavaExceptionNode.callingMethod(TruffleDebugNodes.java:LINE)
+\tfrom org.truffleruby.debug.TruffleDebugNodes$ThrowJavaExceptionNode.throwJavaException(TruffleDebugNodes.java:LINE)
+EOS
     }
   end
 
   it "formats to include the source information including cause" do
     lambda { Truffle::Debug.throw_java_exception_with_cause 'message' }.should raise_error { |e|
       message = e.message.gsub(/:\d+/, ':LINE')
-      message.should include "message\n"
-      message.should include "\tRuntimeException org.truffleruby.debug.TruffleDebugNodes$ThrowJavaExceptionWithCauseNode.throwJavaExceptionWithCause(TruffleDebugNodes.java:LINE)\n"
-      message.should include "\t\tcaused by cause 1 RuntimeException org.truffleruby.debug.TruffleDebugNodes$ThrowJavaExceptionWithCauseNode.throwJavaExceptionWithCause(TruffleDebugNodes.java:LINE)\n"
-      message.should include "\t\tcaused by cause 2 RuntimeException org.truffleruby.debug.TruffleDebugNodes$ThrowJavaExceptionWithCauseNode.throwJavaExceptionWithCause(TruffleDebugNodes.java:LINE)\n"
+
+      message.should include <<EOS
+message (RuntimeException)
+\tfrom org.truffleruby.debug.TruffleDebugNodes$ThrowJavaExceptionWithCauseNode.throwJavaExceptionWithCause(TruffleDebugNodes.java:LINE)
+EOS
+
+      message.should include <<EOS
+Caused by:
+cause 1 (RuntimeException)
+\tfrom org.truffleruby.debug.TruffleDebugNodes$ThrowJavaExceptionWithCauseNode.throwJavaExceptionWithCause(TruffleDebugNodes.java:LINE)
+EOS
+
+      message.should include <<EOS
+Caused by:
+cause 2 (RuntimeException)
+\tfrom org.truffleruby.debug.TruffleDebugNodes$ThrowJavaExceptionWithCauseNode.throwJavaExceptionWithCause(TruffleDebugNodes.java:LINE)
+EOS
     }
   end
 

--- a/src/main/java/org/truffleruby/language/methods/ExceptionTranslatingNode.java
+++ b/src/main/java/org/truffleruby/language/methods/ExceptionTranslatingNode.java
@@ -254,11 +254,11 @@ public class ExceptionTranslatingNode extends RubyNode {
                 messageBuilder.append("\nCaused by:\n\t");
             }
 
-            String message = t.getMessage();
+            final String message;
             Stream<String> extraLines = Stream.empty();
 
             if (t.getClass().getSimpleName().equals("SulongRuntimeException")) {
-                extraLines = Arrays.stream(message.split("\n")).skip(1).map(String::trim);
+                extraLines = Arrays.stream(t.getMessage().split("\n")).skip(1).map(String::trim);
                 message = "error in C extension";
             } else if (t instanceof RaiseException) {
                 /*
@@ -266,9 +266,10 @@ public class ExceptionTranslatingNode extends RubyNode {
                  * multiple lines for each caused-by. However, we print the Java exception on the second line. That's
                  * confusing here, as it breaks the first caused-by. Remove the line break.
                  */
-                message = message.replaceFirst("\n", "");
+                message = t.getMessage().replaceFirst("\n", "");
             } else {
                 extraLines = Arrays.stream(t.getStackTrace()).map(StackTraceElement::toString).skip(1).limit(10);
+                message = t.getMessage();
             }
 
             if (message != null) {

--- a/src/main/java/org/truffleruby/language/methods/ExceptionTranslatingNode.java
+++ b/src/main/java/org/truffleruby/language/methods/ExceptionTranslatingNode.java
@@ -251,7 +251,7 @@ public class ExceptionTranslatingNode extends RubyNode {
 
         while (t != null) {
             if (exceptionCount > 0) {
-                messageBuilder.append("\n\t\tcaused by ");
+                messageBuilder.append("\nCaused by:\n\t");
             }
 
             String message = t.getMessage();

--- a/test/truffle/cexts/backtraces/bin/backtraces
+++ b/test/truffle/cexts/backtraces/bin/backtraces
@@ -13,3 +13,35 @@ begin
 rescue => e
   puts e.full_message
 end
+
+puts
+
+p Backtraces.qsort(-> a, b { a <=> b })
+
+puts
+
+begin
+  Backtraces.qsort(-> a, b {
+    raise "error from Ruby called from instrinsified qsort()"
+  })
+rescue => e
+  puts e.full_message
+end
+
+puts
+
+p Backtraces.native_callback(-> { 6*7 })
+
+puts
+
+def error_helper
+  raise "error from Ruby called from Sulong called from native callback"
+end
+
+begin
+  p Backtraces.native_callback(-> {
+    error_helper
+  })
+rescue RubyTruffleError => e
+  puts e.full_message
+end

--- a/test/truffle/cexts/backtraces/bin/backtraces
+++ b/test/truffle/cexts/backtraces/bin/backtraces
@@ -3,11 +3,13 @@
 require 'backtraces'
 
 class Bar
-
   def bar(baz)
     baz.call(proc { raise 'error' })
   end
-
 end
 
-puts Backtraces.foo(Bar.new)
+begin
+  Backtraces.foo(Bar.new)
+rescue => e
+  puts e.full_message
+end

--- a/test/truffle/cexts/backtraces/expected.txt
+++ b/test/truffle/cexts/backtraces/expected.txt
@@ -1,4 +1,4 @@
-/test/truffle/cexts/backtraces/bin/backtraces:8:in `block in bar': error (RuntimeError)
+/test/truffle/cexts/backtraces/bin/backtraces:7:in `block in bar': error (RuntimeError)
 	from /lib/truffle/truffle/cext.rb:n:in `call'
 	from /lib/truffle/truffle/cext.rb:n:in `__send__'
 	from /lib/truffle/truffle/cext.rb:n:in `rb_funcall'
@@ -6,12 +6,12 @@
 	from /lib/truffle/truffle/cext.rb:n:in `execute_without_conversion'
 	from /lib/truffle/truffle/cext.rb:n:in `execute_with_mutex'
 	from /lib/truffle/truffle/cext.rb:n:in `block in rb_proc_new'
-	from /test/truffle/cexts/backtraces/bin/backtraces:8:in `call'
-	from /test/truffle/cexts/backtraces/bin/backtraces:8:in `bar'
+	from /test/truffle/cexts/backtraces/bin/backtraces:7:in `call'
+	from /test/truffle/cexts/backtraces/bin/backtraces:7:in `bar'
 	from /lib/truffle/truffle/cext.rb:n:in `__send__'
 	from /lib/truffle/truffle/cext.rb:n:in `rb_funcall'
 	from /test/truffle/cexts/backtraces/ext/backtraces/backtraces.c:8:in `foo'
 	from /lib/truffle/truffle/cext.rb:n:in `execute_without_conversion'
 	from /lib/truffle/truffle/cext.rb:n:in `execute_with_mutex'
 	from /lib/truffle/truffle/cext_ruby.rb:n:in `foo'
-	from /test/truffle/cexts/backtraces/bin/backtraces:13:in `<main>'
+	from /test/truffle/cexts/backtraces/bin/backtraces:12:in `<main>'

--- a/test/truffle/cexts/backtraces/expected.txt
+++ b/test/truffle/cexts/backtraces/expected.txt
@@ -33,25 +33,23 @@
 
 42
 
-/lib/truffle/truffle/cext.rb:n:in `execute_without_conversion': error in C extension
-	SulongRuntimeException com.oracle.truffle.llvm.nodes.base.LLVMBasicBlockNode.executeStatements(LLVMBasicBlockNode.java:113)
-	
-	C stack trace:
-	native_callback in backtraces.c:43:17 (LLVM IR Function native_callback in /test/truffle/cexts/backtraces/lib/backtraces/backtraces.su@99ad9fcf9c94a348ed7654b93b702bbf30a13cdd_backtraces.bc in Block {id: 0 name: implicit0})
+/lib/truffle/truffle/cext.rb:n:in `execute_without_conversion': Error in C extension code (SulongRuntimeException):
+com.oracle.truffle.nfi.impl.LibFFIFunction@4407f129[function@1237 '@sulong_callback'] (IllegalStateException)
+	from native_callback in backtraces.c:43:17 (LLVM IR Function native_callback in /test/truffle/cexts/backtraces/lib/backtraces/backtraces.su@99ad9fcf9c94a348ed7654b93b702bbf30a13cdd_backtraces.bc in Block {id: 0 name: implicit0})
+	from com.oracle.truffle.llvm.nodes.func.LLVMNativeCallUtils.callNativeFunction(LLVMNativeCallUtils.java:72)
 Caused by:
-	com.oracle.truffle.nfi.impl.LibFFIFunction@4407f129[function@1237 '@sulong_callback'] IllegalStateException com.oracle.truffle.llvm.nodes.func.LLVMNativeCallUtils.callNativeFunction(LLVMNativeCallUtils.java:72)
-	com.oracle.truffle.llvm.nodes.func.LLVMDispatchNode.doCachedNative(LLVMDispatchNode.java:154)
-	com.oracle.truffle.llvm.nodes.func.LLVMDispatchNodeGen.executeDispatch(LLVMDispatchNodeGen.java:78)
-	com.oracle.truffle.llvm.nodes.func.LLVMLookupDispatchNode.doDirectCached(LLVMLookupDispatchNode.java:70)
-	com.oracle.truffle.llvm.nodes.func.LLVMLookupDispatchNodeGen.executeDispatch(LLVMLookupDispatchNodeGen.java:51)
-	com.oracle.truffle.llvm.nodes.func.LLVMCallNode.executeGeneric(LLVMCallNode.java:73)
-	com.oracle.truffle.llvm.runtime.nodes.api.LLVMExpressionNode.executeI32(LLVMExpressionNode.java:103)
-	com.oracle.truffle.llvm.nodes.others.LLVMValueProfilingNodeFactory$LLVMI32ProfiledValueNodeGen.executeI32(LLVMValueProfilingNodeFactory.java:280)
-	com.oracle.truffle.llvm.nodes.vars.LLVMWriteNodeFactory$LLVMWriteI32NodeGen.executeGeneric(LLVMWriteNodeFactory.java:348)
-	com.oracle.truffle.llvm.nodes.base.LLVMBasicBlockNode.executeStatements(LLVMBasicBlockNode.java:98)
-	com.oracle.truffle.llvm.nodes.control.LLVMDispatchBasicBlockNode.executeGeneric(LLVMDispatchBasicBlockNode.java:92)
-Caused by:
-	error from Ruby called from Sulong called from native callback (RuntimeError) RaiseException (RubyTruffleError)
+/test/truffle/cexts/backtraces/bin/backtraces:38:in `error_helper': error from Ruby called from Sulong called from native callback (RuntimeError)
+	from /test/truffle/cexts/backtraces/bin/backtraces:43:in `lambda'
+	from /lib/truffle/truffle/cext.rb:n:in `call'
+	from /lib/truffle/truffle/cext.rb:n:in `__send__'
+	from /lib/truffle/truffle/cext.rb:n:in `rb_funcall'
+	from /test/truffle/cexts/backtraces/ext/backtraces/backtraces.c:38:in `sulong_callback'
+	from /test/truffle/cexts/backtraces/ext/backtraces/backtraces.c:44:in `native_callback'
+	from /lib/truffle/truffle/cext.rb:n:in `execute_without_conversion'
+	from /lib/truffle/truffle/cext.rb:n:in `execute_with_mutex'
+	from /lib/truffle/truffle/cext_ruby.rb:n:in `native_callback'
+	from /test/truffle/cexts/backtraces/bin/backtraces:42:in `<main>'
+Translated to internal error (RubyTruffleError)
 	from /lib/truffle/truffle/cext.rb:n:in `execute_with_mutex'
 	from /lib/truffle/truffle/cext_ruby.rb:n:in `native_callback'
 	from /test/truffle/cexts/backtraces/bin/backtraces:42:in `<main>'

--- a/test/truffle/cexts/backtraces/expected.txt
+++ b/test/truffle/cexts/backtraces/expected.txt
@@ -38,7 +38,8 @@
 	
 	C stack trace:
 	native_callback in backtraces.c:43:17 (LLVM IR Function native_callback in /test/truffle/cexts/backtraces/lib/backtraces/backtraces.su@99ad9fcf9c94a348ed7654b93b702bbf30a13cdd_backtraces.bc in Block {id: 0 name: implicit0})
-		caused by com.oracle.truffle.nfi.impl.LibFFIFunction@4407f129[function@1237 '@sulong_callback'] IllegalStateException com.oracle.truffle.llvm.nodes.func.LLVMNativeCallUtils.callNativeFunction(LLVMNativeCallUtils.java:72)
+Caused by:
+	com.oracle.truffle.nfi.impl.LibFFIFunction@4407f129[function@1237 '@sulong_callback'] IllegalStateException com.oracle.truffle.llvm.nodes.func.LLVMNativeCallUtils.callNativeFunction(LLVMNativeCallUtils.java:72)
 	com.oracle.truffle.llvm.nodes.func.LLVMDispatchNode.doCachedNative(LLVMDispatchNode.java:154)
 	com.oracle.truffle.llvm.nodes.func.LLVMDispatchNodeGen.executeDispatch(LLVMDispatchNodeGen.java:78)
 	com.oracle.truffle.llvm.nodes.func.LLVMLookupDispatchNode.doDirectCached(LLVMLookupDispatchNode.java:70)
@@ -49,7 +50,8 @@
 	com.oracle.truffle.llvm.nodes.vars.LLVMWriteNodeFactory$LLVMWriteI32NodeGen.executeGeneric(LLVMWriteNodeFactory.java:348)
 	com.oracle.truffle.llvm.nodes.base.LLVMBasicBlockNode.executeStatements(LLVMBasicBlockNode.java:98)
 	com.oracle.truffle.llvm.nodes.control.LLVMDispatchBasicBlockNode.executeGeneric(LLVMDispatchBasicBlockNode.java:92)
-		caused by error from Ruby called from Sulong called from native callback (RuntimeError) RaiseException (RubyTruffleError)
+Caused by:
+	error from Ruby called from Sulong called from native callback (RuntimeError) RaiseException (RubyTruffleError)
 	from /lib/truffle/truffle/cext.rb:n:in `execute_with_mutex'
 	from /lib/truffle/truffle/cext_ruby.rb:n:in `native_callback'
 	from /test/truffle/cexts/backtraces/bin/backtraces:42:in `<main>'

--- a/test/truffle/cexts/backtraces/expected.txt
+++ b/test/truffle/cexts/backtraces/expected.txt
@@ -2,7 +2,7 @@
 	from /lib/truffle/truffle/cext.rb:n:in `call'
 	from /lib/truffle/truffle/cext.rb:n:in `__send__'
 	from /lib/truffle/truffle/cext.rb:n:in `rb_funcall'
-	from /test/truffle/cexts/backtraces/ext/backtraces/backtraces.c:4:in `baz'
+	from /test/truffle/cexts/backtraces/ext/backtraces/backtraces.c:5:in `baz'
 	from /lib/truffle/truffle/cext.rb:n:in `execute_without_conversion'
 	from /lib/truffle/truffle/cext.rb:n:in `execute_with_mutex'
 	from /lib/truffle/truffle/cext.rb:n:in `block in rb_proc_new'
@@ -10,8 +10,46 @@
 	from /test/truffle/cexts/backtraces/bin/backtraces:7:in `bar'
 	from /lib/truffle/truffle/cext.rb:n:in `__send__'
 	from /lib/truffle/truffle/cext.rb:n:in `rb_funcall'
-	from /test/truffle/cexts/backtraces/ext/backtraces/backtraces.c:8:in `foo'
+	from /test/truffle/cexts/backtraces/ext/backtraces/backtraces.c:9:in `foo'
 	from /lib/truffle/truffle/cext.rb:n:in `execute_without_conversion'
 	from /lib/truffle/truffle/cext.rb:n:in `execute_with_mutex'
 	from /lib/truffle/truffle/cext_ruby.rb:n:in `foo'
 	from /test/truffle/cexts/backtraces/bin/backtraces:12:in `<main>'
+
+[1, 2, 3, 4]
+
+/test/truffle/cexts/backtraces/bin/backtraces:25:in `lambda': error from Ruby called from instrinsified qsort() (RuntimeError)
+	from /lib/truffle/truffle/cext.rb:n:in `call'
+	from /lib/truffle/truffle/cext.rb:n:in `__send__'
+	from /lib/truffle/truffle/cext.rb:n:in `rb_funcall'
+	from /test/truffle/cexts/backtraces/ext/backtraces/backtraces.c:17:in `compare_function'
+	from libsulong.bc:@sulong_qsort:1:in `sulong_qsort'
+	from libsulong.bc:@qsort:1:in `qsort'
+	from /test/truffle/cexts/backtraces/ext/backtraces/backtraces.c:25:in `call_qsort'
+	from /lib/truffle/truffle/cext.rb:n:in `execute_without_conversion'
+	from /lib/truffle/truffle/cext.rb:n:in `execute_with_mutex'
+	from /lib/truffle/truffle/cext_ruby.rb:n:in `qsort'
+	from /test/truffle/cexts/backtraces/bin/backtraces:24:in `<main>'
+
+42
+
+/lib/truffle/truffle/cext.rb:n:in `execute_without_conversion': error in C extension
+	SulongRuntimeException com.oracle.truffle.llvm.nodes.base.LLVMBasicBlockNode.executeStatements(LLVMBasicBlockNode.java:113)
+	
+	C stack trace:
+	native_callback in backtraces.c:43:17 (LLVM IR Function native_callback in /test/truffle/cexts/backtraces/lib/backtraces/backtraces.su@99ad9fcf9c94a348ed7654b93b702bbf30a13cdd_backtraces.bc in Block {id: 0 name: implicit0})
+		caused by com.oracle.truffle.nfi.impl.LibFFIFunction@4407f129[function@1237 '@sulong_callback'] IllegalStateException com.oracle.truffle.llvm.nodes.func.LLVMNativeCallUtils.callNativeFunction(LLVMNativeCallUtils.java:72)
+	com.oracle.truffle.llvm.nodes.func.LLVMDispatchNode.doCachedNative(LLVMDispatchNode.java:154)
+	com.oracle.truffle.llvm.nodes.func.LLVMDispatchNodeGen.executeDispatch(LLVMDispatchNodeGen.java:78)
+	com.oracle.truffle.llvm.nodes.func.LLVMLookupDispatchNode.doDirectCached(LLVMLookupDispatchNode.java:70)
+	com.oracle.truffle.llvm.nodes.func.LLVMLookupDispatchNodeGen.executeDispatch(LLVMLookupDispatchNodeGen.java:51)
+	com.oracle.truffle.llvm.nodes.func.LLVMCallNode.executeGeneric(LLVMCallNode.java:73)
+	com.oracle.truffle.llvm.runtime.nodes.api.LLVMExpressionNode.executeI32(LLVMExpressionNode.java:103)
+	com.oracle.truffle.llvm.nodes.others.LLVMValueProfilingNodeFactory$LLVMI32ProfiledValueNodeGen.executeI32(LLVMValueProfilingNodeFactory.java:280)
+	com.oracle.truffle.llvm.nodes.vars.LLVMWriteNodeFactory$LLVMWriteI32NodeGen.executeGeneric(LLVMWriteNodeFactory.java:348)
+	com.oracle.truffle.llvm.nodes.base.LLVMBasicBlockNode.executeStatements(LLVMBasicBlockNode.java:98)
+	com.oracle.truffle.llvm.nodes.control.LLVMDispatchBasicBlockNode.executeGeneric(LLVMDispatchBasicBlockNode.java:92)
+		caused by error from Ruby called from Sulong called from native callback (RuntimeError) RaiseException (RubyTruffleError)
+	from /lib/truffle/truffle/cext.rb:n:in `execute_with_mutex'
+	from /lib/truffle/truffle/cext_ruby.rb:n:in `native_callback'
+	from /test/truffle/cexts/backtraces/bin/backtraces:42:in `<main>'

--- a/test/truffle/cexts/backtraces/expected.txt
+++ b/test/truffle/cexts/backtraces/expected.txt
@@ -34,8 +34,8 @@
 42
 
 /lib/truffle/truffle/cext.rb:n:in `execute_without_conversion': Error in C extension code (SulongRuntimeException):
-com.oracle.truffle.nfi.impl.LibFFIFunction@4407f129[function@1237 '@sulong_callback'] (IllegalStateException)
-	from native_callback in backtraces.c:43:17 (LLVM IR Function native_callback in /test/truffle/cexts/backtraces/lib/backtraces/backtraces.su@99ad9fcf9c94a348ed7654b93b702bbf30a13cdd_backtraces.bc in Block {id: 0 name: implicit0})
+com.oracle.truffle.nfi.impl.LibFFIFunction@HEXA[function@1237 '@sulong_callback'] (IllegalStateException)
+	from native_callback in backtraces.c:43:17 (LLVM IR Function native_callback in /test/truffle/cexts/backtraces/lib/backtraces/backtraces.su@HEXA_backtraces.bc in Block BLOCKINFO)
 	from com.oracle.truffle.llvm.nodes.func.LLVMNativeCallUtils.callNativeFunction(LLVMNativeCallUtils.java:72)
 Caused by:
 /test/truffle/cexts/backtraces/bin/backtraces:38:in `error_helper': error from Ruby called from Sulong called from native callback (RuntimeError)

--- a/test/truffle/cexts/backtraces/ext/backtraces/backtraces.c
+++ b/test/truffle/cexts/backtraces/ext/backtraces/backtraces.c
@@ -1,4 +1,5 @@
 #include <ruby.h>
+#include <stdlib.h>
 
 VALUE baz(VALUE bob) {
   return rb_funcall(bob, rb_intern("call"), 0);
@@ -8,7 +9,44 @@ VALUE foo(VALUE self, VALUE bar) {
   return rb_funcall(bar, rb_intern("bar"), 1, rb_proc_new(baz, Qnil));
 }
 
+VALUE ruby_callback;
+
+static int compare_function(void *a_ptr, void *b_ptr) {
+  int a = *((int*) a_ptr);
+  int b = *((int*) b_ptr);
+  VALUE result = rb_funcall(ruby_callback, rb_intern("call"), 2, INT2FIX(a), INT2FIX(b));
+  return NUM2INT(result);
+}
+
+VALUE call_qsort(VALUE mod, VALUE callback) {
+  int array[] = {1, 3, 4, 2};
+
+  ruby_callback = callback;
+  qsort(array, 4, sizeof(int), compare_function);
+
+  VALUE ary = rb_ary_new();
+  for (int i = 0; i < 4; i++) {
+    rb_ary_push(ary, INT2FIX(array[i]));
+  }
+  return ary;
+}
+
+// From the nativetestlib
+int test_native_callback(int (*callback)(void));
+
+static int sulong_callback(void) {
+  VALUE result = rb_funcall(ruby_callback, rb_intern("call"), 0);
+  return NUM2INT(result);
+}
+
+VALUE native_callback(VALUE mod, VALUE callback) {
+  ruby_callback = callback;
+  return INT2FIX(test_native_callback(sulong_callback));
+}
+
 void Init_backtraces() {
   VALUE module = rb_define_module("Backtraces");
   rb_define_module_function(module, "foo", &foo, 1);
+  rb_define_module_function(module, "qsort", call_qsort, 1);
+  rb_define_module_function(module, "native_callback", native_callback, 1);
 }

--- a/test/truffle/cexts/backtraces/ext/backtraces/extconf.rb
+++ b/test/truffle/cexts/backtraces/ext/backtraces/extconf.rb
@@ -1,2 +1,26 @@
 require 'mkmf'
+
+# Compile a real native library
+# Commands from src/main/c/truffleposix/Makefile
+
+so = RbConfig::CONFIG['NATIVE_DLEXT']
+cc = ENV['CC'] || 'cc'
+
+dir = File.expand_path('../..', __FILE__)
+name = "#{dir}/nativetestlib"
+
+cflags = %w[-Wall -Werror -fPIC -std=c99]
+ldflags = %w[-m64]
+
+def command(*args)
+  $stderr.puts args.join(' ')
+  ret = system(*args)
+  raise unless ret
+end
+
+command 'cc', '-o', "#{name}.o", '-c', *cflags, *ldflags, "#{name}.c"
+command 'cc', '-shared', *ldflags, '-o', "#{name}.#{so}", "#{name}.o"
+
+$LIBS += " -l #{name}.#{so}"
+
 create_makefile('backtraces')

--- a/test/truffle/cexts/backtraces/ext/nativetestlib.c
+++ b/test/truffle/cexts/backtraces/ext/nativetestlib.c
@@ -1,0 +1,3 @@
+int test_native_callback(int (*callback)(void)) {
+  return callback();
+}

--- a/test/truffle/integration/backtraces/cext.rb
+++ b/test/truffle/integration/backtraces/cext.rb
@@ -8,6 +8,8 @@
 
 require_relative 'backtraces'
 
+# See also test/truffle/cexts/backtraces for more tests
+
 # Require some C ext to load C ext support
 require 'syslog'
 

--- a/test/truffle/integration/backtraces/cext_double_lock.backtrace
+++ b/test/truffle/integration/backtraces/cext_double_lock.backtrace
@@ -1,7 +1,7 @@
 PWD/lib/truffle/truffle/cext.rb:LINE:in `lock': deadlock; recursive locking (ThreadError)
 	from PWD/lib/truffle/truffle/cext.rb:LINE:in `rb_mutex_lock'
 	from PWD/src/main/c/cext/ruby.c:LINE:in `rb_mutex_lock'
-/cext.rb:39:in `double_lock'
-/cext.rb:43:in `block in <main>'
+/cext.rb:41:in `double_lock'
+/cext.rb:45:in `block in <main>'
 /backtraces.rb:17:in `check'
-/cext.rb:42:in `<main>'
+/cext.rb:44:in `<main>'

--- a/test/truffle/integration/backtraces/cext_funcallv.backtrace
+++ b/test/truffle/integration/backtraces/cext_funcallv.backtrace
@@ -1,10 +1,10 @@
-/cext.rb:17:in `callback': Ruby callback error (RuntimeError)
+/cext.rb:19:in `callback': Ruby callback error (RuntimeError)
 	from PWD/lib/truffle/truffle/cext.rb:LINE:in `__send__'
 	from PWD/lib/truffle/truffle/cext.rb:LINE:in `rb_funcall'
 	from PWD/lib/truffle/truffle/cext.rb:LINE:in `rb_funcallv'
 	from PWD/src/main/c/cext/ruby.c:LINE:in `rb_funcallv'
-/cext.rb:21:in `ruby_call'
-/cext.rb:25:in `top'
-/cext.rb:29:in `block in <main>'
+/cext.rb:23:in `ruby_call'
+/cext.rb:27:in `top'
+/cext.rb:31:in `block in <main>'
 /backtraces.rb:17:in `check'
-/cext.rb:28:in `<main>'
+/cext.rb:30:in `<main>'

--- a/tool/jt.rb
+++ b/tool/jt.rb
@@ -1086,21 +1086,14 @@ module Commands
           dir = "#{TRUFFLERUBY_DIR}/test/truffle/cexts/#{gem_name}"
           ext_dir = "#{dir}/ext/#{gem_name}/"
           compile_cext gem_name, ext_dir, "#{dir}/lib/#{gem_name}/#{gem_name}.su"
-          case gem_name
-          when 'backtraces'
-            run_ruby "-I#{dir}/lib", "#{dir}/bin/#{gem_name}", err: output_file, continue_on_failure: true
-            actual = File.read(output_file).
-                gsub(TRUFFLERUBY_DIR, '').
-                gsub(/\/cext(_ruby)?\.rb:(\d+)/, '/cext\1.rb:n')
-            expected = File.read("#{dir}/expected.txt")
-            unless actual == expected
-              abort "C extension #{dir} didn't work as expected\nActual:\n#{actual}\nExpected:\n#{expected}"
-            end
-          else
-            run_ruby "-I#{dir}/lib", "#{dir}/bin/#{gem_name}", out: output_file
-            unless File.read(output_file) == File.read("#{dir}/expected.txt")
-              abort "c extension #{dir} didn't work as expected"
-            end
+          run_ruby "-I#{dir}/lib", "#{dir}/bin/#{gem_name}", out: output_file
+          actual = File.read(output_file)
+          if gem_name == 'backtraces'
+            actual = actual.gsub(TRUFFLERUBY_DIR, '').gsub(/\/cext(_ruby)?\.rb:(\d+)/, '/cext\1.rb:n')
+          end
+          expected = File.read("#{dir}/expected.txt")
+          unless actual == expected
+            abort "C extension #{dir} didn't work as expected\nActual:\n#{actual}Expected:\n#{expected}"
           end
         ensure
           File.delete output_file if File.exist? output_file

--- a/tool/jt.rb
+++ b/tool/jt.rb
@@ -1082,13 +1082,12 @@ module Commands
 
         begin
           output_file = 'cext-output.txt'
-          gem_name = test_name
-          dir = "#{TRUFFLERUBY_DIR}/test/truffle/cexts/#{gem_name}"
-          ext_dir = "#{dir}/ext/#{gem_name}/"
-          compile_cext gem_name, ext_dir, "#{dir}/lib/#{gem_name}/#{gem_name}.su"
-          run_ruby "-I#{dir}/lib", "#{dir}/bin/#{gem_name}", out: output_file
+          dir = "#{TRUFFLERUBY_DIR}/test/truffle/cexts/#{test_name}"
+          ext_dir = "#{dir}/ext/#{test_name}/"
+          compile_cext test_name, ext_dir, "#{dir}/lib/#{test_name}/#{test_name}.su"
+          run_ruby "-I#{dir}/lib", "#{dir}/bin/#{test_name}", out: output_file
           actual = File.read(output_file)
-          if gem_name == 'backtraces'
+          if test_name == 'backtraces'
             actual = actual.gsub(TRUFFLERUBY_DIR, '').gsub(/\/cext(_ruby)?\.rb:(\d+)/, '/cext\1.rb:n')
           end
           expected = File.read("#{dir}/expected.txt")

--- a/tool/jt.rb
+++ b/tool/jt.rb
@@ -1083,8 +1083,7 @@ module Commands
         begin
           output_file = 'cext-output.txt'
           dir = "#{TRUFFLERUBY_DIR}/test/truffle/cexts/#{test_name}"
-          ext_dir = "#{dir}/ext/#{test_name}"
-          compile_cext test_name, ext_dir, "#{dir}/lib/#{test_name}/#{test_name}.su"
+          cextc(dir)
           run_ruby "-I#{dir}/lib", "#{dir}/bin/#{test_name}", out: output_file
           actual = File.read(output_file)
           if test_name == 'backtraces'

--- a/tool/jt.rb
+++ b/tool/jt.rb
@@ -1083,7 +1083,7 @@ module Commands
         begin
           output_file = 'cext-output.txt'
           dir = "#{TRUFFLERUBY_DIR}/test/truffle/cexts/#{test_name}"
-          ext_dir = "#{dir}/ext/#{test_name}/"
+          ext_dir = "#{dir}/ext/#{test_name}"
           compile_cext test_name, ext_dir, "#{dir}/lib/#{test_name}/#{test_name}.su"
           run_ruby "-I#{dir}/lib", "#{dir}/bin/#{test_name}", out: output_file
           actual = File.read(output_file)

--- a/tool/jt.rb
+++ b/tool/jt.rb
@@ -1054,7 +1054,7 @@ module Commands
     no_openssl = args.delete('--no-openssl')
     no_gems = args.delete('--no-gems')
     tests = args.empty? ? all_tests : all_tests & args
-    tests.delete 'openssl' if no_openssl
+    tests -= %w[openssl xopenssl] if no_openssl
     tests.delete 'gems' if no_gems
 
     tests.each do |test_name|
@@ -1083,7 +1083,6 @@ module Commands
         begin
           output_file = 'cext-output.txt'
           gem_name = test_name
-          next if gem_name == 'xopenssl' && no_openssl
           dir = "#{TRUFFLERUBY_DIR}/test/truffle/cexts/#{gem_name}"
           ext_dir = "#{dir}/ext/#{gem_name}/"
           compile_cext gem_name, ext_dir, "#{dir}/lib/#{gem_name}/#{gem_name}.su"

--- a/tool/jt.rb
+++ b/tool/jt.rb
@@ -1087,7 +1087,10 @@ module Commands
           run_ruby "-I#{dir}/lib", "#{dir}/bin/#{test_name}", out: output_file
           actual = File.read(output_file)
           if test_name == 'backtraces'
-            actual = actual.gsub(TRUFFLERUBY_DIR, '').gsub(/\/cext(_ruby)?\.rb:(\d+)/, '/cext\1.rb:n')
+            actual = actual.gsub(TRUFFLERUBY_DIR, '')
+                           .gsub(/\/cext(_ruby)?\.rb:(\d+)/, '/cext\1.rb:n')
+                           .gsub(/\h{8,}/, 'HEXA')
+                           .gsub(/\{id: \d+ name: implicit\d+}/, 'BLOCKINFO')
           end
           expected = File.read("#{dir}/expected.txt")
           unless actual == expected

--- a/tool/jt.rb
+++ b/tool/jt.rb
@@ -1090,7 +1090,7 @@ module Commands
             actual = actual.gsub(TRUFFLERUBY_DIR, '')
                            .gsub(/\/cext(_ruby)?\.rb:(\d+)/, '/cext\1.rb:n')
                            .gsub(/\h{8,}/, 'HEXA')
-                           .gsub(/\{id: \d+ name: implicit\d+}/, 'BLOCKINFO')
+                           .gsub(/\{id: \d+ name: [^}]+}/, 'BLOCKINFO')
           end
           expected = File.read("#{dir}/expected.txt")
           unless actual == expected

--- a/tool/jt.rb
+++ b/tool/jt.rb
@@ -1094,7 +1094,7 @@ module Commands
           end
           expected = File.read("#{dir}/expected.txt")
           unless actual == expected
-            abort "C extension #{dir} didn't work as expected\nActual:\n#{actual}Expected:\n#{expected}"
+            abort "C extension #{dir} didn't work as expected\nActual:\n#{actual}\nExpected:\n#{expected}"
           end
         ensure
           File.delete output_file if File.exist? output_file


### PR DESCRIPTION
The C backtrace when there was an error in Sulong were really unclear.
Moreover, if the original error was a Ruby exception thrown from a callback from a real native function, that Ruby exception backtrace would not be displayed at all.

Now we display all exceptions and reformat the Sulong and Java ones nicely like Ruby exceptions.

Before:
```
/lib/truffle/truffle/cext.rb:n:in `execute_without_conversion': error in C extension
        SulongRuntimeException com.oracle.truffle.llvm.nodes.base.LLVMBasicBlockNode.executeStatements(LLVMBasicBlockNode.java:113)

        C stack trace:
        native_callback in backtraces.c:43:17 (LLVM IR Function native_callback in /test/truffle/cexts/backtraces/lib/backtraces/backtraces.su@99ad9fcf9c94a348ed7654b93b702bbf30a13cdd_backtraces.bc in Block {id: 0 name: implicit0})
                caused by com.oracle.truffle.nfi.impl.LibFFIFunction@4407f129[function@1237 '@sulong_callback'] IllegalStateException com.oracle.truffle.llvm.nodes.func.LLVMNativeCallUtils.callNativeFunction(LLVMNativeCallUtils.java:72)
        com.oracle.truffle.llvm.nodes.func.LLVMDispatchNode.doCachedNative(LLVMDispatchNode.java:154)
        com.oracle.truffle.llvm.nodes.func.LLVMDispatchNodeGen.executeDispatch(LLVMDispatchNodeGen.java:78)
        com.oracle.truffle.llvm.nodes.func.LLVMLookupDispatchNode.doDirectCached(LLVMLookupDispatchNode.java:70)
        com.oracle.truffle.llvm.nodes.func.LLVMLookupDispatchNodeGen.executeDispatch(LLVMLookupDispatchNodeGen.java:51)
        com.oracle.truffle.llvm.nodes.func.LLVMCallNode.executeGeneric(LLVMCallNode.java:73)
        com.oracle.truffle.llvm.runtime.nodes.api.LLVMExpressionNode.executeI32(LLVMExpressionNode.java:103)
        com.oracle.truffle.llvm.nodes.others.LLVMValueProfilingNodeFactory$LLVMI32ProfiledValueNodeGen.executeI32(LLVMValueProfilingNodeFactory.java:280)
        com.oracle.truffle.llvm.nodes.vars.LLVMWriteNodeFactory$LLVMWriteI32NodeGen.executeGeneric(LLVMWriteNodeFactory.java:348)
        com.oracle.truffle.llvm.nodes.base.LLVMBasicBlockNode.executeStatements(LLVMBasicBlockNode.java:98)
        com.oracle.truffle.llvm.nodes.control.LLVMDispatchBasicBlockNode.executeGeneric(LLVMDispatchBasicBlockNode.java:92)
                caused by error from Ruby called from Sulong called from native callback (RuntimeError) RaiseException (RubyTruffleError)
        from /lib/truffle/truffle/cext.rb:n:in `execute_with_mutex'
        from /lib/truffle/truffle/cext_ruby.rb:n:in `native_callback'
        from /test/truffle/cexts/backtraces/bin/backtraces:42:in `<main>'
```

After:
```
/lib/truffle/truffle/cext.rb:n:in `execute_without_conversion': Error in C extension code (SulongRuntimeException):
com.oracle.truffle.nfi.impl.LibFFIFunction@4407f129[function@1237 '@sulong_callback'] (IllegalStateException)
	from native_callback in backtraces.c:43:17 (LLVM IR Function native_callback in /test/truffle/cexts/backtraces/lib/backtraces/backtraces.su@99ad9fcf9c94a348ed7654b93b702bbf30a13cdd_backtraces.bc in Block {id: 0 name: implicit0})
	from com.oracle.truffle.llvm.nodes.func.LLVMNativeCallUtils.callNativeFunction(LLVMNativeCallUtils.java:72)
Caused by:
/test/truffle/cexts/backtraces/bin/backtraces:38:in `error_helper': error from Ruby called from Sulong called from native callback (RuntimeError)
	from /test/truffle/cexts/backtraces/bin/backtraces:43:in `lambda'
	from /lib/truffle/truffle/cext.rb:n:in `call'
	from /lib/truffle/truffle/cext.rb:n:in `__send__'
	from /lib/truffle/truffle/cext.rb:n:in `rb_funcall'
	from /test/truffle/cexts/backtraces/ext/backtraces/backtraces.c:38:in `sulong_callback'
	from /test/truffle/cexts/backtraces/ext/backtraces/backtraces.c:44:in `native_callback'
	from /lib/truffle/truffle/cext.rb:n:in `execute_without_conversion'
	from /lib/truffle/truffle/cext.rb:n:in `execute_with_mutex'
	from /lib/truffle/truffle/cext_ruby.rb:n:in `native_callback'
	from /test/truffle/cexts/backtraces/bin/backtraces:42:in `<main>'
Translated to internal error (RubyTruffleError)
	from /lib/truffle/truffle/cext.rb:n:in `execute_with_mutex'
	from /lib/truffle/truffle/cext_ruby.rb:n:in `native_callback'
	from /test/truffle/cexts/backtraces/bin/backtraces:42:in `<main>'
```