### PR TITLE
Coercion fixes for TCPServer.new

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Bug fixes:
 * Match out of range ArgumentError message with MRI (#1774, @rafaelfranca)
 * Raise Encoding::CompatibilityError with incompatible encodings on regexp (#1775, @rafaelfranca).
 * Fixed interactions between attributes and instance variables in structs (#1776, @chrisseaton).
+* Coercion fixes for `TCPServer.new` (#1780, @XrXr)
 
 Compatibility:
 

--- a/lib/truffle/socket/tcp_server.rb
+++ b/lib/truffle/socket/tcp_server.rb
@@ -25,33 +25,8 @@
 # EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 class TCPServer < TCPSocket
-  def initialize(host, service = nil)
+  def initialize(host = nil, service)
     @no_reverse_lookup = self.class.do_not_reverse_lookup
-
-    if host.is_a?(Integer) and service.nil?
-      service = host
-      host    = nil
-    end
-
-    if host.is_a?(String) and service.nil?
-      begin
-        service = Integer(host)
-      rescue ArgumentError
-        raise SocketError, "invalid port number: #{host}"
-      end
-
-      host = nil
-    end
-
-    unless service.is_a?(Integer)
-      service = Truffle::Socket.coerce_to_string(service)
-    end
-
-    if host
-      host = Truffle::Socket.coerce_to_string(host)
-    else
-      host = ''
-    end
 
     remote_addrs = Socket
       .getaddrinfo(host, service, :UNSPEC, :STREAM, 0, Socket::AI_PASSIVE)

--- a/spec/ruby/library/socket/tcpserver/new_spec.rb
+++ b/spec/ruby/library/socket/tcpserver/new_spec.rb
@@ -48,6 +48,24 @@ describe "TCPServer.new" do
     addr[3].should == '0.0.0.0'
   end
 
+  it "binds to a port if the port is explicitly nil" do
+    @server = TCPServer.new('', nil)
+    addr = @server.addr
+    addr[0].should == 'AF_INET'
+    addr[1].should be_kind_of(Integer)
+    addr[2].should == '0.0.0.0'
+    addr[3].should == '0.0.0.0'
+  end
+
+  it "binds to a port if the port is an empty string" do
+    @server = TCPServer.new('', '')
+    addr = @server.addr
+    addr[0].should == 'AF_INET'
+    addr[1].should be_kind_of(Integer)
+    addr[2].should == '0.0.0.0'
+    addr[3].should == '0.0.0.0'
+  end
+
   it "coerces port to string, then determines port from that number or service name" do
     -> { TCPServer.new(SocketSpecs.hostname, Object.new) }.should raise_error(TypeError)
 
@@ -60,6 +78,23 @@ describe "TCPServer.new" do
 
     # TODO: This should also accept strings like 'https', but I don't know how to
     # pick such a service port that will be able to reliably bind...
+  end
+
+  it "has a single argument form and treats it as a port number" do
+    @server = TCPServer.new(0)
+    addr = @server.addr
+    addr[1].should be_kind_of(Integer)
+  end
+
+  it "coerces port to a string when it is the only argument" do
+    -> { TCPServer.new(Object.new) }.should raise_error(TypeError)
+
+    port = Object.new
+    port.should_receive(:to_str).and_return("0")
+
+    @server = TCPServer.new(port)
+    addr = @server.addr
+    addr[1].should be_kind_of(Integer)
   end
 
   it "raises Errno::EADDRNOTAVAIL when the address is unknown" do


### PR DESCRIPTION
Handle nil and empty string and coerce the port number the way MRI does.

https://github.com/Shopify/truffleruby/issues/1