### PR TITLE
Strip trailing whitespaces when BigDecimal gets a string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Bug fixes:
 * Coercion fixes for `TCPServer.new` (#1780, @XrXr)
 * Fix `Float#<=>` not calling `coerce` when `other` argument responds to it (#1783, @XrXr).
 * Do not warn / crash when requiring a file that sets and trigger autoload on itself (#1779, @XrXr).
+* Strip trailing whitespaces when BigDecimal gets a string (#1796, @XrXr).
 
 Compatibility:
 

--- a/spec/ruby/library/bigdecimal/BigDecimal_spec.rb
+++ b/spec/ruby/library/bigdecimal/BigDecimal_spec.rb
@@ -33,8 +33,8 @@ describe "Kernel#BigDecimal" do
     BigDecimal(pi_string).precs[1].should >= pi_string.size-1
   end
 
-  it "ignores leading whitespace" do
-    BigDecimal("  \t\n \r1234").should == BigDecimal("1234")
+  it "ignores leading and trailing whitespace" do
+    BigDecimal("  \t\n \r1234\t\r\n ").should == BigDecimal("1234")
     BigDecimal("  \t\n \rNaN   \n").nan?.should == true
     BigDecimal("  \t\n \rInfinity   \n").infinite?.should == 1
     BigDecimal("  \t\n \r-Infinity   \n").infinite?.should == -1

--- a/src/main/java/org/truffleruby/stdlib/bigdecimal/CreateBigDecimalNode.java
+++ b/src/main/java/org/truffleruby/stdlib/bigdecimal/CreateBigDecimalNode.java
@@ -220,10 +220,11 @@ public abstract class CreateBigDecimalNode extends BigDecimalCoreMethodNode {
         String strValue = string;
 
         strValue = strValue.replaceFirst("^\\s+", "");
+        strValue = strValue.replaceFirst("\\s+$", "");
 
         // TODO (pitr 26-May-2015): create specialization without trims and other cleanups, use rewriteOn
 
-        switch (strValue.trim()) {
+        switch (strValue) {
             case "NaN":
                 return BigDecimalType.NAN;
             case "Infinity":


### PR DESCRIPTION
` ruby -rbigdecimal -ve 'p BigDecimal(" 200 ")'` works on MRI but not on Truffle.

Shopify#1