### PR TITLE
Improve Symbol.all_symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Compatibility:
 * Implemented `rb_str_cat_cstr`.
 * Implemented `rb_fstring`.
 * Support `#refine` for Module (#2021, @ssnickolay).
+* Improved the compatibility of `Symbol.all_symbols` (#2022, @chrisseaton).
 
 Performance:
 

--- a/spec/ruby/core/symbol/all_symbols_spec.rb
+++ b/spec/ruby/core/symbol/all_symbols_spec.rb
@@ -4,7 +4,7 @@ describe "Symbol.all_symbols" do
   it "returns an array of Symbols" do
     all_symbols = Symbol.all_symbols
     all_symbols.should be_an_instance_of(Array)
-    all_symbols.all? { |s| s.is_a?(Symbol) }.should be_true
+    all_symbols.each { |s| s.should be_an_instance_of(Symbol) }
   end
 
   it "includes symbols that are strongly referenced" do

--- a/spec/ruby/core/symbol/all_symbols_spec.rb
+++ b/spec/ruby/core/symbol/all_symbols_spec.rb
@@ -1,14 +1,19 @@
 require_relative '../../spec_helper'
 
 describe "Symbol.all_symbols" do
-  it "returns an array containing all the Symbols in the symbol table" do
+  it "returns an array of Symbols" do
     all_symbols = Symbol.all_symbols
     all_symbols.should be_an_instance_of(Array)
-    all_symbols.all? { |s| s.is_a?(Symbol) }.should == true
+    all_symbols.all? { |s| s.is_a?(Symbol) }.should be_true
   end
 
-  it "returns an Array containing Symbols that have been created" do
+  it "includes symbols that are strongly referenced" do
     symbol = "symbol_specs_#{rand(5_000_000)}".to_sym
     Symbol.all_symbols.should include(symbol)
+  end
+
+  it "includes symbols that are referenced in source code but not yet executed" do
+    Symbol.all_symbols.any? { |s| s.to_s == 'symbol_specs_referenced_in_source_code' }.should be_true
+    :symbol_specs_referenced_in_source_code
   end
 end

--- a/spec/ruby/core/symbol/all_symbols_spec.rb
+++ b/spec/ruby/core/symbol/all_symbols_spec.rb
@@ -4,7 +4,7 @@ describe "Symbol.all_symbols" do
   it "returns an array containing all the Symbols in the symbol table" do
     all_symbols = Symbol.all_symbols
     all_symbols.should be_an_instance_of(Array)
-    all_symbols.all? { |s| s.is_a?(Symbol) ? true : (p s; false) }.should == true
+    all_symbols.all? { |s| s.is_a?(Symbol) }.should == true
   end
 
   it "returns an Array containing Symbols that have been created" do

--- a/spec/tags/core/symbol/all_symbols_tags.txt
+++ b/spec/tags/core/symbol/all_symbols_tags.txt
@@ -1,3 +1,2 @@
 slow:Symbol.all_symbols returns an array containing all the Symbols in the symbol table
 slow:Symbol.all_symbols returns an Array containing Symbols that have been created
-fails:Symbol.all_symbols includes symbols that are referenced in source code but not yet executed

--- a/spec/tags/core/symbol/all_symbols_tags.txt
+++ b/spec/tags/core/symbol/all_symbols_tags.txt
@@ -1,2 +1,3 @@
 slow:Symbol.all_symbols returns an array containing all the Symbols in the symbol table
 slow:Symbol.all_symbols returns an Array containing Symbols that have been created
+fails:Symbol.all_symbols includes symbols that are referenced in source code but not yet executed

--- a/src/main/java/org/truffleruby/core/symbol/SymbolNodes.java
+++ b/src/main/java/org/truffleruby/core/symbol/SymbolNodes.java
@@ -44,6 +44,16 @@ import com.oracle.truffle.api.source.SourceSection;
 @CoreModule(value = "Symbol", isClass = true)
 public abstract class SymbolNodes {
 
+    @CoreMethod(names = "all_symbols", onSingleton = true)
+    public abstract static class AllSymbolsNode extends CoreMethodArrayArgumentsNode {
+
+        @Specialization
+        protected DynamicObject allSymbols() {
+            return createArray(getContext().getSymbolTable().allSymbols());
+        }
+
+    }
+
     @CoreMethod(names = { "==", "eql?" }, required = 1)
     public abstract static class EqualNode extends CoreMethodArrayArgumentsNode {
 

--- a/src/main/java/org/truffleruby/core/symbol/SymbolTable.java
+++ b/src/main/java/org/truffleruby/core/symbol/SymbolTable.java
@@ -150,10 +150,10 @@ public class SymbolTable {
     }
 
     @TruffleBoundary(transferToInterpreterOnException = false)
-    public RubySymbol[] allSymbols() {
+    public Object[] allSymbols() {
         final Collection<RubySymbol> allSymbols = symbolMap.values();
-        // allSymbols is a concrete collection not a view
-        return allSymbols.toArray(new RubySymbol[allSymbols.size()]);
+        // allSymbols is a private concrete collection not a view
+        return allSymbols.toArray();
     }
 
 }

--- a/src/main/java/org/truffleruby/core/symbol/SymbolTable.java
+++ b/src/main/java/org/truffleruby/core/symbol/SymbolTable.java
@@ -149,7 +149,7 @@ public class SymbolTable {
         return name;
     }
 
-    @TruffleBoundary(transferToInterpreterOnException = false)
+    @TruffleBoundary
     public Object[] allSymbols() {
         final Collection<RubySymbol> allSymbols = symbolMap.values();
         // allSymbols is a private concrete collection not a view

--- a/src/main/java/org/truffleruby/core/symbol/SymbolTable.java
+++ b/src/main/java/org/truffleruby/core/symbol/SymbolTable.java
@@ -24,6 +24,8 @@ import org.truffleruby.parser.Identifiers;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.nodes.Node;
 
+import java.util.Collection;
+
 public class SymbolTable {
 
     private final RopeCache ropeCache;
@@ -145,6 +147,13 @@ public class SymbolTable {
                     currentNode));
         }
         return name;
+    }
+
+    @TruffleBoundary(transferToInterpreterOnException = false)
+    public RubySymbol[] allSymbols() {
+        final Collection<RubySymbol> allSymbols = symbolMap.values();
+        // allSymbols is a concrete collection not a view
+        return allSymbols.toArray(new RubySymbol[allSymbols.size()]);
     }
 
 }

--- a/src/main/java/org/truffleruby/language/RubyNode.java
+++ b/src/main/java/org/truffleruby/language/RubyNode.java
@@ -254,6 +254,7 @@ public abstract class RubyNode extends RubyBaseNode implements InstrumentableNod
         }
 
         default DynamicObject createArray(Object[] store) {
+            assert store.getClass() == Object[].class;
             return createArray(store, store.length);
         }
 

--- a/src/main/ruby/truffleruby/core/symbol.rb
+++ b/src/main/ruby/truffleruby/core/symbol.rb
@@ -29,10 +29,6 @@
 class Symbol
   include Comparable
 
-  def self.all_symbols
-    ObjectSpace.each_object(Symbol).to_a
-  end
-
   def <=>(other)
     return unless other.kind_of? Symbol
 


### PR DESCRIPTION
Implementing `all_symbols` as `ObjectSpace.each_object(Symbol).to_a` is neat but doesn't actually match what MRI does, which breaks some real-world code.

https://github.com/Shopify/truffleruby/issues/1