### PR TITLE
Tidy up the change log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ Performance:
 Internal changes:
 
 * The launcher is now part of the TruffleRuby repository, rather than part of
-the GraalVM repository.
+the GraalVM repository and it accepts `--native` and similar options in 
+`TRUFFLERUBYOPT` environment variable.
 
 * `ArrayBuilderNode` now uses `ArrayStrategies` and `ArrayMirrors` to remove
 direct knowledge of array storage.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
-# 0.32, end of February 2018
+# 0.32, March 2018
 
 New features:
 
 * A new embedded configuration is used when TruffleRuby is used from another
-language or application. This disables features like signals which may conflict
-with the embedding application, and enables features like the use of polyglot IO
-streams.
+  language or application. This disables features like signals which may
+  conflict with the embedding application, and threads which may conflict with
+  other languages, and enables features such as the use of polyglot IO streams.
 
 Performance:
 
@@ -13,7 +13,7 @@ Performance:
 
 Bug fixes:
 
-* Launcher accepts `--native` and similar options in  the `TRUFFLERUBYOPT` 
+* The launcher accepts `--native` and similar options in  the `TRUFFLERUBYOPT` 
 environment variable.
 
 Internal changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,11 @@
-# 0.32 (in development)
+# 0.32, end of February 2018
 
 New features:
 
-* ...
-
-Bug fixes:
-
-* ...
+* A new embedded configuration is used when TruffleRuby is used from another
+language or application. This disables features like signals which may conflict
+with the embedding application, and enables features like the use of polyglot IO
+streams.
 
 Performance:
 
@@ -17,5 +16,5 @@ Internal changes:
 * The launcher is now part of the TruffleRuby repository, rather than part of
 the GraalVM repository.
 
-* ArrayBuilderNode now uses ArrayStrategies and ArrayMirrors to remove
+* `ArrayBuilderNode` now uses `ArrayStrategies` and `ArrayMirrors` to remove
 direct knowledge of array storage.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,15 @@ Performance:
 
 * Conversion of ASCII-only Ruby strings to Java strings is now faster.
 
+Bug fixes:
+
+* Launcher accepts `--native` and similar options in  the `TRUFFLERUBYOPT` 
+environment variable.
+
 Internal changes:
 
 * The launcher is now part of the TruffleRuby repository, rather than part of
-the GraalVM repository and it accepts `--native` and similar options in 
-`TRUFFLERUBYOPT` environment variable.
+the GraalVM repository.
 
 * `ArrayBuilderNode` now uses `ArrayStrategies` and `ArrayMirrors` to remove
 direct knowledge of array storage.


### PR DESCRIPTION
We don't know which commit finally gets used for the release, so let's make the change log ready to use at any time.