### PR TITLE
Fix the time metrics

### DIFF
--- a/mx.truffleruby/mx_truffleruby_benchmark.py
+++ b/mx.truffleruby/mx_truffleruby_benchmark.py
@@ -225,7 +225,13 @@ class TimeBenchmarkSuite(MetricsBenchmarkSuite):
 
         jt(['metrics', 'time', '--json'] + metrics_benchmarks[benchmark] + bmSuiteArgs, out=out)
 
-        data = json.loads(out.data)
+        lines = [line for line in out.data.split('\n') if len(line) > 0]
+        print('\n'.join(lines[0:-1]))
+
+        json_data = lines[-1]
+        print('JSON:')
+        print(json_data)
+        data = json.loads(json_data)
 
         return [{
             'benchmark': benchmark,


### PR DESCRIPTION
* Now that we output what each metric benchmark prints and not hide it,
  we need to extract the JSON (last line) out of it.