### PR TITLE
Implementation of Process.clock_getres and thoughts on clock_ids.

### DIFF
--- a/src/main/c/truffleposix/truffleposix.c
+++ b/src/main/c/truffleposix/truffleposix.c
@@ -399,6 +399,15 @@ int64_t truffleposix_clock_gettime(int clock) {
   }
   return ((int64_t) timespec.tv_sec * 1000000000) + (int64_t) timespec.tv_nsec;
 }
+
+int64_t truffleposix_clock_getres(int clock) {
+  struct timespec timespec;
+  int ret = clock_getres((clockid_t) clock, &timespec);
+  if (ret != 0) {
+    return 0;
+  }
+  return ((int64_t) timespec.tv_sec * 1000000000) + (int64_t) timespec.tv_nsec;
+}
 #endif
 
 #define CHECK(call, label) if ((error = call) != 0) { perror(#call); goto label; }

--- a/src/main/ruby/core/posix.rb
+++ b/src/main/ruby/core/posix.rb
@@ -169,6 +169,7 @@ module Truffle::POSIX
   attach_function :chmod, [:string, :mode_t], :int
   attach_function :chown, [:string, :uid_t, :gid_t], :int
   attach_function :chroot, [:string], :int
+  attach_function :truffleposix_clock_getres, [:int], :int64_t, LIBTRUFFLEPOSIX
   attach_function :truffleposix_clock_gettime, [:int], :int64_t, LIBTRUFFLEPOSIX
   attach_function :close, [:int], :int
   attach_function :closedir, [:pointer], :int

--- a/src/main/ruby/core/process.rb
+++ b/src/main/ruby/core/process.rb
@@ -126,7 +126,11 @@ module Process
       Errno.handle if res == 0
     end
 
-    nanoseconds_to_unit(res, unit)
+    if unit == :hertz then
+      1.0 / nanoseconds_to_unit(res,:float_seconds)
+    else
+      nanoseconds_to_unit(res,unit)
+    end
   end
 
   def self.clock_gettime(id, unit=:float_second)

--- a/src/main/ruby/core/process.rb
+++ b/src/main/ruby/core/process.rb
@@ -116,11 +116,17 @@ module Process
   end
 
   def self.clock_getres(id, unit=:float_second)
-    case id = normalize_clock_id(id)
-    when CLOCK_REALTIME
-      res = 1_000_000
-    when CLOCK_MONOTONIC
-      res = 1
+    res = case id
+    when :GETTIMEOFDAY_BASED_CLOCK_REALTIME,
+         :GETRUSAGE_BASED_CLOCK_PROCESS_CPUTIME_ID,
+         :CLOCK_BASED_CLOCK_PROCESS_CPUTIME_ID
+      1_000
+    when :TIME_BASED_CLOCK_REALTIME
+      1_000_000_000
+    when :MACH_ABSOLUTE_TIME_BASED_CLOCK_MONOTONIC,
+         :TIMES_BASED_CLOCK_MONOTONIC
+      1
+    when :TIMES_BASED_CLOCK_PROCESS_CPUTIME_ID
     else
       res = Truffle::POSIX.truffleposix_clock_getres(id)
       Errno.handle if res == 0

--- a/src/main/ruby/core/process.rb
+++ b/src/main/ruby/core/process.rb
@@ -127,7 +127,7 @@ module Process
     end
 
     if unit == :hertz then
-      1.0 / nanoseconds_to_unit(res,:float_seconds)
+      1.0 / nanoseconds_to_unit(res,:float_second)
     else
       nanoseconds_to_unit(res,unit)
     end

--- a/src/main/ruby/core/process.rb
+++ b/src/main/ruby/core/process.rb
@@ -144,7 +144,7 @@ module Process
   end
 
   def self.normalize_clock_id(id)
-    return id unless id.is_a?(Symobl)
+    return id unless id.is_a?(Symbol)
     case id
     when :GETTIMEOFDAY_BASED_CLOCK_REALTIME,
          :TIME_BASED_CLOCK_REALTIME


### PR DESCRIPTION
I am [removing the C and Java extensions from the hitimes gem](https://github.com/copiousfreetime/hitimes/pull/73) mostly because of #1436. In my pure-ruby update I am using `Process.clock_getres`. And I added truffleruby as a Travis CI test ruby version to make sure the pure ruby version of hitimes will work with truffleruby - [and it immediately failed](https://travis-ci.org/copiousfreetime/hitimes/jobs/497872486)

It turns out, an implementation of `Process.clock_getres` is missing from truffleruby.

 As a result - i've implemented a version that passes all the `*clock_getres*` mri tests via `jt test mri ./test/mri/tests/ruby/test_process.rb`. 

I don't particularly like my implementation and I think part of that is all of the emulation symbols that truffleruby is faking out. Its a bit messy. The resolution of various emulation symbols does not match their implementation resolution. Which may be appropriate - since it is an emulation 😄 . I've mapped the resolution of the various symbols to what the documentation **says** it should be, not what it is implemented as.

For instance `:TIME_BASED_CLOCK_REALTIME ` says in the ruby documentation that its resolution is 1 second:
> Use time() defined by ISO C. The resolution is 1 second.

And in truffle ruby this is emulated via ` Truffle.invoke_primitive(:process_time_currenttimemillis)` which technically has a millisecond resolution.

I'm not actually sure that it is necessary for truffleruby to implement all the emulation symbols. All the `clock_id` constants do not exist on all the platforms, or even different MRI builds. An MRI built on OSX will have `:MACH_ABSOLUTE_TIME_BASED_CLOCK_MONOTONIC` defined but it won't exist on an MRI that is built on Linux

According to the documentation - http://ruby-doc.org/core-2.4.5/Process.html#method-c-clock_getres
> clock_id specifies a kind of clock. It is specified as a constant which begins with Process::CLOCK_ such as Process::CLOCK_REALTIME and Process::CLOCK_MONOTONIC.
>
> The supported constants depends on OS and version. Ruby provides following types of clock_id **if available**.

I'm probably missing something, but I think it would be  reasonable for truffleruby to ignore all the emulations as those are system/platform/engine dependent things.

In any case, I'm happy to contribute this pull request - and receive any and all feedback. If you want me to - I'll be happy to fill out and send in the Oracle Contributor Agreement.

