### PR TITLE
Kernel#sprintf: don't unconditionally grant encoding validity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Bug fixes:
 * Do not leak TruffleRuby specific method Array#swap (#1816)
 * Fixed `#inspect` on broken UTF-8 sequences (#1842, @chrisseaton).
 * `Truffle::Interop.keys` should report methods of String and Symbol (#1817)
+* `Kernel#sprintf` encoding validity has been fixed (#1852, @XrXr).
 
 Compatibility:
 

--- a/spec/ruby/core/kernel/shared/sprintf.rb
+++ b/spec/ruby/core/kernel/shared/sprintf.rb
@@ -865,6 +865,20 @@ describe :kernel_sprintf, shared: true do
     end
   end
 
+  describe "encoding" do
+    it "can produce a string with valid encoding" do
+      string = format("good day %{valid}", valid: "e")
+      string.encoding.should == Encoding::UTF_8
+      string.valid_encoding?.should be_true
+    end
+
+    it "can produce a string with invalid encoding" do
+      string = format("good day %{invalid}", invalid: "\x80")
+      string.encoding.should == Encoding::UTF_8
+      string.valid_encoding?.should be_false
+    end
+  end
+
   describe "faulty key" do
     before :all do
       @base_method = @method

--- a/src/main/java/org/truffleruby/core/format/FormatNode.java
+++ b/src/main/java/org/truffleruby/core/format/FormatNode.java
@@ -12,11 +12,9 @@ package org.truffleruby.core.format;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 
-import org.jcodings.specific.USASCIIEncoding;
 import org.truffleruby.core.array.ArrayUtils;
 import org.truffleruby.core.format.exceptions.TooFewArgumentsException;
 import org.truffleruby.core.rope.CodeRange;
-import org.truffleruby.core.rope.RopeOperations;
 import org.truffleruby.language.RubyBaseNode;
 
 import com.oracle.truffle.api.CompilerDirectives;
@@ -162,7 +160,6 @@ public abstract class FormatNode extends RubyBaseNode {
         final int outputPosition = getOutputPosition(frame);
         output[outputPosition] = value;
         setOutputPosition(frame, outputPosition + 1);
-        setStringCodeRange(frame, value >= 0 ? CodeRange.CR_7BIT : CodeRange.CR_VALID);
         increaseStringLength(frame, 1);
     }
 
@@ -175,9 +172,6 @@ public abstract class FormatNode extends RubyBaseNode {
         final int outputPosition = getOutputPosition(frame);
         System.arraycopy(values, 0, output, outputPosition, valuesLength);
         setOutputPosition(frame, outputPosition + valuesLength);
-        setStringCodeRange(
-                frame,
-                RopeOperations.isAsciiOnly(values, USASCIIEncoding.INSTANCE) ? CodeRange.CR_7BIT : CodeRange.CR_VALID);
         increaseStringLength(frame, valuesLength);
     }
 

--- a/src/main/java/org/truffleruby/core/format/FormatRootNode.java
+++ b/src/main/java/org/truffleruby/core/format/FormatRootNode.java
@@ -52,7 +52,7 @@ public class FormatRootNode extends RubyBaseRootNode implements InternalRootNode
         frame.setObject(FormatFrameDescriptor.OUTPUT_SLOT, new byte[expectedLength]);
         frame.setInt(FormatFrameDescriptor.OUTPUT_POSITION_SLOT, 0);
         frame.setInt(FormatFrameDescriptor.STRING_LENGTH_SLOT, 0);
-        frame.setInt(FormatFrameDescriptor.STRING_CODE_RANGE_SLOT, CodeRange.CR_7BIT.toInt());
+        frame.setInt(FormatFrameDescriptor.STRING_CODE_RANGE_SLOT, CodeRange.CR_UNKNOWN.toInt());
         frame.setBoolean(FormatFrameDescriptor.TAINT_SLOT, false);
         frame.setObject(FormatFrameDescriptor.ASSOCIATED_SLOT, null);
 


### PR DESCRIPTION
The old code seems to grant strings with encoding validity when it does not have enough information to make that call. Be defensive and claim we don't know the code range instead.

https://github.com/Shopify/truffleruby/issues/1