### PR TITLE
Accept keyword arguments in GC.start

### DIFF
--- a/src/main/ruby/truffleruby/core/gc.rb
+++ b/src/main/ruby/truffleruby/core/gc.rb
@@ -35,7 +35,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 module GC
-  def self.start
+  def self.start(full_mark: true, immediate_sweep: true)
     run(false)
   end
 


### PR DESCRIPTION
Documentation says the following:

This method is defined with keyword arguments that default to true:

```ruby
def GC.start(full_mark: true, immediate_sweep: true); end
```

Use full_mark: false to perform a minor GC. Use immediate_sweep: false to defer sweeping (use lazy sweep).

Note: These keyword arguments are implementation and version dependent. They are not guaranteed to be future-compatible, and may be ignored if the underlying implementation does not support them.

So TruffleRuby can ignore them.