### PR TITLE
Always fetch llvm with mx fetch-languages

### DIFF
--- a/ci.jsonnet
+++ b/ci.jsonnet
@@ -245,7 +245,7 @@ local part_definitions = {
         # Workaround for NFI when building with different Truffle versions
         ["mx", "clean"],
         ["mx", "build"],
-        ["mx", "fetch-languages", "--ruby"],
+        ["mx", "fetch-languages", "--llvm", "--ruby"],
         # aot-build.log is used for the build-stats metrics
         ["./native-image", "-no-server", "--ruby", "|", "tee", "../../main/aot-build.log"],
         ["cd", "../../main"],

--- a/tool/jt.rb
+++ b/tool/jt.rb
@@ -1784,7 +1784,7 @@ module Commands
       languages = %w[--ruby]
       extra = []
       if sulong
-        languages.unshift '--sulong'
+        languages.unshift '--llvm'
         options = %w[
           -Dtruffleruby.native.libsulong_dir=lib/cext/sulong-libs
         ] + options

--- a/tool/jt.rb
+++ b/tool/jt.rb
@@ -1790,7 +1790,7 @@ module Commands
         ] + options
       end
 
-      mx 'fetch-languages', *languages
+      mx 'fetch-languages', '--llvm', '--ruby'
 
       env = { "JAVA_HOME" => java_home }
       output_options = "-H:Path=#{TRUFFLERUBY_DIR}/bin", '-H:Name=native-ruby'


### PR DESCRIPTION
* Since our suite.py depends on Sulong distributions.
* Whether Sulong is part of the image is decided by `--llvm` being passed to ./native-image.