### PR TITLE
BigDecimal(): deal with large rationals precisely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Bug fixes:
 * Coercion fixes for `TCPServer.new` (#1780, @XrXr)
 * Fix `Float#<=>` not calling `coerce` when `other` argument responds to it (#1783, @XrXr).
 * Do not warn / crash when requiring a file that sets and trigger autoload on itself (#1779, @XrXr).
+* BigDecimal() deal with large rationals precisely (#1797, @XrXr).
 
 Compatibility:
 

--- a/spec/truffle/bigdecimal_spec.rb
+++ b/spec/truffle/bigdecimal_spec.rb
@@ -84,6 +84,12 @@ describe "BigDecimal" do
       BigDecimal(@b, @a.precs[0]).to_s.should == "0.166666666666666667e3"
     end
 
+    it "BigDecimal(Rational) with bigger-than-double numerator" do
+      rational = 99999999999999999999/100r
+      rational.numerator.should > 2**64
+      BigDecimal(rational, 100).to_s.should == "0.99999999999999999999e18"
+    end
+
     # Check the top-level expression works as we expect
 
     it "produces a BigDecimal" do

--- a/src/main/java/org/truffleruby/stdlib/bigdecimal/BigDecimalCastNode.java
+++ b/src/main/java/org/truffleruby/stdlib/bigdecimal/BigDecimalCastNode.java
@@ -135,7 +135,7 @@ public abstract class BigDecimalCastNode extends RubyBaseNode {
         } else if (object instanceof Double) {
             return BigDecimal.valueOf((double) object);
         } else if (RubyGuards.isRubyBignum(object)) {
-            return BigDecimal.valueOf(Layouts.BIGNUM.getValue((DynamicObject) object).doubleValue());
+            return new BigDecimal(Layouts.BIGNUM.getValue((DynamicObject) object));
         } else {
             throw new UnsupportedOperationException();
         }


### PR DESCRIPTION
The old code gives imprecise results when the input contains large integers that doubles can't represent exactly. Use the lossless BigInteger -> BigDecimal constructor instead.

Shopify#1