### PR TITLE
Fix Github releases download URL

### DIFF
--- a/doc/user/standalone-distribution.md
+++ b/doc/user/standalone-distribution.md
@@ -72,7 +72,7 @@ Set `TRUFFLERUBY_VERSION` to the latest TruffleRuby version from
 
 ```bash
 $ export TRUFFLERUBY_VERSION=<desired_version>
-$ curl -L https://github.com/oracle/truffleruby/releases/download/vm-$TRUFFLERUBY_VERSION/truffleruby-$TRUFFLERUBY_VERSION-linux-amd64.tar.gz | tar xz
+$ curl -L https://github.com/oracle/truffleruby/archive/$TRUFFLERUBY_VERSION/truffleruby-$TRUFFLERUBY_VERSION-linux-amd64.tar.gz | tar xz
 $ export PATH="$PWD/truffleruby-$TRUFFLERUBY_VERSION-linux-amd64/bin:$PATH"
 $ $PWD/truffleruby-$TRUFFLERUBY_VERSION-linux-amd64/lib/truffle/post_install_hook.sh
 $ ruby -v # => truffleruby 20.0.0, like ruby x.y.z, GraalVM CE Native [x86_64-linux]

--- a/doc/user/standalone-distribution.md
+++ b/doc/user/standalone-distribution.md
@@ -68,11 +68,11 @@ and run the post-install script.
 ### Latest Release
 
 Set `TRUFFLERUBY_VERSION` to the latest TruffleRuby version from
-[GitHub releases](https://github.com/oracle/truffleruby/releases).
+[GitHub releases](https://github.com/oracle/truffleruby/releases/latest).
 
 ```bash
 $ export TRUFFLERUBY_VERSION=<desired_version>
-$ curl -L https://github.com/oracle/truffleruby/archive/$TRUFFLERUBY_VERSION/truffleruby-$TRUFFLERUBY_VERSION-linux-amd64.tar.gz | tar xz
+$ curl -L https://github.com/oracle/truffleruby/releases/download/vm-$TRUFFLERUBY_VERSION/truffleruby-$TRUFFLERUBY_VERSION-linux-amd64.tar.gz | tar xz
 $ export PATH="$PWD/truffleruby-$TRUFFLERUBY_VERSION-linux-amd64/bin:$PATH"
 $ $PWD/truffleruby-$TRUFFLERUBY_VERSION-linux-amd64/lib/truffle/post_install_hook.sh
 $ ruby -v # => truffleruby 20.0.0, like ruby x.y.z, GraalVM CE Native [x86_64-linux]


### PR DESCRIPTION
Hello!
When I tried to install the latest Github released I noticed the URL was wrong (404 error).
With this change it works, given that you include the `vm-` prefix in the version, for example:
```dockerfile
ENV TRUFFLERUBY_VERSION=vm-20.0.1
```