### PR TITLE
Fix the optimized Hash lookup by index to not call eql? twice

### DIFF
--- a/spec/tags/core/hash/element_reference_tags.txt
+++ b/spec/tags/core/hash/element_reference_tags.txt
@@ -1,1 +1,0 @@
-graalvm:Hash#[] compares keys with the same #hash value via #eql?

--- a/src/main/java/org/truffleruby/core/hash/CompareHashKeysNode.java
+++ b/src/main/java/org/truffleruby/core/hash/CompareHashKeysNode.java
@@ -30,6 +30,18 @@ public class CompareHashKeysNode extends RubyBaseNode {
         }
     }
 
+    /**
+     * Checks if the two keys are the same object, which is used by both modes (by identity or not)
+     * of lookup. Enables to check if the two keys are the same without a method call.
+     */
+    public boolean referenceEqualKeys(boolean compareByIdentity, Object key, int hashed, Object otherKey, int otherHashed) {
+        if (compareByIdentity) {
+            return equal(key, otherKey);
+        } else {
+            return hashed == otherHashed && equal(key, otherKey);
+        }
+    }
+
     private boolean sameOrEql(VirtualFrame frame, Object key1, Object key2) {
         if (sameOrEqlNode == null) {
             CompilerDirectives.transferToInterpreterAndInvalidate();


### PR DESCRIPTION
* Finally found a nice way to fix this.
* It now only compares keys with an identity check (no method call),
  and falls back to a normal lookup otherwise.
