### PR TITLE
Optimize Array#hash for primitive arrays

### DIFF
--- a/src/main/ruby/core/array.rb
+++ b/src/main/ruby/core/array.rb
@@ -530,6 +530,11 @@ class Array
   end
 
   def hash
+    unless Truffle.invoke_primitive(:object_can_contain_object, self)
+      # Primitive arrays do not need the recursion check
+      return hash_internal
+    end
+
     hash_val = size
 
     # This is duplicated and manually inlined code from Thread for performance
@@ -578,6 +583,7 @@ class Array
 
     hash_val
   end
+  Truffle::Graal.always_split instance_method(:hash)
 
   def find_index(obj=undefined)
     super


### PR DESCRIPTION
* The recursion check is not needed.
* This gains quite a bit of time during Optcarrot startup where it calls Array#hash a lot on 2-elements integer arrays.
* Similar to the optimizations for eql?, == and in `Thread.detect_recursion`.