### PR TITLE
Explicitly set the main class for native builds with Sulong.

### DIFF
--- a/tool/jt.rb
+++ b/tool/jt.rb
@@ -1780,7 +1780,6 @@ module Commands
       mx 'build'
 
       languages = %w[--Language:ruby]
-      extra = []
       if sulong
         languages.unshift '--Language:llvm'
         options = %w[
@@ -1791,7 +1790,7 @@ module Commands
       mx 'fetch-languages', '--Language:llvm', '--Language:ruby'
 
       env = { "JAVA_HOME" => java_home }
-      output_options = "-H:Path=#{TRUFFLERUBY_DIR}/bin", '-H:Name=native-ruby'
+      output_options = "-H:Path=#{TRUFFLERUBY_DIR}/bin", '-H:Name=native-ruby', "-H:Class=org.truffleruby.Main"
       raw_sh env, './native-image', '--no-server', *languages, *output_options, *options
     end
   end


### PR DESCRIPTION
Sulong now has its own main class and native-image can't tell which one to use without being instructed to do so. In such cases, it falls back to the generic polyglot main.