### PR TITLE
Don't warn about home not being found if graalvm.libpolyglot is set

### DIFF
--- a/src/main/java/org/truffleruby/RubyContext.java
+++ b/src/main/java/org/truffleruby/RubyContext.java
@@ -141,6 +141,8 @@ public class RubyContext {
 
     private static boolean preInitializeContexts = RubyLauncher.PRE_INITIALIZE_CONTEXTS;
 
+    private static final boolean LIBPOLYGLOT = Boolean.getBoolean("graalvm.libpolyglot");
+
     public RubyContext(RubyLanguage language, TruffleLanguage.Env env) {
         Metrics.printTime("before-context-constructor");
 
@@ -747,7 +749,10 @@ public class RubyContext {
 
         warning.append("* try to set home using -Xhome=PATH option");
 
-        Log.LOGGER.warning("could not determine TruffleRuby's home - the standard library will not be available");
+        if (!LIBPOLYGLOT) {
+            // We have no way to ever find home automatically in libpolyglot, so don't clutter with warnings
+            Log.LOGGER.warning("could not determine TruffleRuby's home - the standard library will not be available");
+        }
 
         if (options.EMBEDDED) {
             Log.LOGGER.config(warning.toString());


### PR DESCRIPTION
I tried to write a spec for this but it's tricky because the bash development launcher sets `-Xhome` so bypasses all this.