### PR TITLE
Option to print backtraces on rescue

### DIFF
--- a/spec/truffle/options/backtraces_rescue_spec.rb
+++ b/spec/truffle/options/backtraces_rescue_spec.rb
@@ -1,0 +1,15 @@
+# Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved. This
+# code is released under a tri EPL/GPL/LGPL license. You can use it,
+# redistribute it and/or modify it under the terms of the:
+#
+# Eclipse Public License version 2.0, or
+# GNU General Public License version 2, or
+# GNU Lesser General Public License version 2.1.
+
+require_relative '../../ruby/spec_helper'
+
+describe "The --backtraces-rescue option" do
+  it "can be used to print backtraces in silent rescues" do
+    ruby_exe("1/0 rescue nil", options: "--experimental-options --backtraces-rescue", args: "2>&1").should include("divided by 0 (ZeroDivisionError)")
+  end
+end

--- a/src/main/java/org/truffleruby/language/exceptions/TryNode.java
+++ b/src/main/java/org/truffleruby/language/exceptions/TryNode.java
@@ -82,6 +82,10 @@ public class TryNode extends RubyNode {
     private Object handleException(VirtualFrame frame, RaiseException exception) {
         for (RescueNode rescue : rescueParts) {
             if (rescue.canHandle(frame, exception.getException())) {
+                if (getContext().getOptions().BACKTRACE_ON_RESCUE) {
+                    getContext().getDefaultBacktraceFormatter().printRubyExceptionOnEnvStderr(exception.getException());
+                }
+
                 if (canOmitBacktrace) {
                     /* If we're in this branch, we've already determined that the rescue body doesn't access `$!`.
                      * Thus, we can safely skip writing that value. Writing to `$!` is quite expensive, so we want

--- a/src/main/java/org/truffleruby/options/Options.java
+++ b/src/main/java/org/truffleruby/options/Options.java
@@ -112,6 +112,8 @@ public class Options {
     public final boolean BACKTRACE_ON_SIGALRM;
     /** --backtraces-raise=false */
     public final boolean BACKTRACE_ON_RAISE;
+    /** --backtraces-rescue=false */
+    public final boolean BACKTRACE_ON_RESCUE;
     /** --cexts=true */
     public final boolean CEXTS;
     /** --cexts-lock=true */
@@ -309,6 +311,7 @@ public class Options {
         BACKTRACE_ON_INTERRUPT = options.get(OptionsCatalog.BACKTRACE_ON_INTERRUPT_KEY);
         BACKTRACE_ON_SIGALRM = options.hasBeenSet(OptionsCatalog.BACKTRACE_ON_SIGALRM_KEY) ? options.get(OptionsCatalog.BACKTRACE_ON_SIGALRM_KEY) : !EMBEDDED;
         BACKTRACE_ON_RAISE = options.get(OptionsCatalog.BACKTRACE_ON_RAISE_KEY);
+        BACKTRACE_ON_RESCUE = options.get(OptionsCatalog.BACKTRACE_ON_RESCUE_KEY);
         CEXTS = options.get(OptionsCatalog.CEXTS_KEY);
         CEXT_LOCK = options.get(OptionsCatalog.CEXT_LOCK_KEY);
         OPTIONS_LOG = options.get(OptionsCatalog.OPTIONS_LOG_KEY);
@@ -478,6 +481,8 @@ public class Options {
                 return BACKTRACE_ON_SIGALRM;
             case "ruby.backtraces-raise":
                 return BACKTRACE_ON_RAISE;
+            case "ruby.backtraces-rescue":
+                return BACKTRACE_ON_RESCUE;
             case "ruby.cexts":
                 return CEXTS;
             case "ruby.cexts-lock":

--- a/src/options.yml
+++ b/src/options.yml
@@ -61,6 +61,7 @@ EXPERT:
     BACKTRACE_ON_INTERRUPT: [backtraces-on-interrupt, boolean, false, Show the backtraces of all Threads on Ctrl+C]
     BACKTRACE_ON_SIGALRM: [backtraces-sigalrm, boolean, '!EMBEDDED', Show the backtraces of all Threads on SIGALRM]
     BACKTRACE_ON_RAISE: [backtraces-raise, boolean, false, Show the backtraces of exceptions at the point of them being raised]
+    BACKTRACE_ON_RESCUE: [backtraces-rescue, boolean, false, Show the backtraces of exceptions at the point of them being rescued]
 
     # C extension options
     CEXTS: [cexts, boolean, true, Enable use of C extensions]

--- a/src/shared/java/org/truffleruby/shared/options/OptionsCatalog.java
+++ b/src/shared/java/org/truffleruby/shared/options/OptionsCatalog.java
@@ -65,6 +65,7 @@ public class OptionsCatalog {
     public static final OptionKey<Boolean> BACKTRACE_ON_INTERRUPT_KEY = new OptionKey<>(false);
     public static final OptionKey<Boolean> BACKTRACE_ON_SIGALRM_KEY = new OptionKey<>(!EMBEDDED_KEY.getDefaultValue());
     public static final OptionKey<Boolean> BACKTRACE_ON_RAISE_KEY = new OptionKey<>(false);
+    public static final OptionKey<Boolean> BACKTRACE_ON_RESCUE_KEY = new OptionKey<>(false);
     public static final OptionKey<Boolean> CEXTS_KEY = new OptionKey<>(true);
     public static final OptionKey<Boolean> CEXT_LOCK_KEY = new OptionKey<>(true);
     public static final OptionKey<Boolean> OPTIONS_LOG_KEY = new OptionKey<>(false);
@@ -452,6 +453,13 @@ public class OptionsCatalog {
     public static final OptionDescriptor BACKTRACE_ON_RAISE = OptionDescriptor
             .newBuilder(BACKTRACE_ON_RAISE_KEY, "ruby.backtraces-raise")
             .help("Show the backtraces of exceptions at the point of them being raised")
+            .category(OptionCategory.EXPERT)
+            .stability(OptionStability.EXPERIMENTAL)
+            .build();
+
+    public static final OptionDescriptor BACKTRACE_ON_RESCUE = OptionDescriptor
+            .newBuilder(BACKTRACE_ON_RESCUE_KEY, "ruby.backtraces-rescue")
+            .help("Show the backtraces of exceptions at the point of them being rescued")
             .category(OptionCategory.EXPERT)
             .stability(OptionStability.EXPERIMENTAL)
             .build();
@@ -1073,6 +1081,8 @@ public class OptionsCatalog {
                 return BACKTRACE_ON_SIGALRM;
             case "ruby.backtraces-raise":
                 return BACKTRACE_ON_RAISE;
+            case "ruby.backtraces-rescue":
+                return BACKTRACE_ON_RESCUE;
             case "ruby.cexts":
                 return CEXTS;
             case "ruby.cexts-lock":
@@ -1275,6 +1285,7 @@ public class OptionsCatalog {
             BACKTRACE_ON_INTERRUPT,
             BACKTRACE_ON_SIGALRM,
             BACKTRACE_ON_RAISE,
+            BACKTRACE_ON_RESCUE,
             CEXTS,
             CEXT_LOCK,
             OPTIONS_LOG,


### PR DESCRIPTION
This helps me diagnose issues where exceptions are being squashed or replaced with something with much less context.

https://github.com/Shopify/truffleruby/issues/1