### PR TITLE
Do not provide Source of an unavailable SourceSection.

### DIFF
--- a/src/main/java/org/truffleruby/language/RubyBaseNode.java
+++ b/src/main/java/org/truffleruby/language/RubyBaseNode.java
@@ -126,7 +126,7 @@ public abstract class RubyBaseNode extends Node {
 
         final SourceSection sourceSection = rootNode.getSourceSection();
 
-        if (sourceSection == null) {
+        if (sourceSection == null || !sourceSection.isAvailable()) {
             return null;
         }
 


### PR DESCRIPTION
When the `RootNode` represents a built-in, for instance (e.g. `Class#new`), it has an unavailable `SourceSection` set. Currently, that unavailable `Source` (with name `(core)`) is taken and a `SourceSection` based on that `Source` is created in `getSourceSection()` method. This is not really expected I think, moreover that new `SourceSection` have the `isAvailable()` true. This leads to exposal of empty sources (that were intended to be unavailable).

This fix assures, that no `SourceSection` is provided if the `RootNode`'s `SourceSection` is not available.

One thing I'm not sure about here is: The `RubyBaseNode` with such a null `SourceSection` will not be instrumented any more. I'm not sure if this is an issue, or not. If it is, it should provide an unavailable `SourceSection` instead.