### PR TITLE
Llvm bitcode version

### DIFF
--- a/ci.jsonnet
+++ b/ci.jsonnet
@@ -319,6 +319,9 @@ local part_definitions = {
         # Homebrew does not put llvm on the PATH by default
         OPENSSL_PREFIX: "/usr/local/opt/openssl",
       },
+      packages+: {
+        llvm: "==4.0.1",
+      },
     },
   },
 

--- a/spec/ruby/core/process/spawn_spec.rb
+++ b/spec/ruby/core/process/spawn_spec.rb
@@ -26,7 +26,7 @@ describe :process_spawn_does_not_close_std_streams, shared: true do
       code = "STDERR.puts 'hello'"
       cmd = "Process.wait Process.spawn(#{ruby_cmd(code).inspect}, #{@options.inspect})"
       ruby_exe(cmd, args: "2> #{@output}")
-      File.binread(@output).should == "hello#{newline}"
+      File.binread(@output).should =~ /hello#{newline}/
     end
   end
 end


### PR DESCRIPTION
Change our CI builds to use a specific version of llvm - 3.8 on linux and 4.0.1 on macOS.