### PR TITLE
Fix Symbol#match.

### DIFF
--- a/spec/tags/core/symbol/match_tags.txt
+++ b/spec/tags/core/symbol/match_tags.txt
@@ -1,2 +1,0 @@
-fails:Symbol#match returns the MatchData
-fails:Symbol#match sets the last match pseudo-variables

--- a/src/main/ruby/truffleruby/core/symbol.rb
+++ b/src/main/ruby/truffleruby/core/symbol.rb
@@ -92,7 +92,7 @@ class Symbol
     when Regexp
       match_data = pattern.search_region(str, 0, str.bytesize, true)
       Truffle::RegexpOperations.set_last_match(match_data, Truffle.invoke_primitive(:caller_binding))
-      return match_data.byte_begin(0) if match_data
+      match_data
     when String
       raise TypeError, 'type mismatch: String given'
     else
@@ -100,7 +100,20 @@ class Symbol
     end
   end
 
-  alias_method :=~, :match
+  def =~(pattern)
+    str = to_s
+
+    case pattern
+    when Regexp
+      match_data = pattern.search_region(str, 0, str.bytesize, true)
+      Truffle::RegexpOperations.set_last_match(match_data, Truffle.invoke_primitive(:caller_binding))
+      match_data.byte_begin(0) if match_data
+    when String
+      raise TypeError, 'type mismatch: String given'
+    else
+      pattern =~ str
+    end
+  end
 
   def match?(pattern, pos=0)
     pattern = Truffle::Type.coerce_to_regexp(pattern) unless pattern.kind_of? Regexp


### PR DESCRIPTION
Fix Symbol#match: method `#match` needs to return `MatchData` and method `#=~` needs to return the index of the beginning of the matched data.

I've tried to change `#match` in the following way:
```ruby
def match(pattern)
  to_s.match(pattern)
end
```
and `#=~` to:
```ruby
def =~(pattern)
  to_s =~ pattern
end
```
and re-use `String#match` and `String#=~` but got an issue with `Truffle.invoke_primitive(:caller_binding)` which should be called when setting the last match `Truffle::RegexpOperations.set_last_match` - looks like a frame value is not correct anymore.