### PR TITLE
Revert "Revert Dir.glob improvements due to issue with filename case-insensitivity on macOS."

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ New features:
 
 Performance:
 
+* `Dir.glob` is much faster and more memory efficient in cases that can reduce
+  to direct filename lookups.
+
 * `SecureRandom` now defers loading OpenSSL until it's needed, reducing time to
   load `SecureRandom`.
 

--- a/src/main/ruby/core/dir_glob.rb
+++ b/src/main/ruby/core/dir_glob.rb
@@ -1,3 +1,6 @@
+# frozen_string_literal: true
+# TODO (nirvdrum 11-Mar-18): The above pragma currently does nothing for 'core' files. We need to fix this limitation in BodyTranslator.
+
 # Copyright (c) 2007-2015, Evan Phoenix and contributors
 # All rights reserved.
 #
@@ -26,6 +29,10 @@
 
 class Dir
   module Glob
+    no_meta_chars = '[^*?\\[\\]{}\\\\]'
+    NO_GLOB_META_CHARS = /\A#{no_meta_chars}+\z/
+    TRAILING_BRACES = /\A(#{no_meta_chars}+)(?:\{(#{no_meta_chars}*)\})?\z/
+
     class Node
       def initialize(nxt, flags)
         @flags = flags
@@ -55,12 +62,12 @@ class Dir
         @dir = dir
       end
 
-      def call(env, path)
+      def call(matches, path)
         full = path_join(path, @dir)
 
         # Don't check if full exists. It just costs us time
         # and the downstream node will be able to check properly.
-        @next.call env, full
+        @next.call matches, full
       end
     end
 
@@ -70,23 +77,23 @@ class Dir
         @name = name
       end
 
-      def call(env, parent)
+      def call(matches, parent)
         path = path_join(parent, @name)
 
         if File.exist? path
-          env.matches << path
+          matches << path
         end
       end
     end
 
     class RootDirectory < Node
-      def call(env, path)
-        @next.call env, '/'
+      def call(matches, path)
+        @next.call matches, '/'
       end
     end
 
     class RecursiveDirectories < Node
-      def call(env, start)
+      def call(matches, start)
         return if !start || !File.exist?(start)
 
         # Even though the recursive entry is zero width
@@ -94,7 +101,7 @@ class Dir
         # dominant one, so we fix things up to use it.
         switched = @next.dup
         switched.separator = @separator
-        switched.call env, start
+        switched.call matches, start
 
         stack = [start]
 
@@ -115,7 +122,7 @@ class Dir
 
             if stat.directory? and (allow_dots or ent.getbyte(0) != 46) # ?.
               stack << full
-              @next.call env, full
+              @next.call matches, full
             end
           end
           dir.close
@@ -124,7 +131,7 @@ class Dir
     end
 
     class StartRecursiveDirectories < Node
-      def call(env, start)
+      def call(matches, start)
         raise 'invalid usage' if start
 
         # Even though the recursive entry is zero width
@@ -133,9 +140,9 @@ class Dir
         if @separator
           switched = @next.dup
           switched.separator = @separator
-          switched.call env, start
+          switched.call matches, start
         else
-          @next.call env, start
+          @next.call matches, start
         end
 
         stack = []
@@ -149,7 +156,7 @@ class Dir
 
           if stat.directory? and (allow_dots or ent.getbyte(0) != 46) # ?.
             stack << ent
-            @next.call env, ent
+            @next.call matches, ent
           end
         end
         dir.close
@@ -164,7 +171,7 @@ class Dir
 
             if stat.directory? and ent.getbyte(0) != 46  # ?.
               stack << full
-              @next.call env, full
+              @next.call matches, full
             end
           end
           dir.close
@@ -175,7 +182,7 @@ class Dir
     class Match < Node
       def initialize(nxt, flags, glob)
         super nxt, flags
-        @glob = glob || ''
+        @glob = glob || +''
       end
 
       def match?(str)
@@ -190,7 +197,7 @@ class Dir
         @glob.gsub! '**', '*'
       end
 
-      def call(env, path)
+      def call(matches, path)
         return if path and !File.exist?("#{path}/.")
 
         dir = Dir.new(path ? path : '.')
@@ -199,7 +206,7 @@ class Dir
             full = path_join(path, ent)
 
             if File.directory? full
-              @next.call env, full
+              @next.call matches, full
             end
           end
         end
@@ -208,7 +215,7 @@ class Dir
     end
 
     class EntryMatch < Match
-      def call(env, path)
+      def call(matches, path)
         return if path and !File.exist?("#{path}/.")
 
         begin
@@ -219,7 +226,7 @@ class Dir
 
         while ent = dir.read
           if match? ent
-            env.matches << path_join(path, ent)
+            matches << path_join(path, ent)
           end
         end
         dir.close
@@ -227,18 +234,10 @@ class Dir
     end
 
     class DirectoriesOnly < Node
-      def call(env, path)
+      def call(matches, path)
         if path and File.exist?("#{path}/.")
-          env.matches << "#{path}/"
+          matches << "#{path}/"
         end
-      end
-    end
-
-    class Environment
-      attr_reader :matches
-
-      def initialize(matches=[])
-        @matches = matches
       end
     end
 
@@ -276,13 +275,17 @@ class Dir
     end
 
     def self.single_compile(glob, flags=0)
+      if glob.getbyte(-1) != 47 && NO_GLOB_META_CHARS.match?(glob) # byte value 47 = ?/
+        return ConstantEntry.new nil, flags, glob
+      end
+
       parts = path_split(glob)
 
       if glob.getbyte(-1) == 47 # ?/
         last = DirectoriesOnly.new nil, flags
       else
         file = parts.pop
-        if /^[a-zA-Z0-9._]+$/.match(file)
+        if NO_GLOB_META_CHARS.match?(file)
           last = ConstantEntry.new nil, flags, file
         else
           last = EntryMatch.new nil, flags, file
@@ -299,8 +302,8 @@ class Dir
           else
             last = RecursiveDirectories.new last, flags
           end
-        elsif /^[^\*\?\]]+$/.match(dir)
-          while /^[^\*\?\]]+$/.match(parts[-2])
+        elsif NO_GLOB_META_CHARS.match?(dir)
+          while NO_GLOB_META_CHARS.match?(parts[-2])
             next_sep = parts.pop
             next_sect = parts.pop
 
@@ -321,21 +324,23 @@ class Dir
     end
 
     def self.run(node, all_matches=[])
-      matches = []
-      env = Environment.new(matches)
-      node.call env, nil
-      # Truffle: ensure glob'd files are always sorted in consistent order,
-      # it avoids headaches due to platform differences (OS X is sorted, Linux not).
-      matches.sort!
-      all_matches.concat(matches)
+      if ConstantEntry === node
+        node.call all_matches, nil
+      else
+        matches = []
+        node.call matches, nil
+        # Truffle: ensure glob'd files are always sorted in consistent order,
+        # it avoids headaches due to platform differences (OS X is sorted, Linux not).
+        matches.sort!
+        all_matches.concat(matches)
+      end
     end
 
     def self.glob(pattern, flags, matches=[])
       # Rubygems uses Dir[] as a glorified File.exist?  to check for multiple
       # extensions. So we went ahead and sped up that specific case.
 
-      if flags == 0 and
-             m = /^([a-zA-Z0-9_.\/\s]*[a-zA-Z0-9_.])(?:\{([^{}\/\*\?]*)\})?$/.match(pattern)
+      if flags == 0 and m = TRAILING_BRACES.match(pattern)
         # no meta characters, so this is a glorified
         # File.exist? check. We allow for a brace expansion
         # only as a suffix.
@@ -361,8 +366,9 @@ class Dir
         return matches
       end
 
-      if pattern.include? '{'
-        patterns = compile(pattern, flags)
+      left_brace_index = pattern.index('{')
+      if left_brace_index
+        patterns = compile(pattern, left_brace_index, flags)
 
         patterns.each do |node|
           run node, matches
@@ -374,14 +380,13 @@ class Dir
       end
     end
 
-    def self.compile(pattern, flags=0, patterns=[])
+    def self.compile(pattern, left_brace_index, flags, patterns=[])
       escape = (flags & File::FNM_NOESCAPE) == 0
 
+      lbrace = left_brace_index
       rbrace = nil
-      lbrace = nil
 
-      # Do a quick search for a { to start the search better
-      i = pattern.index('{')
+      i = left_brace_index
 
       # If there was a { found, then search
       if i
@@ -391,20 +396,15 @@ class Dir
           char = pattern[i]
 
           if char == '{'
-            lbrace = i if nest == 0
             nest += 1
-          end
-
-          if char == '}'
+          elsif char == '}'
             nest -= 1
-          end
 
-          if nest == 0
-            rbrace = i
-            break
-          end
-
-          if char == '\\' and escape
+            if nest == 0
+              rbrace = i
+              break
+            end
+          elsif char == '\\' and escape
             i += 1
           end
 
@@ -425,10 +425,13 @@ class Dir
           last = pos
 
           while pos < rbrace and not (pattern[pos] == ',' and nest == 0)
-            nest += 1 if pattern[pos] == '{'
-            nest -= 1 if pattern[pos] == '}'
+            char = pattern[pos]
 
-            if pattern[pos] == '\\' and escape
+            if char == '{'
+              nest += 1
+            elsif char == '}'
+              nest -= 1
+            elsif char == '\\' and escape
               pos += 1
               break if pos == rbrace
             end
@@ -436,9 +439,23 @@ class Dir
             pos += 1
           end
 
-          brace_pattern = "#{front}#{pattern[last...pos]}#{back}"
+          middle = pattern[last...pos]
+          brace_pattern = "#{front}#{middle}#{back}"
 
-          compile brace_pattern, flags, patterns
+          # The front part of the constructed string can't possibly have a '{' character, but the other parts might.
+          # By searching each part rather than the constructed string, we can reduce the number of characters that
+          # need to be checked.
+          next_left_brace = middle.index('{')
+          if next_left_brace
+            next_left_brace += front.size
+          else
+            next_left_brace = back.index('{')
+            if next_left_brace
+              next_left_brace += front.size + middle.size
+            end
+          end
+
+          compile brace_pattern, next_left_brace, flags, patterns
         end
 
         # No braces found, match the pattern normally


### PR DESCRIPTION
This reverts commit b65c64e9c4fb403434c8c503347701e9e34fb676.