### PR TITLE
Do not show a LazyStackTrace cause as it is an implementation detail

### DIFF
--- a/src/main/java/org/truffleruby/language/methods/ExceptionTranslatingNode.java
+++ b/src/main/java/org/truffleruby/language/methods/ExceptionTranslatingNode.java
@@ -261,6 +261,11 @@ public class ExceptionTranslatingNode extends RubyNode {
         }
 
         while (t != null) {
+            if (t.getClass().getSimpleName().equals("LazyStackTrace")) {
+                // Truffle's lazy stracktrace support, not a real exception
+                break;
+            }
+
             if (!firstException) {
                 builder.append("Caused by:\n");
             }


### PR DESCRIPTION
This should remove the extra cause output related to LazyStackTrace in e.g. #1124. 