### PR TITLE
Fix inactive refinements for blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Performance:
 
 * Enable lazy translation from the parser AST to the Truffle AST for user code by default. This should improve application startup time (#1992).
 
+Bug fixes:
+
+* Fix `#class_exec`, `#module_exec`, `#instance_eval`, and `instance_exec` to use activated refinements (#1988, @ssnickolay).
+
 # 20.1.0
 
 New features:

--- a/doc/contributor/workflow.md
+++ b/doc/contributor/workflow.md
@@ -120,8 +120,8 @@ locally unless we're working on that functionality (instead, the CI runs them).
 Specs under `spec/ruby` are supposed to pass on both Truffle and MRI.
 To run the tests or specs on MRI, pass `--use ruby`:
 ```bash
-jt --use ruby path/to/spec.rb # assumes you have MRI in your PATH
-jt --use /full/path/to/bin/ruby path/to/spec.rb
+jt --use ruby test path/to/spec.rb # assumes you have MRI in your PATH
+jt --use /full/path/to/bin/ruby path/to/spec.rb test
 ```
 
 ## Options

--- a/doc/contributor/workflow.md
+++ b/doc/contributor/workflow.md
@@ -121,7 +121,7 @@ Specs under `spec/ruby` are supposed to pass on both Truffle and MRI.
 To run the tests or specs on MRI, pass `--use ruby`:
 ```bash
 jt --use ruby test path/to/spec.rb # assumes you have MRI in your PATH
-jt --use /full/path/to/bin/ruby path/to/spec.rb test
+jt --use /full/path/to/bin/ruby test path/to/spec.rb
 ```
 
 ## Options

--- a/spec/ruby/core/module/using_spec.rb
+++ b/spec/ruby/core/module/using_spec.rb
@@ -243,6 +243,46 @@ describe "Module#using" do
       mod.call_foo(c).should == "foo from refinement"
     end
 
+    it "is active for module defined via initializer" do
+      refinement = Module.new do
+        refine Integer do
+          def foo; "foo from refinement"; end
+        end
+      end
+
+      result = nil
+
+      Module.new do
+        using refinement
+
+        Module.new do
+          result = 1.foo
+        end
+      end
+
+      result.should == "foo from refinement"
+    end
+
+    it "is active for class defined via initializer" do
+      refinement = Module.new do
+        refine Integer do
+          def foo; "foo from refinement"; end
+        end
+      end
+
+      result = nil
+
+      Class.new do
+        using refinement
+
+        Module.new do
+          result = 1.foo
+        end
+      end
+
+      result.should == "foo from refinement"
+    end
+
     it "is not active if `using` call is not evaluated" do
       result = nil
 

--- a/spec/ruby/core/module/using_spec.rb
+++ b/spec/ruby/core/module/using_spec.rb
@@ -283,6 +283,56 @@ describe "Module#using" do
       result.should == "foo from refinement"
     end
 
+    it "is active for block called via instance_exec" do
+      refinement = Module.new do
+        refine Integer do
+          def foo; "foo from refinement"; end
+        end
+      end
+
+      A = Class.new do
+        using refinement
+
+        def abc
+          block = -> {
+            result = 1.foo
+          }
+
+          self.instance_exec(&block)
+        end
+      end
+
+      A.new.abc.should == "foo from refinement"
+    end
+
+    it "is active for block called via instance_eval" do
+      refinement = Module.new do
+        refine String do
+          def foo; "foo from refinement"; end
+        end
+      end
+
+      A = Class.new do
+        using refinement
+
+        def initialize
+          @a = "1703"
+
+          @a.instance_eval do
+            def abc
+              "#{self}: #{self.foo}"
+            end
+          end
+        end
+
+        def abc
+          @a.abc
+        end
+      end
+
+      A.new.abc.should == "1703: foo from refinement"
+    end
+
     it "is not active if `using` call is not evaluated" do
       result = nil
 

--- a/spec/ruby/core/module/using_spec.rb
+++ b/spec/ruby/core/module/using_spec.rb
@@ -243,7 +243,7 @@ describe "Module#using" do
       mod.call_foo(c).should == "foo from refinement"
     end
 
-    it "is active for module defined via initializer" do
+    it "is active for module defined via Module.new {}" do
       refinement = Module.new do
         refine Integer do
           def foo; "foo from refinement"; end
@@ -263,7 +263,7 @@ describe "Module#using" do
       result.should == "foo from refinement"
     end
 
-    it "is active for class defined via initializer" do
+    it "is active for class defined via Class.new {}" do
       refinement = Module.new do
         refine Integer do
           def foo; "foo from refinement"; end
@@ -272,10 +272,10 @@ describe "Module#using" do
 
       result = nil
 
-      Class.new do
+      Module.new do
         using refinement
 
-        Module.new do
+        Class.new do
           result = 1.foo
         end
       end
@@ -295,7 +295,7 @@ describe "Module#using" do
 
         def abc
           block = -> {
-            result = 1.foo
+            1.foo
           }
 
           self.instance_exec(&block)

--- a/src/main/java/org/truffleruby/core/basicobject/BasicObjectNodes.java
+++ b/src/main/java/org/truffleruby/core/basicobject/BasicObjectNodes.java
@@ -368,7 +368,8 @@ public abstract class BasicObjectNodes {
         protected Object instanceExec(Object receiver, Object[] arguments, DynamicObject block) {
             final DeclarationContext declarationContext = new DeclarationContext(
                     Visibility.PUBLIC,
-                    new SingletonClassOfSelfDefaultDefinee(receiver));
+                    new SingletonClassOfSelfDefaultDefinee(receiver),
+                    Layouts.PROC.getDeclarationContext(block).getRefinements());
             return callBlockNode
                     .executeCallBlock(declarationContext, block, receiver, Layouts.PROC.getBlock(block), arguments);
         }

--- a/src/main/java/org/truffleruby/core/module/ModuleNodes.java
+++ b/src/main/java/org/truffleruby/core/module/ModuleNodes.java
@@ -763,7 +763,9 @@ public abstract class ModuleNodes {
         protected Object classExec(DynamicObject self, Object[] args, DynamicObject block) {
             final DeclarationContext declarationContext = new DeclarationContext(
                     Visibility.PUBLIC,
-                    new FixedDefaultDefinee(self));
+                    new FixedDefaultDefinee(self),
+                    Layouts.PROC.getDeclarationContext(block).getRefinements());
+
             return callBlockNode.executeCallBlock(declarationContext, block, self, Layouts.PROC.getBlock(block), args);
         }
 


### PR DESCRIPTION
_Note: The tests below were green with MRI and red with truffleruby before fixes._

## #class_exec & #module_exec 
We have two different flows to define a class:

1. Classic

```ruby

class A 
  ... 
end
```

Simplified, for this code truffleruby execution call stack looks like:
`BodyTranslator#visitClassNode -> DefineClassNode#execute`. 

Here are no problems.

2. Via Class initializer

```ruby
A = Class.new do
  ...
end
```

Here we have something like that: 
```java
ClassNodes#initialize ->
InitializeClassNode#initialize with block ->
InitializeClassNode#moduleInitialize  ->
ModuleNodes#executeInitialize ->
ModuleNodes#classExec
```

In the last step, we lost refinements because we initialized a new DeclarationContext without refinements, which should be active for the block.

## #instance_eval & #instance_exec 

A similar problem to the previous one. We lose active refinements at the time the block is called.

_BTW, I have sent my OCA to the Oracle email a few hours ago (haven’t received confirmations yet)_

