### PR TITLE
Cleanup the test definitions in CI

### DIFF
--- a/ci.jsonnet
+++ b/ci.jsonnet
@@ -192,6 +192,9 @@
   },
 
   local download_gem_test_pack = jt(["gem-test-pack"]),
+  local gem_test_pack = {
+    setup+: download_gem_test_pack
+  },
 
   jruby_benchmark: {
     setup: common.prelude,
@@ -417,11 +420,6 @@
   },
 
   # Tests
-  test_gems: {
-    setup: common.setup + download_gem_test_pack,
-    run: jt(["test", "gems"])
-  },
-
   test_ecosystem: $.sulong {
     setup: common.setup + $.sulong.setup + download_gem_test_pack,
     run: jt(["test", "ecosystem"])
@@ -539,7 +537,7 @@
     {name: "ruby-test-mri"} + linux_gate + $.sulong + $.fast_cpu_caps + {run: jt(["test", "mri"])},
     {name: "ruby-test-integration"} + linux_gate + $.test_integration,
     {name: "ruby-test-cexts"} + linux_gate + $.test_cexts,
-    {name: "ruby-test-gems"} + linux_gate + $.test_gems,
+    {name: "ruby-test-gems"} + linux_gate + gem_test_pack + {run: jt(["test", "gems"])},
     {name: "ruby-test-ecosystem"} + linux_gate + $.test_ecosystem,
 
     {name: "ruby-test-compiler-graal-core"} + linux_gate + $.graal_core + {run: jt(["test", "compiler"])},

--- a/ci.jsonnet
+++ b/ci.jsonnet
@@ -420,11 +420,6 @@
   },
 
   # Tests
-  test_ecosystem: $.sulong {
-    setup: common.setup + $.sulong.setup + download_gem_test_pack,
-    run: jt(["test", "ecosystem"])
-  },
-
   test_cexts: $.sulong {
     environment+: {
       JAVA_OPTS: java_opts + " -Dgraal.TruffleCompileOnly=nothing",
@@ -538,7 +533,7 @@
     {name: "ruby-test-integration"} + linux_gate + $.test_integration,
     {name: "ruby-test-cexts"} + linux_gate + $.test_cexts,
     {name: "ruby-test-gems"} + linux_gate + gem_test_pack + {run: jt(["test", "gems"])},
-    {name: "ruby-test-ecosystem"} + linux_gate + $.test_ecosystem,
+    {name: "ruby-test-ecosystem"} + linux_gate + $.sulong + gem_test_pack + {run: jt(["test", "ecosystem"])},
 
     {name: "ruby-test-compiler-graal-core"} + linux_gate + $.graal_core + {run: jt(["test", "compiler"])},
     # {name: "ruby-test-compiler-graal-enterprise"} + linux_gate + $.graal_enterprise + {run: jt(["test", "compiler"])},

--- a/ci.jsonnet
+++ b/ci.jsonnet
@@ -430,11 +430,6 @@
     ]
   },
 
-  test_integration: $.sulong {
-    setup: common.setup + $.sulong.setup,
-    run: jt(["test", "integration"])
-  },
-
   local test_compilation_flags = {
     environment+: {
       JAVA_OPTS: java_opts + " -Dgraal.TraceTruffleCompilation=true -Dgraal.TruffleCompilationExceptionsAreFatal=true"
@@ -530,7 +525,7 @@
     {name: "ruby-test-tck"} + linux_gate + {run: [["mx", "rubytck"]]},
     # OpenSSL is required to run RubyGems tests
     {name: "ruby-test-mri"} + linux_gate + $.sulong + $.fast_cpu_caps + {run: jt(["test", "mri"])},
-    {name: "ruby-test-integration"} + linux_gate + $.test_integration,
+    {name: "ruby-test-integration"} + linux_gate + $.sulong + {run: jt(["test", "integration"])},
     {name: "ruby-test-cexts"} + linux_gate + $.test_cexts,
     {name: "ruby-test-gems"} + linux_gate + gem_test_pack + {run: jt(["test", "gems"])},
     {name: "ruby-test-ecosystem"} + linux_gate + $.sulong + gem_test_pack + {run: jt(["test", "ecosystem"])},

--- a/ci.jsonnet
+++ b/ci.jsonnet
@@ -417,13 +417,6 @@
   },
 
   # Tests
-
-  test_mri: $.sulong {
-    # OpenSSL is required to run RubyGems tests
-    setup: common.setup + $.sulong.setup,
-    run: jt(["test", "mri"])
-  },
-
   test_gems: {
     setup: common.setup + gem_test_pack,
     run: jt(["test", "gems"])
@@ -542,7 +535,8 @@
 
     {name: "ruby-lint"} + linux_gate + $.lint,
     {name: "ruby-test-tck"} + linux_gate + {run: [["mx", "rubytck"]]},
-    {name: "ruby-test-mri"} + linux_gate + $.test_mri + $.fast_cpu_caps,
+    # OpenSSL is required to run RubyGems tests
+    {name: "ruby-test-mri"} + linux_gate + $.sulong + $.fast_cpu_caps + {run: jt(["test", "mri"])},
     {name: "ruby-test-integration"} + linux_gate + $.test_integration,
     {name: "ruby-test-cexts"} + linux_gate + $.test_cexts,
     {name: "ruby-test-gems"} + linux_gate + $.test_gems,

--- a/ci.jsonnet
+++ b/ci.jsonnet
@@ -191,7 +191,7 @@
     }
   },
 
-  local gem_test_pack = jt(["gem-test-pack"]),
+  local download_gem_test_pack = jt(["gem-test-pack"]),
 
   jruby_benchmark: {
     setup: common.prelude,
@@ -409,7 +409,7 @@
       TRUFFLERUBYOPT: "-Xcexts.log.load=true",
       USE_CEXTS: "true"
     },
-    setup+: gem_test_pack +
+    setup+: download_gem_test_pack +
       jt(["cextc", "bench/chunky_png/oily_png"]) +
       jt(["cextc", "bench/psd.rb/psd_native"]),
     run: benchmark(["chunky"]),
@@ -418,12 +418,12 @@
 
   # Tests
   test_gems: {
-    setup: common.setup + gem_test_pack,
+    setup: common.setup + download_gem_test_pack,
     run: jt(["test", "gems"])
   },
 
   test_ecosystem: $.sulong {
-    setup: common.setup + $.sulong.setup + gem_test_pack,
+    setup: common.setup + $.sulong.setup + download_gem_test_pack,
     run: jt(["test", "ecosystem"])
   },
 
@@ -431,7 +431,7 @@
     environment+: {
       JAVA_OPTS: java_opts + " -Dgraal.TruffleCompileOnly=nothing",
     },
-    setup: common.setup + $.sulong.setup + gem_test_pack,
+    setup: common.setup + $.sulong.setup + download_gem_test_pack,
     run: [
       ["mx", "--dynamicimports", "sulong", "ruby_testdownstream_sulong"]
     ]


### PR DESCRIPTION
Now that the `setup` parts (of common, sulong, graal, etc) can be composed, it's easier to compose the setups needed of using inheritance.
* No change in the generated JSON.