### PR TITLE
Remove redundant transferToInterpreterAI

### DIFF
--- a/src/main/java/org/truffleruby/language/locals/WriteFrameSlotNode.java
+++ b/src/main/java/org/truffleruby/language/locals/WriteFrameSlotNode.java
@@ -9,7 +9,6 @@
  */
 package org.truffleruby.language.locals;
 
-import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.dsl.ImportStatic;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.Frame;
@@ -91,7 +90,6 @@ public abstract class WriteFrameSlotNode extends Node {
 
     private boolean initialSetKind(Frame frame, FrameSlotKind kind) {
         if (frame.getFrameDescriptor().getFrameSlotKind(frameSlot) == FrameSlotKind.Illegal) {
-            CompilerDirectives.transferToInterpreterAndInvalidate();
             frame.getFrameDescriptor().setFrameSlotKind(frameSlot, kind);
             return true;
         }


### PR DESCRIPTION
It's called only when necessary in [`FrameDescriptor::setFrameSlotKind`](https://github.com/oracle/graal/blob/98804b5189ea7afd352708c2e60634082b195cc3/truffle/src/com.oracle.truffle.api/src/com/oracle/truffle/api/frame/FrameDescriptor.java#L305).