### PR TITLE
Add reference to xcode-select to the "Installing LLVM" user documentation

### DIFF
--- a/doc/user/installing-llvm.md
+++ b/doc/user/installing-llvm.md
@@ -77,10 +77,12 @@ you are on macOS. We would recommend that you install LLVM 4 via
 [Homebrew](https://brew.sh) and then manually set your path.
 
 For building and using C and C++ extensions on macOS we recommend just
-installing the full `llvm` package. We give more specific advice above for Linux
-to support use in containers such as Docker.
+installing the full `llvm` package. Make sure you have also installed the
+standard C headers from Xcode via `xcode-select --install`. We give more
+specific advice above for Linux to support use in containers such as Docker.
 
 ```bash
+xcode-select --install
 brew install llvm@4
 export PATH="/usr/local/opt/llvm@4/bin:$PATH"
 ```


### PR DESCRIPTION
While trying out building native C extensions with TruffleRuby, the builds always failed with [`fatal error: 'stdlib.h' file not found`](https://pbs.twimg.com/media/Dbkoka-XcAAjgQi.png:orig) in the `mkmf.log`.  After several attempts of changing include paths and whatnot I figured that an update of something (might be Xcode or even macOS itself, who knows) had removed the `/usr/include` directory which includes all the C standard headers.  Running `xcode-select --install` installed that directory again.  Yay!