### PR TITLE
RUBY_DESCRIPTION should have architecture followed by operating system

### DIFF
--- a/src/launcher/java/org/truffleruby/launcher/Launcher.java
+++ b/src/launcher/java/org/truffleruby/launcher/Launcher.java
@@ -327,8 +327,8 @@ public class Launcher {
                         "java.runtime.version",
                         System.getProperty("java.version", "unknown runtime version")),
                 isGraal ? "with Graal" : "without Graal",
-                BasicPlatform.getOSName(),
-                BasicPlatform.getArchitecture()
+                BasicPlatform.getArchitecture(),
+                BasicPlatform.getOSName()
         );
     }
 


### PR DESCRIPTION
* Such as [x86_64-linux], like on MRI.