### PR TITLE
Add a truffle boundary on `process_time_currenttimemillis` primitive.

### DIFF
--- a/src/main/java/org/truffleruby/core/ProcessNodes.java
+++ b/src/main/java/org/truffleruby/core/ProcessNodes.java
@@ -36,6 +36,7 @@ public abstract class ProcessNodes {
     @Primitive(name = "process_time_currenttimemillis", needsSelf = false)
     public abstract static class ProcessTimeCurrentTimeMillisNode extends PrimitiveArrayArgumentsNode {
 
+        @TruffleBoundary
         @Specialization
         public long currentTimeMillis() {
             return System.currentTimeMillis();


### PR DESCRIPTION
When running on substratevm optimisation failures are reported on compilations involving this primitive. It doesn't cause any other issues but is quite visible and can be easily triggered when installing gems