### PR TITLE
Fix broken link to GraalVM documentation page

### DIFF
--- a/doc/contributor/svm.md
+++ b/doc/contributor/svm.md
@@ -23,7 +23,7 @@ https://youtu.be/FJY96_6Y3a4?t=10023
 More information can be found in Kevin's
 [blog post](http://nirvdrum.com/2017/02/15/truffleruby-on-the-substrate-vm.html).
 
-The TruffleRuby that is distributed in the [GraalVM](../user/using-graalvm.md)
+The TruffleRuby that is distributed in the [GraalVM](../user/installing-graalvm.md)
 by default uses a version compiled using SVM - this is since version 0.33 of
 GraalVM and was changed to prioritise fast start-up and warm-up time for shorter
 running commands and benchmarks.


### PR DESCRIPTION
I believe https://github.com/oracle/truffleruby/blob/master/doc/user/installing-graalvm.md is the proper link in this case.