### PR TITLE
Improvements to single-threaded mode and failure modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ Changes:
 * You'll now get a more helpful error message telling you to use
   `-Xsingle_threaded` when you try to use a single-threaded language like
   JavaScript in multi-threaded mode.
+  
+* You'll now get a more helpful error message if you use a single-threaded
+  language and then later try to create a thread.
+
+* An error message is now printed if a thread is created but for some reason
+  never responds.
 
 # 1.0 RC 1, April 2018
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Changes:
 * You'll now get a more helpful error message if you use a single-threaded
   language and then later try to create a thread.
 
+* Auto-releasing unmanaged memory no longer creates a Truffle thread, so doesn't
+  cause an error and a hang if you do it after a single-threaded language has
+  been used.
+  
 * An error message is now printed if a thread is created but for some reason
   never responds.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ New features:
 Changes:
 
 * The inline JavaScript functionality `-Xinline_js` has been removed.
+* You'll now get a more helpful error message telling you to use
+  `-Xsingle_threaded` when you try to use a single-threaded language like
+  JavaScript in multi-threaded mode.
 
 # 1.0 RC 1, April 2018
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ New features:
 Changes:
 
 * The inline JavaScript functionality `-Xinline_js` has been removed.
+
 * You'll now get a more helpful error message telling you to use
   `-Xsingle_threaded` when you try to use a single-threaded language like
   JavaScript in multi-threaded mode.

--- a/spec/tags/truffle/interop/single_threaded_tags.txt
+++ b/spec/tags/truffle/interop/single_threaded_tags.txt
@@ -1,0 +1,11 @@
+slow:Single-threaded mode should give a helpful error if a thread is created
+slow:Single-threaded mode allows native memory finalisers created before interop
+slow:Single-threaded mode allows native memory finalisers created after interop
+slow:Single-threaded mode allows files to be read before interop
+slow:Single-threaded mode allows files to be read after interop
+slow:Interop with a single-threaded language in non-single-threaded mode should give a helpful error if a thread has already been created
+slow:Interop with a single-threaded language in non-single-threaded mode should give a helpful error if a thread is created later
+slow:Interop with a single-threaded language in non-single-threaded mode allows native memory finalisers created before interop
+slow:Interop with a single-threaded language in non-single-threaded mode allows native memory finalisers created after interop
+slow:Interop with a single-threaded language in non-single-threaded mode allows files to be read before interop
+slow:Interop with a single-threaded language in non-single-threaded mode allows files to be read after interop

--- a/spec/truffle/interop/single_threaded_spec.rb
+++ b/spec/truffle/interop/single_threaded_spec.rb
@@ -1,0 +1,113 @@
+# Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved. This
+# code is released under a tri EPL/GPL/LGPL license. You can use it,
+# redistribute it and/or modify it under the terms of the:
+# 
+# Eclipse Public License version 1.0
+# GNU General Public License version 2
+# GNU Lesser General Public License version 2.1
+
+require_relative '../../ruby/spec_helper'
+
+describe "Single-threaded mode" do
+
+  it "should give a helpful error if a thread is created" do
+    ruby_exe(
+      "Thread.new { }",
+      options: "-Xsingle_threaded=true",
+      args: '2>&1'
+    ).should =~ /threads not allowed in single-threaded mode/
+  end
+    
+  describe "allows native memory finalisers created" do
+    
+    it "before interop" do
+      ruby_exe(
+        "Truffle::FFI::Pointer.new(14); puts Polyglot.eval('ruby-single-threaded-test', '14')",
+        options: "-Xsingle_threaded=true"
+      ).should == "14\n"
+    end
+    
+    it "after interop" do
+      ruby_exe(
+        "Polyglot.eval('ruby-single-threaded-test', '14'); Truffle::FFI::Pointer.new(14); puts 14",
+        options: "-Xsingle_threaded=true"
+      ).should == "14\n"
+    end
+    
+  end
+  
+  describe "allows files to be read" do
+
+    it "before interop" do
+      ruby_exe(
+        "File.read('README.md'); Polyglot.eval('ruby-single-threaded-test', '14'); puts 14",
+        options: "-Xsingle_threaded=true"
+      ).should == "14\n"
+    end
+    
+    it "after interop" do
+      ruby_exe(
+        "Polyglot.eval('ruby-single-threaded-test', '14'); File.read('README.md'); puts 14",
+        options: "-Xsingle_threaded=true"
+      ).should == "14\n"
+    end
+    
+  end
+
+end
+
+describe "Interop with a single-threaded language in non-single-threaded mode" do
+  
+  it "should give a helpful error if a thread has already been created" do
+    ruby_exe(
+      "thread = Thread.new { }; Polyglot.eval('ruby-single-threaded-test', '14')",
+      options: "-Xsingle_threaded=false",
+      args: '2>&1'
+    ).should =~ /Try running Ruby in single-threaded mode by using -Xsingle_threaded or --ruby.single_threaded./
+  end
+  
+  it "should give a helpful error if a thread is created later" do
+    ruby_exe(
+      "Polyglot.eval('ruby-single-threaded-test', '14'); thread = Thread.new { };",
+      options: "-Xsingle_threaded=false",
+      args: '2>&1'
+    ).should =~ /Are you attempting to create a Ruby thread after you have used a single-threaded language?/
+  end
+
+  describe "allows native memory finalisers created" do
+    
+    it "before interop" do
+      ruby_exe(
+        "Truffle::FFI::Pointer.new(14); puts Polyglot.eval('ruby-single-threaded-test', '14')",
+        options: "-Xsingle_threaded=false"
+      ).should == "14\n"
+    end
+    
+    it "after interop" do
+      ruby_exe(
+        "Polyglot.eval('ruby-single-threaded-test', '14'); Truffle::FFI::Pointer.new(14); puts 14",
+        options: "-Xsingle_threaded=false"
+      ).should == "14\n"
+    end
+    
+  end
+  
+  describe "allows files to be read" do
+
+    it "before interop" do
+      ruby_exe(
+        "File.read('README.md'); Polyglot.eval('ruby-single-threaded-test', '14'); puts 14",
+        options: "-Xsingle_threaded=false"
+      ).should == "14\n"
+    end
+    
+    it "after interop" do
+      ruby_exe(
+        "Polyglot.eval('ruby-single-threaded-test', '14'); File.read('README.md'); puts 14",
+        options: "-Xsingle_threaded=false"
+      ).should == "14\n"
+    end
+    
+  end
+
+end

--- a/spec/truffle/interop/single_threaded_spec.rb
+++ b/spec/truffle/interop/single_threaded_spec.rb
@@ -40,14 +40,14 @@ describe "Single-threaded mode" do
 
     it "before interop" do
       ruby_exe(
-        "File.read('README.md'); Polyglot.eval('ruby-single-threaded-test', '14'); puts 14",
+        "File.read(#{__FILE__.inspect}); Polyglot.eval('ruby-single-threaded-test', '14'); puts 14",
         options: "-Xsingle_threaded=true"
       ).should == "14\n"
     end
     
     it "after interop" do
       ruby_exe(
-        "Polyglot.eval('ruby-single-threaded-test', '14'); File.read('README.md'); puts 14",
+        "Polyglot.eval('ruby-single-threaded-test', '14'); File.read(#{__FILE__.inspect}); puts 14",
         options: "-Xsingle_threaded=true"
       ).should == "14\n"
     end
@@ -96,14 +96,14 @@ describe "Interop with a single-threaded language in non-single-threaded mode" d
 
     it "before interop" do
       ruby_exe(
-        "File.read('README.md'); Polyglot.eval('ruby-single-threaded-test', '14'); puts 14",
+        "File.read(#{__FILE__.inspect}); Polyglot.eval('ruby-single-threaded-test', '14'); puts 14",
         options: "-Xsingle_threaded=false"
       ).should == "14\n"
     end
     
     it "after interop" do
       ruby_exe(
-        "Polyglot.eval('ruby-single-threaded-test', '14'); File.read('README.md'); puts 14",
+        "Polyglot.eval('ruby-single-threaded-test', '14'); File.read(#{__FILE__.inspect}); puts 14",
         options: "-Xsingle_threaded=false"
       ).should == "14\n"
     end

--- a/spec/truffle/interop/single_threaded_spec.rb
+++ b/spec/truffle/interop/single_threaded_spec.rb
@@ -15,7 +15,7 @@ describe "Single-threaded mode" do
       "Thread.new { }",
       options: "-Xsingle_threaded=true",
       args: '2>&1'
-    ).should =~ /threads not allowed in single-threaded mode/
+    ).should include('threads not allowed in single-threaded mode')
   end
     
   describe "allows native memory finalisers created" do
@@ -63,7 +63,7 @@ describe "Interop with a single-threaded language in non-single-threaded mode" d
       "thread = Thread.new { }; Polyglot.eval('ruby-single-threaded-test', '14')",
       options: "-Xsingle_threaded=false",
       args: '2>&1'
-    ).should =~ /Try running Ruby in single-threaded mode by using -Xsingle_threaded or --ruby.single_threaded./
+    ).should include('Try running Ruby in single-threaded mode by using -Xsingle_threaded or --ruby.single_threaded.')
   end
   
   it "should give a helpful error if a thread is created later" do
@@ -71,7 +71,7 @@ describe "Interop with a single-threaded language in non-single-threaded mode" d
       "Polyglot.eval('ruby-single-threaded-test', '14'); thread = Thread.new { };",
       options: "-Xsingle_threaded=false",
       args: '2>&1'
-    ).should =~ /Are you attempting to create a Ruby thread after you have used a single-threaded language?/
+    ).should include('Are you attempting to create a Ruby thread after you have used a single-threaded language?')
   end
 
   describe "allows native memory finalisers created" do

--- a/src/main/java/org/truffleruby/core/objectspace/ObjectSpaceManager.java
+++ b/src/main/java/org/truffleruby/core/objectspace/ObjectSpaceManager.java
@@ -83,7 +83,7 @@ public class ObjectSpaceManager {
             root = null;
         }
 
-        finalizationService.addFinalizer(object, ObjectSpaceManager.class,
+        finalizationService.addFinalizer(true, object, ObjectSpaceManager.class,
                 new CallableFinalizer(context, callable), root);
     }
 
@@ -109,7 +109,7 @@ public class ObjectSpaceManager {
     }
 
     public synchronized void undefineFinalizer(DynamicObject object) {
-        finalizationService.removeFinalizers(object, ObjectSpaceManager.class);
+        finalizationService.removeFinalizers(true, object, ObjectSpaceManager.class);
     }
 
     public void traceAllocationsStart() {

--- a/src/main/java/org/truffleruby/core/thread/ThreadManager.java
+++ b/src/main/java/org/truffleruby/core/thread/ThreadManager.java
@@ -251,8 +251,7 @@ public class ThreadManager {
             try {
                 if (thrown.isDone()
                         && thrown.get() instanceof IllegalStateException
-                        && thrown.get().getMessage().startsWith("Multi threaded access requested")
-                        && context.getEnv().isCreateThreadAllowed()) {
+                        && thrown.get().getMessage().startsWith("Multi threaded access requested")) {
                     message = thrown.get().getMessage() + " Are you attempting to create a Ruby thread after you have used a single-threaded language?";
                 } else {
                     message = "creating thread timed out";

--- a/src/main/java/org/truffleruby/debug/RubySingleThreadedTestLanguage.java
+++ b/src/main/java/org/truffleruby/debug/RubySingleThreadedTestLanguage.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved. This
+ * code is released under a tri EPL/GPL/LGPL license. You can use it,
+ * redistribute it and/or modify it under the terms of the:
+ *
+ * Eclipse Public License version 1.0
+ * GNU General Public License version 2
+ * GNU Lesser General Public License version 2.1
+ */
+package org.truffleruby.debug;
+
+import com.oracle.truffle.api.CallTarget;
+import com.oracle.truffle.api.Truffle;
+import com.oracle.truffle.api.TruffleLanguage;
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.impl.DefaultCallTarget;
+import com.oracle.truffle.api.nodes.RootNode;
+
+@TruffleLanguage.Registration(
+        name = "RubySingleThreadedTestLanguage",
+        id = "ruby-single-threaded-test",
+        mimeType = "application/x-ruby-single-threaded-test",
+        version = "0",
+        internal = true,
+        interactive = false)
+public class RubySingleThreadedTestLanguage extends TruffleLanguage<Object> {
+
+    @Override
+    protected Object createContext(Env env) {
+        return new Object();
+    }
+
+    @Override
+    protected boolean isObjectOfLanguage(Object object) {
+        return false;
+    }
+
+    @Override
+    protected CallTarget parse(ParsingRequest request) {
+        final String source = request.getSource().getCharacters().toString();
+
+        return Truffle.getRuntime().createCallTarget(new RootNode(this) {
+
+            @Override
+            public Object execute(VirtualFrame frame) {
+                return Integer.parseInt(source);
+            }
+
+        });
+    }
+
+}

--- a/src/main/java/org/truffleruby/debug/RubySingleThreadedTestLanguage.java
+++ b/src/main/java/org/truffleruby/debug/RubySingleThreadedTestLanguage.java
@@ -43,7 +43,7 @@ public class RubySingleThreadedTestLanguage extends TruffleLanguage<Object> {
 
             @Override
             public Object execute(VirtualFrame frame) {
-                return Integer.parseInt(source);
+                return Integer.parseInt(source.trim());
             }
 
         });

--- a/src/main/java/org/truffleruby/debug/RubySingleThreadedTestLanguage.java
+++ b/src/main/java/org/truffleruby/debug/RubySingleThreadedTestLanguage.java
@@ -13,7 +13,6 @@ import com.oracle.truffle.api.CallTarget;
 import com.oracle.truffle.api.Truffle;
 import com.oracle.truffle.api.TruffleLanguage;
 import com.oracle.truffle.api.frame.VirtualFrame;
-import com.oracle.truffle.api.impl.DefaultCallTarget;
 import com.oracle.truffle.api.nodes.RootNode;
 
 @TruffleLanguage.Registration(

--- a/src/main/java/org/truffleruby/extra/ffi/Pointer.java
+++ b/src/main/java/org/truffleruby/extra/ffi/Pointer.java
@@ -191,7 +191,7 @@ public class Pointer implements AutoCloseable {
 
         // We must be careful here that the finalizer does not capture the Pointer itself that we'd
         // like to finalize.
-        finalizationService.addFinalizer(this, Pointer.class, new FreeAddressFinalizer(address));
+        finalizationService.addFinalizer(false, this, Pointer.class, new FreeAddressFinalizer(address), null);
 
         autorelease = true;
     }
@@ -221,7 +221,7 @@ public class Pointer implements AutoCloseable {
             return;
         }
 
-        finalizationService.removeFinalizers(this, Pointer.class);
+        finalizationService.removeFinalizers(false, this, Pointer.class);
 
         autorelease = false;
     }

--- a/src/main/java/org/truffleruby/interop/InteropNodes.java
+++ b/src/main/java/org/truffleruby/interop/InteropNodes.java
@@ -1095,4 +1095,14 @@ public abstract class InteropNodes {
 
     }
 
+    @CoreMethod(names = "single_threaded?", onSingleton = true)
+    public abstract static class SingleThreadedNode extends CoreMethodArrayArgumentsNode {
+
+        @Specialization
+        public boolean singleThreaded() {
+            return getContext().getOptions().SINGLE_THREADED;
+        }
+
+    }
+
 }

--- a/src/main/java/org/truffleruby/interop/InteropNodes.java
+++ b/src/main/java/org/truffleruby/interop/InteropNodes.java
@@ -1095,14 +1095,4 @@ public abstract class InteropNodes {
 
     }
 
-    @CoreMethod(names = "single_threaded?", onSingleton = true)
-    public abstract static class SingleThreadedNode extends CoreMethodArrayArgumentsNode {
-
-        @Specialization
-        public boolean singleThreaded() {
-            return getContext().getOptions().SINGLE_THREADED;
-        }
-
-    }
-
 }

--- a/src/main/java/org/truffleruby/language/methods/ExceptionTranslatingNode.java
+++ b/src/main/java/org/truffleruby/language/methods/ExceptionTranslatingNode.java
@@ -234,18 +234,6 @@ public class ExceptionTranslatingNode extends RubyNode {
             throw (AssertionError) throwable;
         }
 
-        if (throwable.getClass().getName().equals("com.oracle.truffle.api.vm.PolyglotIllegalStateException")) {
-            final String message;
-
-            if (throwable.getMessage().startsWith("Multi threaded access requested")) {
-                message = throwable.getMessage() + " Try running Ruby in single-threaded mode by using -Xsingle_threaded or --ruby.single_threaded.";
-            } else {
-                message = throwable.getMessage();
-            }
-
-            return coreExceptions().securityError(message, this);
-        }
-
         if (getContext().getOptions().EXCEPTIONS_PRINT_JAVA
                 || getContext().getOptions().EXCEPTIONS_PRINT_UNCAUGHT_JAVA) {
             throwable.printStackTrace();
@@ -253,6 +241,11 @@ public class ExceptionTranslatingNode extends RubyNode {
             if (getContext().getOptions().EXCEPTIONS_PRINT_RUBY_FOR_JAVA) {
                 getContext().getCallStack().printBacktrace(this);
             }
+        }
+
+        if (throwable instanceof IllegalStateException
+                && throwable.getMessage().startsWith("Multi threaded access requested")) {
+            return coreExceptions().securityError(throwable.getMessage() + " Try running Ruby in single-threaded mode by using -Xsingle_threaded or --ruby.single_threaded.", this);
         }
 
         Throwable t = throwable;

--- a/src/main/java/org/truffleruby/language/methods/ExceptionTranslatingNode.java
+++ b/src/main/java/org/truffleruby/language/methods/ExceptionTranslatingNode.java
@@ -234,6 +234,18 @@ public class ExceptionTranslatingNode extends RubyNode {
             throw (AssertionError) throwable;
         }
 
+        if (throwable.getClass().getName().equals("com.oracle.truffle.api.vm.PolyglotIllegalStateException")) {
+            final String message;
+
+            if (throwable.getMessage().startsWith("Multi threaded access requested")) {
+                message = throwable.getMessage() + " Try running Ruby in single-threaded mode by using -Xsingle_threaded or --ruby.single_threaded.";
+            } else {
+                message = throwable.getMessage();
+            }
+
+            return coreExceptions().securityError(message, this);
+        }
+
         if (getContext().getOptions().EXCEPTIONS_PRINT_JAVA
                 || getContext().getOptions().EXCEPTIONS_PRINT_UNCAUGHT_JAVA) {
             throwable.printStackTrace();


### PR DESCRIPTION
Fixes #1196.

* You'll now get a more helpful error message telling you to use `-Xsingle_threaded` when you try to use a single-threaded language like JavaScript in multi-threaded mode.
  
* You'll now get a more helpful error message if you use a single-threaded language and then later try to create a thread.

* Auto-releasing unmanaged memory no longer creates a Truffle thread, so doesn't cause an error and a hang if you do it after a single-threaded language has been used.
  
* An error message is now printed if a thread is created but for some reason never responds.

Read the specs to understand the new behaviour.