### PR TITLE
Define RbConfig::CONFIG 'ridir' and 'datarootdir' for bin/ri

### DIFF
--- a/lib/truffle/rbconfig.rb
+++ b/lib/truffle/rbconfig.rb
@@ -165,6 +165,11 @@ module RbConfig
     mkconfig['sitearchdir'] = '$(sitelibdir)/$(sitearch)'
     expanded['topdir'] = archdir
     mkconfig['topdir'] = '$(archdir)'
+    datarootdir = \
+    expanded['datarootdir'] = "#{prefix}/share"
+    mkconfig['datarootdir'] = '$(prefix)/share'
+    expanded['ridir'] = "#{datarootdir}/ri"
+    mkconfig['ridir'] = '$(datarootdir)/ri'
   end
 
   launcher = Truffle::Boot.ruby_launcher


### PR DESCRIPTION
Now it works for gems documentation:
```bash
$ jt ruby -S gem i --ri benchmark-ips
Fetching: benchmark-ips-2.7.2.gem (100%)
Successfully installed benchmark-ips-2.7.2
Parsing documentation for benchmark-ips-2.7.2
Installing ri documentation for benchmark-ips-2.7.2
Done installing documentation for benchmark-ips after 17 seconds
1 gem installed

$ jt ruby -S ri Benchmark::IPS

$ jt ruby -S ri
Enter the method name you want to look up.
You can use tab to autocomplete.
Enter a blank line to exit.

>> Benchmark::IPS 
```