### PR TITLE
Don't clone method when setting method to the same visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Bug fixes:
 * Coercion fixes for `TCPServer.new` (#1780, @XrXr)
 * Fix `Float#<=>` not calling `coerce` when `other` argument responds to it (#1783, @XrXr).
 * Do not warn / crash when requiring a file that sets and trigger autoload on itself (#1779, @XrXr).
+* Don't clone methods when setting method to the same visibility (#1794, @XrXr).
 
 Compatibility:
 

--- a/spec/ruby/core/module/shared/set_visibility.rb
+++ b/spec/ruby/core/module/shared/set_visibility.rb
@@ -5,6 +5,23 @@ describe :set_visibility, shared: true do
     Module.should have_private_instance_method(@method, false)
   end
 
+  describe "with argument" do
+    it "does not clone method from the ancestor when setting to the same visibility in a child" do
+      visibility = @method
+      parent = Module.new {
+        def test_method; end
+        send(visibility, :test_method)
+      }
+
+      child = Module.new {
+        include parent
+        send(visibility, :test_method)
+      }
+
+      child.should_not send(:"have_#{visibility}_instance_method", :test_method, false)
+    end
+  end
+
   describe "without arguments" do
     it "sets visibility to following method definitions" do
       visibility = @method

--- a/src/main/java/org/truffleruby/core/module/ModuleNodes.java
+++ b/src/main/java/org/truffleruby/core/module/ModuleNodes.java
@@ -2013,6 +2013,10 @@ public abstract class ModuleNodes {
                         coreExceptions().nameErrorUndefinedMethod(methodName, module, this));
             }
 
+            if (method.getVisibility() == visibility) {
+                return;
+            }
+
             /*
              * If the method was already defined in this class, that's fine
              * {@link addMethod} will overwrite it, otherwise we do actually

--- a/src/main/java/org/truffleruby/core/module/ModuleNodes.java
+++ b/src/main/java/org/truffleruby/core/module/ModuleNodes.java
@@ -2013,6 +2013,7 @@ public abstract class ModuleNodes {
                         coreExceptions().nameErrorUndefinedMethod(methodName, module, this));
             }
 
+            // Do nothing if the method already exists with the same visibility, like MRI
             if (method.getVisibility() == visibility) {
                 return;
             }

--- a/src/main/ruby/truffleruby/core/enumerable.rb
+++ b/src/main/ruby/truffleruby/core/enumerable.rb
@@ -990,10 +990,12 @@ end
 
 class Array
   # Copy methods from Enumerable that should also be defined on Array
-  public :any?
-  public :take
-  public :drop_while, :take_while
-  public :frozen?
-  public :sum
-  public :min, :max
+  alias_method :any?, :any?
+  alias_method :take, :take
+  alias_method :drop_while, :drop_while
+  alias_method :take_while, :take_while
+  alias_method :frozen?, :frozen?
+  alias_method :sum, :sum
+  alias_method :min, :min
+  alias_method :max, :max
 end

--- a/src/main/ruby/truffleruby/core/enumerator.rb
+++ b/src/main/ruby/truffleruby/core/enumerator.rb
@@ -496,11 +496,12 @@ class Enumerator
       end
     end
 
-    public :chunk
-    public :chunk_while
-    public :slice_after
-    public :slice_before
-    public :slice_when
+    # clone these methods from the superclass
+    alias_method :chunk, :chunk
+    alias_method :chunk_while, :chunk_while
+    alias_method :slice_after, :slice_after
+    alias_method :slice_before, :slice_before
+    alias_method :slice_when, :slice_when
 
     def uniq
       if block_given?

--- a/src/main/ruby/truffleruby/core/integer.rb
+++ b/src/main/ruby/truffleruby/core/integer.rb
@@ -40,7 +40,7 @@ Object.deprecate_constant :Fixnum, :Bignum
 class Integer < Numeric
 
   # Have a copy in Integer of the Numeric version, as MRI does
-  public :remainder
+  alias_method :remainder, :remainder
 
   def **(o)
     pow = TrufflePrimitive.integer_pow self, o

--- a/src/main/ruby/truffleruby/core/module.rb
+++ b/src/main/ruby/truffleruby/core/module.rb
@@ -49,7 +49,8 @@
 class Module
 
   # Copy methods from Kernel that should also be defined on Module like on MRI
-  public :==, :freeze
+  alias_method :==, :==
+  alias_method :freeze, :freeze
 
   def include?(mod)
     if !mod.kind_of?(Module) or mod.kind_of?(Class)


### PR DESCRIPTION
This quirk was causing rspec's mock framework to fail within shopify/money. Mocks were not being cleaned up correctly. The following script demonstrates this incompatibility:

```ruby
class Foo
  def foo; end
end

instance = Foo.new
class << instance
  public :foo
end

p instance.singleton_method(:foo) # error on MRI, gets a method back on Truffle
```

Shopify#1