### PR TITLE
Fix warning by defining feature test macros before any system header is included

### DIFF
--- a/lib/cext/include/ruby/ruby.h
+++ b/lib/cext/include/ruby/ruby.h
@@ -21,10 +21,13 @@ extern "C" {
 #endif
 #endif
 
+// Must be first, as it defines feature test macros like _GNU_SOURCE,
+// which influences the definitions exposed by system header files.
+#include "ruby/config.h"
+
 #include <sulong/truffle.h>
 #include <sulong/polyglot.h>
 
-#include "ruby/config.h"
 #include <ctype.h> // isdigit
 
 // Support


### PR DESCRIPTION
* _GNU_SOURCE must be defined for vasprintf, otherwise on Linux the warning is:
```
ruby.c:3234:7: warning: implicit declaration of function 'vasprintf' is invalid in C99 [-Wimplicit-function-declaration]
  if (vasprintf(&buffer, format, args) < 0) {
```

Fixes regression of 1400a531660404f8d5204ed6cf6747e5c1906d17.