### PR TITLE
Ensure Random::DEFAULT has new seed on boot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Bug fixes:
 * Fixed `Digest::SHA2.hexdigest` error with long messages (#1922).
 * Fixed `Date.parse` to dup the coerced string to not modify original (#1946).
 * Update `Comparable` error messages for special constant values (#1941).
+* Fixed `Random::DEFAULT.seed` to be different on boot (#1965, @kipply)
 
 Compatibility:
 

--- a/spec/ruby/core/random/default_spec.rb
+++ b/spec/ruby/core/random/default_spec.rb
@@ -4,4 +4,10 @@ describe "Random::DEFAULT" do
   it "returns a Random instance" do
     Random::DEFAULT.should be_an_instance_of(Random)
   end
+
+  it "changes seed on reboot" do
+    seed1 = ruby_exe('p Random::DEFAULT.seed', options: '--disable-gems')
+    seed2 = ruby_exe('p Random::DEFAULT.seed', options: '--disable-gems')
+    seed1.should != seed2
+  end
 end

--- a/src/main/ruby/truffleruby/core/main.rb
+++ b/src/main/ruby/truffleruby/core/main.rb
@@ -85,3 +85,7 @@ Truffle::Boot.delay do
     end
   end
 end
+
+Truffle::Boot.delay do
+  Random::DEFAULT = Random.new
+end

--- a/src/main/ruby/truffleruby/core/random.rb
+++ b/src/main/ruby/truffleruby/core/random.rb
@@ -183,5 +183,3 @@ class Random
     Primitive.randomizer_bytes @randomizer, length
   end
 end
-
-Random::DEFAULT = Random.new


### PR DESCRIPTION
https://github.com/Shopify/truffleruby/issues/1

![image](https://user-images.githubusercontent.com/13735595/76349644-c70dfb00-62e0-11ea-8a7a-4a124d42d870.png)

Would be nice to be able to update the `Random::DEFAULT` object (similarly to how thread does it in `src/main/ruby/truffleruby/core/thread.rb:425`), though updating seems to be more overhead/complex. 