### PR TITLE
Lower MaxRuntimeCompileMethods to catch smaller increases

### DIFF
--- a/mx.truffleruby/native-image.properties
+++ b/mx.truffleruby/native-image.properties
@@ -9,7 +9,7 @@ Requires = Tool:nfi
 LauncherClass = com.oracle.graalvm.launcher.ruby.RubyLauncher
 
 # The last line ensures non-polyglot image uses org.truffleruby.Main as main class
-Args = -H:MaxRuntimeCompileMethods=11000 \
+Args = -H:MaxRuntimeCompileMethods=7500 \
        -R:YoungGenerationSize=1g \
        -R:OldGenerationSize=2g \
        -H:SubstitutionResources=org/truffleruby/aot/substitutions.json \


### PR DESCRIPTION
* We can easily increase it again if needed.
* As of this commit, there are 7246 methods with graal/substratevm.