### PR TITLE
Make rb_undef_method work for private methods

### DIFF
--- a/lib/truffle/truffle/cext.rb
+++ b/lib/truffle/truffle/cext.rb
@@ -1298,7 +1298,7 @@ module Truffle::CExt
   end
 
   def rb_undef(mod, name)
-    if mod.frozen? or mod.method_defined?(name)
+    if mod.frozen? or mod.method_defined?(name) or mod.private_method_defined?(name)
       mod.send(:undef_method, name)
     end
   end

--- a/spec/ruby/optional/capi/module_spec.rb
+++ b/spec/ruby/optional/capi/module_spec.rb
@@ -322,6 +322,11 @@ describe "CApiModule" do
       @class.should_not have_instance_method(:ruby_test_method)
     end
 
+    it "undefines private methods also" do
+      @m.rb_undef_method @class, "initialize"
+      -> { @class.new }.should raise_error(NoMethodError)
+    end
+
     it "does not raise exceptions when passed a missing name" do
       -> { @m.rb_undef_method @class, "not_exist" }.should_not raise_error
     end

--- a/spec/ruby/optional/capi/module_spec.rb
+++ b/spec/ruby/optional/capi/module_spec.rb
@@ -323,8 +323,8 @@ describe "CApiModule" do
     end
 
     it "undefines private methods also" do
-      @m.rb_undef_method @class, "initialize"
-      -> { @class.new }.should raise_error(NoMethodError)
+      @m.rb_undef_method @class, "initialize_copy"
+      -> { @class.new.dup }.should raise_error(NoMethodError)
     end
 
     it "does not raise exceptions when passed a missing name" do


### PR DESCRIPTION
The `openssl` gem calls `rb_undef_method("initialize_copy")` for `OpenSSL::X509::Store` and `OpenSSL::X509::StoreContext`, to make them unduplicable.

However, on TruffleRuby, this only works for public and protected methods, because `rb_undef` (and therefore `rb_undef_method`) is guarded by a `method_defined?` check. This causes the `OpenSSL::TestX509Store#test_dup` test to fail, because it checks for `NoMethodError` to be raised when `dup` is called on those classes.