### PR TITLE
Warning messages should not be displayed when a magic comment appears after a token has been seen unless running in verbose mode.

### DIFF
--- a/spec/ruby/core/kernel/eval_spec.rb
+++ b/spec/ruby/core/kernel/eval_spec.rb
@@ -341,5 +341,17 @@ CODE
       value.encoding.should == Encoding::BINARY
       value.frozen?.should be_true
     end
+
+    it "ignores the frozen_string_literal magic comment if it appears after a token" do
+      code = <<CODE
+some_token_before_magic_comment = :anything
+# frozen_string_literal: true
+class EvalSpecs
+  Vπstring_not_frozen = "not frozen"
+end
+CODE
+      lambda { eval(code) }.should_not complain
+      EvalSpecs::Vπstring_not_frozen.frozen?.should be_false
+    end
   end
 end

--- a/src/main/java/org/truffleruby/parser/lexer/RubyLexer.java
+++ b/src/main/java/org/truffleruby/parser/lexer/RubyLexer.java
@@ -893,7 +893,7 @@ public class RubyLexer implements MagicCommentHandler {
                     // no point in looking for them. However, if warnings are enabled, we do need to scan for the magic comment
                     // so we can report that it will be ignored.
                     if (!tokenSeen || (parserSupport.getContext() != null &&
-                            parserSupport.getContext().getCoreLibrary().warningsEnabled())) {
+                            parserSupport.getContext().getCoreLibrary().isVerbose())) {
                         if (!parser_magic_comment(lexb, lex_p, lex_pend - lex_p, parserRopeOperations, this)) {
                             if (comment_at_top()) {
                                 set_file_encoding(lex_p, lex_pend);


### PR DESCRIPTION
As an added bonus, there should be a small improvement to parse time in non-verbose mode. The original check was intended to be a short-circuit, but the `warningEnabled()` check would always evaluate to `true` unless `$VERBOSE` was specifically set to `nil` (its default value is non-nil).