### PR TITLE
Use llvm-linker to combine library bitcode files.

### DIFF
--- a/lib/cext/linker.rb
+++ b/lib/cext/linker.rb
@@ -45,7 +45,14 @@ module Truffle::CExt
       libraries = libraries.uniq
       libraries = resolve_libraries(libraries, search_paths)
       files = files.uniq
+      files = link_bitcode(files)
       Truffle::CExt.linker(output, libraries, files)
+    end
+
+    def self.link_bitcode(files)
+      output = 'out.bc'
+      raise 'Linker failed' unless system('llvm-link', '-o', output, *files)
+      [output]
     end
 
     def self.resolve_libraries(libraries, search_paths)

--- a/test/truffle/cexts/backtraces/expected.txt
+++ b/test/truffle/cexts/backtraces/expected.txt
@@ -53,7 +53,7 @@ Test error in callback from a native function
 42
 /lib/truffle/truffle/cext.rb:n:in `execute_without_conversion': Error in C extension code (SulongRuntimeException):
 Exception thrown by a callback during the native call com.oracle.truffle.nfi.impl.LibFFIFunction@HEXA(function@HEXA '@sulong_callback') (IllegalStateException)
-	from native_callback in backtraces.c:43:17 (LLVM IR Function native_callback in /lib/backtraces/backtraces.su@HEXA_backtraces.bc in Block BLOCKINFO)
+	from native_callback in backtraces.c:43:17 (LLVM IR Function native_callback in /lib/backtraces/backtraces.su@HEXA_out.bc in Block BLOCKINFO)
 	from com.oracle.truffle.llvm.nodes.func.LLVMNativeCallUtils.callNativeFunction(LLVMNativeCallUtils.java:72)
 Caused by:
 /bin/backtraces:88:in `error_helper': error from Ruby called from Sulong called from native callback (RuntimeError)


### PR DESCRIPTION
This resolves some sulong function resolution bugs in C extensions.