### PR TITLE
Do not warn / crash when requiring a file that sets and trigger autoload on itself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Bug fixes:
 * Fail earlier for bad handle unwrapping (#1777, @chrisseaton).
 * Match out of range ArgumentError message with MRI (#1774, @rafaelfranca)
 * Raise Encoding::CompatibilityError with incompatible encodings on regexp (#1775, @rafaelfranca).
+* Do not warn / crash when requiring a file that sets and trigger autoload on itself (#1779, @XrXr).
 
 Compatibility:
 

--- a/spec/ruby/core/module/autoload_spec.rb
+++ b/spec/ruby/core/module/autoload_spec.rb
@@ -652,6 +652,16 @@ describe "Module#autoload" do
     ModuleSpecs::Autoload::AutoloadDuringRequire.should be_kind_of(Class)
   end
 
+  it "does not call #require a second time and does not warn if feature sets and trigger autoload on itself" do
+    main = TOPLEVEL_BINDING.eval("self")
+    main.should_not_receive(:require)
+
+    -> {
+      Kernel.require fixture(__FILE__, "autoload_self_during_require.rb")
+    }.should_not complain(verbose: true)
+    ModuleSpecs::Autoload::AutoloadSelfDuringRequire.should be_kind_of(Class)
+  end
+
   it "calls #to_path on non-string filenames" do
     p = mock('path')
     p.should_receive(:to_path).and_return @non_existent

--- a/spec/ruby/core/module/fixtures/autoload_self_during_require.rb
+++ b/spec/ruby/core/module/fixtures/autoload_self_during_require.rb
@@ -1,0 +1,5 @@
+module ModuleSpecs::Autoload
+  autoload :AutoloadSelfDuringRequire, __FILE__
+  class AutoloadSelfDuringRequire
+  end
+end


### PR DESCRIPTION
It is a very simple bug to reproduce:

```ruby
# lib/foo.rb
module Foo
  autoload :Bar, 'foo/something'
  autoload :Baz, 'foo/something'
end

# lib/foo/something
require 'foo'

module Foo
  class Bar
  end

  class Baz
  end
end

ruby -Ilib -r 'foo/something'
truffleruby-bug/lib/foo/something.rb:4:in `const_missing': uninitialized constant Foo::Baz (NameError)
Did you mean?  Foo::Bar
	from /Users/rafaelfranca/src/truffleruby-bug/lib/foo/something.rb:4:in `require'
	from /Users/rafaelfranca/src/truffleruby-bug/lib/foo/something.rb:4:in `require'
	from /Users/rafaelfranca/src/truffleruby-bug/lib/foo/something.rb:4:in `Foo'
	from /Users/rafaelfranca/src/truffleruby-bug/lib/foo/something.rb:3:in `<top (required)>'
	from /Users/rafaelfranca/.rubies/truffleruby-19.2.0/bin/irb:1:in `require'
	from /Users/rafaelfranca/.rubies/truffleruby-19.2.0/bin/irb:1:in `require'
	from /Users/rafaelfranca/.rubies/truffleruby-19.2.0/bin/irb:1:in `<main>'
```

This bug is present when trying to run the `rack` test suite against truffleruby.

Shopify#1