### PR TITLE
CachedBoxedDispatchNode#toString is excessively verbose

### DIFF
--- a/src/main/java/org/truffleruby/language/dispatch/CachedBoxedDispatchNode.java
+++ b/src/main/java/org/truffleruby/language/dispatch/CachedBoxedDispatchNode.java
@@ -107,9 +107,8 @@ public class CachedBoxedDispatchNode extends CachedDispatchNode {
     @Override
     public String toString() {
         return StringUtils.format(
-                "CachedBoxedDispatchNode(:%s, %s@%x, %s)",
+                "CachedBoxedDispatchNode(:%s, %x, %s)",
                 getCachedNameAsSymbol().toString(),
-                expectedShape,
                 expectedShape.hashCode(),
                 method == null ? "null" : method.toString());
     }


### PR DESCRIPTION
This node prints out as many lines of text when you're tracing compilation. This reduces that.

https://github.com/Shopify/truffleruby/issues/1