### PR TITLE
Default close_others to false like Ruby 2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Bug fixes:
 * Coercion fixes for `TCPServer.new` (#1780, @XrXr)
 * Fix `Float#<=>` not calling `coerce` when `other` argument responds to it (#1783, @XrXr).
 * Do not warn / crash when requiring a file that sets and trigger autoload on itself (#1779, @XrXr).
+* Default `close_others` in `Process.exec` to false like Ruby 2.6 (#1798, @XrXr).
 
 Compatibility:
 

--- a/spec/tags/core/process/spawn_tags.txt
+++ b/spec/tags/core/process/spawn_tags.txt
@@ -78,6 +78,5 @@ fails(spurious failure):Process.spawn when passed close_others: false closes fil
 fails(spurious failure):Process.spawn when passed close_others: true closes file descriptors >= 3 in the child process even if fds are set close_on_exec=false
 slow:Process.spawn inside Dir.chdir does not create extra process without chdir
 slow:Process.spawn inside Dir.chdir kills extra chdir processes
-slow:Process.spawn defaults :close_others to true
 slow:Process.spawn redirects both STDERR and STDOUT to the given file descriptor
-fails:Process.spawn defaults :close_others to false
+slow:Process.spawn defaults :close_others to false

--- a/src/main/ruby/truffleruby/core/truffle/process_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/process_operations.rb
@@ -113,7 +113,7 @@ module Truffle
 
     class Execute
       def initialize
-        @options = { close_others: true }
+        @options = {}
         @files_for_child = []
       end
 


### PR DESCRIPTION
This was causing FDs to not show up after an exec, even when the FDs are listed to be mirrored, i.e.
`Process.exec('ruby', {11=>11})`

Now, TruffleRuby is wrong even when `close_others: true`, but we will tackle that separately. This commit is enough to work around Puma's usage.

Shopify#1