### PR TITLE
Add a GitHub Action for building and linting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,26 @@
+name: Lint
+
+on: [ push, pull_request ]
+
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1.1.0
+    - name: Install dependencies
+      run: |
+        sudo apt-get install libz-dev libssl-dev gcc libxml2 make file g++ python ruby ruby-dev
+        sudo gem install rubocop -v 0.66.0
+    - name: Install JVMCI
+      run: tool/jt.rb install jvmci
+    - name: Install mx
+      run: tool/jt.rb mx --version
+    - name: Install Graal
+      run: tool/jt.rb mx sforceimports
+    - name: Build
+      run: tool/jt.rb build --env jvm
+    - name: Lint
+      env:
+        CONTINUOUS_INTEGRATION: true
+      run: tool/jt.rb lint

--- a/ci.jsonnet
+++ b/ci.jsonnet
@@ -300,7 +300,7 @@ local part_definitions = {
       packages+: {
         "pip:pylint": "==1.9.0",
       },
-      run+: jt(["lint"]),
+      run+: jt(["lint", "--testpack"]),
     },
 
     test_basictest: { run+: jt(["test", "basictest"]) },

--- a/tool/jt.rb
+++ b/tool/jt.rb
@@ -1951,16 +1951,21 @@ EOS
   alias :'native-launcher' :native_launcher
 
   def rubocop(*args)
-    gem_home = "#{gem_test_pack}/rubocop-gems"
-    env = {
-      'GEM_HOME' => gem_home,
-      'GEM_PATH' => gem_home,
-      'PATH' => "#{gem_home}/bin:#{ENV['PATH']}"
-    }
+    testpack = args.delete('--testpack')
     if args.empty? or args.all? { |arg| arg.start_with?('-') }
       args += RUBOCOP_INCLUDE_LIST
     end
-    sh env, 'ruby', "#{gem_home}/bin/rubocop", *args
+    if testpack
+      gem_home = "#{gem_test_pack}/rubocop-gems"
+      env = {
+        'GEM_HOME' => gem_home,
+        'GEM_PATH' => gem_home,
+        'PATH' => "#{gem_home}/bin:#{ENV['PATH']}"
+      }
+      sh env, 'ruby', "#{gem_home}/bin/rubocop", *args
+    else
+      sh 'rubocop', '_0.66.0_', *args
+    end
   end
 
   def command_format(*args)
@@ -2083,8 +2088,14 @@ EOS
   end
 
   def lint(*args)
+    testpack = args.delete('--testpack')
+
     check_filename_length
-    rubocop
+
+    rubocop_args = []
+    rubocop_args << '--testpack' if testpack
+    rubocop(*rubocop_args)
+
     sh 'tool/lint.sh'
     mx 'gate', '--tags', 'style'
 

--- a/tool/jt.rb
+++ b/tool/jt.rb
@@ -2070,7 +2070,7 @@ EOS
             new_content << line
           end
         else
-          looking = line.match?(/^ *@(Specialization|Fallback|CreateCast)/)
+          looking = /^ *@(Specialization|Fallback|CreateCast)/ =~ line
           new_content << line
           if looking
             braces = count_braces.(line)


### PR DESCRIPTION
It doesn't currently run:

- the Eclipse formatter, as I haven't added something to download that yet
- the Python formatter, as I haven't installed `pylint` yet

There are some things that could be improved:

- fetch less of the mx and Graal repository histories
- cache mx, JVMCI, and Graal, and perhaps other things we download

Since we can build in GitHub Actions, why aren't we aiming to just run all our tests and specs here?

Note that I believe you can't create a PR to create a GitHub Actions workflow! I think you have to do that in the web UI. But the files you need to add in the UI are there, just called `.github_x` rather than `.github`.

After merging this, you would have to run `jt lint` with `--testpack` in your CI.

https://github.com/Shopify/truffleruby/issues/1