### PR TITLE
Simplify SourceLoader.loadResource()

### DIFF
--- a/src/main/java/org/truffleruby/aot/ParserCache.java
+++ b/src/main/java/org/truffleruby/aot/ParserCache.java
@@ -54,12 +54,17 @@ public class ParserCache {
         final StaticScope staticScope = new StaticScope(StaticScope.Type.LOCAL, null);
         final DynamicScope dynamicScope = new DynamicScope(staticScope);
         final ParserConfiguration parserConfiguration = new ParserConfiguration(null, 0, false, true, false);
+
         final Source source;
+        if (!canonicalPath.startsWith(SourceLoader.RESOURCE_SCHEME)) {
+            throw new UnsupportedOperationException("Not a resource path: " + canonicalPath);
+        }
         try {
             source = SourceLoader.loadResource(canonicalPath);
         } catch (IOException e) {
             throw new JavaException(e);
         }
+
         return driver.parseToJRubyAST(source, dynamicScope, parserConfiguration);
     }
 

--- a/src/main/java/org/truffleruby/language/loader/SourceLoader.java
+++ b/src/main/java/org/truffleruby/language/loader/SourceLoader.java
@@ -165,13 +165,8 @@ public class SourceLoader {
     @TruffleBoundary
     public static Source loadResource(String path) throws IOException {
         if (TruffleOptions.AOT) {
-            if (!path.startsWith(SourceLoader.RESOURCE_SCHEME)) {
-                throw new UnsupportedOperationException();
-            }
-
             final String canonicalPath = SourceLoaderSupport.canonicalizeResourcePath(path);
-            final SourceLoaderSupport.CoreLibraryFile coreFile = SourceLoaderSupport.allCoreLibraryFiles.get(
-                    canonicalPath);
+            final SourceLoaderSupport.CoreLibraryFile coreFile = SourceLoaderSupport.allCoreLibraryFiles.get(canonicalPath);
             if (coreFile == null) {
                 throw new FileNotFoundException(path);
             }
@@ -182,15 +177,8 @@ public class SourceLoader {
                 throw new FileNotFoundException(path);
             }
 
-            final Class<?> relativeClass;
-            final Path relativePath;
-
-            if (path.startsWith(RESOURCE_SCHEME)) {
-                relativeClass = RubyContext.class;
-                relativePath = FileSystems.getDefault().getPath(path.substring(RESOURCE_SCHEME.length()));
-            } else {
-                throw new UnsupportedOperationException();
-            }
+            final Class<?> relativeClass = RubyContext.class;
+            final Path relativePath = FileSystems.getDefault().getPath(path.substring(RESOURCE_SCHEME.length()));
 
             final Path normalizedPath = relativePath.normalize();
             final InputStream stream = relativeClass.getResourceAsStream(


### PR DESCRIPTION
* Move the check to the caller that needs it.