### PR TITLE
Check exceptions in sub-threads in MiscTest

### DIFF
--- a/src/test/java/org/truffleruby/MiscTest.java
+++ b/src/test/java/org/truffleruby/MiscTest.java
@@ -71,13 +71,13 @@ public class MiscTest {
     }
 
     @Test
-    public void testEvalFromIntegratorThreadSingleThreaded() throws InterruptedException {
+    public void testEvalFromIntegratorThreadSingleThreaded() throws Throwable {
         final String codeDependingOnCurrentThread = "Thread.current.object_id";
 
         try (Context context = Context.create()) {
             long thread1 = context.eval("ruby", codeDependingOnCurrentThread).asLong();
 
-            Thread thread = new Thread(() -> {
+            TestingThread thread = new TestingThread(() -> {
                 long thread2 = context.eval("ruby", codeDependingOnCurrentThread).asLong();
                 assertNotEquals(thread1, thread2);
             });
@@ -87,13 +87,13 @@ public class MiscTest {
     }
 
     @Test
-    public void testFiberFromIntegratorThread() throws InterruptedException {
+    public void testFiberFromIntegratorThread() throws Throwable {
         try (Context context = Context.newBuilder()
                 .option(OptionsCatalog.SINGLE_THREADED.getName(), Boolean.FALSE.toString())
                 .allowCreateThread(true).build()) {
             context.eval("ruby", ":init");
 
-            Thread thread = new Thread(() -> {
+            TestingThread thread = new TestingThread(() -> {
                 int value = context.eval("ruby", "Fiber.new { 6 * 7 }.resume").asInt();
                 assertEquals(42, value);
             });

--- a/src/test/java/org/truffleruby/TestingThread.java
+++ b/src/test/java/org/truffleruby/TestingThread.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved. This
+ * code is released under a tri EPL/GPL/LGPL license. You can use it,
+ * redistribute it and/or modify it under the terms of the:
+ *
+ * Eclipse Public License version 1.0
+ * GNU General Public License version 2
+ * GNU Lesser General Public License version 2.1
+ */
+package org.truffleruby;
+
+/**
+ * If the Thread dies from an exception, rethrow it on join().
+ * This Thread can then be used for assert*().
+ */
+public class TestingThread {
+
+    private final Thread thread;
+    private Throwable throwable;
+
+    public TestingThread(Runnable runnable) {
+        thread = new Thread(() -> {
+            try {
+                runnable.run();
+            } catch (Throwable t) {
+                throwable = t;
+            }
+        });
+    }
+
+    public void start() {
+        thread.start();
+    }
+
+    public void join() throws Throwable {
+        thread.join();
+
+        if (throwable != null) {
+            throw throwable;
+        }
+    }
+
+}


### PR DESCRIPTION
Fixes threads failing silently in tests, as in https://github.com/oracle/truffleruby/pull/1251#discussion_r177583256