### PR TITLE
Automatically copy the SULONG_LIBS under the Ruby home on build

### DIFF
--- a/mx.truffleruby/suite.py
+++ b/mx.truffleruby/suite.py
@@ -227,10 +227,23 @@ suite = {
             ],
         },
 
+        # Copy the files from SULONG_LIBS to lib/cext/sulong-libs.
+        # Used by native images, which need a relative path from the Ruby home
+        # to these libraries to pass to Sulong so it can find them.
+        "truffleruby-sulong-libs": {
+            "class": "TruffleRubySulongLibsProject",
+            "outputDir": "lib/cext/sulong-libs",
+            "prefix": "lib/cext/sulong-libs",
+            "buildDependencies": [
+                "sulong:SULONG_LIBS",
+            ],
+        },
+
         "truffleruby-lib": {
             "class": "ArchiveProject",
             "dependencies": [
                 "truffleruby-cext",
+                "truffleruby-sulong-libs",
             ],
             "outputDir": "lib",
             "prefix": "lib",

--- a/tool/jt.rb
+++ b/tool/jt.rb
@@ -1772,6 +1772,11 @@ module Commands
     sulong = options.delete "sulong"
 
     build
+    if sulong
+      FileUtils::Verbose.cp_r "#{SULONG.dir}/mxbuild/sulong-libs", "#{TRUFFLERUBY_DIR}/lib/cext"
+      # Repack TRUFFLERUBY-ZIP to include the sulong-libs
+      mx 'build', '--dependencies', 'TRUFFLERUBY-ZIP'
+    end
 
     java_home = install_jvmci
     graal = checkout_or_update_graal_repo

--- a/tool/jt.rb
+++ b/tool/jt.rb
@@ -1772,11 +1772,6 @@ module Commands
     sulong = options.delete "sulong"
 
     build
-    if sulong
-      FileUtils::Verbose.cp_r "#{SULONG.dir}/mxbuild/sulong-libs", "#{TRUFFLERUBY_DIR}/lib/cext"
-      # Repack TRUFFLERUBY-ZIP to include the sulong-libs
-      mx 'build', '--dependencies', 'TRUFFLERUBY-ZIP'
-    end
 
     java_home = install_jvmci
     graal = checkout_or_update_graal_repo

--- a/tool/make-native-distribution.sh
+++ b/tool/make-native-distribution.sh
@@ -68,6 +68,7 @@ export TRUFFLERUBY_RESILIENT_GEM_HOME=true
 
 # Build
 
+# NOTE: The 3 lines below are no longer needed in the next release
 # Build Sulong first so that TRUFFLERUBY-ZIP includes sulong-libs
 cd ../sulong
 mx build


### PR DESCRIPTION
* Used by native Ruby, which needs a relative path from the Ruby home
  to these libraries, when Sulong is included.