### PR TITLE
Use safer syntax for obscure global variable names

### DIFF
--- a/src/main/ruby/core/process.rb
+++ b/src/main/ruby/core/process.rb
@@ -112,7 +112,7 @@ module Process
   CLOCK_REALTIME          = 2
   CLOCK_THREAD_CPUTIME_ID = 3
   CLOCK_MONOTONIC_RAW_ID  = 4
-  
+
   def self.clock_gettime(id, unit=:float_second)
     case id
     when CLOCK_MONOTONIC
@@ -956,10 +956,10 @@ module Process
 end
 
 Truffle::KernelOperations.define_hooked_variable(
-  :$0,
-  -> { Truffle::KernelOperations.global_variable_get(:$0) },
+  :'$0',
+  -> { Truffle::KernelOperations.global_variable_get(:'$0') },
   -> v { v = StringValue(v)
          Process.setproctitle(v)
-         Truffle::KernelOperations.global_variable_set(:$0, v) })
+         Truffle::KernelOperations.global_variable_set(:'$0', v) })
 
 alias $PROGRAM_NAME $0

--- a/src/main/ruby/core/regexp.rb
+++ b/src/main/ruby/core/regexp.rb
@@ -396,33 +396,33 @@ class MatchData
 end
 
 Truffle::KernelOperations.define_hooked_variable(
-  :$~,
+  :'$~',
   -> b { Truffle::RegexpOperations.last_match(b) },
   -> v, b { Truffle::RegexpOperations.set_last_match(v, b) })
 
 Truffle::KernelOperations.define_hooked_variable(
-  %s{$`},
+  :'$`',
   -> b { match = Truffle::RegexpOperations.last_match(b)
          match.pre_match if match },
   -> { raise SyntaxError, "Can't set variable $`"},
   -> b { 'global-variable' if Truffle::RegexpOperations.last_match(b) })
 
 Truffle::KernelOperations.define_hooked_variable(
-  %s{$'},
+  :"$'",
   -> b { match = Truffle::RegexpOperations.last_match(b)
          match.post_match if match },
   -> { raise SyntaxError, "Can't set variable $'"},
   -> b { 'global-variable' if Truffle::RegexpOperations.last_match(b) })
 
 Truffle::KernelOperations.define_hooked_variable(
-  :$&,
+  :'$&',
   -> b { match = Truffle::RegexpOperations.last_match(b)
          match[0] if match },
   -> { raise SyntaxError, "Can't set variable $&"},
   -> b { 'global-variable' if Truffle::RegexpOperations.last_match(b) })
 
 Truffle::KernelOperations.define_hooked_variable(
-  :$+,
+  :'$+',
   -> b { match = Truffle::RegexpOperations.last_match(b)
          match.captures.reverse.find { |m| !m.nil? } if match },
   -> { raise SyntaxError, "Can't set variable $+"},

--- a/src/main/ruby/core/truffle/regexp_operations.rb
+++ b/src/main/ruby/core/truffle/regexp_operations.rb
@@ -20,7 +20,7 @@ module Truffle
     end
 
     def self.last_match(a_binding)
-      Truffle::KernelOperations.frame_local_variable_get(:$~, a_binding)
+      Truffle::KernelOperations.frame_local_variable_get(:'$~', a_binding)
     end
     Truffle::Graal.always_split(method(:last_match))
 
@@ -29,7 +29,7 @@ module Truffle
         raise TypeError, "Wrong argument type #{value} (expected MatchData)"
       end
       # TODO DMM 2018-01-12 Proc.binding being nil is a bug, we can remove the check once we've fixed it.
-      Truffle::KernelOperations.frame_local_variable_set(:$~, a_binding, value)
+      Truffle::KernelOperations.frame_local_variable_set(:'$~', a_binding, value)
     end
     Truffle::Graal.always_split(method(:set_last_match))
 


### PR DESCRIPTION
It's not correctly parsed in Idea