### PR TITLE
Always consider deprecations as warnings

### DIFF
--- a/ci.jsonnet
+++ b/ci.jsonnet
@@ -70,7 +70,7 @@ local part_definitions = {
     build: {
       setup+: [
         ["mx", "sversions"],
-        ["mx", "build", "--force-javac", "--warning-as-error", "--force-deprecation-as-warning-for-dependencies"] + self["$.use.build"].extra_args,
+        ["mx", "build", "--force-javac", "--warning-as-error", "--force-deprecation-as-warning"] + self["$.use.build"].extra_args,
       ],
     },
 
@@ -403,7 +403,7 @@ local part_definitions = {
       run+: [
         # Build with ECJ to get warnings
         ["mx", "sversions"],
-        ["mx", "build", "--jdt", "$JDT", "--warning-as-error", "--force-deprecation-as-warning-for-dependencies"],
+        ["mx", "build", "--jdt", "$JDT", "--warning-as-error", "--force-deprecation-as-warning"],
       ] + jt(["lint"]) + [
         ["mx", "findbugs"],
       ],

--- a/tool/jt.rb
+++ b/tool/jt.rb
@@ -524,7 +524,7 @@ module Commands
 
     add_default_dynamic_imports
 
-    mx 'build', '--force-javac', '--warning-as-error', '--force-deprecation-as-warning-for-dependencies',
+    mx 'build', '--force-javac', '--warning-as-error', '--force-deprecation-as-warning',
        # show more than default 100 errors not to hide actual errors under pile of missing symbols
        '-A-Xmaxerrs', '-A1000', *options
   end


### PR DESCRIPTION
* So when Truffle introduces a new API and deprecates the old one at
  the same time, we are not forced to adopt the new one immediately.
* "--force-deprecation-as-warning-for-dependencies" means consider
  deprecations as warnings for dependencies but not the main suite.