### PR TITLE
Fix replacement of random hexa characters for the C ext backtraces test

### DIFF
--- a/test/truffle/cexts/backtraces/expected.txt
+++ b/test/truffle/cexts/backtraces/expected.txt
@@ -34,7 +34,7 @@
 42
 
 /lib/truffle/truffle/cext.rb:n:in `execute_without_conversion': Error in C extension code (SulongRuntimeException):
-Exception thrown by a callback during the native call com.oracle.truffle.nfi.impl.LibFFIFunction@HEXA(function@1237 '@sulong_callback') (IllegalStateException)
+Exception thrown by a callback during the native call com.oracle.truffle.nfi.impl.LibFFIFunction@HEXA(function@HEXA '@sulong_callback') (IllegalStateException)
 	from native_callback in backtraces.c:43:17 (LLVM IR Function native_callback in /test/truffle/cexts/backtraces/lib/backtraces/backtraces.su@HEXA_backtraces.bc in Block BLOCKINFO)
 	from com.oracle.truffle.llvm.nodes.func.LLVMNativeCallUtils.callNativeFunction(LLVMNativeCallUtils.java:72)
 Caused by:

--- a/tool/jt.rb
+++ b/tool/jt.rb
@@ -1089,7 +1089,7 @@ module Commands
           if test_name == 'backtraces'
             actual = actual.gsub(TRUFFLERUBY_DIR, '')
                            .gsub(/\/cext(_ruby)?\.rb:(\d+)/, '/cext\1.rb:n')
-                           .gsub(/\h{8,}/, 'HEXA')
+                           .gsub(/@\h+/, '@HEXA')
                            .gsub(/\{id: \d+ name: [^}]+}/, 'BLOCKINFO')
           end
           expected = File.read("#{dir}/expected.txt")


### PR DESCRIPTION
* They can be shorter than 8 hexadigits.