### PR TITLE
Make GC.stat compatible with MRI behaviour

### DIFF
--- a/spec/ruby/core/gc/stat_spec.rb
+++ b/spec/ruby/core/gc/stat_spec.rb
@@ -1,0 +1,16 @@
+require_relative '../../spec_helper'
+
+describe "GC.stat" do
+  it "supports access by key" do
+    keys = [:heap_free_slots, :total_allocated_objects, :count]
+    keys.each do |key|
+      GC.stat(key).should be_kind_of(Integer)
+    end
+  end
+
+  it "returns hash of values" do
+    stat = GC.stat
+    stat.should be_kind_of(Hash)
+    stat.keys.should include(:count)
+  end
+end

--- a/src/main/ruby/truffleruby/core/gc.rb
+++ b/src/main/ruby/truffleruby/core/gc.rb
@@ -76,11 +76,18 @@ module GC
     GC.start
   end
 
-  def self.stat
-    {
+  def self.stat(option = nil)
+    stat = {
       count: GC.count,
       time: GC.time,
     }
+    return stat unless option
+
+    if stat[option]
+      stat[option]
+    else
+      0
+    end
   end
 
   module Profiler


### PR DESCRIPTION
This fixes https://github.com/oracle/truffleruby/issues/1681 and makes Truffle not to fail on activesupport 6.0.

As suggested by @eregon, we should return zeroe when any unknown key is passed to `GC.stat`, like `GC.stat :total_allocated_objects` (what ActiveSupport does).

