### PR TITLE
Recompute runtime Ruby home for pre-initialized context

### DIFF
--- a/lib/truffle/truffle/patching.rb
+++ b/lib/truffle/truffle/patching.rb
@@ -33,6 +33,7 @@ module Truffle::Patching
       insertion_point = paths.
           map { |gem_require_path| $LOAD_PATH.index gem_require_path }.
           min
+      raise "Could not find paths #{paths} in $LOAD_PATH (#{$LOAD_PATH})" unless insertion_point
       ORIGINALS[name] = paths
       Truffle::Patching.log(name, path)
       $LOAD_PATH.insert insertion_point, path if $LOAD_PATH[insertion_point-1] != path

--- a/src/main/java/org/truffleruby/RubyContext.java
+++ b/src/main/java/org/truffleruby/RubyContext.java
@@ -30,6 +30,7 @@ import org.truffleruby.core.Hashing;
 import org.truffleruby.core.array.ArrayOperations;
 import org.truffleruby.core.encoding.EncodingManager;
 import org.truffleruby.core.exception.CoreExceptions;
+import org.truffleruby.core.exception.ExceptionOperations;
 import org.truffleruby.core.inlined.CoreMethods;
 import org.truffleruby.core.kernel.AtExitManager;
 import org.truffleruby.core.kernel.TraceManager;
@@ -48,6 +49,7 @@ import org.truffleruby.language.LexicalScope;
 import org.truffleruby.language.SafepointManager;
 import org.truffleruby.language.arguments.RubyArguments;
 import org.truffleruby.language.control.JavaException;
+import org.truffleruby.language.control.RaiseException;
 import org.truffleruby.language.loader.CodeLoader;
 import org.truffleruby.language.loader.FeatureLoader;
 import org.truffleruby.language.loader.SourceLoader;
@@ -314,6 +316,20 @@ public class RubyContext {
 
         initialized = true;
         return true;
+    }
+
+    protected boolean patchContext(Env newEnv) {
+        try {
+            return patch(newEnv);
+        } catch (RaiseException e) {
+            System.err.println("Exception during RubyContext.patch():");
+            ExceptionOperations.printRubyExceptionOnEnvStderr(this, e);
+            throw e;
+        } catch (Throwable e) {
+            System.err.println("Exception during RubyContext.patch():");
+            e.printStackTrace();
+            throw e;
+        }
     }
 
     private boolean compatibleOptions(Options oldOptions, Options newOptions) {

--- a/src/main/java/org/truffleruby/RubyLanguage.java
+++ b/src/main/java/org/truffleruby/RubyLanguage.java
@@ -128,7 +128,7 @@ public class RubyLanguage extends TruffleLanguage<RubyContext> {
     protected boolean patchContext(RubyContext context, Env newEnv) {
         Log.LOGGER.fine("patchContext()");
         Launcher.printTruffleTimeMetric("before-patch-context");
-        boolean patched = context.patch(newEnv);
+        boolean patched = context.patchContext(newEnv);
         Launcher.printTruffleTimeMetric("after-patch-context");
         return patched;
     }

--- a/src/main/java/org/truffleruby/language/RubyObjectType.java
+++ b/src/main/java/org/truffleruby/language/RubyObjectType.java
@@ -14,7 +14,6 @@ import com.oracle.truffle.api.interop.ForeignAccess;
 import com.oracle.truffle.api.object.DynamicObject;
 import com.oracle.truffle.api.object.ObjectType;
 import org.truffleruby.Layouts;
-import org.truffleruby.core.rope.RopeOperations;
 import org.truffleruby.core.string.StringOperations;
 import org.truffleruby.core.string.StringUtils;
 import org.truffleruby.interop.RubyMessageResolutionForeign;
@@ -25,7 +24,7 @@ public class RubyObjectType extends ObjectType {
     @TruffleBoundary
     public String toString(DynamicObject object) {
         if (RubyGuards.isRubyString(object)) {
-            return RopeOperations.decodeRope(StringOperations.rope(object));
+            return StringOperations.getString(object);
         } else if (RubyGuards.isRubySymbol(object)) {
             return Layouts.SYMBOL.getString(object);
         } else if (RubyGuards.isRubyException(object)) {

--- a/src/main/ruby/core/post.rb
+++ b/src/main/ruby/core/post.rb
@@ -95,19 +95,19 @@ Truffle::Boot.delay do
   $$ = Process.pid if Truffle::Boot.get_option 'platform.native'
 
   ARGV.concat(Truffle::Boot.original_argv)
-end
 
-$LOAD_PATH.concat(Truffle::Boot.original_load_path)
+  $LOAD_PATH.concat(Truffle::Boot.original_load_path)
 
-ruby_home = Truffle::Boot.ruby_home
-if ruby_home
-  # Does not exist but it's used by rubygems to determine index where to insert gem lib directories, as a result
-  # paths supplied by -I will stay before gem lib directories.
-  $LOAD_PATH.push "#{ruby_home}/lib/ruby/site_ruby/2.3.0"
+  ruby_home = Truffle::Boot.ruby_home
+  if ruby_home
+    # Does not exist but it's used by rubygems to determine index where to insert gem lib directories, as a result
+    # paths supplied by -I will stay before gem lib directories.
+    $LOAD_PATH.push "#{ruby_home}/lib/ruby/site_ruby/2.3.0"
 
-  $LOAD_PATH.push "#{ruby_home}/lib/truffle"
-  $LOAD_PATH.push "#{ruby_home}/lib/mri"
-  $LOAD_PATH.push "#{ruby_home}/lib/json/lib"
+    $LOAD_PATH.push "#{ruby_home}/lib/truffle"
+    $LOAD_PATH.push "#{ruby_home}/lib/mri"
+    $LOAD_PATH.push "#{ruby_home}/lib/json/lib"
+  end
 end
 
 # We defined Psych at the top level because several things depend on its name.


### PR DESCRIPTION
* So the image can use another home than the image-build-time home.
* `reInitialize()` is gone now and it's much simpler.