### PR TITLE
Fix Float#<=> not calling coerce when other arg responds to it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Bug fixes:
 * Match out of range ArgumentError message with MRI (#1774, @rafaelfranca)
 * Raise Encoding::CompatibilityError with incompatible encodings on regexp (#1775, @rafaelfranca).
 * Fixed interactions between attributes and instance variables in structs (#1776, @chrisseaton).
+* Fix `Float#<=>` not calling `coerce` when `other` argument responds to it (#1783, @XrXr).
 
 Compatibility:
 

--- a/src/main/java/org/truffleruby/core/numeric/FloatNodes.java
+++ b/src/main/java/org/truffleruby/core/numeric/FloatNodes.java
@@ -420,7 +420,7 @@ public abstract class FloatNodes {
 
         @Specialization(guards = { "!isNaN(a)", "!isRubyBignum(b)" })
         protected Object compare(double a, DynamicObject b,
-                                 @Cached("createPrivate()") CallDispatchHeadNode redoCompare) {
+                @Cached("createPrivate()") CallDispatchHeadNode redoCompare) {
             return redoCompare.call(a, "redo_compare_bad_coerce_return_error", b);
         }
 

--- a/src/main/java/org/truffleruby/core/numeric/FloatNodes.java
+++ b/src/main/java/org/truffleruby/core/numeric/FloatNodes.java
@@ -419,8 +419,9 @@ public abstract class FloatNodes {
         }
 
         @Specialization(guards = { "!isNaN(a)", "!isRubyBignum(b)" })
-        protected DynamicObject compare(double a, DynamicObject b) {
-            return nil();
+        protected Object compare(double a, DynamicObject b,
+                                 @Cached("createPrivate()") CallDispatchHeadNode redoCompare) {
+            return redoCompare.call(a, "redo_compare_bad_coerce_return_error", b);
         }
 
     }

--- a/src/main/ruby/truffleruby/core/numeric.rb
+++ b/src/main/ruby/truffleruby/core/numeric.rb
@@ -257,6 +257,8 @@ class Numeric
       raise TypeError, "#{other.class} can't be coerced into #{self.class}"
     elsif error == :compare_error
       raise ArgumentError, "comparison of #{self.class} with #{other.class} failed"
+    elsif error == :bad_coerce_return_error
+      nil
     elsif error == :no_error
       nil
     end
@@ -290,6 +292,12 @@ class Numeric
     return nil unless b
     a <=> b
   end
+
+   private def redo_compare_bad_coerce_return_error(right)
+     b, a = math_coerce(right, :bad_coerce_return_error)
+     return nil unless b
+     a <=> b
+   end
 
   def redo_bit_coerced(meth, right)
     b, a = bit_coerce(right)


### PR DESCRIPTION
Similar thing is happening for Integer, but that'll be separate.

Shopify#1