### PR TITLE
Fix Tempfile#size and #length when the IO is not flushed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Bug fixes:
 
 * Dump and load instance variables in subclasses of `Exception` (#1766).
 
+* Fix Tempfile#size and #length when the IO is not flushed (#1765, @rafaelfranca)
+
 # 19.3.0
 
 New features:

--- a/spec/tags/library/tempfile/length_tags.txt
+++ b/spec/tags/library/tempfile/length_tags.txt
@@ -1,1 +1,0 @@
-fails:Tempfile#length returns the size of self

--- a/spec/tags/library/tempfile/size_tags.txt
+++ b/spec/tags/library/tempfile/size_tags.txt
@@ -1,1 +1,0 @@
-fails:Tempfile#size returns the size of self

--- a/src/main/ruby/truffleruby/core/file.rb
+++ b/src/main/ruby/truffleruby/core/file.rb
@@ -1318,6 +1318,7 @@ class File < IO
 
   def size
     raise IOError, 'closed stream' if closed?
+    flush
     s = Truffle::POSIX.truffleposix_fstat_size(@descriptor)
 
     if s >= 0


### PR DESCRIPTION
On MRI, `File#size` implementation relies on the fact that it calls `rb_io_flush_raw` and that function flush the IO before calculating the size.

Now we are doing the same to follow the same behavior of MRI.

This bug was found while trying to get the rack test suite passing with TruffleRuby.

https://github.com/Shopify/truffleruby/issues/1