### PR TITLE
Implemented rb_uv_to_utf8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Compatibility:
 * Implemented `ObjectSpace::WeakMap` (#1385, #1958).
 * Implemented `strtod` and `ruby_strtod` (#2007).
 * Fix detection of `#find_type` in FFI to ignore `MakeMakefile#find_type` from `mkmf` (#1896, #2010).
+* Implemented `rb_uv_to_utf8` (#1998).
 
 Performance:
 

--- a/spec/ruby/optional/capi/encoding_spec.rb
+++ b/spec/ruby/optional/capi/encoding_spec.rb
@@ -497,4 +497,21 @@ describe "C-API Encoding function" do
       @s.rb_enc_str_asciionly_p("hüllo").should be_false
     end
   end
+
+  describe "rb_uv_to_utf8" do
+    it 'converts vectors to UTF-8 strings' do
+      str = '      '
+      {
+        0  => "\u0001",
+        0x7f => "\xC2\x80",
+        0x7ff => "\xE0\xA0\x80",
+        0xffff => "\xF0\x90\x80\x80",
+        0x1fffff => "\xF8\x88\x80\x80\x80",
+        0x3ffffff => "\xFC\x84\x80\x80\x80\x80",
+      }.each do |num, result|
+        len = @s.rb_uv_to_utf8(str, num + 1)
+        str[0..len-1].should == result
+      end
+    end
+  end
 end

--- a/spec/ruby/optional/capi/ext/encoding_spec.c
+++ b/spec/ruby/optional/capi/ext/encoding_spec.c
@@ -219,6 +219,10 @@ static VALUE encoding_spec_rb_enc_str_asciionly_p(VALUE self, VALUE str) {
   }
 }
 
+static VALUE encoding_spec_rb_uv_to_utf8(VALUE self, VALUE buf, VALUE num) {
+  return INT2NUM(rb_uv_to_utf8(RSTRING_PTR(buf), NUM2INT(num)));
+}
+
 void Init_encoding_spec(void) {
   VALUE cls;
   native_rb_encoding_pointer = (rb_encoding**) malloc(sizeof(rb_encoding*));
@@ -271,6 +275,7 @@ void Init_encoding_spec(void) {
   rb_define_method(cls, "rb_enc_nth", encoding_spec_rb_enc_nth, 2);
   rb_define_method(cls, "rb_enc_codepoint_len", encoding_spec_rb_enc_codepoint_len, 1);
   rb_define_method(cls, "rb_enc_str_asciionly_p", encoding_spec_rb_enc_str_asciionly_p, 1);
+  rb_define_method(cls, "rb_uv_to_utf8", encoding_spec_rb_uv_to_utf8, 2);
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
I'm not entirely sure if the `numeric.c` is the right location, but this seemed as the most logical to me. This change fixes https://github.com/oracle/truffleruby/issues/1998

```
ruby -rduktape -e 'p Duktape::Context.new.eval_string("1 + 1")'
WARNING: setjmp is unsupported!
WARNING: setjmp is unsupported!
WARNING: setjmp is unsupported!
WARNING: setjmp is unsupported!
2.0
```

I didn't really dig into the `setjmp` warnings, but I guess that's unrelated.