### PR TITLE
Some options tested in specs need --experimental-options

### DIFF
--- a/spec/truffle/launcher_spec.rb
+++ b/spec/truffle/launcher_spec.rb
@@ -179,7 +179,7 @@ describe "The launcher" do
   end
 
   it "logs options if --options-log is set" do
-    out = ruby_exe("14", options: "--log.level=CONFIG --options-log", args: "2>&1")
+    out = ruby_exe("14", options: "--experimental-options --log.level=CONFIG --options-log", args: "2>&1")
     $?.success?.should == true
     out.should include("[ruby] CONFIG")
   end
@@ -195,13 +195,13 @@ describe "The launcher" do
   end
 
   it "sets the log level using --log.level=" do
-    out = ruby_exe("14", options: "--options-log --log.level=CONFIG", args: "2>&1")
+    out = ruby_exe("14", options: "--experimental-options --options-log --log.level=CONFIG", args: "2>&1")
     $?.success?.should == true
     out.should include("CONFIG: option home=")
   end
 
   it "sets the log level using --log.ruby.level=" do
-    out = ruby_exe("14", options: "--options-log --log.ruby.level=CONFIG", args: "2>&1")
+    out = ruby_exe("14", options: "--experimental-options --options-log --log.ruby.level=CONFIG", args: "2>&1")
     $?.success?.should == true
     out.should include("CONFIG: option home=")
   end
@@ -232,7 +232,7 @@ describe "The launcher" do
   end
 
   it "enables deterministic hashing if --hashing-deterministic is set" do
-    out = ruby_exe("puts 14.hash", options: "--hashing-deterministic", args: "2>&1")
+    out = ruby_exe("puts 14.hash", options: "--experimental-options --hashing-deterministic", args: "2>&1")
     $?.success?.should == true
     out.should include("SEVERE: deterministic hashing is enabled - this may make you vulnerable to denial of service attacks")
     out.should include("7141275149799654099")
@@ -279,13 +279,13 @@ describe "The launcher" do
   end
 
   it "understands ruby polyglot options" do
-    out = ruby_exe("p Truffle::Boot.get_option('rubygems')", options: "--ruby.rubygems=false")
+    out = ruby_exe("p Truffle::Boot.get_option('rubygems')", options: "--experimental-options --ruby.rubygems=false")
     $?.success?.should == true
     out.should include('false')
   end
 
   it "understands ruby polyglot options without ruby. prefix" do
-    out = ruby_exe("p Truffle::Boot.get_option('rubygems')", options: "--rubygems=false")
+    out = ruby_exe("p Truffle::Boot.get_option('rubygems')", options: "--experimental-options --rubygems=false")
     $?.success?.should == true
     out.should include('false')
   end

--- a/spec/truffle/options/cexts_spec.rb
+++ b/spec/truffle/options/cexts_spec.rb
@@ -10,14 +10,14 @@ require_relative '../../ruby/spec_helper'
 
 describe "The --cexts option" do
   it "when disabled can run basic expressions" do
-    ruby_exe("p [1, 2, 3].map(&:succ)", options: "--cexts=false").should == "[2, 3, 4]\n"
+    ruby_exe("p [1, 2, 3].map(&:succ)", options: "--experimental-options --cexts=false").should == "[2, 3, 4]\n"
   end
 
   it "when disabled can use reasonable parts of the stdlib" do
-    ruby_exe("require 'uri'; p URI('http://foo.com/posts?id=30&limit=5#time=1305298413').query", options: "--cexts=false").should == "\"id=30&limit=5\"\n"
+    ruby_exe("require 'uri'; p URI('http://foo.com/posts?id=30&limit=5#time=1305298413').query", options: "--experimental-options --cexts=false").should == "\"id=30&limit=5\"\n"
   end
 
   it "when disabled cannot use parts of the stdlib that use C extensions" do
-    ruby_exe("require 'yaml'; p YAML.load('--- foo')", options: "--cexts=false", args: "2>&1").should =~ /disabled/
+    ruby_exe("require 'yaml'; p YAML.load('--- foo')", options: "--experimental-options --cexts=false", args: "2>&1").should =~ /disabled/
   end
 end

--- a/spec/truffle/options/defaults_spec.rb
+++ b/spec/truffle/options/defaults_spec.rb
@@ -16,33 +16,33 @@ describe "Options" do
   end
 
   it "can be set explicitly back to their default value" do
-    ruby_exe("p Truffle::Boot.get_option('dispatch-cache')", options: "--dispatch-cache=8").should == "8\n"
-    ruby_exe("p Truffle::Boot.get_option('polyglot-stdio')", options: "--polyglot-stdio=false").should == "false\n"
+    ruby_exe("p Truffle::Boot.get_option('dispatch-cache')", options: "--experimental-options --dispatch-cache=8").should == "8\n"
+    ruby_exe("p Truffle::Boot.get_option('polyglot-stdio')", options: "--experimental-options --polyglot-stdio=false").should == "false\n"
   end
 
   it "can be set explicitly to a value" do
-    ruby_exe("p Truffle::Boot.get_option('dispatch-cache')", options: "--dispatch-cache=99").should == "99\n"
-    ruby_exe("p Truffle::Boot.get_option('polyglot-stdio')", options: "--polyglot-stdio=true").should == "true\n"
+    ruby_exe("p Truffle::Boot.get_option('dispatch-cache')", options: "--experimental-options --dispatch-cache=99").should == "99\n"
+    ruby_exe("p Truffle::Boot.get_option('polyglot-stdio')", options: "--experimental-options --polyglot-stdio=true").should == "true\n"
   end
 
   it "can be set explicitly to an implicit value" do
-    ruby_exe("p Truffle::Boot.get_option('polyglot-stdio')", options: "--polyglot-stdio").should == "true\n"
+    ruby_exe("p Truffle::Boot.get_option('polyglot-stdio')", options: "--experimental-options --polyglot-stdio").should == "true\n"
   end
 
   it "can be set using a simple referenced option" do
-    ruby_exe("p Truffle::Boot.get_option('dispatch-cache')", options: "--default-cache=99").should == "99\n"
-    ruby_exe("p Truffle::Boot.get_option('polyglot-stdio')", options: "--embedded").should == "true\n"
+    ruby_exe("p Truffle::Boot.get_option('dispatch-cache')", options: "--experimental-options --default-cache=99").should == "99\n"
+    ruby_exe("p Truffle::Boot.get_option('polyglot-stdio')", options: "--experimental-options --embedded").should == "true\n"
   end
 
   it "can be set using a negated referenced option" do
-    ruby_exe("p Truffle::Boot.get_option('polyglot-stdio')", options: "--platform-native=false").should == "true\n"
+    ruby_exe("p Truffle::Boot.get_option('polyglot-stdio')", options: "--experimental-options --platform-native=false").should == "true\n"
   end
 
   it "take an explicit value over a modified referenced option" do
-    ruby_exe("p Truffle::Boot.get_option('dispatch-cache')", options: "--default-cache=101 --dispatch-cache=99").should == "99\n"
-    ruby_exe("p Truffle::Boot.get_option('dispatch-cache')", options: "--dispatch-cache=99 --default-cache=101").should == "99\n"
-    ruby_exe("p Truffle::Boot.get_option('polyglot-stdio')", options: "--embedded --polyglot-stdio=false").should == "false\n"
-    ruby_exe("p Truffle::Boot.get_option('polyglot-stdio')", options: "--polyglot-stdio=false --embedded").should == "false\n"
+    ruby_exe("p Truffle::Boot.get_option('dispatch-cache')", options: "--experimental-options --default-cache=101 --dispatch-cache=99").should == "99\n"
+    ruby_exe("p Truffle::Boot.get_option('dispatch-cache')", options: "--experimental-options --dispatch-cache=99 --default-cache=101").should == "99\n"
+    ruby_exe("p Truffle::Boot.get_option('polyglot-stdio')", options: "--experimental-options --embedded --polyglot-stdio=false").should == "false\n"
+    ruby_exe("p Truffle::Boot.get_option('polyglot-stdio')", options: "--experimental-options --polyglot-stdio=false --embedded").should == "false\n"
   end
 
 end

--- a/spec/truffle/options/embedded_spec.rb
+++ b/spec/truffle/options/embedded_spec.rb
@@ -14,26 +14,26 @@ describe "The --embedded option" do
   end
 
   it "can be set with --embedded, even though it's set by the launcher" do
-    ruby_exe("p Truffle::Boot.get_option('embedded')", options: "--embedded").should == "true\n"
+    ruby_exe("p Truffle::Boot.get_option('embedded')", options: "--experimental-options --embedded").should == "true\n"
   end
 
   it "can be set with --ruby.embedded, even though it's set by the launcher" do
-    ruby_exe("p Truffle::Boot.get_option('embedded')", options: "--ruby.embedded").should == "true\n"
+    ruby_exe("p Truffle::Boot.get_option('embedded')", options: "--experimental-options --ruby.embedded").should == "true\n"
   end
 
   it "sets dependent options when set manually" do
-    ruby_exe("p Truffle::Boot.get_option('single-threaded')", options: "--embedded").should == "true\n"
+    ruby_exe("p Truffle::Boot.get_option('single-threaded')", options: "--experimental-options --embedded").should == "true\n"
   end
 
   it "when enabled can run basic expressions" do
-    ruby_exe("p [1, 2, 3].map(&:succ)", options: "--embedded").should == "[2, 3, 4]\n"
+    ruby_exe("p [1, 2, 3].map(&:succ)", options: "--experimental-options --embedded").should == "[2, 3, 4]\n"
   end
 
   it "when enabled can use reasonable parts of the stdlib" do
-    ruby_exe("require 'uri'; p URI('http://foo.com/posts?id=30&limit=5#time=1305298413').query", options: "--embedded").should == "\"id=30&limit=5\"\n"
+    ruby_exe("require 'uri'; p URI('http://foo.com/posts?id=30&limit=5#time=1305298413').query", options: "--experimental-options --embedded").should == "\"id=30&limit=5\"\n"
   end
 
   it "when enabled will warn about signals" do
-    ruby_exe("Signal.trap('ALRM') { }", options: "--embedded", args: "2>&1").should include("trapping signal ALRM in embedded mode")
+    ruby_exe("Signal.trap('ALRM') { }", options: "--experimental-options --embedded", args: "2>&1").should include("trapping signal ALRM in embedded mode")
   end
 end

--- a/spec/truffle/options/parsing_spec.rb
+++ b/spec/truffle/options/parsing_spec.rb
@@ -14,13 +14,13 @@ describe "Options" do
 
     it "booleans" do
       ruby_exe("p Truffle::Boot.get_option('frozen-string-literals')").should_not == "true\n"
-      ruby_exe("p Truffle::Boot.get_option('frozen-string-literals')", options: "--frozen-string-literals=true").should == "true\n"
-      ruby_exe("p Truffle::Boot.get_option('frozen-string-literals')", options: "--frozen-string-literals").should == "true\n"
+      ruby_exe("p Truffle::Boot.get_option('frozen-string-literals')", options: "--experimental-options --frozen-string-literals=true").should == "true\n"
+      ruby_exe("p Truffle::Boot.get_option('frozen-string-literals')", options: "--experimental-options --frozen-string-literals").should == "true\n"
     end
 
     it "integers" do
       ruby_exe("p Truffle::Boot.get_option('default-cache')").should_not == "99\n"
-      ruby_exe("p Truffle::Boot.get_option('default-cache')", options: "--default-cache=99").should == "99\n"
+      ruby_exe("p Truffle::Boot.get_option('default-cache')", options: "--experimental-options --default-cache=99").should == "99\n"
     end
 
     it "enum values" do
@@ -30,8 +30,8 @@ describe "Options" do
     end
 
     it "strings" do
-      ruby_exe("p Truffle::Boot.get_option('launcher')", options: "--launcher=ruby_spec_test_value").should == "\"ruby_spec_test_value\"\n"
-      ruby_exe("p Truffle::Boot.get_option('launcher')", options: "'--launcher=ruby spec test value with spaces'").should == "\"ruby spec test value with spaces\"\n"
+      ruby_exe("p Truffle::Boot.get_option('launcher')", options: "--experimental-options --launcher=ruby_spec_test_value").should == "\"ruby_spec_test_value\"\n"
+      ruby_exe("p Truffle::Boot.get_option('launcher')", options: "--experimental-options '--launcher=ruby spec test value with spaces'").should == "\"ruby spec test value with spaces\"\n"
     end
 
     it "arrays of strings" do

--- a/spec/truffle/options/platform_native_spec.rb
+++ b/spec/truffle/options/platform_native_spec.rb
@@ -10,14 +10,14 @@ require_relative '../../ruby/spec_helper'
 
 describe "The --platform-native option" do
   it "when disabled enables polyglot stdio" do
-    ruby_exe("p Truffle::Boot.get_option('polyglot-stdio')", options: "--platform-native=false").should == "true\n"
+    ruby_exe("p Truffle::Boot.get_option('polyglot-stdio')", options: "--experimental-options --platform-native=false").should == "true\n"
   end
 
   it "when disabled can run basic expressions" do
-    ruby_exe("p [1, 2, 3].map(&:succ)", options: "--platform-native=false").should == "[2, 3, 4]\n"
+    ruby_exe("p [1, 2, 3].map(&:succ)", options: "--experimental-options --platform-native=false").should == "[2, 3, 4]\n"
   end
 
   it "when disabled can use reasonable parts of the stdlib" do
-    ruby_exe("require 'uri'; p URI('http://foo.com/posts?id=30&limit=5#time=1305298413').query", options: "--platform-native=false").should == "\"id=30&limit=5\"\n"
+    ruby_exe("require 'uri'; p URI('http://foo.com/posts?id=30&limit=5#time=1305298413').query", options: "--experimental-options --platform-native=false").should == "\"id=30&limit=5\"\n"
   end
 end

--- a/spec/truffle/pre_initialization_spec.rb
+++ b/spec/truffle/pre_initialization_spec.rb
@@ -16,7 +16,7 @@ guard -> { TruffleRuby.native? } do
     end
 
     it "is not used if --preinit=false is passed" do
-      out = ruby_exe("p Truffle::Boot.was_preinitialized?", options: "--preinit=false")
+      out = ruby_exe("p Truffle::Boot.was_preinitialized?", options: "--experimental-options --preinit=false")
       out.should == "false\n"
     end
 
@@ -29,7 +29,7 @@ guard -> { TruffleRuby.native? } do
     end
 
     it "is not used when passing incompatible options" do
-      no_native = "--patching=false --disable-gems"
+      no_native = "--experimental-options --patching=false --disable-gems"
       out = ruby_exe("p Truffle::Boot.was_preinitialized?", options: "--log.level=FINE #{no_native}", args: "2>&1")
       out.should include("patchContext()")
       out.should include("not reusing pre-initialized context: loading patching is false")
@@ -42,7 +42,7 @@ guard -> { TruffleRuby.native? } do
 
     it "is not used when the home is unset but was set at build time" do
       code = "p [Truffle::Boot.ruby_home, Truffle::Boot.was_preinitialized?]"
-      out = ruby_exe(code, options: "--log.level=FINE --no-home-provided", args: "2>&1")
+      out = ruby_exe(code, options: "--experimental-options --log.level=FINE --no-home-provided", args: "2>&1")
       out.should include("[nil, false]\n")
       out.should include("not reusing pre-initialized context: Ruby home is unset")
     end


### PR DESCRIPTION
At Shopify we run all CI tests against a release binary tarball, so we don't have `jt` to add these options for us.

https://github.com/Shopify/truffleruby/issues/1