### PR TITLE
Allow rescue to take null 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Bug fixes:
 * Fixed `Kernel#dup` to return self for `Complex` and `Rational` objects.
 * Updated `Kernel.Float()` to handle the `exception: false` parameter.
 * Fixed `String#unpack` `M` format (#1901).
+* Fixed `rb_rescue` to allow null rescue methods. (#1909, @kipply)
 
 Compatibility:
 

--- a/lib/truffle/truffle/cext.rb
+++ b/lib/truffle/truffle/cext.rb
@@ -1613,8 +1613,7 @@ module Truffle::CExt
       Primitive.call_with_c_mutex(b_proc, [data1])
     rescue StandardError => e
       # Allow rescues to be null, or else Graal will error.
-      return if Truffle::Interop.null?(r_proc)
-      Primitive.call_with_c_mutex(r_proc, [data2, Primitive.cext_wrap(e)])
+      Primitive.call_with_c_mutex(r_proc, [data2, Primitive.cext_wrap(e)]) unless Truffle::Interop.null?(r_proc)
     end
   end
 

--- a/lib/truffle/truffle/cext.rb
+++ b/lib/truffle/truffle/cext.rb
@@ -1612,6 +1612,8 @@ module Truffle::CExt
     begin
       Primitive.call_with_c_mutex(b_proc, [data1])
     rescue StandardError => e
+      # Allow rescues to be null, or else Graal will error.
+      return if Truffle::Interop.null?(r_proc)
       Primitive.call_with_c_mutex(r_proc, [data2, Primitive.cext_wrap(e)])
     end
   end

--- a/spec/ruby/optional/capi/ext/kernel_spec.c
+++ b/spec/ruby/optional/capi/ext/kernel_spec.c
@@ -153,6 +153,10 @@ VALUE kernel_spec_rb_rescue(VALUE self, VALUE main_proc, VALUE arg,
   rb_ary_push(main_array, main_proc);
   rb_ary_push(main_array, arg);
 
+  if (raise_proc == Qnil && arg2 == Qnil) {
+    return rb_rescue(kernel_spec_call_proc, main_array, NULL, Qnil);
+  }
+
   raise_array = rb_ary_new();
   rb_ary_push(raise_array, raise_proc);
   rb_ary_push(raise_array, arg2);

--- a/spec/ruby/optional/capi/kernel_spec.rb
+++ b/spec/ruby/optional/capi/kernel_spec.rb
@@ -368,6 +368,10 @@ describe "C-API Kernel function" do
 
       proc_caller { break :value }.should == :value
     end
+
+    it "does not raise an exception if the rescue is null" do
+      @s.rb_rescue(@std_error_proc, nil, nil, nil).class.should == StandardError
+    end 
   end
 
   describe "rb_rescue2" do


### PR DESCRIPTION
Shopify#1

Graal will error with `UnsupportedMessageException` when `rb_rescue` is called with `rb_rescue(x, y, NULL, Qnil);`. This caused a bug in [`Zlib.gzip`](https://github.com/oracle/truffleruby/blob/c24c4074a20b16b2e1968662cf7e62c55460231a/src/main/c/zlib/zlib.c#L4298). 

![image](https://user-images.githubusercontent.com/13735595/74559938-7dc1ca00-4f33-11ea-9959-ef2c2c3cc508.png)
