### PR TITLE
Implement integer modular exponentiation using `BigInteger#mod_pow`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Performance:
 
 * Enable lazy translation from the parser AST to the Truffle AST for user code by default. This should improve application startup time (#1992).
 * `instance variable ... not initialized` and similar warnings are now optimized to have no peak performance impact if they are not printed (depends on `$VERBOSE`).
+* Implement integer modular exponentiation using `BigInteger#mod_pow` (#1999)
 
 # 20.1.0
 

--- a/spec/ruby/core/integer/pow_spec.rb
+++ b/spec/ruby/core/integer/pow_spec.rb
@@ -43,5 +43,9 @@ describe "Integer#pow" do
     it "raises a ZeroDivisionError when the given argument is 0" do
       -> { 2.pow(5, 0) }.should raise_error(ZeroDivisionError)
     end
+
+    it "raises a RangeError when the first argument is negative and the second argument is present" do
+      -> { 2.pow(-5, 1) }.should raise_error(RangeError)
+    end
   end
 end

--- a/src/main/java/org/truffleruby/core/cast/BigIntegerCastNode.java
+++ b/src/main/java/org/truffleruby/core/cast/BigIntegerCastNode.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2013, 2020 Oracle and/or its affiliates. All rights reserved. This
+ * code is released under a tri EPL/GPL/LGPL license. You can use it,
+ * redistribute it and/or modify it under the terms of the:
+ *
+ * Eclipse Public License version 2.0, or
+ * GNU General Public License version 2, or
+ * GNU Lesser General Public License version 2.1.
+ */
+package org.truffleruby.core.cast;
+
+import java.math.BigInteger;
+
+import org.truffleruby.Layouts;
+import org.truffleruby.RubyContext;
+import org.truffleruby.RubyLanguage;
+import org.truffleruby.language.RubySourceNode;
+import org.truffleruby.language.RubyGuards;
+import org.truffleruby.language.RubyNode;
+import org.truffleruby.language.control.RaiseException;
+
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
+import com.oracle.truffle.api.dsl.CachedContext;
+import com.oracle.truffle.api.dsl.GenerateUncached;
+import com.oracle.truffle.api.dsl.ImportStatic;
+import com.oracle.truffle.api.dsl.NodeChild;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.object.DynamicObject;
+
+/** Casts a value into a BigInteger. */
+@GenerateUncached
+@ImportStatic(RubyGuards.class)
+@NodeChild(value = "value", type = RubyNode.class)
+public abstract class BigIntegerCastNode extends RubySourceNode {
+
+    public static BigIntegerCastNode create() {
+        return BigIntegerCastNodeGen.create(null);
+    }
+
+    public static BigIntegerCastNode create(RubyNode value) {
+        return BigIntegerCastNodeGen.create(value);
+    }
+
+    public abstract BigInteger executeCastBigInteger(Object value);
+
+    @Specialization
+    protected BigInteger doInt(int value) {
+        return BigInteger.valueOf(value);
+    }
+
+    @Specialization
+    protected BigInteger doLong(long value) {
+        return BigInteger.valueOf(value);
+    }
+
+    @Specialization(guards = "isRubyBignum(value)")
+    protected BigInteger doBignum(DynamicObject value) {
+        return Layouts.BIGNUM.getValue(value);
+    }
+
+    @Specialization(guards = "!isRubyInteger(value)")
+    protected BigInteger doBasicObject(Object value,
+            @CachedContext(RubyLanguage.class) RubyContext context) {
+        throw new RaiseException(context, notAnInteger(context, value));
+    }
+
+    @TruffleBoundary
+    private DynamicObject notAnInteger(RubyContext context, Object object) {
+        return context.getCoreExceptions().typeErrorIsNotA(
+                object.toString(),
+                "Integer",
+                this);
+    }
+
+}

--- a/src/main/ruby/truffleruby/core/integer.rb
+++ b/src/main/ruby/truffleruby/core/integer.rb
@@ -121,9 +121,15 @@ class Integer < Numeric
   end
 
   def pow(e, m=undefined)
-    return self ** e if Primitive.undefined?(m)
-    raise TypeError, '2nd argument not allowed unless all arguments are integers' unless Primitive.object_kind_of?(m, Integer)
-    (self ** e) % m
+    if Primitive.undefined?(m)
+      self ** e
+    else
+      raise TypeError, '2nd argument not allowed unless a 1st argument is integer' unless Primitive.object_kind_of?(e, Integer)
+      raise TypeError, '2nd argument not allowed unless all arguments are integers' unless Primitive.object_kind_of?(m, Integer)
+      raise RangeError, '1st argument cannot be negative when 2nd argument specified' if e.negative?
+
+      Primitive.mod_pow(self, e, m)
+    end
   end
 
   def times


### PR DESCRIPTION
As @eregon suggested [here](https://github.com/oracle/truffleruby/issues/1999#issuecomment-625283922) I replaced the modular exponentiation in `Integer#pow` with the more effective `BigInteger#mod_pow` using a primitive.

I also found out that the `Integer#pow` wasn't raising a `TypeError` when the 1st argument was not an integer, which results with the following in MRI:
```
irb(main):012:0> 10.pow(0.1, 1)
 => TypeError (Integer#pow() 2nd argument not allowed unless a 1st argument is integer)
```
Note that this message is not grammatically correct, but I copy-pasted it from MRI. If it's not good, please let me know how it should look like.

After this change the [2nd example from here](https://rosettacode.org/wiki/Long_primes#Ruby) runs faster (`2.934s` for me), but still significantly slower than in MRI. However, the profiling shows that the bottleneck is no longer the `pow`:
```
--------------------------------------------------------------------------------------------------------------------------------------------------
 Thread: Thread[main,5,main]
 Name                                                       |      Total Time     |  Opt % ||       Self Time     |  Opt % | Location             
--------------------------------------------------------------------------------------------------------------------------------------------------
 block in Object#divisors                                   |        776ms  30.7% |   0.0% ||        556ms  22.0% |   0.0% | bench.rb~14:508-594 
 Range#each                                                 |       2425ms  95.9% |   0.0% ||        285ms  11.3% |   0.0% | (core)~1:0 
 Object#prime?                                              |        637ms  25.2% |   0.0% ||        272ms  10.8% |   0.0% | bench.rb~1-10:0-433 
 Integer#pow                                                |        269ms  10.6% |   0.0% ||        269ms  10.6% |   0.0% | src/main/ruby/truffleruby/core/integer.rb~123-128:3646-4011 
 Integer#gcd                                                |        234ms   9.3% |   0.0% ||        212ms   8.4% |   0.0% | src/main/ruby/truffleruby/core/integer.rb~231-241:6276-6518 
 Numeric#zero?                                              |        144ms   5.7% |   0.0% ||        144ms   5.7% |   0.0% | src/main/ruby/truffleruby/core/numeric.rb~174-176:4823-4853 
 block in Object#long_prime?                                |        374ms  14.8% |   0.0% ||        105ms   4.2% |   0.0% | bench.rb~22:786-856 
 Object#long_prime?                                         |       2271ms  89.8% |   0.0% ||         80ms   3.2% |   0.0% | bench.rb~20-24:736-868 
 Array#each                                                 |       2407ms  95.2% |   0.0% ||         75ms   3.0% |   0.0% | (core)~1:0 
 BasicObject#!=                                             |         77ms   3.0% |   0.0% ||         69ms   2.7% |   0.0% | (core)~1:0 
 Integer.sqrt                                               |        129ms   5.1% |   0.0% ||         63ms   2.5% |   0.0% | src/main/ruby/truffleruby/core/integer.rb~309-313:7459-7587 
 block in Enumerable#count                                  |       2285ms  90.4% |   0.0% ||         60ms   2.4% |   0.0% | src/main/ruby/truffleruby/core/enumerable.rb~118:4184-4222 
```

Fixes https://github.com/oracle/truffleruby/issues/1999