### PR TITLE
Raise a LocalJumpError if a proc tries to return

### DIFF
--- a/spec/tags/core/proc/new_tags.txt
+++ b/spec/tags/core/proc/new_tags.txt
@@ -1,1 +1,1 @@
-fails:Proc.new with an associated block raises a LocalJumpError when context of the block no longer exists
+fails:Proc.new with an associated block returns from within enclosing method when 'return' is used in the block

--- a/src/main/java/org/truffleruby/language/methods/CatchForProcNode.java
+++ b/src/main/java/org/truffleruby/language/methods/CatchForProcNode.java
@@ -16,6 +16,7 @@ import org.truffleruby.language.control.NextException;
 import org.truffleruby.language.control.RaiseException;
 import org.truffleruby.language.control.RedoException;
 import org.truffleruby.language.control.RetryException;
+import org.truffleruby.language.control.ReturnException;
 
 public class CatchForProcNode extends RubyNode {
 
@@ -24,6 +25,7 @@ public class CatchForProcNode extends RubyNode {
     private final BranchProfile redoProfile = BranchProfile.create();
     private final BranchProfile nextProfile = BranchProfile.create();
     private final BranchProfile retryProfile = BranchProfile.create();
+    private final BranchProfile returnProfile = BranchProfile.create();
 
     public CatchForProcNode(RubyNode body) {
         this.body = body;
@@ -44,6 +46,9 @@ public class CatchForProcNode extends RubyNode {
             } catch (RetryException e) {
                 retryProfile.enter();
                 throw new RaiseException(getContext(), coreExceptions().syntaxErrorInvalidRetry(this));
+            } catch (ReturnException e) {
+                returnProfile.enter();
+                throw new RaiseException(getContext(), coreExceptions().unexpectedReturn(this));
             }
         }
     }

--- a/src/main/java/org/truffleruby/language/methods/CatchForProcNode.java
+++ b/src/main/java/org/truffleruby/language/methods/CatchForProcNode.java
@@ -16,7 +16,6 @@ import org.truffleruby.language.control.NextException;
 import org.truffleruby.language.control.RaiseException;
 import org.truffleruby.language.control.RedoException;
 import org.truffleruby.language.control.RetryException;
-import org.truffleruby.language.control.ReturnException;
 
 public class CatchForProcNode extends RubyNode {
 
@@ -25,7 +24,6 @@ public class CatchForProcNode extends RubyNode {
     private final BranchProfile redoProfile = BranchProfile.create();
     private final BranchProfile nextProfile = BranchProfile.create();
     private final BranchProfile retryProfile = BranchProfile.create();
-    private final BranchProfile returnProfile = BranchProfile.create();
 
     public CatchForProcNode(RubyNode body) {
         this.body = body;
@@ -46,9 +44,6 @@ public class CatchForProcNode extends RubyNode {
             } catch (RetryException e) {
                 retryProfile.enter();
                 throw new RaiseException(getContext(), coreExceptions().syntaxErrorInvalidRetry(this));
-            } catch (ReturnException e) {
-                returnProfile.enter();
-                throw new RaiseException(getContext(), coreExceptions().unexpectedReturn(this));
             }
         }
     }


### PR DESCRIPTION
Trying to `return` from within a `proc { ... }` should result in a `LocalJumpError` being raised.

Fixes #1488.