### PR TITLE
Dump and load instance variables in subclasses of Exception

### DIFF
--- a/spec/ruby/core/marshal/dump_spec.rb
+++ b/spec/ruby/core/marshal/dump_spec.rb
@@ -473,6 +473,12 @@ describe "Marshal.dump" do
       Marshal.dump(obj).should == "\x04\bo:\x0EException\a:\tmesg\"\bfoo:\abt[\x06\"\x12foo/bar.rb:10"
     end
 
+    it "dumps instance variables if they exist" do
+      obj = Exception.new("foo")
+      obj.instance_variable_set(:@ivar, 1)
+      Marshal.dump(obj).should == "\x04\bo:\x0EException\b:\tmesg\"\bfoo:\abt0:\n@ivari\x06"
+    end
+
     it "dumps the cause for the exception" do
       exc = nil
       begin

--- a/spec/ruby/core/marshal/shared/load.rb
+++ b/spec/ruby/core/marshal/shared/load.rb
@@ -529,6 +529,19 @@ describe :marshal_load, shared: true do
       loaded.message.should == obj.message
       loaded.backtrace.should == obj.backtrace
     end
+
+    it "loads an marshalled exception with ivars" do
+      s = 'hi'
+      arr = [:so, :so, s, s]
+      obj = Exception.new("foo")
+      obj.instance_variable_set :@arr, arr
+
+      loaded = Marshal.send(@method, "\x04\bo:\x0EException\b:\tmesg\"\bfoo:\abt0:\t@arr[\t:\aso;\t\"\ahi@\b")
+      new_arr = loaded.instance_variable_get :@arr
+
+      loaded.message.should == obj.message
+      new_arr.should == arr
+    end
   end
 
   describe "for an Object" do

--- a/src/main/ruby/truffleruby/core/marshal.rb
+++ b/src/main/ruby/truffleruby/core/marshal.rb
@@ -1192,6 +1192,8 @@ module Marshal
           TrufflePrimitive.exception_set_message obj, value
         when :cause
           TrufflePrimitive.exception_set_cause obj, value
+        else # Regular instance variable
+          TrufflePrimitive.object_ivar_set obj, ivar, value
         end
       end
     end

--- a/src/main/ruby/truffleruby/core/marshal.rb
+++ b/src/main/ruby/truffleruby/core/marshal.rb
@@ -109,8 +109,10 @@ class Exception
     name = Truffle::Type.module_name cls
     out << ms.serialize(name.to_sym)
 
+    ivars = ms.serializable_instance_variables(self, [:@custom_backtrace])
+    number_of_ivars = ivars.size + 2
     cause = self.cause
-    out << ms.serialize_fixnum(cause ? 3 : 2) # number of ivars
+    out << ms.serialize_fixnum(cause ? number_of_ivars + 1 : number_of_ivars)
     out << ms.serialize(:mesg)
     out << ms.serialize(TrufflePrimitive.exception_message(self))
     out << ms.serialize(:bt)
@@ -119,6 +121,7 @@ class Exception
       out << ms.serialize(:cause)
       out << ms.serialize(cause)
     end
+    out << Truffle::Type.binary_string(ms.serialize_instance_variables(self, ivars))
 
     out
   end
@@ -1044,13 +1047,21 @@ module Marshal
         str = serialize_integer(count)
       end
 
+      str << serialize_instance_variables(obj, ivars)
+
+      Truffle::Type.binary_string(str)
+    end
+
+    def serialize_instance_variables(obj, ivars)
+      str = ''.b
+
       ivars.each do |ivar|
         val = TrufflePrimitive.object_ivar_get obj, ivar
         str << serialize(ivar)
         str << serialize(val)
       end
 
-      Truffle::Type.binary_string(str)
+      str
     end
 
     def serialize_integer(n, prefix = nil)


### PR DESCRIPTION
Exceptions subclasses can have instance variables. Before this change those instance variables were being ignored by Marshal#dump and by consequence not loaded.

This change dumps the instance variables in a format compatible with MRI and are able to load those instance variables too.

This inconsistency was found by running the i18n test suite with TruffleRuby. With this change 100% of the tests of that gem pass with TruffleRuby, in case you want to add this gem as part of you test suite.

I'm not sure if I should send the new specs first to ruby/spec. Let me know if that is the case.

https://github.com/Shopify/truffleruby/issues/1