### PR TITLE
Test context pre-initialization in CI and build SVM images with a pre-initialized context

### DIFF
--- a/mx.truffleruby/native-image.properties
+++ b/mx.truffleruby/native-image.properties
@@ -18,4 +18,5 @@ Args = -H:MaxRuntimeCompileMethods=7500 \
 # Pass the home for context pre-initialization
 # ${.} expands to the destination Ruby home created by mx fetch-languages,
 # such as substratevm/svmbuild/native-image-root/languages/ruby.
-JavaArgs = -Dpolyglot.ruby.home=${.}
+JavaArgs = -Dpolyglot.ruby.home=${.} \
+           -Dpolyglot.engine.PreinitializeContexts=ruby

--- a/spec/truffle/pre_initialization_spec.rb
+++ b/spec/truffle/pre_initialization_spec.rb
@@ -1,0 +1,48 @@
+# Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved. This
+# code is released under a tri EPL/GPL/LGPL license. You can use it,
+# redistribute it and/or modify it under the terms of the:
+#
+# Eclipse Public License version 1.0
+# GNU General Public License version 2
+# GNU Lesser General Public License version 2.1
+# OTHER DEALINGS IN THE SOFTWARE.
+
+require_relative '../ruby/spec_helper'
+
+guard -> { Truffle.native? } do
+  describe "The pre-initialized context" do
+    it "can be used to run specs, as otherwise this spec run is meaningless" do
+      Truffle::Boot.was_preinitialized?.should == true
+    end
+
+    it "is used when passing no incompatible options" do
+      out = ruby_exe("p Truffle::Boot.was_preinitialized?", options: "-Xlog=fine", args: "2>&1")
+      out.should include("patchContext()")
+      out.should_not include("createContext()")
+      out.should_not include("initializeContext()")
+      out.should include("\ntrue\n")
+    end
+
+    it "is not used when passing incompatible options" do
+      no_native = "-Xplatform.native=false -Xpolyglot.stdio=true -Xsync.stdio=true --disable-gems"
+      out = ruby_exe("p Truffle::Boot.was_preinitialized?", options: "-Xlog=fine #{no_native}", args: "2>&1")
+      out.should include("patchContext()")
+      out.should include("not reusing pre-initialized context: -Xplatform.native is false")
+      out.should include("finalizeContext()")
+      out.should include("disposeContext()")
+      out.should include("createContext()")
+      out.should include("initializeContext()")
+      out.should include("\nfalse\n")
+    end
+
+    it "picks up new environment variables" do
+      var = "TR_PRE_INIT_NEW_VAR"
+      ENV[var] = "true"
+      begin
+        ruby_exe("print ENV['#{var}']").should == "true"
+      ensure
+        ENV.delete var
+      end
+    end
+  end
+end

--- a/spec/truffle/pre_initialization_spec.rb
+++ b/spec/truffle/pre_initialization_spec.rb
@@ -9,7 +9,8 @@
 
 require_relative '../ruby/spec_helper'
 
-guard -> { Truffle.native? } do
+# GraalVM does not use the pre-initialized context yet
+guard -> { Truffle.native? and !Truffle::System.get_java_property("org.graalvm.version") } do
   describe "The pre-initialized context" do
     it "can be used to run specs, as otherwise this spec run is meaningless" do
       Truffle::Boot.was_preinitialized?.should == true

--- a/src/main/java/org/truffleruby/RubyContext.java
+++ b/src/main/java/org/truffleruby/RubyContext.java
@@ -123,15 +123,12 @@ public class RubyContext {
 
     private final Object classVariableDefinitionLock = new Object();
 
+    private final boolean preInitialized;
     private boolean preInitializing;
     private boolean initialized;
     private volatile boolean finalizing;
 
     private static boolean preInitializeContexts = Launcher.PRE_INITIALIZE_CONTEXTS;
-
-    public boolean isPreInitializing() {
-        return preInitializing;
-    }
 
     public RubyContext(RubyLanguage language, TruffleLanguage.Env env) {
         Launcher.printTruffleTimeMetric("before-context-constructor");
@@ -142,6 +139,7 @@ public class RubyContext {
 
         this.preInitializing = preInitializeContexts;
         RubyContext.preInitializeContexts = false; // Only the first context is pre-initialized
+        this.preInitialized = preInitializing;
 
         this.language = language;
         this.env = env;
@@ -452,6 +450,14 @@ public class RubyContext {
         if (options.COVERAGE_GLOBAL) {
             coverageManager.print(System.out);
         }
+    }
+
+    public boolean isPreInitializing() {
+        return preInitializing;
+    }
+
+    public boolean wasPreInitialized() {
+        return preInitialized;
     }
 
     public RubyLanguage getLanguage() {

--- a/src/main/java/org/truffleruby/language/TruffleBootNodes.java
+++ b/src/main/java/org/truffleruby/language/TruffleBootNodes.java
@@ -95,6 +95,15 @@ public abstract class TruffleBootNodes {
         }
     }
 
+    @CoreMethod(names = "was_preinitialized?", onSingleton = true)
+    public abstract static class WasPreinitializedNode extends CoreMethodArrayArgumentsNode {
+
+        @Specialization
+        protected boolean wasPreinitializedContext() {
+            return getContext().wasPreInitialized();
+        }
+    }
+
     @CoreMethod(names = "main", onSingleton = true)
     public abstract static class MainNode extends CoreMethodArrayArgumentsNode {
 


### PR DESCRIPTION
* To prevent regressions.
* Not yet in GraalVM (so not in ChangeLog).