### PR TITLE
Split local and non-local returns

### DIFF
--- a/src/launcher/java/org/truffleruby/launcher/RubyLauncher.java
+++ b/src/launcher/java/org/truffleruby/launcher/RubyLauncher.java
@@ -234,6 +234,7 @@ public class RubyLauncher extends AbstractLanguageLauncher {
             Metrics.printTime("after-run");
             return exitCode;
         } catch (PolyglotException e) {
+            System.err.println("truffleruby: an exception escaped out of the interpreter - this is an implementation bug");
             e.printStackTrace();
             return 1;
         }

--- a/src/main/java/org/truffleruby/core/fiber/FiberManager.java
+++ b/src/main/java/org/truffleruby/core/fiber/FiberManager.java
@@ -27,8 +27,8 @@ import org.truffleruby.language.RubyGuards;
 import org.truffleruby.language.control.BreakException;
 import org.truffleruby.language.control.ExitException;
 import org.truffleruby.language.control.KillException;
+import org.truffleruby.language.control.DynamicReturnException;
 import org.truffleruby.language.control.RaiseException;
-import org.truffleruby.language.control.ReturnException;
 import org.truffleruby.language.control.TerminationException;
 import org.truffleruby.language.objects.ObjectIDOperations;
 
@@ -186,7 +186,7 @@ public class FiberManager {
                     fiber,
                     new RaiseException(context, context.getCoreExceptions().breakFromProcClosure(currentNode)),
                     currentNode);
-        } catch (ReturnException e) {
+        } catch (DynamicReturnException e) {
             sendExceptionToParentFiber(
                     fiber,
                     new RaiseException(context, context.getCoreExceptions().unexpectedReturn(currentNode)),

--- a/src/main/java/org/truffleruby/core/thread/ThreadManager.java
+++ b/src/main/java/org/truffleruby/core/thread/ThreadManager.java
@@ -33,8 +33,8 @@ import org.truffleruby.language.RubyGuards;
 import org.truffleruby.language.SafepointManager;
 import org.truffleruby.language.control.ExitException;
 import org.truffleruby.language.control.KillException;
+import org.truffleruby.language.control.DynamicReturnException;
 import org.truffleruby.language.control.RaiseException;
-import org.truffleruby.language.control.ReturnException;
 import org.truffleruby.language.objects.AllocateObjectNode;
 import org.truffleruby.language.objects.ObjectIDOperations;
 import org.truffleruby.language.objects.ReadObjectFieldNodeGen;
@@ -286,7 +286,7 @@ public class ThreadManager {
             setThreadValue(context, thread, nil());
         } catch (RaiseException e) {
             setException(context, thread, e.getException(), currentNode);
-        } catch (ReturnException e) {
+        } catch (DynamicReturnException e) {
             setException(context, thread, context.getCoreExceptions().unexpectedReturn(currentNode), currentNode);
         } finally {
             assert Layouts.THREAD.getValue(thread) != null || Layouts.THREAD.getException(thread) != null;

--- a/src/main/java/org/truffleruby/language/control/DynamicReturnException.java
+++ b/src/main/java/org/truffleruby/language/control/DynamicReturnException.java
@@ -11,14 +11,14 @@ package org.truffleruby.language.control;
 
 import com.oracle.truffle.api.nodes.ControlFlowException;
 
-public final class ReturnException extends ControlFlowException {
+public final class DynamicReturnException extends ControlFlowException {
 
     private static final long serialVersionUID = -45053969587014940L;
 
     private final ReturnID returnID;
     private final Object value;
 
-    public ReturnException(ReturnID returnID, Object value) {
+    public DynamicReturnException(ReturnID returnID, Object value) {
         this.returnID = returnID;
         this.value = value;
     }

--- a/src/main/java/org/truffleruby/language/control/DynamicReturnNode.java
+++ b/src/main/java/org/truffleruby/language/control/DynamicReturnNode.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2013, 2019 Oracle and/or its affiliates. All rights reserved. This
+ * code is released under a tri EPL/GPL/LGPL license. You can use it,
+ * redistribute it and/or modify it under the terms of the:
+ *
+ * Eclipse Public License version 2.0, or
+ * GNU General Public License version 2, or
+ * GNU Lesser General Public License version 2.1.
+ */
+package org.truffleruby.language.control;
+
+import org.truffleruby.language.RubyNode;
+
+import com.oracle.truffle.api.frame.VirtualFrame;
+
+public class DynamicReturnNode extends RubyNode {
+
+    private final ReturnID returnID;
+
+    @Child private RubyNode value;
+
+    public DynamicReturnNode(ReturnID returnID, RubyNode value) {
+        this.returnID = returnID;
+        this.value = value;
+    }
+
+    @Override
+    public Object execute(VirtualFrame frame) {
+        throw new DynamicReturnException(returnID, value.execute(frame));
+    }
+
+}

--- a/src/main/java/org/truffleruby/language/control/LocalReturnException.java
+++ b/src/main/java/org/truffleruby/language/control/LocalReturnException.java
@@ -9,24 +9,20 @@
  */
 package org.truffleruby.language.control;
 
-import org.truffleruby.language.RubyNode;
+import com.oracle.truffle.api.nodes.ControlFlowException;
 
-import com.oracle.truffle.api.frame.VirtualFrame;
+public final class LocalReturnException extends ControlFlowException {
 
-public class ReturnNode extends RubyNode {
+    private static final long serialVersionUID = -98757896543565476L;
 
-    private final ReturnID returnID;
+    private final Object value;
 
-    @Child private RubyNode value;
-
-    public ReturnNode(ReturnID returnID, RubyNode value) {
-        this.returnID = returnID;
+    public LocalReturnException(Object value) {
         this.value = value;
     }
 
-    @Override
-    public Object execute(VirtualFrame frame) {
-        throw new ReturnException(returnID, value.execute(frame));
+    public Object getValue() {
+        return value;
     }
 
 }

--- a/src/main/java/org/truffleruby/language/control/LocalReturnNode.java
+++ b/src/main/java/org/truffleruby/language/control/LocalReturnNode.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2013, 2019 Oracle and/or its affiliates. All rights reserved. This
+ * code is released under a tri EPL/GPL/LGPL license. You can use it,
+ * redistribute it and/or modify it under the terms of the:
+ *
+ * Eclipse Public License version 2.0, or
+ * GNU General Public License version 2, or
+ * GNU Lesser General Public License version 2.1.
+ */
+package org.truffleruby.language.control;
+
+import com.oracle.truffle.api.frame.VirtualFrame;
+import org.truffleruby.language.RubyNode;
+
+public class LocalReturnNode extends RubyNode {
+
+    @Child private RubyNode value;
+
+    public LocalReturnNode(RubyNode value) {
+        this.value = value;
+    }
+
+    @Override
+    public Object execute(VirtualFrame frame) {
+        throw new LocalReturnException(value.execute(frame));
+    }
+
+}

--- a/src/main/java/org/truffleruby/language/methods/CatchForMethodNode.java
+++ b/src/main/java/org/truffleruby/language/methods/CatchForMethodNode.java
@@ -10,10 +10,11 @@
 package org.truffleruby.language.methods;
 
 import org.truffleruby.language.RubyNode;
+import org.truffleruby.language.control.LocalReturnException;
+import org.truffleruby.language.control.DynamicReturnException;
+import org.truffleruby.language.control.ReturnID;
 import org.truffleruby.language.control.RaiseException;
 import org.truffleruby.language.control.RetryException;
-import org.truffleruby.language.control.ReturnException;
-import org.truffleruby.language.control.ReturnID;
 
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.profiles.BranchProfile;
@@ -25,6 +26,7 @@ public class CatchForMethodNode extends RubyNode {
 
     @Child private RubyNode body;
 
+    private final BranchProfile localReturnProfile = BranchProfile.create();
     private final ConditionProfile matchingReturnProfile = ConditionProfile.createBinaryProfile();
     private final BranchProfile retryProfile = BranchProfile.create();
 
@@ -37,7 +39,10 @@ public class CatchForMethodNode extends RubyNode {
     public Object execute(VirtualFrame frame) {
         try {
             return body.execute(frame);
-        } catch (ReturnException e) {
+        } catch (LocalReturnException e) {
+            localReturnProfile.enter();
+            return e.getValue();
+        } catch (DynamicReturnException e) {
             if (matchingReturnProfile.profile(e.getReturnID() == returnID)) {
                 return e.getValue();
             } else {

--- a/src/main/java/org/truffleruby/language/methods/CatchReturnAsErrorNode.java
+++ b/src/main/java/org/truffleruby/language/methods/CatchReturnAsErrorNode.java
@@ -10,8 +10,9 @@
 package org.truffleruby.language.methods;
 
 import org.truffleruby.language.RubyNode;
+import org.truffleruby.language.control.LocalReturnException;
 import org.truffleruby.language.control.RaiseException;
-import org.truffleruby.language.control.ReturnException;
+import org.truffleruby.language.control.DynamicReturnException;
 
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.profiles.BranchProfile;
@@ -30,7 +31,7 @@ public class CatchReturnAsErrorNode extends RubyNode {
     public Object execute(VirtualFrame frame) {
         try {
             return body.execute(frame);
-        } catch (ReturnException e) {
+        } catch (LocalReturnException | DynamicReturnException e) {
             retryProfile.enter();
             throw new RaiseException(getContext(), coreExceptions().unexpectedReturn(this));
         }

--- a/src/main/java/org/truffleruby/parser/BodyTranslator.java
+++ b/src/main/java/org/truffleruby/parser/BodyTranslator.java
@@ -80,15 +80,16 @@ import org.truffleruby.language.control.ElidableResultNode;
 import org.truffleruby.language.control.FrameOnStackNode;
 import org.truffleruby.language.control.IfElseNode;
 import org.truffleruby.language.control.IfNode;
+import org.truffleruby.language.control.LocalReturnNode;
 import org.truffleruby.language.control.NextNode;
+import org.truffleruby.language.control.ReturnID;
+import org.truffleruby.language.control.DynamicReturnNode;
 import org.truffleruby.language.control.NotNode;
 import org.truffleruby.language.control.OnceNode;
 import org.truffleruby.language.control.OrNode;
 import org.truffleruby.language.control.RaiseException;
 import org.truffleruby.language.control.RedoNode;
 import org.truffleruby.language.control.RetryNode;
-import org.truffleruby.language.control.ReturnID;
-import org.truffleruby.language.control.ReturnNode;
 import org.truffleruby.language.control.UnlessNode;
 import org.truffleruby.language.control.WhileNode;
 import org.truffleruby.language.defined.DefinedNode;
@@ -3076,7 +3077,14 @@ public class BodyTranslator extends Translator {
 
         RubyNode translatedChild = translateNodeOrNil(sourceSection, node.getValueNode());
 
-        final RubyNode ret = new ReturnNode(environment.getReturnID(), translatedChild);
+        final RubyNode ret;
+
+        if (environment.isBlock()) {
+            ret = new DynamicReturnNode(environment.getReturnID(), translatedChild);
+        } else {
+            ret = new LocalReturnNode(translatedChild);
+        }
+
         ret.unsafeSetSourceSection(sourceSection);
         return addNewlineIfNeeded(node, ret);
     }


### PR DESCRIPTION
Split local and non-local returns, as the former are simpler to throw and catch, and they can be more compact.

Relates to but doesn't depend on https://github.com/oracle/graal/pull/1926.

https://github.com/Shopify/truffleruby/issues/1