### PR TITLE
Process#exec: set close-on-exec to false for fd redirection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Bug fixes:
 * Don't clone methods when setting method to the same visibility (#1794, @XrXr).
 * BigDecimal() deal with large rationals precisely (#1797, @XrXr).
 * Make it possible to call `instance_exec` with `rb_block_call` (#1802, @XrXr).
+* Process#exec: set close-on-exec to false for fd redirection (#1805, @XrXr, @rafaelfranca).
 
 Compatibility:
 

--- a/spec/tags/core/process/exec_tags.txt
+++ b/spec/tags/core/process/exec_tags.txt
@@ -18,3 +18,5 @@ slow:Process.exec with a command array uses the first element as the command nam
 slow:Process.exec with a command array coerces the argument using to_ary
 slow:Process.exec with a command array raises an ArgumentError if the Array does not have exactly two elements
 slow:Process.exec with an options Hash with Integer option keys maps the key to a file descriptor in the child that inherits the file descriptor from the parent specified by the value
+slow:Process.exec with an options Hash with Integer option keys lets the process after exec have specified file descriptor dispite close_on_exec
+slow:Process.exec with an options Hash with Integer option keys sets close_on_exec to false on specified fd even when it fails


### PR DESCRIPTION
This is specifically for redirecting `fd => fd`.

Process#spawn behaves similarly, but that is more involved
to implement. MRI does it by setting close-on-exec after fork
and before exec while the current spawn implementation uses
posix_spawnp, which spawns in one go and offers less flexibility.

https://github.com/Shopify/truffleruby/issues/1