### PR TITLE
Use Source#getName() instead of Source#getPath()

### DIFF
--- a/src/main/java/org/truffleruby/RubyLanguage.java
+++ b/src/main/java/org/truffleruby/RubyLanguage.java
@@ -87,8 +87,8 @@ public class RubyLanguage extends TruffleLanguage<RubyContext> {
             return "no source section";
         } else {
             final Source source = section.getSource();
+            final String path = source.getName();
 
-            final String path = source.getPath() != null ? source.getPath() : source.getName();
             if (section.isAvailable()) {
                 return path + ":" + section.getStartLine();
             } else {

--- a/src/main/java/org/truffleruby/cext/CExtNodes.java
+++ b/src/main/java/org/truffleruby/cext/CExtNodes.java
@@ -588,7 +588,7 @@ public class CExtNodes {
         @Specialization
         public DynamicObject sourceFile() {
             final SourceSection sourceSection = getTopUserSourceSection("rb_sourcefile", "execute_with_mutex");
-            final String file = sourceSection.getSource().getPath();
+            final String file = sourceSection.getSource().getName();
 
             return makeStringNode.executeMake(file, UTF8Encoding.INSTANCE, CodeRange.CR_UNKNOWN);
         }

--- a/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
+++ b/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
@@ -1379,7 +1379,7 @@ public abstract class KernelNodes {
             } else {
                 final Source source = getContext().getCallStack().getCallerFrameIgnoringSend().getCallNode().getEncapsulatingSourceSection().getSource();
 
-                String sourcePath = source.getPath();
+                String sourcePath = getContext().getSourceLoader().getAbsolutePath(source);
                 if (sourcePath == null) {
                     // Use the filename passed to eval as basepath
                     sourcePath = source.getName();

--- a/src/main/java/org/truffleruby/core/thread/ThreadBacktraceLocationNodes.java
+++ b/src/main/java/org/truffleruby/core/thread/ThreadBacktraceLocationNodes.java
@@ -43,8 +43,7 @@ public class ThreadBacktraceLocationNodes {
             final SourceSection sourceSection = activation.getCallNode().getEncapsulatingSourceSection();
             final Source source = sourceSection.getSource();
 
-            // Get absolute path
-            final String path = source.getPath();
+            final String path = getContext().getSourceLoader().getAbsolutePath(source);
 
             if (path == null) {
                 return coreStrings().UNKNOWN.createInstance();

--- a/src/main/java/org/truffleruby/debug/TruffleDebugNodes.java
+++ b/src/main/java/org/truffleruby/debug/TruffleDebugNodes.java
@@ -61,12 +61,12 @@ public abstract class TruffleDebugNodes {
 
         @TruffleBoundary
         @Specialization(guards = "isRubyString(file)")
-        public DynamicObject setBreak(DynamicObject file, int line, final DynamicObject block) {
+        public DynamicObject setBreak(DynamicObject file, int line, DynamicObject block) {
             final String fileString = StringOperations.getString(file);
 
             final SourceSectionFilter filter = SourceSectionFilter.newBuilder()
                     .mimeTypeIs(RubyLanguage.MIME_TYPE)
-                    .sourceIs(source -> source != null && source.getPath() != null && source.getPath().equals(fileString))
+                    .sourceIs(source -> source != null && source.getName().equals(fileString))
                     .lineIs(line)
                     .tagIs(StandardTags.StatementTag.class)
                     .build();

--- a/src/main/java/org/truffleruby/language/DataNode.java
+++ b/src/main/java/org/truffleruby/language/DataNode.java
@@ -53,7 +53,7 @@ public class DataNode extends RubyNode {
 
     @TruffleBoundary
     private String getPath() {
-        return getEncapsulatingSourceSection().getSource().getPath();
+        return getContext().getSourceLoader().getAbsolutePath(getEncapsulatingSourceSection().getSource());
     }
 
 }

--- a/src/main/java/org/truffleruby/language/backtrace/BacktraceFormatter.java
+++ b/src/main/java/org/truffleruby/language/backtrace/BacktraceFormatter.java
@@ -247,11 +247,6 @@ public class BacktraceFormatter {
             return true;
         }
 
-        final String path = source.getPath();
-        if (path != null) {
-            return path.startsWith(SourceLoader.RESOURCE_SCHEME);
-        }
-
         final String name = source.getName();
         if (name != null) {
             return name.startsWith(SourceLoader.RESOURCE_SCHEME);
@@ -266,7 +261,7 @@ public class BacktraceFormatter {
             return false;
         }
 
-        final String path = sourceSection.getSource().getPath();
+        final String path = sourceSection.getSource().getName();
         if (path.startsWith(context.getCoreLibrary().getCoreLoadPath())) {
             return false;
         }

--- a/src/main/java/org/truffleruby/language/backtrace/BacktraceFormatter.java
+++ b/src/main/java/org/truffleruby/language/backtrace/BacktraceFormatter.java
@@ -17,7 +17,6 @@ import com.oracle.truffle.api.source.Source;
 import com.oracle.truffle.api.source.SourceSection;
 import org.truffleruby.Layouts;
 import org.truffleruby.RubyContext;
-import org.truffleruby.RubyLanguage;
 import org.truffleruby.core.exception.ExceptionOperations;
 import org.truffleruby.core.string.StringUtils;
 import org.truffleruby.language.RubyRootNode;
@@ -275,9 +274,13 @@ public class BacktraceFormatter {
         final SourceSection sourceSection = callNode.getEncapsulatingSourceSection();
 
         if (sourceSection != null) {
-            final String shortDescription = RubyLanguage.fileLine(sourceSection);
+            final Source source = sourceSection.getSource();
+            final String path = source.getPath() != null ? source.getPath() : source.getName();
 
-            builder.append(shortDescription);
+            builder.append(path);
+            if (sourceSection.isAvailable()) {
+                builder.append(":").append(sourceSection.getStartLine());
+            }
 
             final RootNode rootNode = callNode.getRootNode();
 

--- a/src/main/java/org/truffleruby/language/loader/SourceLoader.java
+++ b/src/main/java/org/truffleruby/language/loader/SourceLoader.java
@@ -49,7 +49,7 @@ public class SourceLoader {
         if (source == mainSource) {
             return mainSourceAbsolutePath;
         } else {
-            return source.getPath();
+            return source.getName();
         }
     }
 

--- a/src/main/java/org/truffleruby/language/loader/SourceLoader.java
+++ b/src/main/java/org/truffleruby/language/loader/SourceLoader.java
@@ -68,6 +68,10 @@ public class SourceLoader {
 
     @TruffleBoundary
     public Source loadMainFile(RubyNode currentNode, String path) throws IOException {
+        if (mainSourceAbsolutePath != null) {
+            throw new UnsupportedOperationException("main file already loaded: " + mainSourceAbsolutePath);
+        }
+
         final File file = new File(path).getCanonicalFile();
         ensureReadable(path, file);
 

--- a/src/main/java/org/truffleruby/language/loader/SourceLoader.java
+++ b/src/main/java/org/truffleruby/language/loader/SourceLoader.java
@@ -38,8 +38,19 @@ public class SourceLoader {
 
     private final RubyContext context;
 
+    private Source mainSource = null;
+    private String mainSourceAbsolutePath = null;
+
     public SourceLoader(RubyContext context) {
         this.context = context;
+    }
+
+    public String getAbsolutePath(Source source) {
+        if (source == mainSource) {
+            return mainSourceAbsolutePath;
+        } else {
+            return source.getPath();
+        }
     }
 
     @TruffleBoundary
@@ -60,9 +71,11 @@ public class SourceLoader {
         final File file = new File(path).getCanonicalFile();
         ensureReadable(path, file);
 
-        return Source.newBuilder(file).name(path).content(xOptionStrip(
+        mainSource = Source.newBuilder(file).name(path).content(xOptionStrip(
                 currentNode,
                 new FileReader(file))).mimeType(RubyLanguage.MIME_TYPE).build();
+        mainSourceAbsolutePath = file.getPath();
+        return mainSource;
     }
 
     private String xOptionStrip(RubyNode currentNode, Reader reader) throws IOException {


### PR DESCRIPTION
We cannot control Source#getPath() and it's only available for File-based Source.
So use getName() consistently and handle the rare cases which need an absolute path explicitly.
This is needed for pre-initialization to be more flexible in how we get the name of a Source