### PR TITLE
Remove -H:Path and -H:Name fron native-image.properties

### DIFF
--- a/mx.truffleruby/native-image.properties
+++ b/mx.truffleruby/native-image.properties
@@ -10,8 +10,6 @@ LauncherClass = org.truffleruby.launcher.RubyLauncher
 Args = -H:MaxRuntimeCompileMethods=5400 \
        -H:SubstitutionResources=org/truffleruby/aot/substitutions.json \
        -H:+AddAllCharsets \
-       -H:Path=${.}/bin \
-       -H:Name=truffleruby \
        -H:Class=org.truffleruby.launcher.RubyLauncher
 
 # Pass the home for context pre-initialization


### PR DESCRIPTION
* Otherwise they would be inherited too far (e.g., polyglot images),
  not just for testing in SVM.