### PR TITLE
Raise Encoding::CompatibilityError with incompatible encodings on regexp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Bug fixes:
 * Fix `Tempfile#{size,length}` when the IO is not flushed (#1765, @rafaelfranca).
 * Dump and load instance variables in subclasses of `Exception` (#1766, @rafaelfranca).
 * Fix `Date._iso8601` and `Date._rfc3339` when the string is an invalid date (#1773, @rafaelfranca).
+* Raise Encoding::CompatibilityError with incompatible encodings on regexp (#1775, @rafaelfranca).
 
 Compatibility:
 

--- a/spec/ruby/core/regexp/match_spec.rb
+++ b/spec/ruby/core/regexp/match_spec.rb
@@ -38,6 +38,10 @@ describe "Regexp#match" do
     -> { Regexp.allocate.match('foo') }.should raise_error(TypeError)
   end
 
+  it "raises TypeError on an uninitialized Regexp" do
+    -> { Regexp.allocate.match('foo'.encode("UTF-16LE")) }.should raise_error(TypeError)
+  end
+
   describe "with [string, position]" do
     describe "when given a positive position" do
       it "matches the input at a given position" do

--- a/spec/ruby/language/regexp/encoding_spec.rb
+++ b/spec/ruby/language/regexp/encoding_spec.rb
@@ -42,6 +42,10 @@ describe "Regexps with encoding modifiers" do
     /./n.encoding.should == Encoding::US_ASCII
   end
 
+  it 'uses BINARY when is not initialized' do
+    Regexp.allocate.encoding.should == Encoding::BINARY
+  end
+
   it 'uses BINARY as /n encoding if not all chars are 7-bit' do
     /\xFF/n.encoding.should == Encoding::BINARY
   end

--- a/spec/ruby/language/regexp/encoding_spec.rb
+++ b/spec/ruby/language/regexp/encoding_spec.rb
@@ -100,4 +100,16 @@ describe "Regexps with encoding modifiers" do
   it "selects last of multiple encoding specifiers" do
     /foo/ensuensuens.should == /foo/s
   end
+
+  it "raises Encoding::CompatibilityError when trying match against different encodings" do
+    -> { /\A[[:space:]]*\z/.match(" ".encode("UTF-16LE")) }.should raise_error(Encoding::CompatibilityError)
+  end
+
+  it "raises Encoding::CompatibilityError when trying match? against different encodings" do
+    -> { /\A[[:space:]]*\z/.match?(" ".encode("UTF-16LE")) }.should raise_error(Encoding::CompatibilityError)
+  end
+
+  it "raises Encoding::CompatibilityError when trying =~ against different encodings" do
+    -> { /\A[[:space:]]*\z/ =~ " ".encode("UTF-16LE") }.should raise_error(Encoding::CompatibilityError)
+  end
 end

--- a/src/main/java/org/truffleruby/core/encoding/EncodingNodes.java
+++ b/src/main/java/org/truffleruby/core/encoding/EncodingNodes.java
@@ -660,10 +660,11 @@ public abstract class EncodingNodes {
         }
 
         @Specialization(guards = "isRubyRegexp(object)")
-        protected DynamicObject encodingGetObjectEncodingRegexp(DynamicObject object) {
+        protected DynamicObject encodingGetObjectEncodingRegexp(DynamicObject object,
+                @Cached("createBinaryProfile()") ConditionProfile hasRegexpSource) {
             final Rope regexpSource = Layouts.REGEXP.getSource(object);
 
-            if (regexpSource == null) {
+            if (hasRegexpSource.profile(regexpSource == null)) {
                 return getRubyEncodingNode.executeGetRubyEncoding(EncodingManager.getEncoding("BINARY"));
             } else {
                 return getRubyEncodingNode.executeGetRubyEncoding(regexpSource.getEncoding());

--- a/src/main/java/org/truffleruby/core/encoding/EncodingNodes.java
+++ b/src/main/java/org/truffleruby/core/encoding/EncodingNodes.java
@@ -664,10 +664,10 @@ public abstract class EncodingNodes {
                 @Cached("createBinaryProfile()") ConditionProfile hasRegexpSource) {
             final Rope regexpSource = Layouts.REGEXP.getSource(object);
 
-            if (hasRegexpSource.profile(regexpSource == null)) {
-                return getRubyEncodingNode.executeGetRubyEncoding(EncodingManager.getEncoding("BINARY"));
-            } else {
+            if (hasRegexpSource.profile(regexpSource != null)) {
                 return getRubyEncodingNode.executeGetRubyEncoding(regexpSource.getEncoding());
+            } else {
+                return getRubyEncodingNode.executeGetRubyEncoding(EncodingManager.getEncoding("BINARY"));
             }
         }
 

--- a/src/main/java/org/truffleruby/core/regexp/RegexpNodes.java
+++ b/src/main/java/org/truffleruby/core/regexp/RegexpNodes.java
@@ -464,6 +464,7 @@ public abstract class RegexpNodes {
         @Specialization(guards = {
                 "isInitialized(regexp)",
                 "isRubyString(string)",
+                "isValidEncoding(string, rangeNode)",
                 "!isRubyEncoding(isCompatibleNode.executeCompatibleQuery(regexp, string))" })
         protected Object searchRegionIncompatibleEncoding(DynamicObject regexp, DynamicObject string, int start, int end,
                 boolean forward,

--- a/src/main/ruby/truffleruby/core/truffle/regexp_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/regexp_operations.rb
@@ -16,6 +16,8 @@ module Truffle
       str = str.to_s if str.is_a?(Symbol)
       str = StringValue(str)
 
+      raise Encoding::CompatibilityError unless Encoding.compatible?(re.encoding, str.encoding)
+
       pos = pos < 0 ? pos + str.size : pos
       pos = TrufflePrimitive.string_byte_index_from_char_index(str, pos)
       re.search_region(str, pos, str.bytesize, true)

--- a/src/main/ruby/truffleruby/core/truffle/regexp_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/regexp_operations.rb
@@ -16,8 +16,6 @@ module Truffle
       str = str.to_s if str.is_a?(Symbol)
       str = StringValue(str)
 
-      raise Encoding::CompatibilityError unless Encoding.compatible?(re.encoding, str.encoding)
-
       pos = pos < 0 ? pos + str.size : pos
       pos = TrufflePrimitive.string_byte_index_from_char_index(str, pos)
       re.search_region(str, pos, str.bytesize, true)


### PR DESCRIPTION
When the string and the regular expression have different encodings we should raise an Encoding::CompatibilityError.

This fixes String#blank? of Active Support that depends on this behavior.

https://github.com/rails/rails/blob/ac193d0cc338bd024d1b9f41dee384da4f7c51c4/activesupport/lib/active_support/core_ext/object/blank.rb#L128-L129

Shopify#1