### PR TITLE
Update instructions for ruby-install 0.7.0 release

### DIFF
--- a/doc/user/ruby-managers.md
+++ b/doc/user/ruby-managers.md
@@ -52,20 +52,9 @@ Check your version with:
 ruby-install --version
 ```
 
-`ruby-install` 0.7.0 is not yet released at the time of writing.
-As a workaround in the meantime, you can just clone the repository:
-
-```bash
-git clone --branch 0.7.0 https://github.com/postmodern/ruby-install.git
-cd ruby-install
-bin/ruby-install --latest
-bin/ruby-install truffleruby
-```
-
-Once `ruby-install` 0.7.0 is released, you can update to latest `ruby-install`.
-Follow the [installation instructions](https://github.com/postmodern/ruby-install#install),
-since the steps for upgrading `ruby-install` are the same as the steps for
-installing it. Then install truffleruby with:
+Follow the [installation instructions](https://github.com/postmodern/ruby-install#install)
+if you need to upgrade, since the steps for upgrading `ruby-install` are the
+same as the steps for installing it. Then install truffleruby with:
 
 ```bash
 ruby-install --latest


### PR DESCRIPTION
The ruby-install instructions can now be simplified a bit since ruby-install 0.7.0 has been released.