### PR TITLE
Rethrow UnsupportedMessageException in findFunctionInLibraries()

### DIFF
--- a/src/main/java/org/truffleruby/language/loader/RequireNode.java
+++ b/src/main/java/org/truffleruby/language/loader/RequireNode.java
@@ -200,7 +200,7 @@ public abstract class RequireNode extends RubyNode {
                 // TODO CS 18-Mar-18 it's not ideal that we're catching and throwing an exception when we don't find Init_ in each file
                 continue;
             } catch (UnsupportedMessageException e) {
-                continue;
+                throw new JavaException(e);
             }
 
             if (initObject != null) {


### PR DESCRIPTION
* If the library does not handle READ then we should fail early.

From https://github.com/oracle/truffleruby/pull/1218#discussion_r175564594