### PR TITLE
Fail early for bad handle unwraps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Bug fixes:
 
 * Fix `Tempfile#{size,length}` when the IO is not flushed (#1765, @rafaelfranca).
 * Dump and load instance variables in subclasses of `Exception` (#1766, @rafaelfranca).
+* Fail earlier for bad handle unwrapping (#1777, @chrisseaton).
 
 Compatibility:
 


### PR DESCRIPTION
I'm not sure why we were letting these errors propagate? But in my experience they're much easier to understand if they fail like this, and I was dealing with a lot of them.

https://github.com/Shopify/truffleruby/issues/1