### PR TITLE
Optimize lazy initializations 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 New features:
 
+* `||=` will not compile the right-hand-side if it's only executed once, to match the idiomatic lazy-initialisation use-case (#1887, @kipply).
 
 Bug fixes:
 

--- a/src/main/java/org/truffleruby/language/control/OrLazyValueDefinedNode.java
+++ b/src/main/java/org/truffleruby/language/control/OrLazyValueDefinedNode.java
@@ -33,7 +33,9 @@ public class OrLazyValueDefinedNode extends RubyNode {
     @Child private BooleanCastNode leftCast;
 
     private enum RightUsage {
-        NEVER, ONCE, MANY;
+        NEVER,
+        ONCE,
+        MANY;
 
         public RightUsage next() {
             if (this == NEVER) {

--- a/src/main/java/org/truffleruby/language/control/OrLazyValueDefinedNode.java
+++ b/src/main/java/org/truffleruby/language/control/OrLazyValueDefinedNode.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2013, 2020 Oracle and/or its affiliates. All rights reserved. This
+ * code is released under a tri EPL/GPL/LGPL license. You can use it,
+ * redistribute it and/or modify it under the terms of the:
+ *
+ * Eclipse Public License version 2.0, or
+ * GNU General Public License version 2, or
+ * GNU Lesser General Public License version 2.1.
+ */
+package org.truffleruby.language.control;
+
+import org.truffleruby.core.cast.BooleanCastNode;
+import org.truffleruby.core.cast.BooleanCastNodeGen;
+import org.truffleruby.language.RubyNode;
+
+import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.profiles.ConditionProfile;
+
+/**
+ * OrLazyValueDefinedNode is used as the 'or' node for ||=, because we know from idiomatic Ruby usage that this is
+ * often used to lazy initialize a value. In that case normal counting profiling gives a misleading result. With the
+ * RHS having been executed once (the lazy initialization) it will be compiled expecting it to be used again. We know
+ * that it's unlikely to be used again, so only compile it in when it's been used more than once, by using a small
+ * saturating counter.
+ */
+public class OrLazyValueDefinedNode extends RubyNode {
+
+    @Child private RubyNode left;
+    @Child private RubyNode right;
+
+    @Child private BooleanCastNode leftCast;
+
+    private enum RightUsage {
+        NEVER, ONCE, MANY;
+
+        public RightUsage next() {
+            if (this == NEVER) {
+                return ONCE;
+            } else {
+                return MANY;
+            }
+        }
+
+    }
+
+    @CompilationFinal private RightUsage rightUsage = RightUsage.NEVER;
+
+    private final ConditionProfile conditionProfile = ConditionProfile.createCountingProfile();
+
+    public OrLazyValueDefinedNode(RubyNode left, RubyNode right) {
+        this.left = left;
+        this.right = right;
+    }
+
+    @Override
+    public Object execute(VirtualFrame frame) {
+        final Object leftValue = left.execute(frame);
+
+        if (conditionProfile.profile(castToBoolean(leftValue))) {
+            return leftValue;
+        } else {
+            if (CompilerDirectives.inInterpreter()) {
+                // Count how many times the RHS is used
+                rightUsage = rightUsage.next();
+            }
+
+            if (rightUsage != RightUsage.MANY) {
+                // Don't compile the RHS of a lazy initialization unless it has been used many times
+                CompilerDirectives.transferToInterpreterAndInvalidate();
+            }
+
+            return right.execute(frame);
+        }
+    }
+
+    private boolean castToBoolean(final Object value) {
+        if (leftCast == null) {
+            CompilerDirectives.transferToInterpreterAndInvalidate();
+            leftCast = insert(BooleanCastNodeGen.create(null));
+        }
+        return leftCast.executeToBoolean(value);
+    }
+
+}

--- a/src/main/java/org/truffleruby/parser/BodyTranslator.java
+++ b/src/main/java/org/truffleruby/parser/BodyTranslator.java
@@ -85,6 +85,7 @@ import org.truffleruby.language.control.DynamicReturnNode;
 import org.truffleruby.language.control.NotNode;
 import org.truffleruby.language.control.OnceNode;
 import org.truffleruby.language.control.OrNode;
+import org.truffleruby.language.control.OrLazyValueDefinedNode;
 import org.truffleruby.language.control.RaiseException;
 import org.truffleruby.language.control.RedoNode;
 import org.truffleruby.language.control.RetryNode;
@@ -2548,7 +2549,7 @@ public class BodyTranslator extends Translator {
 
         final RubyNode ret = new DefinedWrapperNode(
                 context.getCoreStrings().ASSIGNMENT,
-                new OrNode(lhs, rhs));
+                new OrLazyValueDefinedNode(lhs, rhs));
         ret.unsafeSetSourceSection(sourceSection);
         return addNewlineIfNeeded(node, ret);
     }

--- a/test/truffle/compiler/optional-assignment-lazy-load.sh
+++ b/test/truffle/compiler/optional-assignment-lazy-load.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+source test/truffle/common.sh.inc
+
+jt ruby --engine.CompilationExceptionsAreThrown test/truffle/compiler/optional-assignment-lazy-load/optional-assignment-lazy-load.rb

--- a/test/truffle/compiler/optional-assignment-lazy-load/optional-assignment-lazy-load.rb
+++ b/test/truffle/compiler/optional-assignment-lazy-load/optional-assignment-lazy-load.rb
@@ -1,0 +1,76 @@
+# Copyright (c) 2015, 2019 Oracle and/or its affiliates. All rights reserved. This
+# code is released under a tri EPL/GPL/LGPL license. You can use it,
+# redistribute it and/or modify it under the terms of the:
+#
+# Eclipse Public License version 2.0, or
+# GNU General Public License version 2, or
+# GNU Lesser General Public License version 2.1.
+
+abort 'not running the GraalVM Compiler' unless TruffleRuby.jit?
+
+def init_once
+  $init_once ||= (TrufflePrimitive.compiler_bailout('init compiled'); true)
+end
+
+begin
+  loop do
+    init_once
+    TrufflePrimitive.assert_not_compiled
+  end
+rescue Exception => e
+  if e.message.include? 'assert_not_compiled'
+    puts "correctly does not compile in the RHS of an init once expression"
+  elsif e.message.include? 'init compiled'
+    puts "incorrectly compiles in the RHS of an init once expression"
+    exit 1
+  else
+    puts e.message, 'some other error'
+    exit 1
+  end
+end
+
+def init_many
+  $init_many ||= (TrufflePrimitive.compiler_bailout('init compiled'); true)
+end
+
+begin
+  loop do
+    init_many
+    $init_many = false
+    TrufflePrimitive.assert_not_compiled
+  end
+rescue Exception => e
+  if e.message.include? 'assert_not_compiled'
+    puts "incorrectly does not compile in the RHS of an init many expression"
+    exit 1
+  elsif e.message.include? 'init compiled'
+    puts "correctly compiles in the RHS of an init many expression"
+  else
+    puts e.message, 'some other error'
+    exit 1
+  end
+end
+
+def init_never
+  $init_never ||= (TrufflePrimitive.compiler_bailout('init compiled'); true)
+end
+
+begin
+  $init_never = true
+  loop do
+    init_never
+    TrufflePrimitive.assert_not_compiled
+  end
+rescue Exception => e
+  if e.message.include? 'assert_not_compiled'
+    puts "correctly does not compile in the RHS of an init never expression"
+  elsif e.message.include? 'init compiled'
+    puts "incorrectly compiles in the RHS of an init never expression"
+    exit 1
+  else
+    puts e.message, 'some other error'
+    exit 1
+  end
+end
+
+exit 0


### PR DESCRIPTION
semantically, `||=` is "assign if", though it is usually used as "assign once".

These changes make it so that the interpreter is aware of this behaviour, and compiles the right hand side iff the assignment happens more than once. This saves some time and space! 

Fairly reliable [static profiling](https://gist.github.com/kipply/b64bdedc3c8accd869777642726adbc3) was done on 20 projects (2082 `||=` operators) and could safely confirm usage as lazy initialization 64% of the time. 