### PR TITLE
Fix rb_warn and rb_warning macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ New features:
 Bug fixes:
 
 * Fixed `Exception#dup` to copy exception backtrace string array.
+* Fixed `rb_warn` and `rb_warning` when used as statements (#1886, @chrisseaton).
 
 Compatibility:
 

--- a/lib/cext/include/truffleruby/truffleruby.h
+++ b/lib/cext/include/truffleruby/truffleruby.h
@@ -82,13 +82,13 @@ typedef void *(*gvl_call)(void *);
 if (polyglot_as_boolean(polyglot_invoke(RUBY_CEXT, "warn?"))) { \
   RUBY_INVOKE(rb_mKernel, "warn", rb_sprintf(FORMAT, ##__VA_ARGS__));   \
 } \
-} while (0);
+} while (0)
 
 #define rb_warning(FORMAT, ...) do { \
 if (polyglot_as_boolean(polyglot_invoke(RUBY_CEXT, "warning?"))) { \
   RUBY_INVOKE(rb_mKernel, "warn", rb_sprintf(FORMAT, ##__VA_ARGS__)); \
 } \
-} while (0);
+} while (0)
 
 #define rb_tr_scan_args_1(ARGC, ARGV, FORMAT, V1) rb_tr_scan_args(ARGC, ARGV, FORMAT, V1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
 #define rb_tr_scan_args_2(ARGC, ARGV, FORMAT, V1, V2) rb_tr_scan_args(ARGC, ARGV, FORMAT, V1, V2, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)


### PR DESCRIPTION
These can't have a `;` at the end of them - think of the case:

    if (...)
        rb_warn(...);
    else
        ...

This won't work with the `;;` you'll get before the `else`.

The change in `byebug`: https://github.com/deivid-rodriguez/byebug/compare/v11.0.1...v11.1.0#diff-cba2d7f9da55366f27f120efb50dbb19R364

Much of the Ruby ecosystem seems to be broken without this fix.

https://github.com/shopify/truffleruby/issues/1