### PR TITLE
Tag launchers specs failing on SVM

### DIFF
--- a/spec/tags/truffle/launcher_tags.txt
+++ b/spec/tags/truffle/launcher_tags.txt
@@ -52,3 +52,11 @@ slow:The launcher 'ri' runs when symlinked
 slow:The launcher 'ruby' runs when symlinked
 slow:The launcher 'testrb' runs when symlinked
 slow:The launcher 'truffleruby' runs when symlinked
+aot:The launcher 'gem' runs when symlinked
+aot:The launcher 'irb' runs when symlinked
+aot:The launcher 'rake' runs when symlinked
+aot:The launcher 'rdoc' runs when symlinked
+aot:The launcher 'ri' runs when symlinked
+aot:The launcher 'ruby' runs when symlinked
+aot:The launcher 'testrb' runs when symlinked
+aot:The launcher 'truffleruby' runs when symlinked


### PR DESCRIPTION
* Due to the SVM binary not being invoked by irb/gem/etc.