### PR TITLE
Add an option to not reuse the pre-initialized context

### DIFF
--- a/spec/tags/truffle/pre_initialization_tags.txt
+++ b/spec/tags/truffle/pre_initialization_tags.txt
@@ -2,3 +2,4 @@ slow:The pre-initialized context is used when passing no incompatible options
 slow:The pre-initialized context is not used when passing incompatible options
 slow:The pre-initialized context is not used when the home is unset but was set at build time
 slow:The pre-initialized context picks up new environment variables
+slow:The pre-initialized context is not used if -Xpreinit=false is passed

--- a/spec/truffle/pre_initialization_spec.rb
+++ b/spec/truffle/pre_initialization_spec.rb
@@ -15,6 +15,11 @@ guard -> { Truffle.native? } do
       Truffle::Boot.was_preinitialized?.should == true
     end
 
+    it "is not used if -Xpreinit=false is passed" do
+      out = ruby_exe("p Truffle::Boot.was_preinitialized?", options: "-Xpreinit=false")
+      out.should == "false\n"
+    end
+
     it "is used when passing no incompatible options" do
       out = ruby_exe("p Truffle::Boot.was_preinitialized?", options: "-Xlog=fine", args: "2>&1")
       out.should include("patchContext()")

--- a/src/launcher/java/org/truffleruby/launcher/options/Options.java
+++ b/src/launcher/java/org/truffleruby/launcher/options/Options.java
@@ -52,6 +52,7 @@ public class Options {
     public final boolean NATIVE_INTERRUPT;
     public final boolean HANDLE_INTERRUPT;
     public final boolean CEXT_LOCK;
+    public final boolean PREINITIALIZATION;
     public final boolean TRACE_CALLS;
     public final boolean COVERAGE_GLOBAL;
     public final boolean INLINE_JS;
@@ -175,6 +176,7 @@ public class Options {
         NATIVE_INTERRUPT = builder.getOrDefault(OptionsCatalog.NATIVE_INTERRUPT, NATIVE_PLATFORM);
         HANDLE_INTERRUPT = builder.getOrDefault(OptionsCatalog.HANDLE_INTERRUPT, !EMBEDDED);
         CEXT_LOCK = builder.getOrDefault(OptionsCatalog.CEXT_LOCK);
+        PREINITIALIZATION = builder.getOrDefault(OptionsCatalog.PREINITIALIZATION);
         TRACE_CALLS = builder.getOrDefault(OptionsCatalog.TRACE_CALLS);
         COVERAGE_GLOBAL = builder.getOrDefault(OptionsCatalog.COVERAGE_GLOBAL);
         INLINE_JS = builder.getOrDefault(OptionsCatalog.INLINE_JS);
@@ -336,6 +338,8 @@ public class Options {
                 return HANDLE_INTERRUPT;
             case "ruby.cexts.lock":
                 return CEXT_LOCK;
+            case "ruby.preinit":
+                return PREINITIALIZATION;
             case "ruby.trace.calls":
                 return TRACE_CALLS;
             case "ruby.coverage.global":

--- a/src/launcher/java/org/truffleruby/launcher/options/OptionsCatalog.java
+++ b/src/launcher/java/org/truffleruby/launcher/options/OptionsCatalog.java
@@ -196,6 +196,11 @@ public class OptionsCatalog {
             "Use a Global Lock when running C extensions",
             null,
             true);
+    public static final BooleanOptionDescription PREINITIALIZATION = new BooleanOptionDescription(
+            "ruby.preinit",
+            "Use the pre-initialized context when available",
+            null,
+            true);
     public static final BooleanOptionDescription TRACE_CALLS = new BooleanOptionDescription(
             "ruby.trace.calls",
             "Support tracing (set_trace_func, TracePoint) of method calls",
@@ -696,6 +701,8 @@ public class OptionsCatalog {
                 return HANDLE_INTERRUPT;
             case "ruby.cexts.lock":
                 return CEXT_LOCK;
+            case "ruby.preinit":
+                return PREINITIALIZATION;
             case "ruby.trace.calls":
                 return TRACE_CALLS;
             case "ruby.coverage.global":
@@ -909,6 +916,7 @@ public class OptionsCatalog {
             NATIVE_INTERRUPT,
             HANDLE_INTERRUPT,
             CEXT_LOCK,
+            PREINITIALIZATION,
             TRACE_CALLS,
             COVERAGE_GLOBAL,
             INLINE_JS,

--- a/src/main/java/org/truffleruby/RubyContext.java
+++ b/src/main/java/org/truffleruby/RubyContext.java
@@ -332,6 +332,11 @@ public class RubyContext {
     private boolean compatibleOptions(Options oldOptions, Options newOptions, String oldHome, String newHome) {
         final String notReusingContext = "not reusing pre-initialized context: ";
 
+        if (!newOptions.PREINITIALIZATION) {
+            Log.LOGGER.fine(notReusingContext + "-Xpreinit is false");
+            return false;
+        }
+
         if (!newOptions.CORE_LOAD_PATH.equals(OptionsCatalog.CORE_LOAD_PATH.getDefaultValue())) {
             Log.LOGGER.fine(notReusingContext + "-Xcore.load_path is set: " + newOptions.CORE_LOAD_PATH);
             return false; // Should load the specified core files

--- a/tool/options.yml
+++ b/tool/options.yml
@@ -38,6 +38,7 @@ NATIVE_PLATFORM: [platform.native, boolean, true, Enables native calls via Truff
 NATIVE_INTERRUPT: [platform.native_interrupt, boolean, NATIVE_PLATFORM, Use the SIGVTALRM signal to interrupt native blocking calls]
 HANDLE_INTERRUPT: [platform.handle_interrupt, boolean, '!EMBEDDED', Handle the interrupt signal and raise an Interrupt exception]
 CEXT_LOCK: [cexts.lock, boolean, true, Use a Global Lock when running C extensions]
+PREINITIALIZATION: [preinit, boolean, true, Use the pre-initialized context when available]
 
 TRACE_CALLS: [trace.calls, boolean, true, 'Support tracing (set_trace_func, TracePoint) of method calls']
 COVERAGE_GLOBAL: [coverage.global, boolean, false, Run coverage for all code and print results on exit]


### PR DESCRIPTION
* Useful for debugging issues related to context pre-initialization.