### PR TITLE
Remove extra VirtualFrame argument in regexp_search_region

### DIFF
--- a/src/main/java/org/truffleruby/core/regexp/RegexpNodes.java
+++ b/src/main/java/org/truffleruby/core/regexp/RegexpNodes.java
@@ -486,7 +486,7 @@ public abstract class RegexpNodes {
         }
 
         @Specialization(guards = { "isInitialized(regexp)", "isRubyString(string)", "isValidEncoding(string)" })
-        public Object searchRegion(VirtualFrame frame, DynamicObject regexp, DynamicObject string, int start, int end, boolean forward,
+        public Object searchRegion(DynamicObject regexp, DynamicObject string, int start, int end, boolean forward,
                 @Cached("create()") RopeNodes.BytesNode bytesNode,
                 @Cached("create()") TruffleRegexpNodes.MatchNode matchNode) {
             final Rope rope = StringOperations.rope(string);


### PR DESCRIPTION
Without that I got this locally:

truffleruby/src/main/ruby/core/regexp.rb:95:in `search_region': Truffle doesn't have a case for the org.truffleruby.core.regexp.RegexpNodesFactory$RegexpSearchRegionPrimitiveNodeFactory$RegexpSearchRegionPrimitiveNodeGen node with values of type  Regexp(com.oracle.truffle.object.basic.DynamicObjectBasic) String(com.oracle.truffle.object.basic.DynamicObjectBasic) java.lang.Integer=0 java.lang.Integer=6 java.lang.Boolean=true (TypeError)


But after removing it and adding it back I could not reproduce.
Maybe some weird interaction with incremental compilation.