### PR TITLE
Static inline to fix protobuf build issues

### DIFF
--- a/lib/cext/include/truffleruby/truffleruby-pre.h
+++ b/lib/cext/include/truffleruby/truffleruby-pre.h
@@ -44,7 +44,7 @@ typedef VALUE ID;
 extern void* rb_tr_cext;
 #define RUBY_CEXT rb_tr_cext
 
-#define MUST_INLINE __attribute__((always_inline)) inline
+#define MUST_INLINE __attribute__((always_inline)) static inline
 
 // Wrapping and unwrapping of values.
 

--- a/src/main/c/cext/ruby.c
+++ b/src/main/c/cext/ruby.c
@@ -2790,7 +2790,6 @@ int rb_tr_writable(int mode) {
   return polyglot_as_boolean(polyglot_invoke(RUBY_CEXT, "rb_tr_writable", mode));
 }
 
-MUST_INLINE
 int rb_io_extract_encoding_option(VALUE opt, rb_encoding **enc_p, rb_encoding **enc2_p, int *fmode_p) {
   // TODO (pitr-ch 12-Jun-2017): review, just approximate implementation
   VALUE encoding = rb_cEncoding;


### PR DESCRIPTION
This is another change that I'm not totally sure about yet. It enables compilation of the `protobuf` gem, which otherwise fails in linking because somehow there are multiple copies of these inlined methods not inlined?

I think we probably shouldn't have `inline` without `static`. Does that make sense to other people? Can you try it in your CI as well?

(Formatting slightly unusual due to our build system.)

```
linking shared-object google/protobuf_c.so
--
  | ld.lld: error: duplicate symbol: rb_tr_gc_guard
  | >>> defined in protobuf.o
  | >>> defined in defs.o
  |  
  | ld.lld: error: duplicate symbol: rb_nativethread_lock_initialize
  | >>> defined in protobuf.o
  | >>> defined in defs.o
  |  
  | ld.lld: error: duplicate symbol: rb_nativethread_lock_destroy
  | >>> defined in protobuf.o
  | >>> defined in defs.o
````

https://github.com/Shopify/truffleruby/issues/1