### PR TITLE
Simplify RubyBaseNode#getContext()

### DIFF
--- a/src/main/java/org/truffleruby/language/RubyBaseNode.java
+++ b/src/main/java/org/truffleruby/language/RubyBaseNode.java
@@ -100,15 +100,7 @@ public abstract class RubyBaseNode extends Node {
     public RubyContext getContext() {
         if (context == null) {
             CompilerDirectives.transferToInterpreterAndInvalidate();
-
-            final RootNode rootNode = getRootNode();
-
-            if (rootNode instanceof RubyBaseRootNode) {
-                context = rootNode.getLanguage(RubyLanguage.class).getContextReference().get();
-            } else {
-                // For example in a foreign node
-                context = RubyLanguage.getCurrentContext();
-            }
+            context = RubyLanguage.getCurrentContext();
         }
 
         return context;


### PR DESCRIPTION
* It is slow-path, so no need for a ContextReference.