### PR TITLE
Store the classpath and Java properties at build time from mx to use in the Bash launcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,5 +122,8 @@ bin/*
 !bin/truffleruby.sh
 !bin/testrb
 
+# For the Bash launcher
+tool/jvm_args
+
 # Diagnostic output directory
 dumps/

--- a/mx.truffleruby/mx_truffleruby.py
+++ b/mx.truffleruby/mx_truffleruby.py
@@ -100,7 +100,8 @@ class TruffleRubyLauncherBuildTask(mx.ArchivableBuildTask):
             os.remove(self.launcher)
 
     def store_jvm_args(self):
-        jvm_args = mx.get_runtime_jvm_args(['TRUFFLERUBY', 'TRUFFLERUBY-LAUNCHER', 'SULONG'])
+        distributions = [dep.name for dep in self.subject.buildDependencies]
+        jvm_args = mx.get_runtime_jvm_args(distributions)
         properties = []
         while jvm_args:
             arg = jvm_args.pop(0)

--- a/mx.truffleruby/suite.py
+++ b/mx.truffleruby/suite.py
@@ -244,6 +244,11 @@ suite = {
 
         "truffleruby-bin": {
             "class": "TruffleRubyLauncherProject",
+            "buildDependencies": [
+                "TRUFFLERUBY",
+                "TRUFFLERUBY-LAUNCHER",
+                "sulong:SULONG",
+            ],
             "outputDir": "bin",
             "prefix": "bin",
             "license": [

--- a/mx.truffleruby/suite.py
+++ b/mx.truffleruby/suite.py
@@ -7,7 +7,7 @@ suite = {
             {
                 "name": "truffle",
                 "subdir": True,
-                "version": "adc717026ebd7175de71a2638f42d2bcd3506ea2",
+                "version": "dc33b5df22c06ce60b4a5cf482aae4a966767260",
                 "urls": [
                     {"url": "https://github.com/graalvm/graal.git", "kind": "git"},
                     {"url": "https://curio.ssw.jku.at/nexus/content/repositories/snapshots", "kind": "binary"},


### PR DESCRIPTION
* So they can be reused by the launcher easily, without hardcoding paths.
* Source vs binary suite handling is done automatically by mx.
* No need to figure out the mx os + arch.
