### PR TITLE
Depend on Sulong in suite.py

### DIFF
--- a/ci.jsonnet
+++ b/ci.jsonnet
@@ -87,15 +87,6 @@ local part_definitions = {
         CPPFLAGS: "-I$LIBGMP/include",
         LD_LIBRARY_PATH: "$LIBGMP/lib:$LLVM/lib:$LD_LIBRARY_PATH",
       },
-
-      setup+: [
-        ["git", "clone", ["mx", "urlrewrite", "https://github.com/graalvm/sulong.git"], "../sulong"],
-        ["mx", "sforceimports"],  # ensure versions declared in TruffleRuby
-        ["cd", "../sulong"],
-        ["mx", "sversions"],
-        ["mx", "build"],
-        ["cd", "../main"],
-      ],
     },
 
     truffleruby: {

--- a/ci.jsonnet
+++ b/ci.jsonnet
@@ -74,12 +74,6 @@ local part_definitions = {
       ],
     },
 
-    sulong: {
-      environment+: {
-        LD_LIBRARY_PATH: "$LLVM/lib:$LD_LIBRARY_PATH",
-      },
-    },
-
     truffleruby: {
       "$.benchmark.server":: { options: [] },
       environment+: {
@@ -575,13 +569,11 @@ local composition_environment = utils.add_inclusion_tracking(part_definitions, "
 
       "ruby-lint": linux_gate + $.run.lint + { timelimit: "30:00" },  # timilimit override
       "ruby-test-tck": linux_gate + $.use.build + { run+: [["mx", "rubytck"]] },
-      "ruby-test-mri": $.cap.fast_cpu + linux_gate +
-                       $.use.build + $.use.sulong + # OpenSSL is required to run RubyGems tests
-                       $.run.test_mri,
-      "ruby-test-integration": linux_gate + $.use.build + $.use.sulong + $.run.test_integration,
-      "ruby-test-cexts": linux_gate + $.use.build + $.use.sulong + $.use.gem_test_pack + $.run.test_cexts,
+      "ruby-test-mri": $.cap.fast_cpu + linux_gate + $.use.build + $.run.test_mri,
+      "ruby-test-integration": linux_gate + $.use.build + $.run.test_integration,
+      "ruby-test-cexts": linux_gate + $.use.build + $.use.gem_test_pack + $.run.test_cexts,
       "ruby-test-gems": linux_gate + $.use.build + $.use.gem_test_pack + $.run.test_gems,
-      "ruby-test-ecosystem": linux_gate + $.use.build + $.use.sulong + $.use.gem_test_pack + $.run.test_ecosystem,
+      "ruby-test-ecosystem": linux_gate + $.use.build + $.use.gem_test_pack + $.run.test_ecosystem,
 
       "ruby-test-compiler-graal-core": linux_gate + $.use.build + $.use.truffleruby + $.graal.core +
                                        $.run.test_compiler,
@@ -681,9 +673,9 @@ local composition_environment = utils.add_inclusion_tracking(part_definitions, "
       local chunky = $.benchmark.runner + $.benchmark.chunky + { timelimit: "01:00:00" },
       "ruby-benchmarks-chunky-mri": shared + chunky + other_rubies.mri,
       "ruby-benchmarks-chunky-jruby": shared + chunky + other_rubies.jruby,
-      "ruby-benchmarks-chunky-graal-core": shared + chunky + $.use.sulong + graal_configurations["graal-core"],
-      "ruby-benchmarks-chunky-graal-enterprise": shared + chunky + $.use.sulong + graal_configurations["graal-enterprise"],
-      "ruby-benchmarks-chunky-graal-enterprise-no-om": shared + chunky + $.use.sulong + graal_configurations["graal-enterprise-no-om"],
+      "ruby-benchmarks-chunky-graal-core": shared + chunky + graal_configurations["graal-core"],
+      "ruby-benchmarks-chunky-graal-enterprise": shared + chunky + graal_configurations["graal-enterprise"],
+      "ruby-benchmarks-chunky-graal-enterprise-no-om": shared + chunky + graal_configurations["graal-enterprise-no-om"],
       local psd = $.benchmark.runner + $.benchmark.psd + { timelimit: "02:00:00" },
       "ruby-benchmarks-psd-mri": shared + psd + other_rubies.mri,
       "ruby-benchmarks-psd-jruby": shared + psd + other_rubies.jruby,
@@ -736,7 +728,7 @@ local composition_environment = utils.add_inclusion_tracking(part_definitions, "
       "ruby-benchmarks-cext":
         $.platform.linux + $.jdk.labsjdk8 + $.use.common +
         $.use.truffleruby + $.use.truffleruby_cexts +
-        $.use.build + $.use.sulong + $.graal.core + $.use.gem_test_pack +
+        $.use.build + $.graal.core + $.use.gem_test_pack +
         $.cap.bench + $.cap.daily +
         $.benchmark.runner + $.benchmark.cext_chunky +
         { timelimit: "02:00:00" },

--- a/ci.jsonnet
+++ b/ci.jsonnet
@@ -146,6 +146,7 @@ local part_definitions = {
 
   graal: {
     core: {
+      is_after+:: ["$.use.build"],
       setup+: [
         ["cd", "../graal/compiler"],
         ["mx", "sversions"],
@@ -169,8 +170,8 @@ local part_definitions = {
     },
 
     enterprise: {
-      # Otherwise sulong will change runtime truffle version
-      is_after_optional+:: ["$.use.sulong"],
+      # Otherwise the TruffleRuby build will change the runtime Truffle version
+      is_after+:: ["$.use.build"],
       setup+: [
         [
           "git",
@@ -206,8 +207,6 @@ local part_definitions = {
   svm: {
     core: {
       is_after+:: ["$.use.build"],
-      # Otherwise sulong will change runtime truffle version
-      is_after_optional+:: ["$.use.sulong"],
 
       setup+: [
         ["cd", "../graal/substratevm"],
@@ -228,9 +227,8 @@ local part_definitions = {
     },
 
     enterprise: {
+      # Otherwise the TruffleRuby build will change the runtime Truffle version
       is_after+:: ["$.use.build"],
-      # Otherwise sulong will change runtime truffle version
-      is_after_optional+:: ["$.use.sulong"],
 
       setup+: [
         [

--- a/ci.jsonnet
+++ b/ci.jsonnet
@@ -70,7 +70,7 @@ local part_definitions = {
     build: {
       setup+: [
         ["mx", "sversions"],
-        ["mx", "build", "--force-javac", "--warning-as-error"],
+        ["mx", "build", "--force-javac", "--warning-as-error"] + self["$.use.build"].extra_args,
       ],
     },
 
@@ -311,6 +311,7 @@ local part_definitions = {
   platform: {
     linux: {
       local build = self,
+      "$.use.build":: { extra_args: [] },
       "$.run.deploy_and_spec":: { test_spec_options: ["-Gci"] },
       "$.cap":: {
         normal_machine: ["linux", "amd64"],
@@ -324,6 +325,7 @@ local part_definitions = {
       },
     },
     darwin: {
+      "$.use.build":: { extra_args: [] },
       "$.run.deploy_and_spec":: { test_spec_options: ["-GdarwinCI"] },
       "$.cap":: {
         normal_machine: ["darwin_sierra", "amd64"],
@@ -336,6 +338,10 @@ local part_definitions = {
       },
     },
     solaris: {
+      "$.use.build":: {
+        # Sulong cannot be built on Solaris, so only build the TruffleRuby distributions
+        extra_args: ["--dependencies", "TRUFFLERUBY,TRUFFLERUBY-LAUNCHER,TRUFFLERUBY-ZIP,TRUFFLERUBY-TEST,TRUFFLERUBY-SPECS"]
+      },
       "$.run.deploy_and_spec":: { test_spec_options: [] },
       "$.cap":: {
         normal_machine: ["solaris", "sparcv9"],

--- a/ci.jsonnet
+++ b/ci.jsonnet
@@ -75,17 +75,8 @@ local part_definitions = {
     },
 
     sulong: {
-      downloads+: {
-        LIBGMP: {
-          name: "libgmp",
-          version: "6.1.0",
-          platformspecific: true,
-        },
-      },
-
       environment+: {
-        CPPFLAGS: "-I$LIBGMP/include",
-        LD_LIBRARY_PATH: "$LIBGMP/lib:$LLVM/lib:$LD_LIBRARY_PATH",
+        LD_LIBRARY_PATH: "$LLVM/lib:$LD_LIBRARY_PATH",
       },
     },
 

--- a/doc/contributor/make-distribution.md
+++ b/doc/contributor/make-distribution.md
@@ -41,9 +41,7 @@ When asked which Java to use by `mx`, select the system OpenJDK.
 
 ```bash
 $ ./tool/make-distribution.sh ../../truffleruby-releases minimal
-$ ./tool/make-distribution.sh ../../truffleruby-releases graal
-$ ./tool/make-distribution.sh ../../truffleruby-releases sulong
-# full is Graal + Sulong
+# full is Graal + JVM
 $ ./tool/make-distribution.sh ../../truffleruby-releases full
 ```
 

--- a/doc/contributor/workflow.md
+++ b/doc/contributor/workflow.md
@@ -77,15 +77,6 @@ Note that build information such as the date and Git revision hash will not be
 updated when you build for a second time. Releases should always be built from
 scratch.
 
-## Sulong
-
-TruffleRuby runs C extension using Sulong. You should build Sulong from source.
-You can clone Sulong and build it with:
-
-```bash
-jt build sulong
-```
-
 ## Testing
 
 We have 'specs' which come from the Ruby Spec Suite. These are usually high

--- a/doc/user/distribution.md
+++ b/doc/user/distribution.md
@@ -5,8 +5,7 @@ for running TruffleRuby. GraalVM also includes other languages like JavaScript,
 R and Python. However, GraalVM currently requires a click-through license and
 is distributed under the OTN license.
 
-Distributions of TruffleRuby with or without Sulong
-and with or without Graal are also made available on the
+Distributions of TruffleRuby *for testing* are made available on the
 [Releases page](https://github.com/oracle/truffleruby/releases).
 
 Currently, these distributions are limited to Linux as we do not know a way to
@@ -31,4 +30,5 @@ $ ruby -v
 # => truffleruby
 ```
 
-The minimal distribution only needs JRE 8, curl and bash.
+The minimal distribution needs JRE 8, [LLVM](installing-llvm.md),
+[libssl](installing-libssl.md), curl and bash.

--- a/mx.truffleruby/suite.py
+++ b/mx.truffleruby/suite.py
@@ -13,6 +13,14 @@ suite = {
                     {"url": "https://curio.ssw.jku.at/nexus/content/repositories/snapshots", "kind": "binary"},
                 ]
             },
+            {
+                "name": "sulong",
+                "version": "f997ffd41955ac79efaa140639bd8ff310d651aa",
+                "urls": [
+                    {"url": "https://github.com/graalvm/sulong.git", "kind": "git"},
+                    {"url": "https://curio.ssw.jku.at/nexus/content/repositories/snapshots", "kind": "binary"},
+                ]
+            },
         ],
     },
 

--- a/tool/docker/fedora/Dockerfile
+++ b/tool/docker/fedora/Dockerfile
@@ -42,10 +42,6 @@ RUN git clone https://github.com/oracle/graal.git
 RUN cd graal/compiler && mx build
 ENV GRAAL_HOME=/build/graal/compiler
 
-# Build Sulong
-RUN git clone https://github.com/graalvm/sulong.git
-RUN cd sulong && mx build
-
 # Build TruffleRuby
 RUN git clone https://github.com/oracle/truffleruby.git
 RUN cd truffleruby && mx build

--- a/tool/docker/oraclelinux/Dockerfile
+++ b/tool/docker/oraclelinux/Dockerfile
@@ -43,10 +43,6 @@ RUN git clone --depth 1 https://github.com/oracle/graal.git
 RUN cd graal/compiler && mx build
 ENV GRAAL_HOME=/build/graal/compiler
 
-# Build Sulong
-RUN git clone https://github.com/graalvm/sulong.git
-RUN cd sulong && mx build
-
 # Build TruffleRuby
 RUN git clone https://github.com/oracle/truffleruby.git
 RUN cd truffleruby && mx build

--- a/tool/docker/ubuntu/Dockerfile
+++ b/tool/docker/ubuntu/Dockerfile
@@ -46,10 +46,6 @@ RUN git clone https://github.com/oracle/graal.git
 RUN cd graal/compiler && mx build
 ENV GRAAL_HOME=/build/graal/compiler
 
-# Build Sulong
-RUN git clone https://github.com/graalvm/sulong.git
-RUN cd sulong && mx build
-
 # Build TruffleRuby
 RUN git clone https://github.com/oracle/truffleruby.git
 RUN cd truffleruby && mx build

--- a/tool/jt.rb
+++ b/tool/jt.rb
@@ -56,33 +56,6 @@ end
 # wait for sub-processes to handle the interrupt
 trap(:INT) {}
 
-class MxSuite
-  attr_reader :name, :dir
-  def initialize(name, dir)
-    @name = name
-    @dir = dir
-    @mx_dir = "#{dir}/mx.#{name}"
-  end
-
-  def env_file
-    "#{@mx_dir}/env"
-  end
-
-  def binary_suites
-    return [] unless File.exist?(env_file)
-    line = File.readlines(env_file).find { |line| line.start_with? 'MX_BINARY_SUITES=' }
-    return [] unless line
-    line[/^MX_BINARY_SUITES=(.+)/, 1].split(',')
-  end
-
-  def binary_suite?(suite)
-    binary_suites.include?(suite)
-  end
-end
-
-TRUFFLERUBY = MxSuite.new('truffleruby', TRUFFLERUBY_DIR)
-SULONG = MxSuite.new('sulong', File.expand_path('../sulong', TRUFFLERUBY_DIR))
-
 module Utilities
   def self.truffle_version
     suite = File.read("#{TRUFFLERUBY_DIR}/mx.truffleruby/suite.py")

--- a/tool/jt.rb
+++ b/tool/jt.rb
@@ -398,10 +398,6 @@ module ShellUtils
     raw_sh Utilities.find_mx, *args
   end
 
-  def mx_sulong(*args)
-    mx '--dynamicimports', 'sulong', *args
-  end
-
   def mspec(command, *args)
     env_vars = {}
     if command.is_a?(Hash)
@@ -1060,7 +1056,7 @@ module Commands
         end
 
         sh 'clang', '-c', '-emit-llvm', *openssl_cflags, 'test/truffle/cexts/xopenssl/main.c', '-o', 'test/truffle/cexts/xopenssl/main.bc'
-        out, _ = mx_sulong('lli', "-Dpolyglot.llvm.libraries=#{openssl_lib}", 'test/truffle/cexts/xopenssl/main.bc', capture: true)
+        out, _ = mx('lli', "-Dpolyglot.llvm.libraries=#{openssl_lib}", 'test/truffle/cexts/xopenssl/main.bc', capture: true)
         raise out.inspect unless out == "5d41402abc4b2a76b9719d911017c592\n"
 
       when 'minimum', 'method', 'module', 'globals', 'backtraces', 'xopenssl'

--- a/tool/jt.rb
+++ b/tool/jt.rb
@@ -518,9 +518,15 @@ module Commands
       build_native_image(*options)
     when nil
       mx 'sforceimports'
+
+      # Do not build Sulong if TRUFFLERUBY_CEXT_ENABLED is "false"
+      if ENV["TRUFFLERUBY_CEXT_ENABLED"] == "false"
+        extra_args = %w[--dependencies TRUFFLERUBY,TRUFFLERUBY-LAUNCHER,TRUFFLERUBY-ZIP,TRUFFLERUBY-TEST,TRUFFLERUBY-SPECS]
+      end
+
       mx 'build', '--force-javac', '--warning-as-error',
          # show more than default 100 errors not to hide actual errors under pile of missing symbols
-         '-A-Xmaxerrs', '-A1000'
+         '-A-Xmaxerrs', '-A1000', *extra_args
     else
       raise ArgumentError, project
     end


### PR DESCRIPTION
This means `mx build` and `jt build` will also build Sulong.

* Sulong is now always built (except on Solaris where it doesn't build).
* SVM images are still built with Sulong only when asked, it is a separate concern.
* Cleanup redundant logic in `jt` and remove `jt build sulong`.
* This PR keeps an explicit Truffle dependency to be simple, we can try removing it separately.