### PR TITLE
Make gem-test-pack optional

### DIFF
--- a/test/truffle/ecosystem/02_blog.sh
+++ b/test/truffle/ecosystem/02_blog.sh
@@ -23,14 +23,23 @@ alias truffleruby="jt ruby -S"
 
 set -xe
 
-gem_test_pack="$(jt gem-test-pack)"
+if [ "$1" != "--no-gem-test-pack" ]; then
+  gem_test_pack_path="$(jt gem-test-pack)"
+fi
 
 cd test/truffle/ecosystem/blog
 
-truffleruby bundle config --local cache_path "$gem_test_pack/gem-cache"
+if [ "$gem_test_pack_path" ] ; then
+  truffleruby bundle config --local cache_path "$gem_test_pack_path/gem-cache"
+fi
+
 truffleruby bundle config --local without postgresql mysql
 
-truffleruby bundle install --local --no-cache
+if [ "$gem_test_pack_path" ] ; then
+  truffleruby bundle install --local
+else
+  truffleruby bundle install
+fi
 
 truffleruby bin/rails db:setup
 truffleruby bin/rails log:clear tmp:clear

--- a/tool/jt.rb
+++ b/tool/jt.rb
@@ -1251,7 +1251,8 @@ EOS
   end
 
   private def test_ecosystem(*args)
-    gem_test_pack
+    use_gem_test_pack = args.delete("--no-gem-test-pack") == nil
+    gem_test_pack if use_gem_test_pack
 
     tests_path             = "#{TRUFFLERUBY_DIR}/test/truffle/ecosystem"
     single_test            = !args.empty?
@@ -1265,7 +1266,11 @@ EOS
       exit 1
     end
     success = candidates.all? do |test_script|
-      sh test_script, continue_on_failure: true
+      if use_gem_test_pack
+        sh test_script, continue_on_failure: true
+      else
+        sh test_script, "--no-gem-test-pack", continue_on_failure: true
+      end
     end
     exit success
   end


### PR DESCRIPTION
Fixes https://github.com/oracle/truffleruby/issues/1735

As far as I understand, no contributors outside of Oracle would have gem-test-pack present, so I went ahead and make it optional with `--gem-test-pack` flag. By default, it will now download gems from Rubygems like all ruby apps do.