### PR TITLE
Ensure finalizer thread exits when ruby context is finalized.

### DIFF
--- a/src/main/java/org/truffleruby/core/FinalizationService.java
+++ b/src/main/java/org/truffleruby/core/FinalizationService.java
@@ -164,7 +164,7 @@ public class FinalizationService {
 
     private void runFinalizer(FinalizerReference finalizerReference) {
         try {
-            while (true) {
+            while (!context.isFinalizing()) {
                 final Finalizer finalizer;
                 synchronized (this) {
                     finalizer = finalizerReference.getFirstFinalizer();


### PR DESCRIPTION
This change won't prevent errors occasionally occurring in threads with callbacks from native code, but it will ensure the finalizer thread will exit when the ruby context itself is being finalized.