### PR TITLE
No extra spacing around assignment

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -322,6 +322,14 @@ Style/CaseIndentation:
   Enabled: true
   EnforcedStyle: 'end'
 
+# Supports --auto-correct
+Style/ExtraSpacing:
+  Description: 'Disallow extra horizontal spacing, e.g., around = and before comments.
+    Avoids changing unrelated lines and making lines longer than needed.'
+  Enabled: true
+  AllowForAlignment: false
+  ForceEqualSignAlignment: false
+
 Style/IndentationConsistency:
   Enabled: true
 

--- a/lib/cext/linker.rb
+++ b/lib/cext/linker.rb
@@ -33,7 +33,7 @@ module Truffle::CExt
           raise '-L needs to be followed by a directory name' if argv.empty?
           search_paths << argv.shift
         when /\A-L(.+)\z/ # -L/libdir as a single argument
-          search_paths <<  $1
+          search_paths << $1
         else
           if arg.start_with?('-')
             raise "Unknown argument: #{arg}"

--- a/lib/truffle/bigdecimal.rb
+++ b/lib/truffle/bigdecimal.rb
@@ -12,27 +12,27 @@ class Truffle::BigDecimal < Numeric
   BASE = 10_000
 
   SIGN_NEGATIVE_INFINITE = -3
-  SIGN_NEGATIVE_FINITE   = -2
-  SIGN_NEGATIVE_ZERO     = -1
-  SIGN_NaN               = 0
-  SIGN_POSITIVE_ZERO     = 1
-  SIGN_POSITIVE_FINITE   = 2
+  SIGN_NEGATIVE_FINITE = -2
+  SIGN_NEGATIVE_ZERO = -1
+  SIGN_NaN = 0
+  SIGN_POSITIVE_ZERO = 1
+  SIGN_POSITIVE_FINITE = 2
   SIGN_POSITIVE_INFINITE = 3
 
-  EXCEPTION_INFINITY   = 1
-  EXCEPTION_OVERFLOW   = 1
-  EXCEPTION_NaN        = 2
-  EXCEPTION_UNDERFLOW  = 4
+  EXCEPTION_INFINITY = 1
+  EXCEPTION_OVERFLOW = 1
+  EXCEPTION_NaN = 2
+  EXCEPTION_UNDERFLOW = 4
   EXCEPTION_ZERODIVIDE = 16
-  EXCEPTION_ALL        = 255
-  ROUND_MODE           = 256
+  EXCEPTION_ALL = 255
+  ROUND_MODE = 256
 
-  ROUND_UP        = 1
-  ROUND_DOWN      = 2
-  ROUND_HALF_UP   = 3
+  ROUND_UP = 1
+  ROUND_DOWN = 2
+  ROUND_HALF_UP = 3
   ROUND_HALF_DOWN = 4
-  ROUND_CEILING   = 5
-  ROUND_FLOOR     = 6
+  ROUND_CEILING = 5
+  ROUND_FLOOR = 6
   ROUND_HALF_EVEN = 7
 
   def self.mode(key, value = nil)
@@ -65,7 +65,7 @@ class Truffle::BigDecimal < Numeric
     Thread.current[:'BigDecimal.precision_limit'] ||= 0
     if limit
       raise ArgumentError, 'requires key to be Fixnum' unless limit.is_a? Fixnum
-      old                                           = Thread.current[:'BigDecimal.precision_limit']
+      old = Thread.current[:'BigDecimal.precision_limit']
       Thread.current[:'BigDecimal.precision_limit'] = limit
       old
     else
@@ -201,30 +201,30 @@ class Truffle::BigDecimal < Numeric
 
   def to_s(format = 'E')
     if finite?
-      float_format    = format[-1] == 'F'
+      float_format = format[-1] == 'F'
       space_frequency = format.to_i
-      prefix          = if self > 0 && [' ', '+'].include?(format[0])
-                          format[0]
-                        elsif self < 0
-                          '-'
-                        else
-                          ''
-                        end
-      unscaled_value  = unscaled
-      exponent_value  = exponent
+      prefix = if self > 0 && [' ', '+'].include?(format[0])
+                 format[0]
+               elsif self < 0
+                 '-'
+               else
+                 ''
+               end
+      unscaled_value = unscaled
+      exponent_value = exponent
 
       if float_format
         case
         when exponent_value > unscaled_value.size
           before_dot = unscaled_value + '0' * (exponent_value - unscaled_value.size)
-          after_dot  = '0'
+          after_dot = '0'
         when exponent_value <= 0
           before_dot = '0'
-          after_dot  = '0' * exponent_value.abs + unscaled_value
+          after_dot = '0' * exponent_value.abs + unscaled_value
         else
           before_dot = unscaled_value[0...exponent_value]
-          rest       = unscaled_value[exponent_value..-1]
-          after_dot  = rest.empty? ? '0' : rest
+          rest = unscaled_value[exponent_value..-1]
+          after_dot = rest.empty? ? '0' : rest
         end
 
         format '%s%s.%s',
@@ -269,8 +269,8 @@ class Truffle::BigDecimal < Numeric
     return string if space_frequency == 0
 
     remainder = string.size % space_frequency
-    shift     = reverse ? remainder : 0
-    pieces    = (string.size / space_frequency).times.map { |i| string[space_frequency*i + shift, space_frequency] }
+    shift = reverse ? remainder : 0
+    pieces = (string.size / space_frequency).times.map { |i| string[space_frequency*i + shift, space_frequency] }
 
     if remainder > 0
       if reverse

--- a/lib/truffle/date.rb
+++ b/lib/truffle/date.rb
@@ -298,34 +298,34 @@ class Date
 
   # The Julian Day Number of the Day of Calendar Reform for Italy
   # and the Catholic countries.
-  ITALY     = 2299161 # 1582-10-15
+  ITALY = 2299161 # 1582-10-15
 
   # The Julian Day Number of the Day of Calendar Reform for England
   # and her Colonies.
-  ENGLAND   = 2361222 # 1752-09-14
+  ENGLAND = 2361222 # 1752-09-14
 
   # A constant used to indicate that a Date should always use the
   # Julian calendar.
-  JULIAN    =  Infinity.new
+  JULIAN = Infinity.new
 
   # A constant used to indicate that a Date should always use the
   # Gregorian calendar.
   GREGORIAN = -Infinity.new
 
-  HALF_DAYS_IN_DAY       = Rational(1, 2) # :nodoc:
-  HOURS_IN_DAY           = Rational(1, 24) # :nodoc:
-  MINUTES_IN_DAY         = Rational(1, 1440) # :nodoc:
-  SECONDS_IN_DAY         = Rational(1, 86400) # :nodoc:
-  MILLISECONDS_IN_DAY    = Rational(1, 86400*10**3) # :nodoc:
-  NANOSECONDS_IN_DAY     = Rational(1, 86400*10**9) # :nodoc:
+  HALF_DAYS_IN_DAY = Rational(1, 2) # :nodoc:
+  HOURS_IN_DAY = Rational(1, 24) # :nodoc:
+  MINUTES_IN_DAY = Rational(1, 1440) # :nodoc:
+  SECONDS_IN_DAY = Rational(1, 86400) # :nodoc:
+  MILLISECONDS_IN_DAY = Rational(1, 86400*10**3) # :nodoc:
+  NANOSECONDS_IN_DAY = Rational(1, 86400*10**9) # :nodoc:
   MILLISECONDS_IN_SECOND = Rational(1, 10**3) # :nodoc:
-  NANOSECONDS_IN_SECOND  = Rational(1, 10**9) # :nodoc:
+  NANOSECONDS_IN_SECOND = Rational(1, 10**9) # :nodoc:
 
-  MJD_EPOCH_IN_AJD       = Rational(4800001, 2) # 1858-11-17 # :nodoc:
-  UNIX_EPOCH_IN_AJD      = Rational(4881175, 2) # 1970-01-01 # :nodoc:
-  MJD_EPOCH_IN_CJD       = 2400001 # :nodoc:
-  UNIX_EPOCH_IN_CJD      = 2440588 # :nodoc:
-  LD_EPOCH_IN_CJD        = 2299160 # :nodoc:
+  MJD_EPOCH_IN_AJD = Rational(4800001, 2) # 1858-11-17 # :nodoc:
+  UNIX_EPOCH_IN_AJD = Rational(4881175, 2) # 1970-01-01 # :nodoc:
+  MJD_EPOCH_IN_CJD = 2400001 # :nodoc:
+  UNIX_EPOCH_IN_CJD = 2440588 # :nodoc:
+  LD_EPOCH_IN_CJD = 2299160 # :nodoc:
 
   t = Module.new do
 
@@ -515,9 +515,9 @@ class Date
     # Convert a fractional day +fr+ to [hours, minutes, seconds,
     # fraction_of_a_second]
     def day_fraction_to_time(fr) # :nodoc:
-      ss,  fr = fr.divmod(SECONDS_IN_DAY) # 4p
-      h,   ss = ss.divmod(3600)
-      min, s  = ss.divmod(60)
+      ss, fr = fr.divmod(SECONDS_IN_DAY) # 4p
+      h, ss = ss.divmod(3600)
+      min, s = ss.divmod(60)
       [h, min, s, fr * 86400]
     end
 
@@ -557,11 +557,11 @@ class Date
 
     # Convert a count of the number of days since the adoption
     # of the Gregorian Calendar (in Italy) to a Julian Day Number.
-    def ld_to_jd(ld) ld +  LD_EPOCH_IN_CJD end # :nodoc:
+    def ld_to_jd(ld) ld + LD_EPOCH_IN_CJD end # :nodoc:
 
     # Convert a Julian Day Number to the number of days since
     # the adoption of the Gregorian Calendar (in Italy).
-    def jd_to_ld(jd) jd -  LD_EPOCH_IN_CJD end # :nodoc:
+    def jd_to_ld(jd) jd - LD_EPOCH_IN_CJD end # :nodoc:
 
     # Convert a Julian Day Number to the day of the week.
     #
@@ -677,7 +677,7 @@ class Date
       end
       if n < 0
         ny, nm = (y * 12 + m).divmod(12)
-        nm,    = (nm + 1)    .divmod(1)
+        nm, = (nm + 1) .divmod(1)
         ny, nm, nn, _ =
           jd_to_nth_kday(nth_kday_to_jd(ny, nm, 1, k, sg) + n * 7, sg)
         return unless [ny, nm] == [y, m]
@@ -699,9 +699,9 @@ class Date
     # wraparound is performed.
     def _valid_time? (h, min, s) # :nodoc:
       return unless h.is_a?(Integer) && min.is_a?(Integer)
-      h   += 24 if h   < 0
+      h += 24 if h < 0
       min += 60 if min < 0
-      s   += 60 if s   < 0
+      s += 60 if s < 0
       return unless ((0...24) === h &&
                      (0...60) === min &&
                      (0...60) === s) ||
@@ -713,7 +713,7 @@ class Date
 
   end
 
-  extend  t
+  extend t
   include t
 
   # Is a year a leap year in the Julian calendar?
@@ -859,10 +859,10 @@ class Date
     elem ||= {}
     if seconds = elem[:seconds]
       seconds += elem[:offset] if elem[:offset]
-      d,   fr = seconds.divmod(86400)
-      h,   fr = fr.divmod(3600)
+      d, fr = seconds.divmod(86400)
+      h, fr = fr.divmod(3600)
       min, fr = fr.divmod(60)
-      s,   fr = fr.divmod(1)
+      s, fr = fr.divmod(1)
       elem[:jd] = UNIX_EPOCH_IN_CJD + d
       elem[:hour] = h
       elem[:min] = min
@@ -906,7 +906,7 @@ class Date
           break if elem[e]
           elem[e] = d.__send__(e)
         end
-        elem[:mon]  ||= 1
+        elem[:mon] ||= 1
         elem[:mday] ||= 1
       when :commercial
         g[1].each do |e|
@@ -923,14 +923,14 @@ class Date
           elem[e] = d.__send__(e)
         end
         elem[:wnum0] ||= 0
-        elem[:wday]  ||= 0
+        elem[:wday] ||= 0
       when :wnum1
         g[1].each do |e|
           break if elem[e]
           elem[e] = d.__send__(e)
         end
         elem[:wnum1] ||= 0
-        elem[:wday]  ||= 1
+        elem[:wday] ||= 1
       end
     end
 
@@ -942,8 +942,8 @@ class Date
     end
 
     elem[:hour] ||= 0
-    elem[:min]  ||= 0
-    elem[:sec]  ||= 0
+    elem[:min] ||= 0
+    elem[:sec] ||= 0
     elem[:sec] = elem[:sec] == 60 ? 59 : elem[:sec]
 
     elem
@@ -1356,7 +1356,7 @@ class Date
   def - (x)
     case x
     when Numeric; return self.class.new!(@ajd - x, @of, @sg)
-    when Date;    return @ajd - x.ajd
+    when Date; return @ajd - x.ajd
     end
     raise TypeError, 'expected numeric or date'
   end
@@ -1375,7 +1375,7 @@ class Date
   def <=> (other)
     case other
     when Numeric; return @ajd <=> other
-    when Date;    return @ajd <=> other.ajd
+    when Date; return @ajd <=> other.ajd
     else
       begin
         l, r = other.coerce(self)
@@ -1395,7 +1395,7 @@ class Date
   def === (other)
     case other
     when Numeric; return jd == other
-    when Date;    return jd == other.jd
+    when Date; return jd == other.jd
     else
       begin
         l, r = other.coerce(self)
@@ -1422,7 +1422,7 @@ class Date
   # of the returned Date will be the last day of the target month.
   def >> (n)
     y, m = (year * 12 + (mon - 1) + n).divmod(12)
-    m,   = (m + 1)                    .divmod(1)
+    m, = (m + 1) .divmod(1)
     d = mday
     until jd2 = _valid_civil?(y, m, d, @sg)
       d -= 1
@@ -1849,6 +1849,6 @@ class DateTime < Date
   def to_datetime() self end
 
   private_class_method :today
-  public_class_method  :now
+  public_class_method :now
 
 end

--- a/lib/truffle/date/delta.rb
+++ b/lib/truffle/date/delta.rb
@@ -110,8 +110,8 @@ class Date
 
     def self.delta_to_dhms(delta)
       fr = delta.imag.abs
-      y,   fr = fr.divmod(12)
-      m,   _ = fr.divmod(1)
+      y, fr = fr.divmod(12)
+      m, _ = fr.divmod(1)
 
       if delta.imag < 0
         y = -y
@@ -119,10 +119,10 @@ class Date
       end
 
       fr = delta.real.abs
-      ss,  fr = fr.divmod(SECONDS_IN_DAY) # 4p
-      d,   ss = ss.divmod(86400)
-      h,   ss = ss.divmod(3600)
-      min, s  = ss.divmod(60)
+      ss, fr = fr.divmod(SECONDS_IN_DAY) # 4p
+      d, ss = ss.divmod(86400)
+      h, ss = ss.divmod(3600)
+      min, s = ss.divmod(60)
 
       if delta.real < 0
         d = -d
@@ -320,7 +320,7 @@ class Date
       end
       case other
       when Numeric; return @delta.real <=> other
-      when Delta;   return @delta.real <=> other.delta.real
+      when Delta; return @delta.real <=> other.delta.real
       else
         begin
           l, r = other.coerce(self)
@@ -334,7 +334,7 @@ class Date
     def == (other)
       case other
       when Numeric; return @delta == other
-      when Delta;   return @delta == other
+      when Delta; return @delta == other
       else
         begin
           l, r = other.coerce(self)
@@ -418,7 +418,7 @@ class Date
   def - (x)
     case x
     when Numeric; return self.class.new!(@ajd - x, @of, @sg)
-    when Date;    return @ajd - x.ajd
+    when Date; return @ajd - x.ajd
     when Delta
       d = x.__send__(:delta)
       return (self << d.imag) - d.real

--- a/lib/truffle/ffi.rb
+++ b/lib/truffle/ffi.rb
@@ -14,10 +14,10 @@ module FFI
   Platform = Truffle::FFI::Platform
 
   class DynamicLibrary
-    RTLD_LAZY   = Truffle::Config['platform.dlopen.RTLD_LAZY']
-    RTLD_NOW    = Truffle::Config['platform.dlopen.RTLD_NOW']
+    RTLD_LAZY = Truffle::Config['platform.dlopen.RTLD_LAZY']
+    RTLD_NOW = Truffle::Config['platform.dlopen.RTLD_NOW']
     RTLD_GLOBAL = Truffle::Config['platform.dlopen.RTLD_GLOBAL']
-    RTLD_LOCAL  = Truffle::Config['platform.dlopen.RTLD_LOCAL']
+    RTLD_LOCAL = Truffle::Config['platform.dlopen.RTLD_LOCAL']
 
     attr_reader :name
 
@@ -58,9 +58,9 @@ module FFI
 
     # Indicies are based on the NativeTypes enum
     TO_NFI_TYPE = [
-      'SINT8',  # char
-      'UINT8',  # uchar
-      'UINT8',  # bool
+      'SINT8', # char
+      'UINT8', # uchar
+      'UINT8', # bool
       'SINT16', # short
       'UINT16', # ushort
       'SINT32', # int
@@ -69,10 +69,10 @@ module FFI
       'UINT64', # ulong
       'SINT64', # ll
       'UINT64', # ull
-      'FLOAT',  # float
+      'FLOAT', # float
       'DOUBLE', # double
       'POINTER',# ptr
-      'VOID',   # void
+      'VOID', # void
       'STRING', # string
       # strptr
       # chararr

--- a/lib/truffle/java/env_java.rb
+++ b/lib/truffle/java/env_java.rb
@@ -28,7 +28,7 @@ module Java
     end
 
     def to_s
-      '{' + (self.map { |x| '"' + x[0].to_s + '"=>"' + x[1].to_s +  + '"' }).join(', ') + '}'
+      '{' + (self.map { |x| '"' + x[0].to_s + '"=>"' + x[1].to_s + + '"' }).join(', ') + '}'
     end
 
     def inspect

--- a/lib/truffle/java/method_selector.rb
+++ b/lib/truffle/java/method_selector.rb
@@ -269,7 +269,7 @@ module JavaUtilities
       wide_type = temp_hash[w]
       widening_type = WideningType.new(prim_type, java_type, wide_type)
       temp_hash[t] = widening_type
-      WideningType::PrimitiveTypes.put_if_absent(prim_type,  widening_type)
+      WideningType::PrimitiveTypes.put_if_absent(prim_type, widening_type)
     end
   end
 
@@ -397,7 +397,7 @@ module JavaUtilities
       @callables = methods.map { |m| Callable.new(m) }
     end
 
-    def find_callable_candidates(args)  # list of arguments
+    def find_callable_candidates(args) # list of arguments
       methods = self.callables
       retained = methods # Need to handle the case where there are no arguments.
       (0...args.size).each do |i|

--- a/lib/truffle/pathname.rb
+++ b/lib/truffle/pathname.rb
@@ -769,7 +769,7 @@ class Pathname
   end
 end
 
-class Pathname    # * IO *
+class Pathname # * IO *
   #
   # #each_line iterates over the line in the file.  It yields a String object
   # for each line.
@@ -802,7 +802,7 @@ class Pathname    # * IO *
 end
 
 
-class Pathname    # * File *
+class Pathname # * File *
 
   # See <tt>File.atime</tt>.  Returns last access time.
   def atime() File.atime(@path) end
@@ -883,7 +883,7 @@ class Pathname    # * File *
 end
 
 
-class Pathname    # * FileTest *
+class Pathname # * FileTest *
 
   # See <tt>FileTest.blockdev?</tt>.
   def blockdev?() FileTest.blockdev?(@path) end
@@ -959,7 +959,7 @@ class Pathname    # * FileTest *
 end
 
 
-class Pathname    # * Dir *
+class Pathname # * Dir *
   # See <tt>Dir.glob</tt>.  Returns or yields Pathname objects.
   def Pathname.glob(*args) # :yield: pathname
     if block_given?
@@ -998,7 +998,7 @@ class Pathname    # * Dir *
 end
 
 
-class Pathname    # * Find *
+class Pathname # * Find *
   #
   # Pathname#find is an iterator to traverse a directory tree in a depth first
   # manner.  It yields a Pathname for each file under "this" directory.
@@ -1020,7 +1020,7 @@ class Pathname    # * Find *
 end
 
 
-class Pathname    # * FileUtils *
+class Pathname # * FileUtils *
   # See <tt>FileUtils.mkpath</tt>.  Creates a full path, including any
   # intermediate directories that don't yet exist.
   def mkpath
@@ -1040,7 +1040,7 @@ class Pathname    # * FileUtils *
 end
 
 
-class Pathname    # * mixed *
+class Pathname # * mixed *
   # Removes a file or directory, using <tt>File.unlink</tt> or
   # <tt>Dir.unlink</tt> as necessary.
   def unlink()

--- a/lib/truffle/rbconfig-for-mkmf.rb
+++ b/lib/truffle/rbconfig-for-mkmf.rb
@@ -39,12 +39,12 @@ end
 
 opt_passes = ['-always-inline', '-mem2reg', '-constprop'].join(' ')
 linkflags = [
-  '-g',                              # Show debug information such as line numbers in backtrace
+  '-g', # Show debug information such as line numbers in backtrace
   '-Wimplicit-function-declaration', # To make missing C ext functions clear
-  '-Wno-unknown-warning-option',     # If we're on an earlier version of clang without a warning option, ignore it
-  '-Wno-int-conversion',             # MRI has VALUE defined as long while we have it as void*
-  '-Wno-int-to-pointer-cast',        # Same as above
-  '-Wno-unused-value',               # RB_GC_GUARD leaves
+  '-Wno-unknown-warning-option', # If we're on an earlier version of clang without a warning option, ignore it
+  '-Wno-int-conversion', # MRI has VALUE defined as long while we have it as void*
+  '-Wno-int-to-pointer-cast', # Same as above
+  '-Wno-unused-value', # RB_GC_GUARD leaves
   '-Wno-incompatible-pointer-types', # Fix byebug 8.2.1 compile (st_data_t error)
   '-ferror-limit=500'
 ].join(' ')
@@ -71,10 +71,10 @@ common = {
 expanded.merge!(common)
 mkconfig.merge!(common)
 
-mkconfig['COMPILE_C']   = "ruby #{cext_dir}/preprocess.rb $< | $(CC) $(INCFLAGS) $(CPPFLAGS) $(CFLAGS) $(COUTFLAG) -xc - -o $@ && #{opt} #{opt_passes} $@ -o $@"
+mkconfig['COMPILE_C'] = "ruby #{cext_dir}/preprocess.rb $< | $(CC) $(INCFLAGS) $(CPPFLAGS) $(CFLAGS) $(COUTFLAG) -xc - -o $@ && #{opt} #{opt_passes} $@ -o $@"
 mkconfig['COMPILE_CXX'] = "ruby #{cext_dir}/preprocess.rb $< | $(CXX) $(INCFLAGS) $(CPPFLAGS) $(CXXFLAGS) $(COUTFLAG) -xc++ - -o $@ && #{opt} #{opt_passes} $@ -o $@"
-mkconfig['LINK_SO']     = "#{RbConfig.ruby} -Xgraal.warn_unless=false #{cext_dir}/linker.rb -o $@ $(OBJS) $(LIBS)"
-mkconfig['TRY_LINK']    = "#{cc} -o conftest $(CPPFLAGS) #{cext_dir}/ruby.bc #{cext_dir}/trufflemock.bc $(src) $(INCFLAGS) #{linkflags} $(LIBS)"
+mkconfig['LINK_SO'] = "#{RbConfig.ruby} -Xgraal.warn_unless=false #{cext_dir}/linker.rb -o $@ $(OBJS) $(LIBS)"
+mkconfig['TRY_LINK'] = "#{cc} -o conftest $(CPPFLAGS) #{cext_dir}/ruby.bc #{cext_dir}/trufflemock.bc $(src) $(INCFLAGS) #{linkflags} $(LIBS)"
 
 %w[COMPILE_C COMPILE_CXX LINK_SO TRY_LINK].each do |key|
   expanded[key] = mkconfig[key].gsub(/\$\((\w+)\)/) { expanded.fetch($1, $&) }

--- a/lib/truffle/rbconfig.rb
+++ b/lib/truffle/rbconfig.rb
@@ -34,7 +34,7 @@
 
 module RbConfig
 
-  host_os  = Truffle::System.host_os
+  host_os = Truffle::System.host_os
   host_cpu = Truffle::System.host_cpu
   host_vendor = 'unknown'
   # Some config entries report linux-gnu rather than simply linux.
@@ -44,16 +44,16 @@ module RbConfig
     host_os_full = host_os
   end
   # Host should match the target triplet for clang or GCC, otherwise some C extension builds will fail.
-  host         = "#{host_cpu}-#{host_vendor}-#{host_os_full}"
+  host = "#{host_cpu}-#{host_vendor}-#{host_os_full}"
 
   ruby_install_name = 'truffleruby'
 
   ruby_base_name = 'ruby'
-  ruby_version   = Truffle::RUBY_BASE_VERSION
+  ruby_version = Truffle::RUBY_BASE_VERSION
 
-  arch         = "#{host_cpu}-#{host_os}"
-  cppflags     = ''
-  libs         = ''
+  arch = "#{host_cpu}-#{host_os}"
+  cppflags = ''
+  libs = ''
 
   # Sorted alphabetically using sort(1)
   CONFIG = {
@@ -183,10 +183,10 @@ module RbConfig
       if !(v = $1 || $2)
         '$'
       elsif key = config[v = v[/\A[^:]+(?=(?::(.*?)=(.*))?\z)/]]
-        pat, sub  = $1, $2
+        pat, sub = $1, $2
         config[v] = false
         config[v] = RbConfig.expand(key, config)
-        key       = key.gsub(/#{Regexp.quote(pat)}(?=\s|\z)/n) {sub} if pat
+        key = key.gsub(/#{Regexp.quote(pat)}(?=\s|\z)/n) {sub} if pat
         key
       else
         var

--- a/lib/truffle/securerandom.rb
+++ b/lib/truffle/securerandom.rb
@@ -255,7 +255,7 @@ module SecureRandom
     get_last_error = Win32API.new('kernel32', 'GetLastError', '', 'L')
     format_message = Win32API.new('kernel32', 'FormatMessageA', 'LPLLPLPPPPPPPP', 'L')
     format_message_ignore_inserts = 0x00000200
-    format_message_from_system    = 0x00001000
+    format_message_from_system = 0x00001000
 
     code = get_last_error.call
     msg = "\0" * 1024

--- a/lib/truffle/socket/addrinfo.rb
+++ b/lib/truffle/socket/addrinfo.rb
@@ -39,7 +39,7 @@ class Addrinfo
       lfamily, lport, lhost, laddress, _, lsocktype, lprotocol = pair
 
       sockaddr = Socket.pack_sockaddr_in(lport, laddress)
-      addr     = Addrinfo.new(sockaddr, lfamily, lsocktype, lprotocol)
+      addr = Addrinfo.new(sockaddr, lfamily, lsocktype, lprotocol)
 
       if flags and flags | Socket::AI_CANONNAME
         addr.instance_variable_set(:@canonname, lhost)
@@ -51,21 +51,21 @@ class Addrinfo
 
   def self.ip(ip)
     sockaddr = Socket.sockaddr_in(0, ip)
-    family   = Truffle::Socket.family_for_sockaddr_in(sockaddr)
+    family = Truffle::Socket.family_for_sockaddr_in(sockaddr)
 
     new(sockaddr, family)
   end
 
   def self.tcp(ip, port)
     sockaddr = Socket.sockaddr_in(port, ip)
-    pfamily  = Truffle::Socket.family_for_sockaddr_in(sockaddr)
+    pfamily = Truffle::Socket.family_for_sockaddr_in(sockaddr)
 
     new(sockaddr, pfamily, Socket::SOCK_STREAM, Socket::IPPROTO_TCP)
   end
 
   def self.udp(ip, port)
     sockaddr = Socket.sockaddr_in(port, ip)
-    pfamily  = Truffle::Socket.family_for_sockaddr_in(sockaddr)
+    pfamily = Truffle::Socket.family_for_sockaddr_in(sockaddr)
 
     new(sockaddr, pfamily, Socket::SOCK_DGRAM, Socket::IPPROTO_UDP)
   end
@@ -97,8 +97,8 @@ class Addrinfo
 
   def initialize(sockaddr, pfamily = nil, socktype = 0, protocol = 0)
     if sockaddr.kind_of?(Array)
-      @afamily    = Truffle::Socket.address_family(sockaddr[0])
-      @ip_port    = sockaddr[1]
+      @afamily = Truffle::Socket.address_family(sockaddr[0])
+      @ip_port = sockaddr[1]
       @ip_address = sockaddr[3]
 
       # When using AF_INET6 the protocol family can only be PF_INET6
@@ -108,7 +108,7 @@ class Addrinfo
     else
       if sockaddr.bytesize == Truffle::Socket::Foreign::SockaddrUn.size
         @unix_path = Socket.unpack_sockaddr_un(sockaddr)
-        @afamily   = Socket::AF_UNIX
+        @afamily = Socket::AF_UNIX
       else
         @ip_port, @ip_address = Socket.unpack_sockaddr_in(sockaddr)
 
@@ -458,8 +458,8 @@ class Addrinfo
   def marshal_load(array)
     afamily, address, pfamily, socktype, protocol, canonname = array
 
-    @afamily  = Truffle::Socket.address_family(afamily)
-    @pfamily  = Truffle::Socket.protocol_family(pfamily)
+    @afamily = Truffle::Socket.address_family(afamily)
+    @pfamily = Truffle::Socket.protocol_family(pfamily)
     @socktype = Truffle::Socket.socket_type(socktype)
 
     if protocol and protocol != 0
@@ -472,8 +472,8 @@ class Addrinfo
       @unix_path = address
     else
       @ip_address = address[0]
-      @ip_port    = address[1].to_i
-      @canonname  = canonname
+      @ip_port = address[1].to_i
+      @canonname = canonname
     end
   end
 end

--- a/lib/truffle/socket/ancillary_data.rb
+++ b/lib/truffle/socket/ancillary_data.rb
@@ -77,14 +77,14 @@ class Socket < BasicSocket
 
     def initialize(family, level, type, data)
       @family = Truffle::Socket.address_family(family)
-      @data   = Truffle::Socket.coerce_to_string(data)
-      @level  = Truffle::Socket::AncillaryData.level(level)
-      @type   = Truffle::Socket::AncillaryData.type(@family, @level, type)
+      @data = Truffle::Socket.coerce_to_string(data)
+      @level = Truffle::Socket::AncillaryData.level(level)
+      @type = Truffle::Socket::AncillaryData.type(@family, @level, type)
     end
 
     def cmsg_is?(level, type)
       level = Truffle::Socket::AncillaryData.level(level)
-      type  = Truffle::Socket::AncillaryData.type(@family, level, type)
+      type = Truffle::Socket::AncillaryData.type(@family, level, type)
 
       @level == level && @type == type
     end

--- a/lib/truffle/socket/basic_socket.rb
+++ b/lib/truffle/socket/basic_socket.rb
@@ -56,10 +56,10 @@ class BasicSocket < IO
 
   def getsockopt(level, optname)
     sockname = Truffle::Socket::Foreign.getsockname(descriptor)
-    family   = Truffle::Socket.family_for_sockaddr_in(sockname)
-    level    = Truffle::Socket::SocketOptions.socket_level(level, family)
-    optname  = Truffle::Socket::SocketOptions.socket_option(level, optname)
-    data     = Truffle::Socket::Foreign.getsockopt(descriptor, level, optname)
+    family = Truffle::Socket.family_for_sockaddr_in(sockname)
+    level = Truffle::Socket::SocketOptions.socket_level(level, family)
+    optname = Truffle::Socket::SocketOptions.socket_option(level, optname)
+    data = Truffle::Socket::Foreign.getsockopt(descriptor, level, optname)
 
     Socket::Option.new(family, level, optname, data)
   end
@@ -75,9 +75,9 @@ class BasicSocket < IO
     elsif level_or_option.is_a?(Socket::Option)
       raise(ArgumentError, 'given 2, expected 1') if optname
 
-      level   = level_or_option.level
+      level = level_or_option.level
       optname = level_or_option.optname
-      optval  = level_or_option.data
+      optval = level_or_option.data
     else
       raise TypeError,
         'expected the first argument to be a Fixnum, Symbol, String, or Socket::Option'
@@ -87,10 +87,10 @@ class BasicSocket < IO
     optval = 0 if optval == false
 
     sockname = Truffle::Socket::Foreign.getsockname(descriptor)
-    family   = Truffle::Socket.family_for_sockaddr_in(sockname)
-    level    = Truffle::Socket::SocketOptions.socket_level(level, family)
-    optname  = Truffle::Socket::SocketOptions.socket_option(level, optname)
-    error    = 0
+    family = Truffle::Socket.family_for_sockaddr_in(sockname)
+    level = Truffle::Socket::SocketOptions.socket_level(level, family)
+    optname = Truffle::Socket::SocketOptions.socket_option(level, optname)
+    error = 0
 
     if optval.is_a?(Fixnum)
       Truffle::Socket::Foreign.memory_pointer(:socklen_t) do |pointer|
@@ -124,7 +124,7 @@ class BasicSocket < IO
   end
 
   def send(message, flags, dest_sockaddr = nil)
-    bytes      = message.bytesize
+    bytes = message.bytesize
     bytes_sent = 0
 
     if dest_sockaddr.is_a?(Addrinfo)
@@ -178,9 +178,9 @@ class BasicSocket < IO
 
     loop do
       msg_buffer = Truffle::Socket::Foreign.char_pointer(msg_len)
-      address    = Truffle::Socket.sockaddr_class_for_socket(self).new
-      io_vec     = Truffle::Socket::Foreign::Iovec.with_buffer(msg_buffer)
-      header     = Truffle::Socket::Foreign::Msghdr.with_buffers(address, io_vec)
+      address = Truffle::Socket.sockaddr_class_for_socket(self).new
+      io_vec = Truffle::Socket::Foreign::Iovec.with_buffer(msg_buffer)
+      header = Truffle::Socket::Foreign::Msghdr.with_buffers(address, io_vec)
 
       begin
         need_more = false
@@ -224,9 +224,9 @@ class BasicSocket < IO
 
   def sendmsg(message, flags = 0, dest_sockaddr = nil, *_)
     msg_buffer = Truffle::Socket::Foreign.char_pointer(message.bytesize)
-    io_vec     = Truffle::Socket::Foreign::Iovec.with_buffer(msg_buffer)
-    header     = Truffle::Socket::Foreign::Msghdr.new
-    address    = nil
+    io_vec = Truffle::Socket::Foreign::Iovec.with_buffer(msg_buffer)
+    header = Truffle::Socket::Foreign::Msghdr.new
+    address = nil
 
     begin
       msg_buffer.write_string(message)

--- a/lib/truffle/socket/ifaddr.rb
+++ b/lib/truffle/socket/ifaddr.rb
@@ -29,13 +29,13 @@ class Socket < BasicSocket
     attr_reader :addr, :broadaddr, :dstaddr, :flags, :ifindex, :name, :netmask
 
     def initialize(addr: nil, broadaddr: nil, dstaddr: nil, flags: nil, ifindex: nil, name: nil, netmask: nil)
-      @addr      = addr
+      @addr = addr
       @broadaddr = broadaddr
-      @dstaddr   = dstaddr
-      @flags     = flags
-      @ifindex   = ifindex
-      @name      = name
-      @netmask   = netmask
+      @dstaddr = dstaddr
+      @flags = flags
+      @ifindex = ifindex
+      @name = name
+      @netmask = netmask
     end
 
     def inspect

--- a/lib/truffle/socket/ip_socket.rb
+++ b/lib/truffle/socket/ip_socket.rb
@@ -44,7 +44,7 @@ class IPSocket < BasicSocket
 
     message, addr = recvmsg(maxlen, flags)
 
-    aname    = Truffle::Socket.address_family_name(addr.afamily)
+    aname = Truffle::Socket.address_family_name(addr.afamily)
     hostname = addr.ip_address
 
     # We're re-using recvmsg which doesn't return the reverse hostname, thus

--- a/lib/truffle/socket/option.rb
+++ b/lib/truffle/socket/option.rb
@@ -50,10 +50,10 @@ class Socket < BasicSocket
     end
 
     def initialize(family, level, optname, data)
-      @family  = Truffle::Socket.address_family(family)
-      @level   = Truffle::Socket::SocketOptions.socket_level(level, @family)
+      @family = Truffle::Socket.address_family(family)
+      @level = Truffle::Socket::SocketOptions.socket_level(level, @family)
       @optname = Truffle::Socket::SocketOptions.socket_option(@level, optname)
-      @data    = data
+      @data = data
     end
 
     def unpack(template)
@@ -103,7 +103,7 @@ class Socket < BasicSocket
       end
 
       linger = Truffle::Socket::Foreign::Linger.from_string(@data)
-      onoff  = nil
+      onoff = nil
 
       case linger.on_off
       when 0

--- a/lib/truffle/socket/socket.rb
+++ b/lib/truffle/socket/socket.rb
@@ -53,8 +53,8 @@ class Socket < BasicSocket
       service = Truffle::Socket.coerce_to_string(service)
     end
 
-    family    = Truffle::Socket.address_family(family)
-    socktype  = Truffle::Socket.socket_type(socktype)
+    family = Truffle::Socket.address_family(family)
+    socktype = Truffle::Socket.socket_type(socktype)
     addrinfos = Truffle::Socket::Foreign
       .getaddrinfo(host, service, family, socktype, protocol, flags)
 
@@ -87,15 +87,15 @@ class Socket < BasicSocket
   end
 
   def self.getnameinfo(sockaddr, flags = 0)
-    port   = nil
-    host   = nil
+    port = nil
+    host = nil
     family = Socket::AF_UNSPEC
 
     if sockaddr.is_a?(Array)
       if sockaddr.size == 3
         af, port, host = sockaddr
       elsif sockaddr.size == 4
-        af   = sockaddr[0]
+        af = sockaddr[0]
         port = sockaddr[1]
         host = sockaddr[3] || sockaddr[2]
       else
@@ -130,9 +130,9 @@ class Socket < BasicSocket
     addrinfos = Socket
       .getaddrinfo(hostname, nil, nil, :STREAM, nil, Socket::AI_CANONNAME)
 
-    hostname     = addrinfos[0][2]
-    family       = addrinfos[0][4]
-    addresses    = []
+    hostname = addrinfos[0][2]
+    family = addrinfos[0][4]
+    addresses = []
     alternatives = Truffle::Socket.aliases_for_hostname(hostname)
 
     addrinfos.each do |a|
@@ -141,11 +141,11 @@ class Socket < BasicSocket
 
       if a[4] == AF_INET
         offset, type = Truffle::Socket::Foreign::SockaddrIn.layout[:sin_addr]
-        size = FFI.type_size(type)  # TODO BJF 30-Apr-2017 This appears to be a bug in rubysl-socket?
+        size = FFI.type_size(type) # TODO BJF 30-Apr-2017 This appears to be a bug in rubysl-socket?
         addresses << sockaddr.byteslice(offset, size)
       elsif a[4] == AF_INET6
         offset, type = Truffle::Socket::Foreign::SockaddrIn6.layout[:sin6_addr]
-        size = FFI.type_size(type)  # TODO BJF 30-Apr-2017 This appears to be a bug in rubysl-socket?
+        size = FFI.type_size(type) # TODO BJF 30-Apr-2017 This appears to be a bug in rubysl-socket?
         addresses << sockaddr.byteslice(offset, size)
       end
     end
@@ -201,9 +201,9 @@ class Socket < BasicSocket
 
   def self.getifaddrs
     initial = Truffle::Socket::Foreign::Ifaddrs.new
-    status  = Truffle::Socket::Foreign.getifaddrs(initial.pointer)
+    status = Truffle::Socket::Foreign.getifaddrs(initial.pointer)
     ifaddrs = []
-    index   = 1
+    index = 1
 
     Errno.handle('getifaddrs()') if status < 0
 
@@ -247,7 +247,7 @@ class Socket < BasicSocket
 
   def self.socketpair(family, type, protocol = 0)
     family = Truffle::Socket.address_family(family)
-    type   = Truffle::Socket.socket_type(type)
+    type = Truffle::Socket.socket_type(type)
 
     fd0, fd1 = Truffle::Socket::Foreign.socketpair(family, type, protocol)
 
@@ -261,7 +261,7 @@ class Socket < BasicSocket
 
   if Truffle::Socket.unix_socket_support?
     def self.pack_sockaddr_un(file)
-      max_path_size =  Truffle::Config['platform.sockaddr_un.sun_path.size'] - 1
+      max_path_size = Truffle::Config['platform.sockaddr_un.sun_path.size'] - 1
       if file.bytesize > max_path_size
         raise ArgumentError, "too long unix socket path (#{file.bytesize} bytes given but #{max_path_size} bytes max)"
       end
@@ -295,7 +295,7 @@ class Socket < BasicSocket
   def initialize(family, socket_type, protocol = 0)
     @no_reverse_lookup = self.class.do_not_reverse_lookup
 
-    @family      = Truffle::Socket.protocol_family(family)
+    @family = Truffle::Socket.protocol_family(family)
     @socket_type = Truffle::Socket.socket_type(socket_type)
 
     descriptor = Truffle::Socket::Foreign.socket(@family, @socket_type, protocol)

--- a/lib/truffle/socket/tcp_server.rb
+++ b/lib/truffle/socket/tcp_server.rb
@@ -30,7 +30,7 @@ class TCPServer < TCPSocket
 
     if host.is_a?(Fixnum) and service.nil?
       service = host
-      host    = nil
+      host = nil
     end
 
     if host.is_a?(String) and service.nil?

--- a/lib/truffle/socket/tcp_socket.rb
+++ b/lib/truffle/socket/tcp_socket.rb
@@ -29,9 +29,9 @@ class TCPSocket < IPSocket
     addrinfos = Socket
       .getaddrinfo(hostname, nil, nil, :STREAM, nil, Socket::AI_CANONNAME)
 
-    hostname     = addrinfos[0][2]
-    family       = addrinfos[0][4]
-    addresses    = addrinfos.map { |a| a[3] }
+    hostname = addrinfos[0][2]
+    family = addrinfos[0][4]
+    addresses = addrinfos.map { |a| a[3] }
     alternatives = []
 
     Truffle::Socket.aliases_for_hostname(hostname).each do |name|
@@ -73,7 +73,7 @@ class TCPSocket < IPSocket
         .getaddrinfo(local_host, local_service, :UNSPEC, :STREAM)
     end
 
-    descriptor     = nil
+    descriptor = nil
     connect_status = 0
 
     # Because we don't know exactly what address family to bind to we'll just
@@ -121,14 +121,14 @@ class TCPSocket < IPSocket
   end
 
   def local_address
-    address  = addr
+    address = addr
     sockaddr = Socket.pack_sockaddr_in(address[1], address[3])
 
     Addrinfo.new(sockaddr, address[0], :STREAM)
   end
 
   def remote_address
-    address  = peeraddr
+    address = peeraddr
     sockaddr = Socket.pack_sockaddr_in(address[1], address[3])
 
     Addrinfo.new(sockaddr, address[0], :STREAM)

--- a/lib/truffle/socket/truffle.rb
+++ b/lib/truffle/socket/truffle.rb
@@ -103,7 +103,7 @@ module Truffle
 
     def self.listen(source, backlog)
       backlog = Truffle::Type.coerce_to(backlog, Fixnum, :to_int)
-      err     = Foreign.listen(source.descriptor, backlog)
+      err = Foreign.listen(source.descriptor, backlog)
 
       Error.read_error('listen(2)', source) if err < 0
 

--- a/lib/truffle/socket/truffle/foreign.rb
+++ b/lib/truffle/socket/truffle/foreign.rb
@@ -132,13 +132,13 @@ module Truffle
                            protocol = nil, flags = nil)
         hints = Addrinfo.new
 
-        hints[:ai_family]   = family || 0
+        hints[:ai_family] = family || 0
         hints[:ai_socktype] = socktype || 0
         hints[:ai_protocol] = protocol || 0
-        hints[:ai_flags]    = flags || 0
+        hints[:ai_flags] = flags || 0
 
         res_p = memory_pointer(:pointer)
-        err   = _getaddrinfo(host, service, hints.pointer, res_p)
+        err = _getaddrinfo(host, service, hints.pointer, res_p)
 
         raise SocketError, gai_strerror(err) unless err == 0
 
@@ -264,9 +264,9 @@ module Truffle
 
         hints = Addrinfo.new
 
-        hints[:ai_family]   = family
+        hints[:ai_family] = family
         hints[:ai_socktype] = type
-        hints[:ai_flags]    = flags
+        hints[:ai_flags] = flags
 
         if host and host.empty?
           host = '0.0.0.0'
@@ -334,8 +334,8 @@ module Truffle
 
       def self.pointers_of_type(current, type)
         pointers = []
-        size     = Truffle::FFI.type_size(type)
-        pointer  = current.read_pointer
+        size = Truffle::FFI.type_size(type)
+        pointer = current.read_pointer
 
         until pointer.null?
           pointers << pointer

--- a/lib/truffle/socket/truffle/foreign/iovec.rb
+++ b/lib/truffle/socket/truffle/foreign/iovec.rb
@@ -34,7 +34,7 @@ module Truffle
           vec = new
 
           vec[:iov_base] = buffer
-          vec[:iov_len]  = buffer.total
+          vec[:iov_len] = buffer.total
 
           vec
         end

--- a/lib/truffle/socket/truffle/foreign/msghdr.rb
+++ b/lib/truffle/socket/truffle/foreign/msghdr.rb
@@ -41,12 +41,12 @@ module Truffle
         end
 
         def address=(address)
-          self[:msg_name]    = address.pointer
+          self[:msg_name] = address.pointer
           self[:msg_namelen] = address.pointer.total
         end
 
         def message=(vec)
-          self[:msg_iov]    = vec.pointer
+          self[:msg_iov] = vec.pointer
           self[:msg_iovlen] = 1
         end
 

--- a/lib/truffle/socket/udp_socket.rb
+++ b/lib/truffle/socket/udp_socket.rb
@@ -27,7 +27,7 @@
 class UDPSocket < IPSocket
   def initialize(family = Socket::AF_INET)
     @no_reverse_lookup = self.class.do_not_reverse_lookup
-    @family            = Truffle::Socket.address_family(family)
+    @family = Truffle::Socket.address_family(family)
 
     descriptor = Truffle::Socket::Foreign
       .socket(@family, Socket::SOCK_DGRAM, Socket::IPPROTO_UDP)
@@ -39,7 +39,7 @@ class UDPSocket < IPSocket
   end
 
   def bind(host, port)
-    addr   = Socket.sockaddr_in(port.to_i, host)
+    addr = Socket.sockaddr_in(port.to_i, host)
     status = Truffle::Socket::Foreign.bind(descriptor, addr)
 
     Errno.handle('bind(2)') if status < 0
@@ -85,14 +85,14 @@ class UDPSocket < IPSocket
   end
 
   def local_address
-    address  = addr
+    address = addr
     sockaddr = Socket.pack_sockaddr_in(address[1], address[3])
 
     Addrinfo.new(sockaddr, address[0], :DGRAM)
   end
 
   def remote_address
-    address  = peeraddr
+    address = peeraddr
     sockaddr = Socket.pack_sockaddr_in(address[1], address[3])
 
     Addrinfo.new(sockaddr, address[0], :DGRAM)

--- a/lib/truffle/socket/unix_server.rb
+++ b/lib/truffle/socket/unix_server.rb
@@ -27,7 +27,7 @@
 class UNIXServer < UNIXSocket
   def initialize(path)
     @no_reverse_lookup = self.class.do_not_reverse_lookup
-    @path              = path
+    @path = path
 
     fd = Truffle::Socket::Foreign.socket(Socket::AF_UNIX, Socket::SOCK_STREAM, 0)
 
@@ -37,7 +37,7 @@ class UNIXServer < UNIXSocket
     binmode
 
     sockaddr = Socket.sockaddr_un(@path)
-    status   = Truffle::Socket::Foreign.bind(descriptor, sockaddr)
+    status = Truffle::Socket::Foreign.bind(descriptor, sockaddr)
 
     Errno.handle('bind(2)') if status < 0
 

--- a/lib/truffle/socket/unix_socket.rb
+++ b/lib/truffle/socket/unix_socket.rb
@@ -29,7 +29,7 @@ class UNIXSocket < BasicSocket
 
   def self.socketpair(type = Socket::SOCK_STREAM, protocol = 0)
     family = Socket::AF_UNIX
-    type   = Truffle::Socket.socket_type(type)
+    type = Truffle::Socket.socket_type(type)
 
     fd0, fd1 = Truffle::Socket::Foreign.socketpair(family, type, protocol)
 
@@ -42,7 +42,7 @@ class UNIXSocket < BasicSocket
 
   def initialize(path)
     @no_reverse_lookup = self.class.do_not_reverse_lookup
-    @path              = '' # empty for client sockets
+    @path = '' # empty for client sockets
 
     fd = Truffle::Socket::Foreign.socket(Socket::AF_UNIX, Socket::SOCK_STREAM, 0)
 
@@ -52,7 +52,7 @@ class UNIXSocket < BasicSocket
     binmode
 
     sockaddr = Socket.sockaddr_un(path)
-    status   = Truffle::Socket::Foreign.connect(descriptor, sockaddr)
+    status = Truffle::Socket::Foreign.connect(descriptor, sockaddr)
 
     Errno.handle('connect(2)') if status < 0
   end

--- a/lib/truffle/truffle/cext.rb
+++ b/lib/truffle/truffle/cext.rb
@@ -154,37 +154,37 @@ module Truffle::CExt
     alias_method :pointer?, :act_like_pointer
   end
 
-  T_NONE     = 0x00
+  T_NONE = 0x00
 
-  T_OBJECT   = 0x01
-  T_CLASS    = 0x02
-  T_MODULE   = 0x03
-  T_FLOAT    = 0x04
-  T_STRING   = 0x05
-  T_REGEXP   = 0x06
-  T_ARRAY    = 0x07
-  T_HASH     = 0x08
-  T_STRUCT   = 0x09
-  T_BIGNUM   = 0x0a
-  T_FILE     = 0x0b
-  T_DATA     = 0x0c
-  T_MATCH    = 0x0d
-  T_COMPLEX  = 0x0e
+  T_OBJECT = 0x01
+  T_CLASS = 0x02
+  T_MODULE = 0x03
+  T_FLOAT = 0x04
+  T_STRING = 0x05
+  T_REGEXP = 0x06
+  T_ARRAY = 0x07
+  T_HASH = 0x08
+  T_STRUCT = 0x09
+  T_BIGNUM = 0x0a
+  T_FILE = 0x0b
+  T_DATA = 0x0c
+  T_MATCH = 0x0d
+  T_COMPLEX = 0x0e
   T_RATIONAL = 0x0f
 
-  T_NIL      = 0x11
-  T_TRUE     = 0x12
-  T_FALSE    = 0x13
-  T_SYMBOL   = 0x14
-  T_FIXNUM   = 0x15
-  T_UNDEF    = 0x16
+  T_NIL = 0x11
+  T_TRUE = 0x12
+  T_FALSE = 0x13
+  T_SYMBOL = 0x14
+  T_FIXNUM = 0x15
+  T_UNDEF = 0x16
 
-  T_IMEMO    = 0x1a
-  T_NODE     = 0x1b
-  T_ICLASS   = 0x1c
-  T_ZOMBIE   = 0x1d
+  T_IMEMO = 0x1a
+  T_NODE = 0x1b
+  T_ICLASS = 0x1c
+  T_ZOMBIE = 0x1d
 
-  T_MASK     = 0x1f
+  T_MASK = 0x1f
 
   RUBY_ENC_CODERANGE_UNKNOWN = 0
   RUBY_ENC_CODERANGE_7BIT = 1
@@ -1159,7 +1159,7 @@ module Truffle::CExt
 
   def rb_funcall(recv, meth, n, *args)
     # see #call_with_thread_locally_stored_block
-    thread_local_block           = Thread.current[:__C_BLOCK__]
+    thread_local_block = Thread.current[:__C_BLOCK__]
     Thread.current[:__C_BLOCK__] = nil
     recv.__send__(meth, *args, &thread_local_block)
   ensure

--- a/lib/truffle/truffle/ffi/ffi.rb
+++ b/lib/truffle/truffle/ffi/ffi.rb
@@ -109,80 +109,80 @@ module Truffle::FFI
   end
 
   # Converts a char
-  add_typedef TYPE_CHAR,    :char
+  add_typedef TYPE_CHAR, :char
 
   # Converts an unsigned char
-  add_typedef TYPE_UCHAR,   :uchar
+  add_typedef TYPE_UCHAR, :uchar
 
   # The C++ boolean type
-  add_typedef TYPE_BOOL,    :bool
+  add_typedef TYPE_BOOL, :bool
 
   # Converts a short
-  add_typedef TYPE_SHORT,   :short
+  add_typedef TYPE_SHORT, :short
 
   # Converts an unsigned short
-  add_typedef TYPE_USHORT,  :ushort
+  add_typedef TYPE_USHORT, :ushort
 
   # Converts an int
-  add_typedef TYPE_INT,     :int
+  add_typedef TYPE_INT, :int
 
   # Converts an unsigned int
-  add_typedef TYPE_UINT,    :uint
+  add_typedef TYPE_UINT, :uint
 
   # Converts a long
-  add_typedef TYPE_LONG,    :long
+  add_typedef TYPE_LONG, :long
 
   # Converts an unsigned long
-  add_typedef TYPE_ULONG,   :ulong
+  add_typedef TYPE_ULONG, :ulong
 
   # Converts a size_t
-  add_typedef TYPE_ULONG,   :size_t
+  add_typedef TYPE_ULONG, :size_t
 
   # Converts a long long
-  add_typedef TYPE_LL,      :long_long
+  add_typedef TYPE_LL, :long_long
 
   # Converts an unsigned long long
-  add_typedef TYPE_ULL,     :ulong_long
+  add_typedef TYPE_ULL, :ulong_long
 
   # Converts a float
-  add_typedef TYPE_FLOAT,   :float
+  add_typedef TYPE_FLOAT, :float
 
   # Converts a double
-  add_typedef TYPE_DOUBLE,  :double
+  add_typedef TYPE_DOUBLE, :double
 
   # Converts a pointer to opaque data
-  add_typedef TYPE_PTR,     :pointer
+  add_typedef TYPE_PTR, :pointer
 
   # For when a function has no return value
-  add_typedef TYPE_VOID,    :void
+  add_typedef TYPE_VOID, :void
 
   # Converts NULL-terminated C strings
-  add_typedef TYPE_STRING,  :string
+  add_typedef TYPE_STRING, :string
 
   # Use strptr when you need to free the result of some operation.
-  add_typedef TYPE_STRPTR,  :strptr
-  add_typedef TYPE_STRPTR,  :string_and_pointer
+  add_typedef TYPE_STRPTR, :strptr
+  add_typedef TYPE_STRPTR, :string_and_pointer
 
   # Use for a C struct with a char [] embedded inside.
   add_typedef TYPE_CHARARR, :char_array
 
   # A set of unambiguous integer types
-  add_typedef TYPE_CHAR,   :int8
-  add_typedef TYPE_UCHAR,  :uint8
-  add_typedef TYPE_SHORT,  :int16
+  add_typedef TYPE_CHAR, :int8
+  add_typedef TYPE_UCHAR, :uint8
+  add_typedef TYPE_SHORT, :int16
   add_typedef TYPE_USHORT, :uint16
-  add_typedef TYPE_INT,    :int32
-  add_typedef TYPE_UINT,   :uint32
+  add_typedef TYPE_INT, :int32
+  add_typedef TYPE_UINT, :uint32
 
   # Converts a varargs argument
   add_typedef TYPE_VARARGS, :varargs
 
   if Truffle::Platform::L64
-    add_typedef TYPE_LONG,  :int64
+    add_typedef TYPE_LONG, :int64
     add_typedef TYPE_ULONG, :uint64
   else
-    add_typedef TYPE_LL,    :int64
-    add_typedef TYPE_ULL,   :uint64
+    add_typedef TYPE_LL, :int64
+    add_typedef TYPE_ULL, :uint64
   end
 
   TypeSizes = {}
@@ -221,25 +221,25 @@ module Truffle::FFI
 
     Struct = StructByValue
 
-    CHAR    = TYPE_CHAR
-    UCHAR   = TYPE_UCHAR
-    BOOL    = TYPE_BOOL
-    SHORT   = TYPE_SHORT
-    USHORT  = TYPE_USHORT
-    INT     = TYPE_INT
-    UINT    = TYPE_UINT
-    LONG    = TYPE_LONG
-    ULONG   = TYPE_ULONG
-    LL      = TYPE_LL
-    ULL     = TYPE_ULL
-    FLOAT   = TYPE_FLOAT
-    DOUBLE  = TYPE_DOUBLE
-    PTR     = TYPE_PTR
-    VOID    = TYPE_VOID
-    STRING  = TYPE_STRING
-    STRPTR  = TYPE_STRPTR
+    CHAR = TYPE_CHAR
+    UCHAR = TYPE_UCHAR
+    BOOL = TYPE_BOOL
+    SHORT = TYPE_SHORT
+    USHORT = TYPE_USHORT
+    INT = TYPE_INT
+    UINT = TYPE_UINT
+    LONG = TYPE_LONG
+    ULONG = TYPE_ULONG
+    LL = TYPE_LL
+    ULL = TYPE_ULL
+    FLOAT = TYPE_FLOAT
+    DOUBLE = TYPE_DOUBLE
+    PTR = TYPE_PTR
+    VOID = TYPE_VOID
+    STRING = TYPE_STRING
+    STRPTR = TYPE_STRPTR
     CHARARR = TYPE_CHARARR
-    ENUM    = TYPE_ENUM
+    ENUM = TYPE_ENUM
     VARARGS = TYPE_VARARGS
   end
 end

--- a/lib/truffle/truffle/ffi/ffi_struct.rb
+++ b/lib/truffle/truffle/ffi/ffi_struct.rb
@@ -195,11 +195,11 @@ module Truffle::FFI
       cspec = {}
 
       fields.each do |field|
-        field  = field.to_sym
+        field = field.to_sym
         offset = Truffle::Config["#{base}.#{field}.offset"]
-        size   = Truffle::Config["#{base}.#{field}.size"]
-        type   = Truffle::Config.lookup("#{base}.#{field}.type")
-        type   = type ? type.to_sym : FFI.size_to_type(size)
+        size = Truffle::Config["#{base}.#{field}.size"]
+        type = Truffle::Config.lookup("#{base}.#{field}.type")
+        type = type ? type.to_sym : FFI.size_to_type(size)
 
         code = FFI.find_type type
         cspec[field] = [offset, code]

--- a/lib/truffleruby-tool/lib/config.rb
+++ b/lib/truffleruby-tool/lib/config.rb
@@ -233,8 +233,8 @@ class TruffleTool::CIEnvironment
   end
 
   def rails_ci_setup(has_exclusions: false)
-    options           = {}
-    options[:debug]   = ['-d', '--[no-]debug', 'Run tests with remote debugging enabled.', STORE_NEW_VALUE, false]
+    options = {}
+    options[:debug] = ['-d', '--[no-]debug', 'Run tests with remote debugging enabled.', STORE_NEW_VALUE, false]
     options[:exclude] = ['--[no-]exclusion', 'Exclude known failing tests', STORE_NEW_VALUE, true] if has_exclusions
 
     declare_options options
@@ -447,7 +447,7 @@ begin # not tested in CI
     rails_ci_setup
 
     adapters = %w[inline delayed_job qu que queue_classic resque sidekiq sneakers sucker_punch backburner test]
-    results  = adapters.map do |adapter|
+    results = adapters.map do |adapter|
       rails_ci_run(environment:     { 'AJ_ADAPTER' => adapter },
                    require_pattern: 'test/cases/**/*_test.rb')
     end

--- a/lib/truffleruby-tool/lib/truffle_tool.rb
+++ b/lib/truffleruby-tool/lib/truffle_tool.rb
@@ -35,12 +35,12 @@ end
 class TruffleTool
   module CmdUtils
     def execute_cmd(cmd, dir: nil, raise: true, print: false)
-      result      = nil
+      result = nil
       system_call = proc do
         begin
-          pid       = Process.spawn(*print_cmd(cmd, dir, print))
+          pid = Process.spawn(*print_cmd(cmd, dir, print))
           _, status = Process.waitpid2 pid
-          result    = status.success?
+          result = status.success?
         rescue SignalException => e
           # terminate the child process on signal received
           Process.kill 'TERM', pid
@@ -197,7 +197,7 @@ class TruffleTool
 
     def search_up(*names)
       previous = nil
-      current  = File.expand_path(Pathname.pwd).untaint
+      current = File.expand_path(Pathname.pwd).untaint
 
       until !File.directory?(current) || current == previous
         if ENV['BUNDLE_SPEC_RUN']
@@ -210,7 +210,7 @@ class TruffleTool
           yield filename
         end
         previous = current
-        current  = File.expand_path('..', current)
+        current = File.expand_path('..', current)
       end
     end
 
@@ -223,24 +223,24 @@ class TruffleTool
 
   attr_reader :options
 
-  EXECUTABLE        = File.basename($PROGRAM_NAME)
-  BRANDING          = 'TruffleRuby'
+  EXECUTABLE = File.basename($PROGRAM_NAME)
+  BRANDING = 'TruffleRuby'
   LOCAL_CONFIG_FILE = '.truffleruby-tool.yaml'
-  ROOT              = Pathname(__FILE__).dirname.parent.expand_path
-  TRUFFLERUBY_PATH  = ROOT.join('../..').expand_path
-  TRUFFLERUBY_BIN   = TRUFFLERUBY_PATH.join('bin', 'truffleruby')
+  ROOT = Pathname(__FILE__).dirname.parent.expand_path
+  TRUFFLERUBY_PATH = ROOT.join('../..').expand_path
+  TRUFFLERUBY_BIN = TRUFFLERUBY_PATH.join('bin', 'truffleruby')
 
   module OptionBlocks
-    STORE_NEW_VALUE         = -> (new, _old, _) { new }
+    STORE_NEW_VALUE = -> (new, _old, _) { new }
     STORE_NEW_NEGATED_VALUE = -> (new, _old, _) { !new }
-    ADD_TO_ARRAY            = -> (new, old, _) { old << new }
-    MERGE_TO_HASH           = -> ((k, v), old, _) { old.merge k => v }
+    ADD_TO_ARRAY = -> (new, old, _) { old << new }
+    MERGE_TO_HASH = -> ((k, v), old, _) { old.merge k => v }
   end
 
   include OptionBlocks
 
   begin
-    apply_pattern          = -> (pattern, old, options) do
+    apply_pattern = -> (pattern, old, options) do
       Dir.glob(pattern).sort.each do |file|
         if options[:exclude_pattern].any? { |p| /#{p}/ =~ file }
           puts "skipped: #{file}"
@@ -264,7 +264,7 @@ class TruffleTool
     #                                                     -> (new_value, old_value, options) { result_of_this_block_is_stored },
     #                                                     default_value]
     #   }
-    OPTION_DEFINITIONS     = {
+    OPTION_DEFINITIONS = {
         global: { verbose:             ['-v', '--verbose', 'Run verbosely (prints options)', STORE_NEW_VALUE, false],
                   help:                ['-h', '--help', 'Show this message', STORE_NEW_VALUE, false],
                   debug_port:          ['--debug-port PORT', 'Debug port', STORE_NEW_VALUE, '51819'],
@@ -398,12 +398,12 @@ class TruffleTool
   attr_reader :options, :config
 
   def initialize(argv, options = {})
-    @options        = deep_merge construct_default_options, options
+    @options = deep_merge construct_default_options, options
     @option_parsers = build_option_parsers
 
     @subcommand, *argv_after_global = @option_parsers[:global].order argv
-    @called_from_dir                = Dir.pwd
-    @options[:global][:dir]         = File.expand_path(@options[:global][:dir] || @called_from_dir)
+    @called_from_dir = Dir.pwd
+    @options[:global][:dir] = File.expand_path(@options[:global][:dir] || @called_from_dir)
 
     log({ argv: argv, options: options }.pretty_inspect) if verbose?
 
@@ -436,7 +436,7 @@ class TruffleTool
       @subcommand = @subcommand.to_sym
 
       subcommand_option_parser = @option_parsers[@subcommand] || raise("unknown subcommand: #{@subcommand}")
-      @argv_after_subcommand   = subcommand_option_parser.order argv_after_global
+      @argv_after_subcommand = subcommand_option_parser.order argv_after_global
 
       print_options
       help @subcommand if @options[@subcommand][:help] && @subcommand != :readme
@@ -461,7 +461,7 @@ class TruffleTool
       *args, description, block, default = data
 
       option_parser.on(*args, description + " (default: #{default.inspect})") do |new_value|
-        old_value            = options_hash[option]
+        old_value = options_hash[option]
         options_hash[option] = instance_exec new_value, old_value, options_hash, &block
       end
     end
@@ -564,11 +564,11 @@ class TruffleTool
 
     new_lines = File.read(gemfile).lines.map do |line|
       if line =~ /^( +)gem.*git:/
-        space               = $1
-        gem_name, options   = parse_gemfile_line(line)
-        repo_name           = options[:git].split('/').last
-        repo_match          = "#{gems_path}/bundler/gems/#{repo_name}-*"
-        repo_path           = Dir[repo_match].sort.first
+        space = $1
+        gem_name, options = parse_gemfile_line(line)
+        repo_name = options[:git].split('/').last
+        repo_match = "#{gems_path}/bundler/gems/#{repo_name}-*"
+        repo_path = Dir[repo_match].sort.first
         options_without_git = options.merge(path: repo_path).tap do |h|
           h.delete(:git)
           h.delete(:branch)
@@ -594,8 +594,8 @@ class TruffleTool
 
   def subcommand_setup(rest)
     bundle_options = @options[:global][:bundle_options].split(' ')
-    offline        = @options[:setup][:offline]
-    execute_all    = lambda do |cmd|
+    offline = @options[:setup][:offline]
+    execute_all = lambda do |cmd|
       case cmd
       when Proc
         cmd.call
@@ -731,14 +731,14 @@ class TruffleTool
                           File.read(Pathname(@called_from_dir).join(path))
                         end
                       end
-      cis_to_run    = YAML.load(batch_content)
+      cis_to_run = YAML.load(batch_content)
 
       results = cis_to_run.map do |ci|
         # ci is just a name or a array of name and options
 
-        options       = {}
+        options = {}
         option_parser = build_option_parser OPTION_DEFINITIONS[:ci], options
-        rest          = option_parser.order Array(ci)
+        rest = option_parser.order Array(ci)
 
         gem_name = rest.first
         CIEnvironment.new(@options[:global][:dir], gem_name, self, rest[1..-1]).success?
@@ -747,7 +747,7 @@ class TruffleTool
       results.all?
     else
       gem_name = rest.first
-      ci       = CIEnvironment.new @options[:global][:dir], gem_name, self, rest[1..-1], definition: options[:ci][:definition]
+      ci = CIEnvironment.new @options[:global][:dir], gem_name, self, rest[1..-1], definition: options[:ci][:definition]
 
       case ci.result
       when nil # error, setup failed
@@ -814,19 +814,19 @@ class TruffleTool
     attr_reader :gem_name, :result
 
     def initialize(working_dir, gem_name, runner, rest, definition: nil)
-      @runner   = runner
-      @options  = {}
+      @runner = runner
+      @options = {}
       @gem_name = gem_name
-      @rest     = rest
+      @rest = rest
 
-      @working_dir     = Pathname(working_dir)
+      @working_dir = Pathname(working_dir)
       @repository_name = gem_name
-      @subdir          = '.'
-      @result          = nil
+      @subdir = '.'
+      @result = nil
 
-      option_parser         = @option_parser = OptionParser.new
+      option_parser = @option_parser = OptionParser.new
       @option_parser.banner = "\nUsage: #{EXECUTABLE} [options] ci [subcommand-options] #{gem_name} [options-declared-in-CI-definition]\n\n"
-      @option_parsed        = false
+      @option_parsed = false
 
       declare_options parse_options: false, help: ['-h', '--help', 'Show this message', -> (_new, _old, _) { puts option_parser; exit }, false]
 

--- a/src/main/ruby/core/array.rb
+++ b/src/main/ruby/core/array.rb
@@ -452,7 +452,7 @@ class Array
       right = Truffle::Type.coerce_to_collection_length one.end
       right += size if right < 0
       right += 1 unless one.exclude_end?
-      return self if right <= left           # Nothing to modify
+      return self if right <= left # Nothing to modify
 
     elsif one
       left = Truffle::Type.coerce_to_collection_length one
@@ -597,10 +597,10 @@ class Array
 
     # Adjust the index for correct insertion
     idx = Truffle::Type.coerce_to_collection_index idx
-    idx += (size + 1) if idx < 0    # Negatives add AFTER the element
+    idx += (size + 1) if idx < 0 # Negatives add AFTER the element
     raise IndexError, "#{idx} out of bounds" if idx < 0
 
-    self[idx, 0] = items   # Cheat
+    self[idx, 0] = items # Cheat
     self
   end
   Truffle::Graal.always_split instance_method(:insert)
@@ -1559,7 +1559,7 @@ class Array
 
         range_length = range_end - range_start
         range_length += 1 unless range.exclude_end?
-        range_end    -= 1 if     range.exclude_end?
+        range_end -= 1 if range.exclude_end?
 
         if range_start < size && range_start >= 0 && range_end < size && range_end >= 0 && range_length > 0
           delete_range(range_start, range_length)

--- a/src/main/ruby/core/comparable.rb
+++ b/src/main/ruby/core/comparable.rb
@@ -81,7 +81,7 @@ module Comparable
   def self.compare_int(int)
     return int if int.kind_of? Fixnum
 
-    return 1  if int > 0
+    return 1 if int > 0
     return -1 if int < 0
     0
   end

--- a/src/main/ruby/core/dir_glob.rb
+++ b/src/main/ruby/core/dir_glob.rb
@@ -162,7 +162,7 @@ class Dir
             full = path_join(path, ent)
             stat = File::Stat.lstat full
 
-            if stat.directory? and ent.getbyte(0) != 46  # ?.
+            if stat.directory? and ent.getbyte(0) != 46 # ?.
               stack << full
               @next.call env, full
             end
@@ -313,7 +313,7 @@ class Dir
         end
       end
 
-      if glob.getbyte(0) == 47  # ?/
+      if glob.getbyte(0) == 47 # ?/
         last = RootDirectory.new last, flags
       end
 

--- a/src/main/ruby/core/file.rb
+++ b/src/main/ruby/core/file.rb
@@ -46,36 +46,36 @@ class File < IO
   FNM_SYSCASE = CASEFOLD_FILESYSTEM ? FNM_CASEFOLD : 0
 
   module Constants
-    F_GETFL  = Truffle::Config['platform.fcntl.F_GETFL']
-    F_SETFL  = Truffle::Config['platform.fcntl.F_SETFL']
+    F_GETFL = Truffle::Config['platform.fcntl.F_GETFL']
+    F_SETFL = Truffle::Config['platform.fcntl.F_SETFL']
 
-    F_GETFD  = Truffle::Config['platform.fcntl.F_GETFD']
-    F_SETFD  = Truffle::Config['platform.fcntl.F_SETFD']
+    F_GETFD = Truffle::Config['platform.fcntl.F_GETFD']
+    F_SETFD = Truffle::Config['platform.fcntl.F_SETFD']
     FD_CLOEXEC = Truffle::Config['platform.fcntl.FD_CLOEXEC']
 
-    RDONLY   = Truffle::Config['platform.file.O_RDONLY']
-    WRONLY   = Truffle::Config['platform.file.O_WRONLY']
-    RDWR     = Truffle::Config['platform.file.O_RDWR']
-    ACCMODE  = Truffle::Config['platform.file.O_ACCMODE']
+    RDONLY = Truffle::Config['platform.file.O_RDONLY']
+    WRONLY = Truffle::Config['platform.file.O_WRONLY']
+    RDWR = Truffle::Config['platform.file.O_RDWR']
+    ACCMODE = Truffle::Config['platform.file.O_ACCMODE']
 
-    CREAT    = Truffle::Config['platform.file.O_CREAT']
-    EXCL     = Truffle::Config['platform.file.O_EXCL']
-    NOCTTY   = Truffle::Config['platform.file.O_NOCTTY']
-    TRUNC    = Truffle::Config['platform.file.O_TRUNC']
-    APPEND   = Truffle::Config['platform.file.O_APPEND']
+    CREAT = Truffle::Config['platform.file.O_CREAT']
+    EXCL = Truffle::Config['platform.file.O_EXCL']
+    NOCTTY = Truffle::Config['platform.file.O_NOCTTY']
+    TRUNC = Truffle::Config['platform.file.O_TRUNC']
+    APPEND = Truffle::Config['platform.file.O_APPEND']
     NONBLOCK = Truffle::Config['platform.file.O_NONBLOCK']
-    SYNC     = Truffle::Config['platform.file.O_SYNC']
+    SYNC = Truffle::Config['platform.file.O_SYNC']
 
     if value = Truffle::Config.lookup('platform.file.O_TMPFILE')
       TMPFILE = value
     end
 
     # TODO: these flags should probably be imported from Platform
-    LOCK_SH  = 0x01
-    LOCK_EX  = 0x02
-    LOCK_NB  = 0x04
-    LOCK_UN  = 0x08
-    BINARY   = 0x04
+    LOCK_SH = 0x01
+    LOCK_EX = 0x02
+    LOCK_NB = 0x04
+    LOCK_UN = 0x08
+    BINARY = 0x04
 
     # TODO: "OK" constants aren't in File::Constants in MRI
     F_OK = 0 # test for existence of file
@@ -87,7 +87,7 @@ class File < IO
     FNM_PATHNAME = 0x02
     FNM_DOTMATCH = 0x04
     FNM_CASEFOLD = 0x08
-    FNM_EXTGLOB  = 0x10
+    FNM_EXTGLOB = 0x10
 
     if Truffle::Platform.windows?
       NULL = 'NUL'
@@ -158,7 +158,7 @@ class File < IO
         data = path.bytes
         found = false
         pos.downto(0) do |i|
-          if data[i] != 47  # ?/
+          if data[i] != 47 # ?/
             path = path.byteslice(0, i+1)
             found = true
             break
@@ -371,7 +371,7 @@ class File < IO
     start ||= (path.size - 1)
 
     start.downto(0) do |i|
-      if data[i] != 47  # ?/
+      if data[i] != 47 # ?/
         return i
       end
     end
@@ -712,8 +712,8 @@ class File < IO
 
   def self.fnmatch(pattern, path, flags=0)
     pattern = StringValue(pattern)
-    path    = Truffle::Type.coerce_to_path(path)
-    flags   = Truffle::Type.coerce_to(flags, Fixnum, :to_int)
+    path = Truffle::Type.coerce_to_path(path)
+    flags = Truffle::Type.coerce_to(flags, Fixnum, :to_int)
     brace_match = false
 
     if (flags & FNM_EXTGLOB) != 0
@@ -1219,9 +1219,9 @@ class File < IO
   end
 
   class << self
-    alias_method :delete,   :unlink
-    alias_method :empty?,   :zero?
-    alias_method :exists?,  :exist?
+    alias_method :delete, :unlink
+    alias_method :empty?, :zero?
+    alias_method :exists?, :exist?
     alias_method :fnmatch?, :fnmatch
   end
 
@@ -1332,7 +1332,7 @@ class File < IO
     raise IOError, 'closed stream' if closed?
     stat.size
   end
-end     # File
+end # File
 
 # Inject the constants into IO
 class IO

--- a/src/main/ruby/core/fixnum.rb
+++ b/src/main/ruby/core/fixnum.rb
@@ -41,7 +41,7 @@
 class Fixnum < Integer
 
   MIN = -9223372036854775808
-  MAX =  9223372036854775807
+  MAX = 9223372036854775807
 
   def [](index)
     index = Truffle::Type.coerce_to(index, Integer, :to_int)

--- a/src/main/ruby/core/float.rb
+++ b/src/main/ruby/core/float.rb
@@ -60,19 +60,19 @@
 
 class Float < Numeric
 
-  NAN        = -(0.0 / 0.0) # to match MRI binary representation
-  INFINITY   = 1.0 / 0.0
-  EPSILON    = 2.2204460492503131e-16
-  RADIX      = 2
-  ROUNDS     = 1
-  MIN        = 2.2250738585072014e-308
-  MAX        = 1.7976931348623157e+308
-  MIN_EXP    = -1021
-  MAX_EXP    = 1024
+  NAN = -(0.0 / 0.0) # to match MRI binary representation
+  INFINITY = 1.0 / 0.0
+  EPSILON = 2.2204460492503131e-16
+  RADIX = 2
+  ROUNDS = 1
+  MIN = 2.2250738585072014e-308
+  MAX = 1.7976931348623157e+308
+  MIN_EXP = -1021
+  MAX_EXP = 1024
   MIN_10_EXP = -307
   MAX_10_EXP = 308
-  DIG        = 15
-  MANT_DIG   = 53
+  DIG = 15
+  MANT_DIG = 53
 
   def equal_fallback(other)
     # Fallback from Rubinius' Float#==, after the primitive call

--- a/src/main/ruby/core/gc.rb
+++ b/src/main/ruby/core/gc.rb
@@ -91,7 +91,7 @@ module GC
 
   module Profiler
     @enabled = true
-    @since   = 0
+    @since = 0
 
     def self.clear
       @since = GC.time

--- a/src/main/ruby/core/hash.rb
+++ b/src/main/ruby/core/hash.rb
@@ -369,7 +369,7 @@ class Hash
     out = []
     return '{...}' if Thread.detect_recursion self do
       each_pair do |key,value|
-        str =  Truffle::Type.rb_inspect(key)
+        str = Truffle::Type.rb_inspect(key)
         str << '=>'
         str << Truffle::Type.rb_inspect(value)
         out << str

--- a/src/main/ruby/core/io.rb
+++ b/src/main/ruby/core/io.rb
@@ -711,10 +711,10 @@ class IO
       mode, external, internal = mode.split(':')
       raise ArgumentError, 'invalid access mode' unless mode
 
-      binary = true  if mode[1] === ?b
+      binary = true if mode[1] === ?b
       binary = false if mode[1] === ?t
     elsif mode
-      binary = true  if (mode & BINARY) != 0
+      binary = true if (mode & BINARY) != 0
     end
 
     if options
@@ -948,7 +948,7 @@ class IO
     pipe.pid = pid
 
     ch_write.close if readable
-    ch_read.close  if writable
+    ch_read.close if writable
 
     return pipe unless block_given?
 
@@ -1155,9 +1155,9 @@ class IO
     io.close if io.descriptor
 
     io.descriptor = fd
-    io.mode       = mode || cur_mode
-    io.sync       = !!sync
-    io.autoclose  = true
+    io.mode = mode || cur_mode
+    io.sync = !!sync
+    io.autoclose = true
     io.instance_variable_set :@ibuffer, IO::InternalBuffer.new
     io.instance_variable_set :@lineno, 0
 

--- a/src/main/ruby/core/marshal.rb
+++ b/src/main/ruby/core/marshal.rb
@@ -289,7 +289,7 @@ end
 
 class String
   private def __marshal__(ms)
-    out =  ms.serialize_instance_variables_prefix(self)
+    out = ms.serialize_instance_variables_prefix(self)
     out << ms.serialize_extended_object(self)
     out << ms.serialize_user_class(self, String)
     out << ms.serialize_string(self)
@@ -313,7 +313,7 @@ end
 class Regexp
   private def __marshal__(ms)
     str = self.source
-    out =  ms.serialize_instance_variables_prefix(self)
+    out = ms.serialize_instance_variables_prefix(self)
     out << ms.serialize_extended_object(self)
     out << ms.serialize_user_class(self, Regexp)
     out << '/'
@@ -329,7 +329,7 @@ class Struct
   private def __marshal__(ms)
     exclude = _attrs.map { |a| :"@#{a}" }
 
-    out =  ms.serialize_instance_variables_prefix(self, exclude)
+    out = ms.serialize_instance_variables_prefix(self, exclude)
     out << ms.serialize_extended_object(self)
 
     out << 'S'
@@ -350,7 +350,7 @@ end
 
 class Array
   private def __marshal__(ms)
-    out =  ms.serialize_instance_variables_prefix(self)
+    out = ms.serialize_instance_variables_prefix(self)
     out << ms.serialize_extended_object(self)
     out << ms.serialize_user_class(self, Array)
     out << '['
@@ -370,7 +370,7 @@ class Hash
   private def __marshal__(ms)
     raise TypeError, "can't dump hash with default proc" if default_proc
 
-    out =  ms.serialize_instance_variables_prefix(self)
+    out = ms.serialize_instance_variables_prefix(self)
     out << ms.serialize_extended_object(self)
     out << ms.serialize_user_class(self, Hash)
     out << (self.default ? '}' : '{')
@@ -447,7 +447,7 @@ module Marshal
   TYPE_EXTENDED = ?e
   TYPE_UCLASS = ?C
   TYPE_OBJECT = ?o
-  TYPE_DATA = ?d  # no specs
+  TYPE_DATA = ?d # no specs
   TYPE_USERDEF = ?u
   TYPE_USRMARSHAL = ?U
   TYPE_FLOAT = ?f
@@ -458,7 +458,7 @@ module Marshal
   TYPE_HASH = ?{
   TYPE_HASH_DEF = ?}
   TYPE_STRUCT = ?S
-  TYPE_MODULE_OLD = ?M  # no specs
+  TYPE_MODULE_OLD = ?M # no specs
   TYPE_CLASS = ?c
   TYPE_MODULE = ?m
 
@@ -546,47 +546,47 @@ module Marshal
     def construct(ivar_index = nil, call_proc = true)
       type = consume_byte()
       obj = case type
-            when 48   # ?0
+            when 48 # ?0
               nil
-            when 84   # ?T
+            when 84 # ?T
               true
-            when 70   # ?F
+            when 70 # ?F
               false
-            when 99   # ?c
+            when 99 # ?c
               construct_class
-            when 109  # ?m
+            when 109 # ?m
               construct_module
-            when 77   # ?M
+            when 77 # ?M
               construct_old_module
-            when 105  # ?i
+            when 105 # ?i
               construct_integer
-            when 108  # ?l
+            when 108 # ?l
               construct_bignum
-            when 102  # ?f
+            when 102 # ?f
               construct_float
-            when 58   # ?:
+            when 58 # ?:
               construct_symbol
-            when 34   # ?"
+            when 34 # ?"
               construct_string
-            when 47   # ?/
+            when 47 # ?/
               construct_regexp
-            when 91   # ?[
+            when 91 # ?[
               construct_array
-            when 123  # ?{
+            when 123 # ?{
               construct_hash
-            when 125  # ?}
+            when 125 # ?}
               construct_hash_def
-            when 83   # ?S
+            when 83 # ?S
               construct_struct
-            when 111  # ?o
+            when 111 # ?o
               construct_object
-            when 117  # ?u
+            when 117 # ?u
               construct_user_defined ivar_index
-            when 85   # ?U
+            when 85 # ?U
               construct_user_marshal
-            when 100  # ?d
+            when 100 # ?d
               construct_data
-            when 64   # ?@
+            when 64 # ?@
               num = construct_integer
 
               begin
@@ -596,14 +596,14 @@ module Marshal
                 raise ArgumentError, 'dump format error (unlinked)'
               end
 
-            when 59   # ?;
+            when 59 # ?;
               num = construct_integer
               sym = @symbols[num]
 
               raise ArgumentError, 'bad symbol' unless sym
 
               return sym
-            when 101  # ?e
+            when 101 # ?e
               @modules ||= []
 
               name = get_symbol
@@ -614,13 +614,13 @@ module Marshal
               extend_object obj
 
               obj
-            when 67   # ?C
+            when 67 # ?C
               name = get_symbol
               @user_class = name
 
               construct nil, false
 
-            when 73   # ?I
+            when 73 # ?I
               ivar_index = @has_ivar.length
               @has_ivar.push true
 
@@ -680,7 +680,7 @@ module Marshal
     end
 
     def construct_bignum
-      sign = consume_byte() == 45 ? -1 : 1  # ?-
+      sign = consume_byte() == 45 ? -1 : 1 # ?-
       size = construct_integer * 2
 
       result = 0

--- a/src/main/ruby/core/process.rb
+++ b/src/main/ruby/core/process.rb
@@ -37,21 +37,21 @@ module Process
     EXIT_SUCCESS = Truffle::Config['platform.process.EXIT_SUCCESS'] || 0
     EXIT_FAILURE = Truffle::Config['platform.process.EXIT_FAILURE'] || 1
 
-    PRIO_PGRP    = Truffle::Config['platform.process.PRIO_PGRP']
+    PRIO_PGRP = Truffle::Config['platform.process.PRIO_PGRP']
     PRIO_PROCESS = Truffle::Config['platform.process.PRIO_PROCESS']
-    PRIO_USER    = Truffle::Config['platform.process.PRIO_USER']
+    PRIO_USER = Truffle::Config['platform.process.PRIO_USER']
 
-    RLIM_INFINITY  = Truffle::Config['platform.process.RLIM_INFINITY']
+    RLIM_INFINITY = Truffle::Config['platform.process.RLIM_INFINITY']
     RLIM_SAVED_MAX = Truffle::Config['platform.process.RLIM_SAVED_MAX']
     RLIM_SAVED_CUR = Truffle::Config['platform.process.RLIM_SAVED_CUR']
 
-    RLIMIT_AS      = Truffle::Config['platform.process.RLIMIT_AS']
-    RLIMIT_CORE    = Truffle::Config['platform.process.RLIMIT_CORE']
-    RLIMIT_CPU     = Truffle::Config['platform.process.RLIMIT_CPU']
-    RLIMIT_DATA    = Truffle::Config['platform.process.RLIMIT_DATA']
-    RLIMIT_FSIZE   = Truffle::Config['platform.process.RLIMIT_FSIZE']
-    RLIMIT_NOFILE  = Truffle::Config['platform.process.RLIMIT_NOFILE']
-    RLIMIT_STACK   = Truffle::Config['platform.process.RLIMIT_STACK']
+    RLIMIT_AS = Truffle::Config['platform.process.RLIMIT_AS']
+    RLIMIT_CORE = Truffle::Config['platform.process.RLIMIT_CORE']
+    RLIMIT_CPU = Truffle::Config['platform.process.RLIMIT_CPU']
+    RLIMIT_DATA = Truffle::Config['platform.process.RLIMIT_DATA']
+    RLIMIT_FSIZE = Truffle::Config['platform.process.RLIMIT_FSIZE']
+    RLIMIT_NOFILE = Truffle::Config['platform.process.RLIMIT_NOFILE']
+    RLIMIT_STACK = Truffle::Config['platform.process.RLIMIT_STACK']
 
     %i[RLIMIT_MEMLOCK RLIMIT_NPROC RLIMIT_RSS RLIMIT_SBSIZE].each do |limit|
       if value = Truffle::Config.lookup("platform.process.#{limit}")
@@ -60,14 +60,14 @@ module Process
     end
 
     if Truffle::Config.lookup('platform.process.RLIMIT_RTPRIO')
-      RLIMIT_RTPRIO     = Truffle::Config['platform.process.RLIMIT_RTPRIO']
-      RLIMIT_RTTIME     = Truffle::Config['platform.process.RLIMIT_RTTIME']
+      RLIMIT_RTPRIO = Truffle::Config['platform.process.RLIMIT_RTPRIO']
+      RLIMIT_RTTIME = Truffle::Config['platform.process.RLIMIT_RTTIME']
       RLIMIT_SIGPENDING = Truffle::Config['platform.process.RLIMIT_SIGPENDING']
-      RLIMIT_MSGQUEUE   = Truffle::Config['platform.process.RLIMIT_MSGQUEUE']
-      RLIMIT_NICE       = Truffle::Config['platform.process.RLIMIT_NICE']
+      RLIMIT_MSGQUEUE = Truffle::Config['platform.process.RLIMIT_MSGQUEUE']
+      RLIMIT_NICE = Truffle::Config['platform.process.RLIMIT_NICE']
     end
 
-    WNOHANG =   Truffle::Config['platform.process.WNOHANG']
+    WNOHANG = Truffle::Config['platform.process.WNOHANG']
     WUNTRACED = Truffle::Config['platform.process.WUNTRACED']
   end
   include Constants
@@ -108,10 +108,10 @@ module Process
     raise PrimitiveFailure, 'Process.time primitive failed'
   end
 
-  CLOCK_MONOTONIC         = 1
-  CLOCK_REALTIME          = 2
+  CLOCK_MONOTONIC = 1
+  CLOCK_REALTIME = 2
   CLOCK_THREAD_CPUTIME_ID = 3
-  CLOCK_MONOTONIC_RAW_ID  = 4
+  CLOCK_MONOTONIC_RAW_ID = 4
   
   def self.clock_gettime(id, unit=:float_second)
     case id
@@ -224,7 +224,7 @@ module Process
   private_class_method :setproctitle_linux_from_proc_maps
 
   def self.setrlimit(resource, cur_limit, max_limit=undefined)
-    resource =  coerce_rlimit_resource(resource)
+    resource = coerce_rlimit_resource(resource)
     cur_limit = Truffle::Type.coerce_to cur_limit, Integer, :to_int
 
     if undefined.equal? max_limit
@@ -452,7 +452,7 @@ module Process
 
   def self.getpriority(kind, id)
     kind = Truffle::Type.coerce_to kind, Integer, :to_int
-    id =   Truffle::Type.coerce_to id, Integer, :to_int
+    id = Truffle::Type.coerce_to id, Integer, :to_int
 
     ret = Truffle::POSIX.truffleposix_getpriority(kind, id)
     if ret <= -100
@@ -463,7 +463,7 @@ module Process
 
   def self.setpriority(kind, id, priority)
     kind = Truffle::Type.coerce_to kind, Integer, :to_int
-    id =   Truffle::Type.coerce_to id, Integer, :to_int
+    id = Truffle::Type.coerce_to id, Integer, :to_int
     priority = Truffle::Type.coerce_to priority, Integer, :to_int
 
     ret = Truffle::POSIX.setpriority(kind, id, priority)

--- a/src/main/ruby/core/random.rb
+++ b/src/main/ruby/core/random.rb
@@ -41,7 +41,7 @@ class Truffle::Randomizer
   end
 
   def swap_seed(new_seed)
-    old_seed  = self.seed
+    old_seed = self.seed
     self.seed = new_seed
     old_seed
   end
@@ -106,8 +106,8 @@ class Truffle::Randomizer
   # @return [Time|Date|DateTime]
   #
   def random_time_range(range)
-    min  = time_to_float(range.min)
-    max  = time_to_float(range.max)
+    min = time_to_float(range.min)
+    max = time_to_float(range.max)
     time = Time.at(random(min..max))
 
     if Object.const_defined?(:DateTime) && range.min.is_a?(DateTime)

--- a/src/main/ruby/core/regexp.rb
+++ b/src/main/ruby/core/regexp.rb
@@ -33,16 +33,16 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 class Regexp
-  IGNORECASE         = 1
-  EXTENDED           = 2
-  MULTILINE          = 4
-  FIXEDENCODING      = 16
-  NOENCODING         = 32
+  IGNORECASE = 1
+  EXTENDED = 2
+  MULTILINE = 4
+  FIXEDENCODING = 16
+  NOENCODING = 32
   DONT_CAPTURE_GROUP = 128
-  CAPTURE_GROUP      = 256
+  CAPTURE_GROUP = 256
 
   KCODE_NONE = (1 << 9)
-  KCODE_EUC  = (2 << 9)
+  KCODE_EUC = (2 << 9)
   KCODE_SJIS = (3 << 9)
   KCODE_UTF8 = (4 << 9)
   KCODE_MASK = KCODE_NONE | KCODE_EUC | KCODE_SJIS | KCODE_UTF8
@@ -60,25 +60,25 @@ class Regexp
 
   # The character literals (?x) are Fixnums in 1.8 and Strings in 1.9
   # so we use literal values instead so this is 1.8/1.9 compatible.
-  ESCAPE_TABLE[9]   = '\\t'
-  ESCAPE_TABLE[10]  = '\\n'
-  ESCAPE_TABLE[11]  = '\\v'
-  ESCAPE_TABLE[12]  = '\\f'
-  ESCAPE_TABLE[13]  = '\\r'
-  ESCAPE_TABLE[32]  = '\\ '
-  ESCAPE_TABLE[35]  = '\\#'
-  ESCAPE_TABLE[36]  = '\\$'
-  ESCAPE_TABLE[40]  = '\\('
-  ESCAPE_TABLE[41]  = '\\)'
-  ESCAPE_TABLE[42]  = '\\*'
-  ESCAPE_TABLE[43]  = '\\+'
-  ESCAPE_TABLE[45]  = '\\-'
-  ESCAPE_TABLE[46]  = '\\.'
-  ESCAPE_TABLE[63]  = '\\?'
-  ESCAPE_TABLE[91]  = '\\['
-  ESCAPE_TABLE[92]  = '\\\\'
-  ESCAPE_TABLE[93]  = '\\]'
-  ESCAPE_TABLE[94]  = '\\^'
+  ESCAPE_TABLE[9] = '\\t'
+  ESCAPE_TABLE[10] = '\\n'
+  ESCAPE_TABLE[11] = '\\v'
+  ESCAPE_TABLE[12] = '\\f'
+  ESCAPE_TABLE[13] = '\\r'
+  ESCAPE_TABLE[32] = '\\ '
+  ESCAPE_TABLE[35] = '\\#'
+  ESCAPE_TABLE[36] = '\\$'
+  ESCAPE_TABLE[40] = '\\('
+  ESCAPE_TABLE[41] = '\\)'
+  ESCAPE_TABLE[42] = '\\*'
+  ESCAPE_TABLE[43] = '\\+'
+  ESCAPE_TABLE[45] = '\\-'
+  ESCAPE_TABLE[46] = '\\.'
+  ESCAPE_TABLE[63] = '\\?'
+  ESCAPE_TABLE[91] = '\\['
+  ESCAPE_TABLE[92] = '\\\\'
+  ESCAPE_TABLE[93] = '\\]'
+  ESCAPE_TABLE[94] = '\\^'
   ESCAPE_TABLE[123] = '\\{'
   ESCAPE_TABLE[124] = '\\|'
   ESCAPE_TABLE[125] = '\\}'
@@ -353,8 +353,8 @@ class MatchData
 
   def ==(other)
     other.kind_of?(MatchData) &&
-      string == other.string  &&
-      regexp == other.regexp  &&
+      string == other.string &&
+      regexp == other.regexp &&
       captures == other.captures
   end
   alias_method :eql?, :==

--- a/src/main/ruby/core/stat.rb
+++ b/src/main/ruby/core/stat.rb
@@ -28,31 +28,31 @@ class File
   class Stat
     include Comparable
 
-    S_IRUSR  = Truffle::Config['platform.file.S_IRUSR']
-    S_IWUSR  = Truffle::Config['platform.file.S_IWUSR']
-    S_IXUSR  = Truffle::Config['platform.file.S_IXUSR']
-    S_IRGRP  = Truffle::Config['platform.file.S_IRGRP']
-    S_IWGRP  = Truffle::Config['platform.file.S_IWGRP']
-    S_IXGRP  = Truffle::Config['platform.file.S_IXGRP']
-    S_IROTH  = Truffle::Config['platform.file.S_IROTH']
-    S_IWOTH  = Truffle::Config['platform.file.S_IWOTH']
-    S_IXOTH  = Truffle::Config['platform.file.S_IXOTH']
+    S_IRUSR = Truffle::Config['platform.file.S_IRUSR']
+    S_IWUSR = Truffle::Config['platform.file.S_IWUSR']
+    S_IXUSR = Truffle::Config['platform.file.S_IXUSR']
+    S_IRGRP = Truffle::Config['platform.file.S_IRGRP']
+    S_IWGRP = Truffle::Config['platform.file.S_IWGRP']
+    S_IXGRP = Truffle::Config['platform.file.S_IXGRP']
+    S_IROTH = Truffle::Config['platform.file.S_IROTH']
+    S_IWOTH = Truffle::Config['platform.file.S_IWOTH']
+    S_IXOTH = Truffle::Config['platform.file.S_IXOTH']
 
-    S_IRUGO  = S_IRUSR | S_IRGRP | S_IROTH
-    S_IWUGO  = S_IWUSR | S_IWGRP | S_IWOTH
-    S_IXUGO  = S_IXUSR | S_IXGRP | S_IXOTH
+    S_IRUGO = S_IRUSR | S_IRGRP | S_IROTH
+    S_IWUGO = S_IWUSR | S_IWGRP | S_IWOTH
+    S_IXUGO = S_IXUSR | S_IXGRP | S_IXOTH
 
-    S_IFMT   = Truffle::Config['platform.file.S_IFMT']
-    S_IFIFO  = Truffle::Config['platform.file.S_IFIFO']
-    S_IFCHR  = Truffle::Config['platform.file.S_IFCHR']
-    S_IFDIR  = Truffle::Config['platform.file.S_IFDIR']
-    S_IFBLK  = Truffle::Config['platform.file.S_IFBLK']
-    S_IFREG  = Truffle::Config['platform.file.S_IFREG']
-    S_IFLNK  = Truffle::Config['platform.file.S_IFLNK']
+    S_IFMT = Truffle::Config['platform.file.S_IFMT']
+    S_IFIFO = Truffle::Config['platform.file.S_IFIFO']
+    S_IFCHR = Truffle::Config['platform.file.S_IFCHR']
+    S_IFDIR = Truffle::Config['platform.file.S_IFDIR']
+    S_IFBLK = Truffle::Config['platform.file.S_IFBLK']
+    S_IFREG = Truffle::Config['platform.file.S_IFREG']
+    S_IFLNK = Truffle::Config['platform.file.S_IFLNK']
     S_IFSOCK = Truffle::Config['platform.file.S_IFSOCK']
-    S_ISUID  = Truffle::Config['platform.file.S_ISUID']
-    S_ISGID  = Truffle::Config['platform.file.S_ISGID']
-    S_ISVTX  = Truffle::Config['platform.file.S_ISVTX']
+    S_ISUID = Truffle::Config['platform.file.S_ISUID']
+    S_ISGID = Truffle::Config['platform.file.S_ISGID']
+    S_ISVTX = Truffle::Config['platform.file.S_ISVTX']
 
     attr_reader :path
 

--- a/src/main/ruby/core/string.rb
+++ b/src/main/ruby/core/string.rb
@@ -282,7 +282,7 @@ class String
     index = 0
     while index < bytesize
       current = index
-      while current < bytesize && data[current] != 92  # ?\\
+      while current < bytesize && data[current] != 92 # ?\\
         current += 1
       end
       result.append(byteslice(index, current - index))
@@ -298,15 +298,15 @@ class String
       cap = data[index]
 
       additional = case cap
-                   when 38   # ?&
+                   when 38 # ?&
                      match[0]
-                   when 96   # ?`
+                   when 96 # ?`
                      match.pre_match
-                   when 39   # ?'
+                   when 39 # ?'
                      match.post_match
-                   when 43   # ?+
+                   when 43 # ?+
                      match.captures.compact[-1].to_s
-                   when 48..57   # ?0..?9
+                   when 48..57 # ?0..?9
                      match[cap - 48].to_s
                    when 92 # ?\\ escaped backslash
                      '\\'
@@ -329,7 +329,7 @@ class String
                      else
                        '\\'.append(cap.chr)
                      end
-                   else     # unknown escape
+                   else # unknown escape
                      '\\'.append(cap.chr)
                    end
       result.append(additional)
@@ -541,11 +541,11 @@ class String
           byte = getbyte(index)
           if byte >= 7 and byte <= 92
             case byte
-            when 7  # \a
+            when 7 # \a
               escaped = '\a'
-            when 8  # \b
+            when 8 # \b
               escaped = '\b'
-            when 9  # \t
+            when 9 # \t
               escaped = '\t'
             when 10 # \n
               escaped = '\n'
@@ -561,11 +561,11 @@ class String
               escaped = '\"'
             when 35 # #
               case getbyte(index += 1)
-              when 36   # $
+              when 36 # $
                 escaped = '\#$'
-              when 64   # @
+              when 64 # @
                 escaped = '\#@'
-              when 123  # {
+              when 123 # {
                 escaped = '\#{'
               else
                 index -= 1
@@ -1519,7 +1519,7 @@ class String
       # Normalize the results to be in {-1, 0, 1}. Also, since at this point we've inverted the objects being compared,
       # we must now invert the results.
       return -1 if tmp > 0
-      return 1  if tmp < 0
+      return 1 if tmp < 0
       return 0
     end
 

--- a/src/main/ruby/core/struct.rb
+++ b/src/main/ruby/core/struct.rb
@@ -228,7 +228,7 @@ class Struct
 
     Thread.detect_recursion self, other do
       _attrs.each do |var|
-        mine =   instance_variable_get(:"@#{var}")
+        mine = instance_variable_get(:"@#{var}")
         theirs = other.instance_variable_get(:"@#{var}")
 
         return false unless mine.eql? theirs
@@ -333,13 +333,13 @@ class Struct
 
       if name =~ /^@[a-z_]\w*$/i
         assigns << "#{name} = a#{i}"
-        vars    << name
+        vars << name
       else
         assigns << "instance_variable_set(:#{name.inspect}, a#{i})"
-        vars    << "instance_variable_get(:#{name.inspect})"
+        vars << "instance_variable_get(:#{name.inspect})"
       end
 
-      args   << "a#{i} = nil"
+      args << "a#{i} = nil"
       hashes << "#{vars[-1]}.hash"
     end
 

--- a/src/main/ruby/core/symbol.rb
+++ b/src/main/ruby/core/symbol.rb
@@ -54,9 +54,9 @@ class Symbol
     str = to_s
 
     case str
-    when /\A(\$|@@?)[a-z_][a-z_\d]*\z/i,                      # Variable names
-         /\A[a-z_][a-z_\d]*[=?!]?\z/i,                        # Method names
-         /\A\$(-[a-z_\d]|[+~:?<_\/'"$.,`!;\\=*>&@]|\d+)\z/i,  # Special global variables
+    when /\A(\$|@@?)[a-z_][a-z_\d]*\z/i, # Variable names
+         /\A[a-z_][a-z_\d]*[=?!]?\z/i, # Method names
+         /\A\$(-[a-z_\d]|[+~:?<_\/'"$.,`!;\\=*>&@]|\d+)\z/i, # Special global variables
          /\A([|^&\/%~`!]|!=|!~|<<|>>|<=>|===?|=~|[<>]=?|[+-]@?|\*\*?|\[\]=?)\z/ # Operators
       ":#{str}"
     else

--- a/src/main/ruby/core/thread.rb
+++ b/src/main/ruby/core/thread.rb
@@ -297,7 +297,7 @@ class Thread
 
     if undefined.equal? exc
       no_argument = true
-      exc         = nil
+      exc = nil
     end
 
     if exc.respond_to? :exception

--- a/src/main/ruby/core/time.rb
+++ b/src/main/ruby/core/time.rb
@@ -125,7 +125,7 @@ class Time
       r = (other <=> self)
       return nil if r == nil
       return -1 if r > 0
-      return  1 if r < 0
+      return 1 if r < 0
       0
     end
   end
@@ -217,14 +217,14 @@ class Time
     else
       major &= ~(1 << 31)
 
-      is_gmt =  (major >> 30) & 0x1
-      year   = ((major >> 14) & 0xffff) + 1900
-      mon    = ((major >> 10) & 0xf) + 1
-      mday   =  (major >>  5) & 0x1f
-      hour   =  major         & 0x1f
+      is_gmt = (major >> 30) & 0x1
+      year = ((major >> 14) & 0xffff) + 1900
+      mon = ((major >> 10) & 0xf) + 1
+      mday = (major >> 5) & 0x1f
+      hour = major & 0x1f
 
-      min   =  (minor >> 26) & 0x3f
-      sec   =  (minor >> 20) & 0x3f
+      min = (minor >> 26) & 0x3f
+      sec = (minor >> 20) & 0x3f
 
       usec = minor & 0xfffff
 
@@ -245,14 +245,14 @@ class Time
 
     gmt = gmt? ? 1 : 0
 
-    major =  1             << 31 | # 1 bit
-             gmt           << 30 | # 1 bit
+    major = 1 << 31 | # 1 bit
+             gmt << 30 | # 1 bit
             (tm[5] - 1900) << 14 | # 16 bits
-            (tm[4] - 1)    << 10 | # 4 bits
-             tm[3]         <<  5 | # 5 bits
-             tm[2]                 # 5 bits
-    minor =  tm[1]   << 26 | # 6 bits
-             tm[0]   << 20 | # 6 bits
+            (tm[4] - 1) << 10 | # 4 bits
+             tm[3] << 5 | # 5 bits
+             tm[2] # 5 bits
+    minor = tm[1] << 26 | # 6 bits
+             tm[0] << 20 | # 6 bits
              usec # 20 bits
 
     [major, minor].pack 'VV'
@@ -280,7 +280,7 @@ class Time
       s = Truffle::Type.coerce_to_exact_num(sec)
       u = Truffle::Type.coerce_to_exact_num(usec)
 
-      sec       = s.to_i
+      sec = s.to_i
       nsec_frac = s % 1.0
 
       sec -= 1 if s < 0 && nsec_frac > 0
@@ -302,7 +302,7 @@ class Time
       else
         s = Truffle::Type.coerce_to_exact_num(sec || 0)
 
-        sec       = s.to_i
+        sec = s.to_i
         nsec_frac = s % 1.0
 
         if s < 0 && nsec_frac > 0
@@ -355,9 +355,9 @@ class Time
         m = Truffle::Type.coerce_to(m || 1, Integer, :to_int)
       end
 
-      y   = y.kind_of?(String)   ? y.to_i   : Truffle::Type.coerce_to(y,        Integer, :to_int)
-      d   = d.kind_of?(String)   ? d.to_i   : Truffle::Type.coerce_to(d   || 1, Integer, :to_int)
-      hr  = hr.kind_of?(String)  ? hr.to_i  : Truffle::Type.coerce_to(hr  || 0, Integer, :to_int)
+      y = y.kind_of?(String) ? y.to_i : Truffle::Type.coerce_to(y, Integer, :to_int)
+      d = d.kind_of?(String) ? d.to_i : Truffle::Type.coerce_to(d || 1, Integer, :to_int)
+      hr = hr.kind_of?(String) ? hr.to_i : Truffle::Type.coerce_to(hr || 0, Integer, :to_int)
       min = min.kind_of?(String) ? min.to_i : Truffle::Type.coerce_to(min || 0, Integer, :to_int)
 
       nsec = nil

--- a/src/main/ruby/core/truffle/interop.rb
+++ b/src/main/ruby/core/truffle/interop.rb
@@ -89,11 +89,11 @@ module Truffle
     
     def self.key_info_flags_from_bits(bits)
       flags = []
-      flags << :existing  if existing_bit?(bits)
-      flags << :readable  if readable_bit?(bits)
-      flags << :writable  if writable_bit?(bits)
+      flags << :existing if existing_bit?(bits)
+      flags << :readable if readable_bit?(bits)
+      flags << :writable if writable_bit?(bits)
       flags << :invocable if invocable_bit?(bits)
-      flags << :internal  if internal_bit?(bits)
+      flags << :internal if internal_bit?(bits)
       flags
     end
     

--- a/src/main/ruby/core/truffle/numeric_operations.rb
+++ b/src/main/ruby/core/truffle/numeric_operations.rb
@@ -78,7 +78,7 @@ module Truffle
     def self.stepping_forever?(limit, step, asc)
       return true if limit.nil? || step.zero?
       if asc
-        limit == Float::INFINITY  && step != Float::INFINITY
+        limit == Float::INFINITY && step != Float::INFINITY
       else
         limit == -Float::INFINITY && step != -Float::INFINITY
       end

--- a/src/main/ruby/core/truffle/process_operations.rb
+++ b/src/main/ruby/core/truffle/process_operations.rb
@@ -61,29 +61,29 @@ module Truffle
   module ProcessOperations
 
     SHELL_META_CHARS = [
-      '*',  # Pathname Expansion
-      '?',  # Pathname Expansion
-      '{',  # Grouping Commands
-      '}',  # Grouping Commands
-      '[',  # Pathname Expansion
-      ']',  # Pathname Expansion
-      '<',  # Redirection
-      '>',  # Redirection
-      '(',  # Grouping Commands
-      ')',  # Grouping Commands
-      '~',  # Tilde Expansion
-      '&',  # AND Lists, Asynchronous Lists
-      '|',  # OR Lists, Pipelines
+      '*', # Pathname Expansion
+      '?', # Pathname Expansion
+      '{', # Grouping Commands
+      '}', # Grouping Commands
+      '[', # Pathname Expansion
+      ']', # Pathname Expansion
+      '<', # Redirection
+      '>', # Redirection
+      '(', # Grouping Commands
+      ')', # Grouping Commands
+      '~', # Tilde Expansion
+      '&', # AND Lists, Asynchronous Lists
+      '|', # OR Lists, Pipelines
       '\\', # Escape Character
-      '$',  # Parameter Expansion
-      ';',  # Sequential Lists
+      '$', # Parameter Expansion
+      ';', # Sequential Lists
       '\'', # Single-Quotes
-      '`',  # Command Substitution
-      '"',  # Double-Quotes
+      '`', # Command Substitution
+      '"', # Double-Quotes
       "\n", # Lists
-      '#',  # Comment
-      '=',  # Assignment preceding command name
-      '%'   # (used in Parameter Expansion)
+      '#', # Comment
+      '=', # Assignment preceding command name
+      '%' # (used in Parameter Expansion)
     ]
     SHELL_META_CHAR_PATTERN = Regexp.new("[#{SHELL_META_CHARS.map(&Regexp.method(:escape)).join}]")
 
@@ -301,7 +301,7 @@ module Truffle
           when 2
             if obj[0] == :child
               fd = convert_to_fd obj[1], target
-              fd.kind_of?(::Fixnum) ?  -(fd + 1) : fd
+              fd.kind_of?(::Fixnum) ? -(fd + 1) : fd
             else
               open_file_for_child(obj[0], convert_file_mode(obj[1]), 0644)
             end
@@ -358,11 +358,11 @@ module Truffle
       # Mapping of string open modes to integer oflag versions.
       OFLAGS = {
         'r'  => ::File::RDONLY,
-        'r+' => ::File::RDWR   | ::File::CREAT,
-        'w'  => ::File::WRONLY | ::File::CREAT  | ::File::TRUNC,
-        'w+' => ::File::RDWR   | ::File::CREAT  | ::File::TRUNC,
+        'r+' => ::File::RDWR | ::File::CREAT,
+        'w'  => ::File::WRONLY | ::File::CREAT | ::File::TRUNC,
+        'w+' => ::File::RDWR | ::File::CREAT | ::File::TRUNC,
         'a'  => ::File::WRONLY | ::File::APPEND | ::File::CREAT,
-        'a+' => ::File::RDWR   | ::File::APPEND | ::File::CREAT
+        'a+' => ::File::RDWR | ::File::APPEND | ::File::CREAT
       }
 
       def spawn_setup(alter_process)

--- a/src/main/ruby/core/truffle/range_operations.rb
+++ b/src/main/ruby/core/truffle/range_operations.rb
@@ -63,8 +63,8 @@ module Truffle
         # if any are floats they all must be
         begin
           step_size = Float(from = step_size)
-          first     = Float(from = first)
-          last      = Float(from = last)
+          first = Float(from = first)
+          last = Float(from = last)
         rescue ArgumentError
           raise TypeError, "no implicit conversion to float from #{from.class}"
         end


### PR DESCRIPTION
I think it catches of lots of unintended extra spacing and I think many cases are just as readable without the value alignment.
In editors other than IntelliJ, this value alignment has to be handled manually, which is cumbersome and often means it becomes inconsistent over time, as the diff shows.
Moreover, aligning with values changes lines above and below, often for not much gain, which makes the diff bigger and less readable, and makes lines longer.

There are a few cases where aligning based on the value is useful (e.g., related constants), which we can have by disabling the cop on these spots.

What do you guys think?
Please mark a few places where you like or dislike the change.