### PR TITLE
Make ossl_asn1prim_to_der work in TruffleRuby

### DIFF
--- a/src/main/c/openssl/ossl_asn1.c
+++ b/src/main/c/openssl/ossl_asn1.c
@@ -1159,7 +1159,8 @@ ossl_asn1prim_to_der(VALUE self)
     if (j & 0x80)
 	ossl_raise(eASN1Error, "ASN1_get_object"); /* should not happen */
 
-    return to_der_internal(self, 0, 0, rb_str_drop_bytes(str, alllen - bodylen));
+    rb_str_update(str, 0, alllen - bodylen, rb_str_new(NULL, 0));
+    return to_der_internal(self, 0, 0, str);
 }
 
 /*


### PR DESCRIPTION
In the `openssl` gem, `ossl_asn1prim_to_der` uses `rb_str_drop_bytes` in its implementation, which is unimplemented in TruffleRuby. There is an alternative method, `rb_str_update`, which can be used to achieve the same results, which is available.

Since this is TruffleRuby-specific, I'm not sure whether it's worth submitting to https://github.com/ruby/openssl. This change makes the `OpenSSL::TestASN1` tests completely pass under TruffleRuby.