### PR TITLE
Lower the MaxRuntimeCompileMethods limit

### DIFF
--- a/mx.truffleruby/native-image.properties
+++ b/mx.truffleruby/native-image.properties
@@ -7,7 +7,7 @@ Requires = Tool:nfi
 
 LauncherClass = org.truffleruby.launcher.RubyLauncher
 
-Args = -H:MaxRuntimeCompileMethods=7500 \
+Args = -H:MaxRuntimeCompileMethods=5400 \
        -H:SubstitutionResources=org/truffleruby/aot/substitutions.json \
        -H:+AddAllCharsets \
        -H:Class=org.truffleruby.launcher.RubyLauncher

--- a/src/main/java/org/truffleruby/language/loader/RequireNode.java
+++ b/src/main/java/org/truffleruby/language/loader/RequireNode.java
@@ -73,21 +73,20 @@ public abstract class RequireNode extends RubyNode {
             throw new RaiseException(getContext().getCoreExceptions().loadErrorCannotLoad(feature, this));
         }
 
-        final String expandedPath = expandedPathRaw.intern();
-
-        final DynamicObject pathString = makeStringNode.executeMake(expandedPath, UTF8Encoding.INSTANCE, CodeRange.CR_UNKNOWN);
+        final DynamicObject pathString = makeStringNode.executeMake(expandedPathRaw, UTF8Encoding.INSTANCE, CodeRange.CR_UNKNOWN);
 
         if (isLoadedProfile.profile(isFeatureLoaded(pathString))) {
             return false;
         } else {
-            return doRequire(feature, expandedPath, pathString);
+            return doRequire(feature, expandedPathRaw, pathString);
         }
     }
 
     @TruffleBoundary
-    private boolean doRequire(String feature, String expandedPath, DynamicObject pathString) {
+    private boolean doRequire(String feature, String expandedPathRaw, DynamicObject pathString) {
         final FeatureLoader featureLoader = getContext().getFeatureLoader();
         final ReentrantLockFreeingMap<String> fileLocks = featureLoader.getFileLocks();
+        final String expandedPath = expandedPathRaw.intern();
 
         while (true) {
             final ReentrantLock lock = fileLocks.get(expandedPath);

--- a/src/main/java/org/truffleruby/language/loader/RequireNode.java
+++ b/src/main/java/org/truffleruby/language/loader/RequireNode.java
@@ -82,7 +82,7 @@ public abstract class RequireNode extends RubyNode {
         }
     }
 
-    @TruffleBoundary
+    @TruffleBoundary(transferToInterpreterOnException = false)
     private boolean doRequire(String feature, String expandedPathRaw, DynamicObject pathString) {
         final FeatureLoader featureLoader = getContext().getFeatureLoader();
         final ReentrantLockFreeingMap<String> fileLocks = featureLoader.getFileLocks();


### PR DESCRIPTION
* Current build has 5278 runtime compilable methods.
* We can bump when needed.
* A closer limit enables to catch smaller increases.