### PR TITLE
Lazy-translate core methods for context pre-initialization too

### DIFF
--- a/src/main/java/org/truffleruby/parser/MethodTranslator.java
+++ b/src/main/java/org/truffleruby/parser/MethodTranslator.java
@@ -77,7 +77,7 @@ public class MethodTranslator extends BodyTranslator {
         this.isBlock = isBlock;
         this.argsNode = argsNode;
 
-        if (parserContext == ParserContext.EVAL || context.getCoverageManager().isEnabled() || context.isPreInitializing()) {
+        if (parserContext == ParserContext.EVAL || context.getCoverageManager().isEnabled()) {
             shouldLazyTranslate = false;
         } else if (context.getSourceLoader().getPath(source).startsWith(context.getCoreLibrary().getCoreLoadPath())) {
             shouldLazyTranslate = context.getOptions().LAZY_TRANSLATION_CORE;


### PR DESCRIPTION
* So we have the smaller JRuby ASTs in the image heap instead of
  many Truffle ASTs for core library methods written in Ruby.
* The Truffle AST will be created on first usage.