### PR TITLE
Add #refine support for Module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Compatibility:
 * Implemented `rb_uv_to_utf8` (#1998).
 * Implemented `rb_str_cat_cstr`.
 * Implemented `rb_fstring`.
+* Support `#refine` for Module (#2021, @ssnickolay).
 
 Performance:
 

--- a/spec/ruby/core/module/refine_spec.rb
+++ b/spec/ruby/core/module/refine_spec.rb
@@ -87,6 +87,31 @@ describe "Module#refine" do
     inner_self.public_instance_methods.should include(:blah)
   end
 
+  it "applies refinements to the module" do
+    refinement = Module.new do
+      refine(Enumerable) do
+        def foo?
+          self.any? ? "yes" : "no"
+        end
+      end
+    end
+
+    Foo = Class.new do
+      using refinement
+
+      def initialize(items)
+        @items = items
+      end
+
+      def result
+        @items.foo?
+      end
+    end
+
+    Foo.new([]).result.should == "no"
+    Foo.new([1]).result.should == "yes"
+  end
+
   it "raises ArgumentError if not given a block" do
     -> do
       Module.new do

--- a/spec/tags/core/module/refine_tags.txt
+++ b/spec/tags/core/module/refine_tags.txt
@@ -1,5 +1,2 @@
-fails:Module#refine for methods accessed indirectly is not honored by Kernel#public_send
-fails:Module#refine for methods accessed indirectly is not honored by &
-fails:Module#refine accepts a module as argument
 fails:Module#refine for methods accessed indirectly is honored by string interpolation
 fails:Module#refine for methods accessed indirectly is honored by Kernel#respond_to?

--- a/src/main/java/org/truffleruby/core/module/ModuleFields.java
+++ b/src/main/java/org/truffleruby/core/module/ModuleFields.java
@@ -79,8 +79,8 @@ public class ModuleFields extends ModuleChain implements ObjectGraphNode {
 
     /** Whether this is a refinement module (R), created by #refine */
     private boolean isRefinement = false;
-    /** The class (C) refined by this refinement module */
-    private DynamicObject refinedClass;
+    /** The module or class (C) refined by this refinement module */
+    private DynamicObject refinedModule;
     /** The namespace module (M) around the #refine call */
     private DynamicObject refinementNamespace;
 
@@ -89,7 +89,7 @@ public class ModuleFields extends ModuleChain implements ObjectGraphNode {
     private final ConcurrentMap<String, Object> classVariables = new ConcurrentHashMap<>();
 
     /** The refinements (calls to Module#refine) nested under/contained in this namespace module (M). Represented as a
-     * map of refined classes (C) to refinement modules (R). */
+     * map of refined classes and modules (C) to refinement modules (R). */
     private final ConcurrentMap<DynamicObject, DynamicObject> refinements = new ConcurrentHashMap<>();
 
     private final CyclicAssumption methodsUnmodifiedAssumption;
@@ -477,7 +477,7 @@ public class ModuleFields extends ModuleChain implements ObjectGraphNode {
         }
 
         if (isRefinement()) {
-            return Layouts.MODULE.getFields(getRefinedClass()).deepMethodSearch(context, name);
+            return Layouts.MODULE.getFields(getRefinedModule()).deepMethodSearch(context, name);
         } else {
             return null;
         }
@@ -601,14 +601,14 @@ public class ModuleFields extends ModuleChain implements ObjectGraphNode {
         return isRefinement;
     }
 
-    public void setupRefinementModule(DynamicObject refinedClass, DynamicObject refinementNamespace) {
+    public void setupRefinementModule(DynamicObject refinedModule, DynamicObject refinementNamespace) {
         this.isRefinement = true;
-        this.refinedClass = refinedClass;
+        this.refinedModule = refinedModule;
         this.refinementNamespace = refinementNamespace;
     }
 
-    public DynamicObject getRefinedClass() {
-        return refinedClass;
+    public DynamicObject getRefinedModule() {
+        return refinedModule;
     }
 
     public DynamicObject getRefinementNamespace() {

--- a/src/main/java/org/truffleruby/core/module/ModuleOperations.java
+++ b/src/main/java/org/truffleruby/core/module/ModuleOperations.java
@@ -67,8 +67,8 @@ public abstract class ModuleOperations {
         if (!RubyGuards.isRubyClass(origin)) { // Module (not Class) methods can always be bound
             return true;
         } else if (Layouts.MODULE.getFields(module).isRefinement()) {
-            DynamicObject refinedClass = Layouts.MODULE.getFields(module).getRefinedClass();
-            return RubyGuards.isRubyClass(refinedClass) && ModuleOperations.assignableTo(refinedClass, origin);
+            DynamicObject refinedModule = Layouts.MODULE.getFields(module).getRefinedModule();
+            return RubyGuards.isRubyClass(refinedModule) && ModuleOperations.assignableTo(refinedModule, origin);
         } else {
             return RubyGuards.isRubyClass(module) && ModuleOperations.assignableTo(module, origin);
         }
@@ -313,7 +313,7 @@ public abstract class ModuleOperations {
 
         if (Layouts.MODULE.getFields(module).isRefinement()) {
             for (DynamicObject ancestor : Layouts.MODULE
-                    .getFields(Layouts.MODULE.getFields(module).getRefinedClass())
+                    .getFields(Layouts.MODULE.getFields(module).getRefinedModule())
                     .ancestors()) {
                 for (InternalMethod method : Layouts.MODULE.getFields(ancestor).getMethods()) {
                     methods.putIfAbsent(method.getName(), method);

--- a/src/main/java/org/truffleruby/language/methods/AddMethodNode.java
+++ b/src/main/java/org/truffleruby/language/methods/AddMethodNode.java
@@ -46,8 +46,8 @@ public abstract class AddMethodNode extends RubyContextNode {
         }
 
         if (Layouts.MODULE.getFields(module).isRefinement()) {
-            final DynamicObject refinedClass = Layouts.MODULE.getFields(module).getRefinedClass();
-            addRefinedMethodEntry(refinedClass, method, visibility);
+            final DynamicObject refinedModule = Layouts.MODULE.getFields(module).getRefinedModule();
+            addRefinedMethodEntry(refinedModule, method, visibility);
         }
 
         doAddMethod(module, method, visibility);

--- a/src/main/java/org/truffleruby/language/methods/UsingNode.java
+++ b/src/main/java/org/truffleruby/language/methods/UsingNode.java
@@ -68,17 +68,17 @@ public abstract class UsingNode extends RubyContextNode {
         return newRefinements;
     }
 
-    private void usingRefinement(DynamicObject refinedClass, DynamicObject refinementModule,
+    private void usingRefinement(DynamicObject refinedModule, DynamicObject refinementModule,
             Map<DynamicObject, DynamicObject[]> newRefinements) {
-        final DynamicObject[] refinements = newRefinements.get(refinedClass);
+        final DynamicObject[] refinements = newRefinements.get(refinedModule);
         if (refinements == null) {
-            newRefinements.put(refinedClass, new DynamicObject[]{ refinementModule });
+            newRefinements.put(refinedModule, new DynamicObject[]{ refinementModule });
         } else {
             if (ArrayUtils.contains(refinements, refinementModule)) {
                 // Already using this refinement
             } else {
                 // Add new refinement in front
-                newRefinements.put(refinedClass, unshift(refinements, refinementModule));
+                newRefinements.put(refinedModule, unshift(refinements, refinementModule));
             }
         }
     }


### PR DESCRIPTION
I thought about duplication for modules all the tests that are written for classes (through the [shared_examples](https://relishapp.com/rspec/rspec-core/docs/example-groups/shared-examples)), but for now it seems a little redundant.
From the point of view of refinement, the modules and classes are the same and there should be no problems.
Am I right or should I add more tests for modules? (maybe spy them in CRuby)