### PR TITLE
Fix .gitignore to ignore the truffleruby-gem-test-pack repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,7 +82,7 @@ test/mri/tests/cext-c/**/*.o
 
 # Tests
 /test/truffle/integration/gem-testing
-/truffleruby-gem-test-pack-*
+/truffleruby-gem-test-pack
 /test/truffle/docker/*/*.tar.gz
 /test/truffle/docker/*/*.jar
 


### PR DESCRIPTION
* aa01c1ff4c accidentally reverted this change.

It is safe to remove the old test-packs files with:
```
rm -rf truffleruby-gem-test-pack-*
```