### PR TITLE
Change lookup methods to achieve Refinements specification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Compatibility:
 * Do not create a finalizers `Thread` if there are other public languages, which is helpful for polyglot cases (#2035).
 * Implemented `rb_enc_isalnum` and `rb_enc_isspace`.
 * `RUBY_REVISION` is now the full commit hash used to build TruffleRuby, similar to MRI 2.7+.
+* Change the lookup methods to achieve Refinements specification (#2033, @ssnickolay)
 
 Performance:
 

--- a/doc/contributor/refinements.md
+++ b/doc/contributor/refinements.md
@@ -24,12 +24,11 @@ module M
 end
 ```
 
-The `refine` block is module eval'ed into a new anonymous module `R`. `R` is the
-refinement module and contains the method definitions from the refine block.
-Each method added in a refinement module also gets defined in the refined class
-`C` with a *refined* flag. If the refined class `C` contains an existing method
-with the same name, it is chained as the *original method* of the refined
-method. This makes it easy to account for refined methods in method lookup.
+The `refine` block is module eval'ed into a new anonymous module `R`.
+`R` is the refinement module and contains:
+1. The method definitions from the refine block.
+2. Included and prepended modules from the refine block.
+3. `C` ancestors. This is useful for `super` lookup, because `C`'s ancestors have a higher priority than, other active refinements.
 
 Next, `refine` puts the new `R` module into module `M`'s refinements tables,
 which is a map of refined classes to refinement modules. This specific entry
@@ -66,16 +65,33 @@ method and so the DeclarationContext can be looked up only once and doesn't need
 to be checked after.
 
 ## Method Dispatch
+Example:
+```ruby
+using M1; # R1.ancestors = [R1, A, B, C, Object, Kernel, ...]
+using M2; # R2.ancestors = [R2, D, E, C, Object, Kernel, ...]
 
-During method lookup, if a *refined* method is found, the `DeclarationContext`
-(from the frame) is consulted to see if refinements apply to that specific call.
-This *refined* flag enables to only check methods which have refinements for
-refinements and not every module in the ancestor chain. The same happens for
-`super` calls.
+C.new.foo # => ?
+```
+
+If there are active refinements for the module is found, method lookup recursively iterates by them to find refinement method in `[R, ..Rn]`'s ancestors. To avoid repeated calculations, we stop the search for the ancestors of `R` when `C` is found and proceed to the next active refinement.
+
+If nothing was found in active refinements, then the lookup will continue with default behavior and will search in `C` and its ancestors.
+
+The lookup order:
+```ruby
+R1 -> A -> B -> R2 -> D -> E -> C -> ...
+```
+
+The `super` lookup works in much the same way, except `C` ancestors have a higher priority than other active refinements.
+
+The lookup order for `super`:
+```ruby
+R1 -> A -> B -> C -> ... -> R2 -> D -> E -> C -> ...
+```
 
 ## References
 
 - [Refinements Spec](https://bugs.ruby-lang.org/projects/ruby-trunk/wiki/RefinementsSpec)
-- [Refinements Docs](https://ruby-doc.org/core-2.3.0/doc/syntax/refinements_rdoc.html)
-- [Module#refine](https://ruby-doc.org/core-2.3.0/Module.html#method-i-refine)
-- [Module#using](https://ruby-doc.org/core-2.3.0/Module.html#method-i-using)
+- [Refinements Docs](https://ruby-doc.org/core-2.7.0/doc/syntax/refinements_rdoc.html)
+- [Module#refine](https://ruby-doc.org/core-2.7.0/Module.html#method-i-refine)
+- [Module#using](https://ruby-doc.org/core-2.7.0/Module.html#method-i-using)

--- a/doc/contributor/refinements.md
+++ b/doc/contributor/refinements.md
@@ -8,20 +8,22 @@ This example creates a refinement `R` under the module `M` for the refined class
 `C`. The method `refine` is used inside a `Module` to create a refinement.
 
 ```ruby
-class C
-  def one
-    "one unrefined"
-  end
-end
+class C; end # C is the refined module or class
 
-module M
-  refine C do
-    # self is R, the anonymous refinement module
-    def one
-      "one refined"
+module M # M is the namespace module
+  R = refine C do # R is the refinement module
+    def foo # is the refined method
+      "foo"
     end
   end
 end
+
+C.foo
+#=> UndefinedMethod
+
+using M # activate the refinements from the namespace
+C.foo
+#=> "foo"
 ```
 
 The `refine` block is module eval'ed into a new anonymous module `R`.
@@ -73,7 +75,11 @@ using M2; # R2.ancestors = [R2, D, E, C, Object, Kernel, ...]
 C.new.foo # => ?
 ```
 
-If there are active refinements for the module is found, method lookup recursively iterates by them to find refinement method in `[R, ..Rn]`'s ancestors. To avoid repeated calculations, we stop the search for the ancestors of `R` when `C` is found and proceed to the next active refinement.
+During method lookup, if active refinements are found in the the `DeclarationContext` (from the frame),
+then we check if any of the ancestors has refinements.
+For each refined module, method lookup recursively searches for a refinement method in `[R, ...Rn]`'s ancestors.
+To avoid repeated calculations, and to not search C and above before other refinements,
+we stop the search for the ancestors of `R` when `C` is found and proceed to the next active refinement.
 
 If nothing was found in active refinements, then the lookup will continue with default behavior and will search in `C` and its ancestors.
 

--- a/spec/ruby/core/module/fixtures/refine.rb
+++ b/spec/ruby/core/module/fixtures/refine.rb
@@ -10,8 +10,8 @@ module ModuleSpecs
   module IncludedModule
     def foo; "foo from included module"; end
   end
-end
 
-def build_refined_class
-  Class.new(ModuleSpecs::ClassWithFoo)
+  def self.build_refined_class
+    Class.new(ClassWithFoo)
+  end
 end

--- a/spec/ruby/core/module/fixtures/refine.rb
+++ b/spec/ruby/core/module/fixtures/refine.rb
@@ -11,3 +11,7 @@ module ModuleSpecs
     def foo; "foo from included module"; end
   end
 end
+
+def build_refined_class
+  Class.new(ModuleSpecs::ClassWithFoo)
+end

--- a/spec/ruby/core/module/refine_spec.rb
+++ b/spec/ruby/core/module/refine_spec.rb
@@ -244,23 +244,27 @@ describe "Module#refine" do
     end
 
     it "looks in the included modules for builtin methods" do
-      a = Module.new do
-        def /(other) quo(other) end
-      end
-
-      refinement = Module.new do
-        refine Integer do
-          include a
+      result = ruby_exe(<<-RUBY)
+        a = Module.new do
+          def /(other) quo(other) end
         end
-      end
 
-      result = nil
-      Module.new do
-        using refinement
-        result = 1 / 2
-      end
+        refinement = Module.new do
+          refine Integer do
+            include a
+          end
+        end
 
-      result.should == Rational(1, 2)
+        result = nil
+        Module.new do
+          using refinement
+          result = 1 / 2
+        end
+
+        print result
+      RUBY
+
+      result.should == Rational(1, 2).to_s
     end
 
     it "looks in later included modules of the refined module first" do

--- a/spec/ruby/core/module/refine_spec.rb
+++ b/spec/ruby/core/module/refine_spec.rb
@@ -267,6 +267,38 @@ describe "Module#refine" do
       result.should == "foo"
     end
 
+    it "looks in later prepended modules to the refined module first" do
+      module A
+        def foo
+         "foo from A"
+        end
+      end
+
+      module IncludeMeLater
+        def foo
+          "foo from IncludeMeLater"
+        end
+      end
+
+      class C
+        include A
+      end
+
+      refinement =
+        Module.new do
+          refine C do; end
+        end
+
+      result = nil
+      Module.new do
+        using refinement
+        C.include IncludeMeLater
+        result = C.new.foo
+      end
+
+      result.should == "foo from IncludeMeLater"
+    end
+
     it "looks in prepended modules from the refinement first" do
       refinement = Module.new do
         refine ModuleSpecs::ClassWithFoo  do

--- a/spec/ruby/core/module/refine_spec.rb
+++ b/spec/ruby/core/module/refine_spec.rb
@@ -221,7 +221,7 @@ describe "Module#refine" do
   #   * The included modules of C
   describe "method lookup" do
     it "looks in the object singleton class first" do
-      refined_class = build_refined_class
+      refined_class = ModuleSpecs.build_refined_class
 
       refinement = Module.new do
         refine refined_class do
@@ -243,7 +243,7 @@ describe "Module#refine" do
       result.should == "foo from singleton class"
     end
 
-    it "looks in later prepended modules to the refined module first" do
+    it "looks in later included modules of the refined module first" do
       a = Module.new do
         def foo
          "foo from A"
@@ -260,10 +260,9 @@ describe "Module#refine" do
         include a
       end
 
-      refinement =
-        Module.new do
-          refine c do; end
-        end
+      refinement = Module.new do
+         refine c do; end
+       end
 
       result = nil
       Module.new do
@@ -276,7 +275,7 @@ describe "Module#refine" do
     end
 
     it "looks in prepended modules from the refinement first" do
-      refined_class = build_refined_class
+      refined_class = ModuleSpecs.build_refined_class
 
       refinement = Module.new do
         refine refined_class do
@@ -297,7 +296,7 @@ describe "Module#refine" do
     end
 
     it "looks in refinement then" do
-      refined_class = build_refined_class
+      refined_class = ModuleSpecs.build_refined_class
 
       refinement = Module.new do
         refine(refined_class) do
@@ -317,7 +316,7 @@ describe "Module#refine" do
     end
 
     it "looks in included modules from the refinement then" do
-      refined_class = build_refined_class
+      refined_class = ModuleSpecs.build_refined_class
 
       refinement = Module.new do
         refine refined_class do
@@ -335,7 +334,7 @@ describe "Module#refine" do
     end
 
     it "looks in the class then" do
-      refined_class = build_refined_class
+      refined_class = ModuleSpecs.build_refined_class
 
       refinement = Module.new do
         refine(refined_class) { }
@@ -354,7 +353,7 @@ describe "Module#refine" do
 
   # methods in a subclass have priority over refinements in a superclass
   it "does not override methods in subclasses" do
-    refined_class = build_refined_class
+    refined_class = ModuleSpecs.build_refined_class
 
     subclass = Class.new(refined_class) do
       def foo; "foo from subclass"; end
@@ -377,7 +376,7 @@ describe "Module#refine" do
 
   context "for methods accessed indirectly" do
     it "is honored by Kernel#send" do
-      refined_class = build_refined_class
+      refined_class = ModuleSpecs.build_refined_class
 
       refinement = Module.new do
         refine refined_class do
@@ -395,7 +394,7 @@ describe "Module#refine" do
     end
 
     it "is honored by BasicObject#__send__" do
-      refined_class = build_refined_class
+      refined_class = ModuleSpecs.build_refined_class
 
       refinement = Module.new do
         refine refined_class do
@@ -432,7 +431,7 @@ describe "Module#refine" do
 
     ruby_version_is "" ... "2.6" do
       it "is not honored by Kernel#public_send" do
-        refined_class = build_refined_class
+        refined_class = ModuleSpecs.build_refined_class
 
         refinement = Module.new do
           refine refined_class do
@@ -452,7 +451,7 @@ describe "Module#refine" do
 
     ruby_version_is "2.6" do
       it "is honored by Kernel#public_send" do
-        refined_class = build_refined_class
+        refined_class = ModuleSpecs.build_refined_class
 
         refinement = Module.new do
           refine refined_class do
@@ -667,7 +666,7 @@ describe "Module#refine" do
 
   context "when super is called in a refinement" do
     it "looks in the included to refinery module" do
-      refined_class = build_refined_class
+      refined_class = ModuleSpecs.build_refined_class
       
       refinement = Module.new do
         refine refined_class do
@@ -689,7 +688,7 @@ describe "Module#refine" do
     end
 
     it "looks in the refined class" do
-      refined_class = build_refined_class
+      refined_class = ModuleSpecs.build_refined_class
 
       refinement = Module.new do
         refine refined_class do
@@ -712,7 +711,7 @@ describe "Module#refine" do
     # class even if there is another refinement which has been activated
     # in the same context.
     it "looks in the refined class even if there is another active refinement" do
-      refined_class = build_refined_class
+      refined_class = ModuleSpecs.build_refined_class
 
       refinement = Module.new do
         refine refined_class do

--- a/spec/ruby/core/module/refine_spec.rb
+++ b/spec/ruby/core/module/refine_spec.rb
@@ -241,6 +241,32 @@ describe "Module#refine" do
       result.should == "foo from singleton class"
     end
 
+    it "this is temporary test to verify the new lookup" do
+      module A
+        def foo
+          "foo"
+        end
+      end
+
+      class B
+      end
+
+      refinement =
+        Module.new do
+          refine B do
+            include A
+          end
+        end
+
+      result = nil
+      Module.new do
+        using refinement
+        result = B.new.foo
+      end
+
+      result.should == "foo"
+    end
+
     it "looks in prepended modules from the refinement first" do
       refinement = Module.new do
         refine ModuleSpecs::ClassWithFoo  do

--- a/spec/ruby/core/module/refine_spec.rb
+++ b/spec/ruby/core/module/refine_spec.rb
@@ -242,58 +242,57 @@ describe "Module#refine" do
     end
 
     it "this is temporary test to verify the new lookup" do
-      module A
+      a = Module.new do
         def foo
           "foo"
         end
       end
 
-      class B
-      end
+      b = Class.new
 
       refinement =
         Module.new do
-          refine B do
-            include A
+          refine b do
+            include a
           end
         end
 
       result = nil
       Module.new do
         using refinement
-        result = B.new.foo
+        result = b.new.foo
       end
 
       result.should == "foo"
     end
 
     it "looks in later prepended modules to the refined module first" do
-      module A
+      a = Module.new do
         def foo
          "foo from A"
         end
       end
 
-      module IncludeMeLater
+      include_me_later = Module.new do
         def foo
           "foo from IncludeMeLater"
         end
       end
 
-      class C
-        include A
+      c = Class.new do
+        include a
       end
 
       refinement =
         Module.new do
-          refine C do; end
+          refine c do; end
         end
 
       result = nil
       Module.new do
         using refinement
-        C.include IncludeMeLater
-        result = C.new.foo
+        c.include include_me_later
+        result = c.new.foo
       end
 
       result.should == "foo from IncludeMeLater"

--- a/spec/ruby/core/module/refine_spec.rb
+++ b/spec/ruby/core/module/refine_spec.rb
@@ -261,10 +261,10 @@ describe "Module#refine" do
           result = 1 / 2
         end
 
-        print result
+        print result.class
       RUBY
 
-      result.should == Rational(1, 2).to_s
+      result.should == 'Rational'
     end
 
     it "looks in later included modules of the refined module first" do

--- a/spec/ruby/core/module/refine_spec.rb
+++ b/spec/ruby/core/module/refine_spec.rb
@@ -243,6 +243,26 @@ describe "Module#refine" do
       result.should == "foo from singleton class"
     end
 
+    it "looks in the included modules for builtin methods" do
+      a = Module.new do
+        def /(other) quo(other) end
+      end
+
+      refinement = Module.new do
+        refine Integer do
+          include a
+        end
+      end
+
+      result = nil
+      Module.new do
+        using refinement
+        result = 1 / 2
+      end
+
+      result.should == Rational(1, 2)
+    end
+
     it "looks in later included modules of the refined module first" do
       a = Module.new do
         def foo

--- a/spec/tags/core/module/refine_tags.txt
+++ b/spec/tags/core/module/refine_tags.txt
@@ -1,2 +1,3 @@
 fails:Module#refine for methods accessed indirectly is honored by string interpolation
 fails:Module#refine for methods accessed indirectly is honored by Kernel#respond_to?
+slow:Module#refine method lookup looks in the included modules for builtin methods

--- a/src/main/java/org/truffleruby/core/method/MethodFilter.java
+++ b/src/main/java/org/truffleruby/core/method/MethodFilter.java
@@ -20,14 +20,14 @@ public abstract class MethodFilter {
     public static final MethodFilter PUBLIC = new MethodFilter() {
         @Override
         public boolean filter(InternalMethod method) {
-            return isNotDefinedInRefinementOnly(method) && method.getVisibility() == Visibility.PUBLIC;
+            return method.getVisibility() == Visibility.PUBLIC;
         }
     };
 
     public static final MethodFilter PUBLIC_PROTECTED = new MethodFilter() {
         @Override
         public boolean filter(InternalMethod method) {
-            return isNotDefinedInRefinementOnly(method) && (method.getVisibility() == Visibility.PUBLIC ||
+            return (method.getVisibility() == Visibility.PUBLIC ||
                     method.getVisibility() == Visibility.PROTECTED);
         }
     };
@@ -35,14 +35,14 @@ public abstract class MethodFilter {
     public static final MethodFilter PROTECTED = new MethodFilter() {
         @Override
         public boolean filter(InternalMethod method) {
-            return isNotDefinedInRefinementOnly(method) && method.getVisibility() == Visibility.PROTECTED;
+            return method.getVisibility() == Visibility.PROTECTED;
         }
     };
 
     public static final MethodFilter PRIVATE = new MethodFilter() {
         @Override
         public boolean filter(InternalMethod method) {
-            return isNotDefinedInRefinementOnly(method) && method.getVisibility() == Visibility.PRIVATE;
+            return method.getVisibility() == Visibility.PRIVATE;
         }
     };
 
@@ -60,9 +60,4 @@ public abstract class MethodFilter {
                 throw new IllegalArgumentException("unsupported visibility: " + visibility);
         }
     }
-
-    private static boolean isNotDefinedInRefinementOnly(InternalMethod method) {
-        return !method.isRefined() || method.getOriginalMethod() != null;
-    }
-
 }

--- a/src/main/java/org/truffleruby/core/module/ModuleFields.java
+++ b/src/main/java/org/truffleruby/core/module/ModuleFields.java
@@ -597,6 +597,7 @@ public class ModuleFields extends ModuleChain implements ObjectGraphNode {
         this.isRefinement = true;
         this.refinedModule = refinedModule;
         this.refinementNamespace = refinementNamespace;
+        this.parentModule = Layouts.MODULE.getFields(refinedModule).start;
     }
 
     public DynamicObject getRefinedModule() {

--- a/src/main/java/org/truffleruby/core/module/ModuleFields.java
+++ b/src/main/java/org/truffleruby/core/module/ModuleFields.java
@@ -310,7 +310,7 @@ public class ModuleFields extends ModuleChain implements ObjectGraphNode {
             this.newHierarchyVersion();
         }
 
-        prependInvalidation();
+        invalidateBuiltinsAssumptions();
     }
 
     /** Set the value of a constant, possibly redefining it. */
@@ -630,6 +630,15 @@ public class ModuleFields extends ModuleChain implements ObjectGraphNode {
     public void newHierarchyVersion() {
         newConstantsVersion();
         newMethodsVersion();
+        newBultinsVersion();
+    }
+
+    public void invalidateBuiltinsAssumptions() {
+        if (!inlinedBuiltinsAssumptions.isEmpty()) {
+            for (Assumption assumption : inlinedBuiltinsAssumptions.values()) {
+                assumption.invalidate();
+            }
+        }
     }
 
     public void newMethodsVersion() {
@@ -806,18 +815,16 @@ public class ModuleFields extends ModuleChain implements ObjectGraphNode {
         return assumption;
     }
 
+    private void newBultinsVersion() {
+        if (isRefinement()) {
+            Layouts.MODULE.getFields(getRefinedModule()).invalidateBuiltinsAssumptions();
+        }
+    }
+
     private void changedMethod(String name) {
         Assumption assumption = inlinedBuiltinsAssumptions.get(name);
         if (assumption != null) {
             assumption.invalidate();
-        }
-    }
-
-    private void prependInvalidation() {
-        if (!inlinedBuiltinsAssumptions.isEmpty()) {
-            for (Assumption assumption : inlinedBuiltinsAssumptions.values()) {
-                assumption.invalidate();
-            }
         }
     }
 }

--- a/src/main/java/org/truffleruby/core/module/ModuleFields.java
+++ b/src/main/java/org/truffleruby/core/module/ModuleFields.java
@@ -626,14 +626,9 @@ public class ModuleFields extends ModuleChain implements ObjectGraphNode {
     public void newHierarchyVersion() {
         newConstantsVersion();
         newMethodsVersion();
-        newBultinsVersion();
-    }
 
-    public void invalidateBuiltinsAssumptions() {
-        if (!inlinedBuiltinsAssumptions.isEmpty()) {
-            for (Assumption assumption : inlinedBuiltinsAssumptions.values()) {
-                assumption.invalidate();
-            }
+        if (isRefinement()) {
+            Layouts.MODULE.getFields(getRefinedModule()).invalidateBuiltinsAssumptions();
         }
     }
 
@@ -811,16 +806,18 @@ public class ModuleFields extends ModuleChain implements ObjectGraphNode {
         return assumption;
     }
 
-    private void newBultinsVersion() {
-        if (isRefinement()) {
-            Layouts.MODULE.getFields(getRefinedModule()).invalidateBuiltinsAssumptions();
-        }
-    }
-
     private void changedMethod(String name) {
         Assumption assumption = inlinedBuiltinsAssumptions.get(name);
         if (assumption != null) {
             assumption.invalidate();
+        }
+    }
+
+    private void invalidateBuiltinsAssumptions() {
+        if (!inlinedBuiltinsAssumptions.isEmpty()) {
+            for (Assumption assumption : inlinedBuiltinsAssumptions.values()) {
+                assumption.invalidate();
+            }
         }
     }
 }

--- a/src/main/java/org/truffleruby/core/module/ModuleFields.java
+++ b/src/main/java/org/truffleruby/core/module/ModuleFields.java
@@ -375,12 +375,6 @@ public class ModuleFields extends ModuleChain implements ObjectGraphNode {
     }
 
     @TruffleBoundary
-    public void handleRefinedMethod(String methodName) {
-        // invalidate assumption to not use an AST-inlined method
-        changedMethod(methodName);
-    }
-
-    @TruffleBoundary
     public void addMethod(RubyContext context, Node currentNode, InternalMethod method) {
         assert ModuleOperations.canBindMethodTo(method, rubyModuleObject) ||
                 ModuleOperations.assignableTo(context.getCoreLibrary().objectClass, method.getDeclaringModule()) ||
@@ -404,7 +398,11 @@ public class ModuleFields extends ModuleChain implements ObjectGraphNode {
 
         if (!context.getCoreLibrary().isInitializing()) {
             newMethodsVersion();
+            // invalidate assumptions to not use an AST-inlined methods
             changedMethod(method.getName());
+            if (refinedModule != null) {
+                Layouts.MODULE.getFields(refinedModule).changedMethod(method.getName());
+            }
         }
 
         if (context.getCoreLibrary().isLoaded() && !method.isUndefined()) {

--- a/src/main/java/org/truffleruby/core/module/ModuleFields.java
+++ b/src/main/java/org/truffleruby/core/module/ModuleFields.java
@@ -376,12 +376,8 @@ public class ModuleFields extends ModuleChain implements ObjectGraphNode {
 
     @TruffleBoundary
     public void handleRefinedMethod(String methodName) {
-        final InternalMethod method = getMethod(methodName);
-
-        if (method != null) {
-            // invalidate assumptions not to use Inlined methods
-            changedMethod(methodName);
-        }
+        // invalidate assumption to not use an AST-inlined method
+        changedMethod(methodName);
     }
 
     @TruffleBoundary

--- a/src/main/java/org/truffleruby/core/module/ModuleFields.java
+++ b/src/main/java/org/truffleruby/core/module/ModuleFields.java
@@ -424,15 +424,7 @@ public class ModuleFields extends ModuleChain implements ObjectGraphNode {
             return false;
         }
 
-        if (method.isRefined()) {
-            if (method.getOriginalMethod() == null) {
-                return false;
-            } else {
-                methods.put(methodName, method.withOriginalMethod(null));
-            }
-        } else {
-            methods.remove(methodName);
-        }
+        methods.remove(methodName);
 
         newMethodsVersion();
         changedMethod(methodName);

--- a/src/main/java/org/truffleruby/core/module/ModuleFields.java
+++ b/src/main/java/org/truffleruby/core/module/ModuleFields.java
@@ -375,6 +375,16 @@ public class ModuleFields extends ModuleChain implements ObjectGraphNode {
     }
 
     @TruffleBoundary
+    public void handleRefinedMethod(String methodName) {
+        final InternalMethod method = getMethod(methodName);
+
+        if (method != null) {
+            // invalidate assumptions not to use Inlined methods
+            changedMethod(methodName);
+        }
+    }
+
+    @TruffleBoundary
     public void addMethod(RubyContext context, Node currentNode, InternalMethod method) {
         assert ModuleOperations.canBindMethodTo(method, rubyModuleObject) ||
                 ModuleOperations.assignableTo(context.getCoreLibrary().objectClass, method.getDeclaringModule()) ||

--- a/src/main/java/org/truffleruby/core/module/ModuleNodes.java
+++ b/src/main/java/org/truffleruby/core/module/ModuleNodes.java
@@ -2148,8 +2148,6 @@ public abstract class ModuleNodes {
                     null,
                     this);
             final ModuleFields refinementFields = Layouts.MODULE.getFields(refinement);
-            // add all moduleToRefine's (C) ancestors to the new refinement (R)
-            refinementFields.include(getContext(), this, moduleToRefine);
             refinementFields.setupRefinementModule(moduleToRefine, namespace);
             return refinement;
         }

--- a/src/main/java/org/truffleruby/core/module/ModuleNodes.java
+++ b/src/main/java/org/truffleruby/core/module/ModuleNodes.java
@@ -2148,6 +2148,8 @@ public abstract class ModuleNodes {
                     null,
                     this);
             final ModuleFields refinementFields = Layouts.MODULE.getFields(refinement);
+            // add all moduleToRefine's (C) ancestors to the new refinement (R)
+            refinementFields.include(getContext(), this, moduleToRefine);
             refinementFields.setupRefinementModule(moduleToRefine, namespace);
             return refinement;
         }

--- a/src/main/java/org/truffleruby/core/module/ModuleOperations.java
+++ b/src/main/java/org/truffleruby/core/module/ModuleOperations.java
@@ -17,7 +17,6 @@ import java.util.function.Function;
 
 import org.truffleruby.Layouts;
 import org.truffleruby.RubyContext;
-import org.truffleruby.core.array.ArrayUtils;
 import org.truffleruby.core.string.StringUtils;
 import org.truffleruby.language.LexicalScope;
 import org.truffleruby.language.RubyConstant;
@@ -567,9 +566,13 @@ public abstract class ModuleOperations {
         //     R1.ancestors = [R1, A, C, ...]
         //     R2.ancestors = [R2, B, C, ...]
         //     R3.ancestors = [R3, D, C, ...]
-        // we are looking BEFORE С for the first n - 1 refinements:
+        // we should look among C ancestors only for the last active refinement:
         // R3 -> D -> R2 -> B -> R1 -> A -> C -> ...
-        return (i == refinements.length - 1) ? null : refinedModule;
+        if (i != refinements.length - 1) {
+            return refinedModule;
+        }
+
+        return null;
     }
 
     private static Assumption[] toArray(ArrayList<Assumption> assumptions) {

--- a/src/main/java/org/truffleruby/core/module/ModuleOperations.java
+++ b/src/main/java/org/truffleruby/core/module/ModuleOperations.java
@@ -405,7 +405,6 @@ public abstract class ModuleOperations {
         for (DynamicObject ancestor : Layouts.MODULE.getFields(module).ancestors()) {
             if ((refinements = getRefinementsFor(declarationContext, ancestor)) != null) {
                 for (DynamicObject refinement : refinements) {
-                    // TODO: pass new declaration context without current refinements
                     final MethodLookupResult refinedMethod = lookupMethodCached(refinement, name, null);
                     if (refinedMethod.isDefined()) {
                         for (Assumption assumption : refinedMethod.getAssumptions()) {
@@ -436,7 +435,6 @@ public abstract class ModuleOperations {
         for (DynamicObject ancestor : Layouts.MODULE.getFields(module).ancestors()) {
             if ((refinements = getRefinementsFor(declarationContext, ancestor)) != null) {
                 for (DynamicObject refinement : refinements) {
-                    // TODO: pass new declaration context without current refinements
                     final InternalMethod refinedMethod = lookupMethodUncached(refinement, name, null);
                     if (refinedMethod != null) {
                         return refinedMethod;
@@ -487,7 +485,8 @@ public abstract class ModuleOperations {
         for (DynamicObject module : Layouts.MODULE.getFields(objectMetaClass).ancestors()) {
             if ((refinements = getRefinementsFor(declarationContext, module)) != null) {
                 for (DynamicObject refinement : refinements) {
-
+                    // TODO: pass new declaration context without current refinements
+                    //       to lookup super in other namespaces
                     final MethodLookupResult superMethodInRefinement = lookupSuperMethod(
                             declaringModule,
                             name,

--- a/src/main/java/org/truffleruby/core/module/ModuleOperations.java
+++ b/src/main/java/org/truffleruby/core/module/ModuleOperations.java
@@ -533,10 +533,10 @@ public abstract class ModuleOperations {
                             name,
                             refinement,
                             null);
+                    for (Assumption assumption : superMethodInRefinement.getAssumptions()) {
+                        assumptions.add(assumption);
+                    }
                     if (superMethodInRefinement.isDefined()) {
-                        for (Assumption assumption : superMethodInRefinement.getAssumptions()) {
-                            assumptions.add(assumption);
-                        }
                         return new MethodLookupResult(
                                 superMethodInRefinement.getMethod(),
                                 toArray(assumptions));

--- a/src/main/java/org/truffleruby/core/module/ModuleOperations.java
+++ b/src/main/java/org/truffleruby/core/module/ModuleOperations.java
@@ -464,18 +464,17 @@ public abstract class ModuleOperations {
 
             if (refinements != null) {
                 for (DynamicObject refinement : refinements) {
-
                     final InternalMethod refinedMethod = lookupMethodUncached(
                             refinement,
                             ancestor,
                             name,
                             null);
-
                     if (refinedMethod != null) {
                         return refinedMethod;
                     }
                 }
             }
+
             final ModuleFields fields = Layouts.MODULE.getFields(ancestor);
             final InternalMethod method = fields.getMethod(name);
 

--- a/src/main/java/org/truffleruby/core/module/ModuleOperations.java
+++ b/src/main/java/org/truffleruby/core/module/ModuleOperations.java
@@ -405,6 +405,7 @@ public abstract class ModuleOperations {
             DeclarationContext declarationContext) {
         final ArrayList<Assumption> assumptions = new ArrayList<>();
 
+        // Look in ancestors
         for (DynamicObject ancestor : Layouts.MODULE.getFields(module).ancestors()) {
             if (ancestor == lookupTo) {
                 return new MethodLookupResult(null, toArray(assumptions));
@@ -417,7 +418,7 @@ public abstract class ModuleOperations {
                     //     R1.ancestors = [R1, A, C, ...]
                     //     R2.ancestors = [R2, B, C, ...]
                     //     R3.ancestors = [R3, D, C, ...]
-                    // we are only looking to C
+                    // we are only looking up to C
                     // R3 -> D -> R2 -> B -> R1 -> A
                     final MethodLookupResult refinedMethod = lookupMethodCached(
                             refinement,
@@ -508,8 +509,7 @@ public abstract class ModuleOperations {
 
     @TruffleBoundary
     private static MethodLookupResult lookupSuperMethod(DynamicObject declaringModule, DynamicObject lookupTo,
-            String name,
-            DynamicObject objectMetaClass, DeclarationContext declarationContext) {
+            String name, DynamicObject objectMetaClass, DeclarationContext declarationContext) {
         assert RubyGuards.isRubyModule(declaringModule);
         assert RubyGuards.isRubyModule(objectMetaClass);
 
@@ -525,8 +525,6 @@ public abstract class ModuleOperations {
 
             if (refinements != null) {
                 for (DynamicObject refinement : refinements) {
-                    // TODO: pass new declaration context without current refinements
-                    //       to lookup super in other namespaces
                     final MethodLookupResult superMethodInRefinement = lookupSuperMethod(
                             declaringModule,
                             null, // super in refined class takes precedence

--- a/src/main/java/org/truffleruby/core/module/ModuleOperations.java
+++ b/src/main/java/org/truffleruby/core/module/ModuleOperations.java
@@ -420,9 +420,6 @@ public abstract class ModuleOperations {
                 final InternalMethod method = fields.getMethod(name);
 
                 if (method != null) {
-                    if (method.getOriginalMethod() != null) {
-                        return new MethodLookupResult(method.getOriginalMethod(), toArray(assumptions));
-                    }
                     return new MethodLookupResult(method, toArray(assumptions));
                 }
             }
@@ -450,9 +447,6 @@ public abstract class ModuleOperations {
                 final InternalMethod method = fields.getMethod(name);
 
                 if (method != null) {
-                    if (method.getOriginalMethod() != null) {
-                        return method.getOriginalMethod();
-                    }
                     return method;
                 }
             }

--- a/src/main/java/org/truffleruby/language/methods/AddMethodNode.java
+++ b/src/main/java/org/truffleruby/language/methods/AddMethodNode.java
@@ -45,26 +45,21 @@ public abstract class AddMethodNode extends RubyContextNode {
             visibility = Visibility.PRIVATE;
         }
 
-        if (Layouts.MODULE.getFields(module).isRefinement()) {
-            final DynamicObject refinedModule = Layouts.MODULE.getFields(module).getRefinedModule();
-            addRefinedMethodEntry(refinedModule, method, visibility);
-        }
-
         doAddMethod(module, method, visibility);
     }
 
-    @TruffleBoundary
-    private void addRefinedMethodEntry(DynamicObject module, InternalMethod method, Visibility visibility) {
-        final MethodLookupResult result = ModuleOperations.lookupMethodCached(module, method.getName(), null);
-        final InternalMethod originalMethod = result.getMethod();
-        if (originalMethod == null) {
-            doAddMethod(module, method.withRefined(true).withOriginalMethod(null), visibility);
-        } else if (originalMethod.isRefined()) {
-            // Already marked as refined
-        } else {
-            doAddMethod(module, originalMethod.withRefined(true).withOriginalMethod(originalMethod), visibility);
-        }
-    }
+    //    @TruffleBoundary
+    //    private void addRefinedMethodEntry(DynamicObject module, InternalMethod method, Visibility visibility) {
+    //        final MethodLookupResult result = ModuleOperations.lookupMethodCached(module, method.getName(), null);
+    //        final InternalMethod originalMethod = result.getMethod();
+    //        if (originalMethod == null) {
+    //            doAddMethod(module, method.withRefined(true).withOriginalMethod(null), visibility);
+    //        } else if (originalMethod.isRefined()) {
+    //            // Already marked as refined
+    //        } else {
+    //            doAddMethod(module, originalMethod.withRefined(true).withOriginalMethod(originalMethod), visibility);
+    //        }
+    //    }
 
     private void doAddMethod(DynamicObject module, InternalMethod method, Visibility visibility) {
         if (visibility == Visibility.MODULE_FUNCTION) {

--- a/src/main/java/org/truffleruby/language/methods/AddMethodNode.java
+++ b/src/main/java/org/truffleruby/language/methods/AddMethodNode.java
@@ -10,7 +10,6 @@
 package org.truffleruby.language.methods;
 
 import org.truffleruby.Layouts;
-import org.truffleruby.core.module.MethodLookupResult;
 import org.truffleruby.core.module.ModuleOperations;
 import org.truffleruby.language.RubyContextNode;
 import org.truffleruby.language.Visibility;

--- a/src/main/java/org/truffleruby/language/methods/AddMethodNode.java
+++ b/src/main/java/org/truffleruby/language/methods/AddMethodNode.java
@@ -43,17 +43,8 @@ public abstract class AddMethodNode extends RubyContextNode {
         if (!ignoreNameVisibility && ModuleOperations.isMethodPrivateFromName(method.getName())) {
             visibility = Visibility.PRIVATE;
         }
-        if (Layouts.MODULE.getFields(module).isRefinement()) {
-            final DynamicObject refinedModule = Layouts.MODULE.getFields(module).getRefinedModule();
-            handleRefinedMethodEntry(refinedModule, method);
-        }
 
         doAddMethod(module, method, visibility);
-    }
-
-    @TruffleBoundary
-    private void handleRefinedMethodEntry(DynamicObject refinedModule, InternalMethod method) {
-        Layouts.MODULE.getFields(refinedModule).handleRefinedMethod(method.getName());
     }
 
     private void doAddMethod(DynamicObject module, InternalMethod method, Visibility visibility) {

--- a/src/main/java/org/truffleruby/language/methods/AddMethodNode.java
+++ b/src/main/java/org/truffleruby/language/methods/AddMethodNode.java
@@ -48,19 +48,6 @@ public abstract class AddMethodNode extends RubyContextNode {
         doAddMethod(module, method, visibility);
     }
 
-    //    @TruffleBoundary
-    //    private void addRefinedMethodEntry(DynamicObject module, InternalMethod method, Visibility visibility) {
-    //        final MethodLookupResult result = ModuleOperations.lookupMethodCached(module, method.getName(), null);
-    //        final InternalMethod originalMethod = result.getMethod();
-    //        if (originalMethod == null) {
-    //            doAddMethod(module, method.withRefined(true).withOriginalMethod(null), visibility);
-    //        } else if (originalMethod.isRefined()) {
-    //            // Already marked as refined
-    //        } else {
-    //            doAddMethod(module, originalMethod.withRefined(true).withOriginalMethod(originalMethod), visibility);
-    //        }
-    //    }
-
     private void doAddMethod(DynamicObject module, InternalMethod method, Visibility visibility) {
         if (visibility == Visibility.MODULE_FUNCTION) {
             addMethodToModule(module, method.withVisibility(Visibility.PRIVATE));

--- a/src/main/java/org/truffleruby/language/methods/AddMethodNode.java
+++ b/src/main/java/org/truffleruby/language/methods/AddMethodNode.java
@@ -44,8 +44,17 @@ public abstract class AddMethodNode extends RubyContextNode {
         if (!ignoreNameVisibility && ModuleOperations.isMethodPrivateFromName(method.getName())) {
             visibility = Visibility.PRIVATE;
         }
+        if (Layouts.MODULE.getFields(module).isRefinement()) {
+            final DynamicObject refinedModule = Layouts.MODULE.getFields(module).getRefinedModule();
+            handleRefinedMethodEntry(refinedModule, method);
+        }
 
         doAddMethod(module, method, visibility);
+    }
+
+    @TruffleBoundary
+    private void handleRefinedMethodEntry(DynamicObject refinedModule, InternalMethod method) {
+        Layouts.MODULE.getFields(refinedModule).handleRefinedMethod(method.getName());
     }
 
     private void doAddMethod(DynamicObject module, InternalMethod method, Visibility visibility) {

--- a/src/main/java/org/truffleruby/language/methods/DeclarationContext.java
+++ b/src/main/java/org/truffleruby/language/methods/DeclarationContext.java
@@ -32,6 +32,7 @@ import com.oracle.truffle.api.object.DynamicObject;
  * </ul>
 */
 public class DeclarationContext {
+    private static final Map<DynamicObject, DynamicObject[]> NO_REFINEMENTS = Collections.emptyMap();
 
     /** @see <a href="http://yugui.jp/articles/846">http://yugui.jp/articles/846</a> */
     private interface DefaultDefinee {
@@ -80,7 +81,7 @@ public class DeclarationContext {
     private final Map<DynamicObject, DynamicObject[]> refinements; // immutable
 
     public DeclarationContext(Visibility visibility, DefaultDefinee defaultDefinee) {
-        this(visibility, defaultDefinee, Collections.emptyMap());
+        this(visibility, defaultDefinee, NO_REFINEMENTS);
     }
 
     public DeclarationContext(
@@ -89,7 +90,7 @@ public class DeclarationContext {
             Map<DynamicObject, DynamicObject[]> refinements) {
         this.visibility = visibility;
         this.defaultDefinee = defaultDefinee;
-        this.refinements = refinements;
+        this.refinements = refinements == null || refinements.isEmpty() ? NO_REFINEMENTS : refinements;
     }
 
     @TruffleBoundary
@@ -159,7 +160,10 @@ public class DeclarationContext {
         return defaultDefinee.getModuleToDefineMethods(singletonClassNode);
     }
 
+    public boolean hasRefinements() {
+        return refinements != NO_REFINEMENTS;
+    }
+
     /** Used when we know there cannot be a method definition inside a given method. */
     public static final DeclarationContext NONE = new DeclarationContext(Visibility.PUBLIC, null);
-
 }

--- a/src/main/java/org/truffleruby/language/methods/DeclarationContext.java
+++ b/src/main/java/org/truffleruby/language/methods/DeclarationContext.java
@@ -88,6 +88,8 @@ public class DeclarationContext {
             Visibility visibility,
             DefaultDefinee defaultDefinee,
             Map<DynamicObject, DynamicObject[]> refinements) {
+        assert refinements == NO_REFINEMENTS ||
+                !refinements.isEmpty() : "Should use NO_REFINEMENTS if empty for faster getRefinementsFor()";
         this.visibility = visibility;
         this.defaultDefinee = defaultDefinee;
         this.refinements = refinements;

--- a/src/main/java/org/truffleruby/language/methods/DeclarationContext.java
+++ b/src/main/java/org/truffleruby/language/methods/DeclarationContext.java
@@ -90,7 +90,7 @@ public class DeclarationContext {
             Map<DynamicObject, DynamicObject[]> refinements) {
         this.visibility = visibility;
         this.defaultDefinee = defaultDefinee;
-        this.refinements = refinements == null || refinements.isEmpty() ? NO_REFINEMENTS : refinements;
+        this.refinements = refinements;
     }
 
     @TruffleBoundary

--- a/src/main/java/org/truffleruby/language/methods/InternalMethod.java
+++ b/src/main/java/org/truffleruby/language/methods/InternalMethod.java
@@ -37,13 +37,10 @@ public class InternalMethod implements ObjectGraphNode {
     private final boolean undefined;
     private final boolean unimplemented; // similar to MRI's rb_f_notimplement
     private final boolean builtIn;
-    /** A flag to tell whether there exist refinements of this method */
-    private final boolean refined;
     private final DynamicObject proc; // only if method is created from a Proc
 
     private final RootCallTarget callTarget;
     private final DynamicObject capturedBlock;
-    private final InternalMethod originalMethod;
 
     public static InternalMethod fromProc(
             RubyContext context,
@@ -113,11 +110,9 @@ public class InternalMethod implements ObjectGraphNode {
                 undefined,
                 false,
                 !context.getCoreLibrary().isLoaded(),
-                false,
                 proc,
                 callTarget,
-                capturedBlock,
-                null);
+                capturedBlock);
     }
 
     private InternalMethod(
@@ -130,14 +125,11 @@ public class InternalMethod implements ObjectGraphNode {
             boolean undefined,
             boolean unimplemented,
             boolean builtIn,
-            boolean refined,
             DynamicObject proc,
             RootCallTarget callTarget,
-            DynamicObject capturedBlock,
-            InternalMethod originalMethod) {
+            DynamicObject capturedBlock) {
         assert RubyGuards.isRubyModule(declaringModule);
         assert lexicalScope != null;
-        assert originalMethod == null || !originalMethod.isRefined();
         this.sharedMethodInfo = sharedMethodInfo;
         this.lexicalScope = lexicalScope;
         this.declarationContext = declarationContext;
@@ -147,11 +139,9 @@ public class InternalMethod implements ObjectGraphNode {
         this.undefined = undefined;
         this.unimplemented = unimplemented;
         this.builtIn = builtIn;
-        this.refined = refined;
         this.proc = proc;
         this.callTarget = callTarget;
         this.capturedBlock = capturedBlock;
-        this.originalMethod = originalMethod;
     }
 
     public SharedMethodInfo getSharedMethodInfo() {
@@ -182,16 +172,8 @@ public class InternalMethod implements ObjectGraphNode {
         return builtIn;
     }
 
-    public boolean isRefined() {
-        return refined;
-    }
-
     public RootCallTarget getCallTarget() {
         return callTarget;
-    }
-
-    public InternalMethod getOriginalMethod() {
-        return originalMethod;
     }
 
     public InternalMethod withDeclaringModule(DynamicObject newDeclaringModule) {
@@ -210,11 +192,9 @@ public class InternalMethod implements ObjectGraphNode {
                     undefined,
                     unimplemented,
                     builtIn,
-                    refined,
                     proc,
                     callTarget,
-                    capturedBlock,
-                    originalMethod);
+                    capturedBlock);
         }
     }
 
@@ -232,55 +212,9 @@ public class InternalMethod implements ObjectGraphNode {
                     undefined,
                     unimplemented,
                     builtIn,
-                    refined,
                     proc,
                     callTarget,
-                    capturedBlock,
-                    originalMethod);
-        }
-    }
-
-    public InternalMethod withRefined(boolean newRefined) {
-        if (refined == newRefined) {
-            return this;
-        } else {
-            return new InternalMethod(
-                    sharedMethodInfo,
-                    lexicalScope,
-                    declarationContext,
-                    name,
-                    declaringModule,
-                    visibility,
-                    undefined,
-                    unimplemented,
-                    builtIn,
-                    newRefined,
-                    proc,
-                    callTarget,
-                    capturedBlock,
-                    originalMethod);
-        }
-    }
-
-    public InternalMethod withOriginalMethod(InternalMethod newOriginalMethod) {
-        if (originalMethod == newOriginalMethod) {
-            return this;
-        } else {
-            return new InternalMethod(
-                    sharedMethodInfo,
-                    lexicalScope,
-                    declarationContext,
-                    name,
-                    declaringModule,
-                    visibility,
-                    undefined,
-                    unimplemented,
-                    builtIn,
-                    refined,
-                    proc,
-                    callTarget,
-                    capturedBlock,
-                    newOriginalMethod);
+                    capturedBlock);
         }
     }
 
@@ -298,11 +232,9 @@ public class InternalMethod implements ObjectGraphNode {
                     undefined,
                     unimplemented,
                     builtIn,
-                    refined,
                     proc,
                     callTarget,
-                    capturedBlock,
-                    originalMethod);
+                    capturedBlock);
         }
     }
 
@@ -320,11 +252,9 @@ public class InternalMethod implements ObjectGraphNode {
                     undefined,
                     unimplemented,
                     builtIn,
-                    refined,
                     proc,
                     callTarget,
-                    capturedBlock,
-                    originalMethod);
+                    capturedBlock);
         }
     }
 
@@ -339,11 +269,9 @@ public class InternalMethod implements ObjectGraphNode {
                 true,
                 unimplemented,
                 builtIn,
-                refined,
                 proc,
                 callTarget,
-                capturedBlock,
-                originalMethod);
+                capturedBlock);
     }
 
     public InternalMethod unimplemented() {
@@ -357,11 +285,9 @@ public class InternalMethod implements ObjectGraphNode {
                 undefined,
                 true,
                 builtIn,
-                refined,
                 proc,
                 callTarget,
-                capturedBlock,
-                originalMethod);
+                capturedBlock);
     }
 
     @TruffleBoundary

--- a/src/main/java/org/truffleruby/language/methods/LookupMethodNode.java
+++ b/src/main/java/org/truffleruby/language/methods/LookupMethodNode.java
@@ -128,16 +128,16 @@ public abstract class LookupMethodNode extends RubyBaseNode {
             throw Utils.unsupportedOperation("method lookup not supported on foreign objects");
         }
 
+        final DeclarationContext declarationContext = RubyArguments.tryGetDeclarationContext(frame);
         final InternalMethod method;
         // Lookup first in the metaclass as we are likely to find the method there
         final ModuleFields fields = Layouts.MODULE.getFields(metaClass);
         InternalMethod topMethod;
         if (noPrependedModulesProfile.profile(fields.getFirstModuleChain() == fields) &&
                 onMetaClassProfile.profile((topMethod = fields.getMethod(name)) != null) &&
-                !isRefinedProfile.profile(topMethod.isRefined())) {
+                !isRefinedProfile.profile(declarationContext != null && declarationContext.getRefinements() != null)) {
             method = topMethod;
         } else {
-            final DeclarationContext declarationContext = RubyArguments.tryGetDeclarationContext(frame);
             method = ModuleOperations.lookupMethodUncached(metaClass, name, declarationContext);
         }
 

--- a/src/main/java/org/truffleruby/language/methods/LookupMethodNode.java
+++ b/src/main/java/org/truffleruby/language/methods/LookupMethodNode.java
@@ -111,7 +111,7 @@ public abstract class LookupMethodNode extends RubyBaseNode {
             @Cached BranchProfile foreignProfile,
             @Cached ConditionProfile noPrependedModulesProfile,
             @Cached ConditionProfile onMetaClassProfile,
-            @Cached ConditionProfile isRefinedProfile,
+            @Cached ConditionProfile hasRefinementsProfile,
             @Cached ConditionProfile notFoundProfile,
             @Cached ConditionProfile publicProfile,
             @Cached ConditionProfile privateProfile,
@@ -135,7 +135,7 @@ public abstract class LookupMethodNode extends RubyBaseNode {
         InternalMethod topMethod;
         if (noPrependedModulesProfile.profile(fields.getFirstModuleChain() == fields) &&
                 onMetaClassProfile.profile((topMethod = fields.getMethod(name)) != null) &&
-                !isRefinedProfile.profile(declarationContext != null && declarationContext.getRefinements() != null)) {
+                !hasRefinementsProfile.profile(declarationContext != null && declarationContext.hasRefinements())) {
             method = topMethod;
         } else {
             method = ModuleOperations.lookupMethodUncached(metaClass, name, declarationContext);

--- a/src/main/java/org/truffleruby/language/methods/UsingNode.java
+++ b/src/main/java/org/truffleruby/language/methods/UsingNode.java
@@ -42,7 +42,9 @@ public abstract class UsingNode extends RubyContextNode {
         final Frame callerFrame = getContext().getCallStack().getCallerFrameIgnoringSend(FrameAccess.READ_WRITE);
         final DeclarationContext declarationContext = RubyArguments.getDeclarationContext(callerFrame);
         final Map<DynamicObject, DynamicObject[]> newRefinements = usingModule(declarationContext, module);
-        DeclarationContext.setRefinements(callerFrame, declarationContext, newRefinements);
+        if (!newRefinements.isEmpty()) {
+            DeclarationContext.setRefinements(callerFrame, declarationContext, newRefinements);
+        }
     }
 
     @TruffleBoundary


### PR DESCRIPTION
Related to https://github.com/oracle/truffleruby/issues/2026
Specification: https://docs.ruby-lang.org/en/2.7.0/syntax/refinements_rdoc.html

These are massive changes, so I prepared a detailed description to make sure that we all on the same page. I want to share with you the proposal before polishing PR.

## Specification

**Example#0**:

```ruby
class C; end # C is the refined module or class

module M # M is the namespace module
  R = refine C do # R is the refinement module
    def foo # is the refined method
      "foo"
    end
  end
end

C.foo
#=> UndefinedMethod

using M # activate the refinements from the namespace
C.foo
#=> "foo"
```

_Note: I use `M, R, C` below as abbreviations considering that everyone understands their meaning._

## Current Implementation

Let's briefly overview of how we work with refinements for now.

### Internals

1) To keep information about methods, we have an `InternalMethod` class. This class has two attributes, especially for refinements:

 - The flag to mark the method as "placed in some R"
https://github.com/oracle/truffleruby/blob/b9ae9c27df0dcc4aa98c2fe61decf4cfe0c926ee/src/main/java/org/truffleruby/language/methods/InternalMethod.java#L41

 - Link to the original method from `C`
https://github.com/oracle/truffleruby/blob/b9ae9c27df0dcc4aa98c2fe61decf4cfe0c926ee/src/main/java/org/truffleruby/language/methods/InternalMethod.java#L46

2) A module body is described in `ModuleFields` and we have these flags when `ModuleFields` is `R`:
https://github.com/oracle/truffleruby/blob/b9ae9c27df0dcc4aa98c2fe61decf4cfe0c926ee/src/main/java/org/truffleruby/core/module/ModuleFields.java#L80-L85

3) When we handle `addMethod` action, we check if we are working with `R`: 
https://github.com/oracle/truffleruby/blob/b9ae9c27df0dcc4aa98c2fe61decf4cfe0c926ee/src/main/java/org/truffleruby/language/methods/AddMethodNode.java#L48-L51

If so, we add the additional `InternalMethod` with `refined = true` to the `C`.
https://github.com/oracle/truffleruby/blob/b9ae9c27df0dcc4aa98c2fe61decf4cfe0c926ee/src/main/java/org/truffleruby/language/methods/AddMethodNode.java#L61-L65

⚠️ This is important. In this case, we add **two** methods:
- One the usual (`refined = false`) to `R`
- One the special (`refined = true`) to `C`

4) This is all used to implement `Lookup` methods like:
https://github.com/oracle/truffleruby/blob/b9ae9c27df0dcc4aa98c2fe61decf4cfe0c926ee/src/main/java/org/truffleruby/core/module/ModuleOperations.java#L404-L411

### How it Works

```ruby
class C
  def hello; end
end

module M 
  R = refine C do
    def foo; end
  end
end

module M1
  R1 = refine C do
    def bar; end
  end
end

# On TruffleRuby side we have:
DynamicObject(name = C) # our module
ModuleFields(name = M), ModuleFields(name = M1) # namespaceses 

ModuleFields(name = R, methods: [
    InternalMethod(name = "foo", refined = false)
])
ModuleFields(name = R1, methods: [
    InternalMethod(name = "bar", refined = false)
])
ModuleFields(name = C, methods: [
    InternalMethod(name = "bar", refined = true),
    InternalMethod(name = "foo", refined = true),
    InternalMethod(name = "hello", refined = false)
])
```

Let's activate the one refinement and use the method:
```ruby
using M1
C.new.bar

# On TruffleRuby side:
declarationContext: DeclarationContext(refinements: <C, M1>) # here is only activated M1
name = "bar"

func lookup (module, name, declarationContext): Result {
  ancestors = C.ancestors() #=> [C, Object, ...]
  for (ancestor: ancestors) { # first is C
      method = ancestor.getMethod(name) # => the "bar" from C.methods
      if method.isRefined { # true
          activated_Rs = declarationContext.getRefinementsFor(ancestor)
          theOriginalMethod = # find the original method from activated_Rs
          return_if_not_null theOriginalMethod # => R1.methods[0]
      }
    }
}
```

Pros:
1. It works
2. It works when we have _active_ refinements not for `C` but one of the ancestors: `C < A < B < E` and activated `refine E`

### Current Implementation Problems

#### 1. refine + include does not work

**Example#1** (inspired by https://github.com/oracle/truffleruby/issues/2026): 

```ruby
module A
  def foo; end
end
class C; end

module M
  refine C do
    include A
  end
end
```

This example does not work because `include A` does not trigger `addMethod` (3), so no one is adding `InternalMethod(name = "foo", refined = true)` to `C`.

But why [ruby\spec passes](https://github.com/oracle/truffleruby/issues/2026#issuecomment-638797555) if this does not work?
The reason is we mutate `C` methods **globally** we invoke `refine`. Thus, when we run the entire test file, one of the other tests adds to `C` a method with the name `foo` and the test passes. If we run only one test, it fails (because no one affects the global state of `C`).

For me, this is one of the critical problems of the current solution -  it is very similar to a thread-safe issue, but not precisely because we don't expose internal API to the public. However, a mutating global state is causing unpredictable behavior, and we have proof of this (the test).

#### 2. refine + include + ancestors is not possible

**Example#2**

```ruby
module A
  def foo
    "foo from A"
  end
end

class C
  include A

  def foo
    "foo from C"
  end
end

using(Module.new do
  refine C do
    include A
  end
end)

# With CRuby:
puts C.new.foo
# => "foo from C"
```

Perhaps the result of Example#2 is not entirely predictable, but this is how ancestors work. In the current implementation, when we base our lookup on what methods are added to `C`, it is very difficult\not possible to achieve the same result.

#### 3. A few places when we have to "fight" with refined methods
Since `ModuleFields` can contains usual methods and refined methods at the same time, there are several places when we need to check it (via `InternalMethod#isRefined()` and `InternalMethod#getOriginalMethod()`). We do it with if\else statement, and it just increases code complexity.

## Proposal

First of all, let's look at one interesting thing:

#### R.ancestors: CRuby vs TruffleRuby (what we have for now)

Here are `R.ancestors` of examples from prev chapters:

```ruby
puts R.ancestors # =>

Example#0:
(CRuby):       [#<refinement:C@#<Module:0x220>>, C, Object, Kernel, BasicObject]
(TruffleRuby): [#<refinement:C@#<Module:0x220>>]

Example#1:
(CRuby):       [#<refinement:C@#<Module:0x220>>, A, C, Object, Kernel, BasicObject]
(TruffleRuby): [#<refinement:C@#<Module:0x220>>, A]

Example#2:
(CRuby):       [#<refinement:C@#<Module:0x220>>, C, A, Object, Kernel, BasicObject]
(TruffleRuby): [#<refinement:C@#<Module:0x220>>, A]
```

You can notice two exciting things:
- Results are different :)
- In CRuby `R` _always_ has refined class (aka `C`) in ancestors.
- In "Example#2" `R.ancestors` have `C` before `A`, and this is the answer to why we get `foo from C` as a result.

**BASED ON THESE THREE MAIN POINTS, I PROPOSE TO CHANGE THE LOOKUP METHODS:**

#### 1. Achieve R.ancestors as in Ruby 

Just add all `C.ancestors` to the `R` with one line of code (see `ModuleNodes` changes)

I tested many crazy examples (not only three above), and with this change, CRuby and TruffleRuby start to work the same way.

#### 2. Change lookup methods to use modified R.ancestors

Here is a schematic description of the new algorithm of lookup(s):

```ruby
func lookup (module, name, declarationContext): Result {
    ancestors = C.ancestors() # we still iterate by C ancestors
    for (ancestor: ancestors) { # first is C
        # was: method = ancestor.getMethod("bar") # => the "bar" from C.methods
        refinements = # as the first step we try to find activaed refinements
                               # for the ancestor using declarationContext
        if (refinements != null) { 
            for (refinement: refinements) {
                # recursive lookup where the module will be R
                method = lookup(refinement, name, null) 
                if (method.isDefined()) {
                    return method
                }
            }
        } {
            # there are no activated refinements or declarationContext is null
            # just search in ancestor fields as we did before
            method = ancestor.getFields(name);
            if (method != null) { ... }
        }
    }
}
```

I think that the idea is clear, but if you need the examples, fill free to ping me.

#### 3. Remove InternalMethod attributes related to refinements

Since we don't use the concept of "refined" methods in `C`, we can remove all code related to this and simplify existing lookups (see `lookupSuperMethod`).

## Formal TODO list

- [x] Change R.ancestors to be like CRuby
- [x] Rewrite `lookupMethodCached`
- [x] Rewrite `lookupMethodUncached`
- [x] Rewrite `lookupSuperMethod`
   - [x] Existing tests work
   - [x] ~Handle case when `super` can use the top method from other namespaces. I made such a conclusion from the specification, and I have a local example that works with CRuby and does not work with TruffleRuby. See `//TODO` in the changes.~ (Moved to https://github.com/oracle/truffleruby/issues/2036)
- [x] `AddMethodNode` does not add "refined" methods to C
- [x] Remove `InternalMethod#refined`, `InternalMethod#originalMethod` and all related code
- [x] Check `assumptions` in modified methods
- [x] Verify `isRefinedProfile` changes. See comment below
- [x] Refactor `refine_spec.rb` suites; Delete temporary test
- [x] Update `doc/contributor/refinements.md`. Should we delete this document? It seems that if we meet the specifications, then a separate document inside the TruffleRuby is not needed.
- [x] Benchmarks. Should we prove that there is no performance degradation with new lookups? In my mind, 99% of Ruby code has no global activated refinements (`declarationContext.refinements == null`), and new methods should not affect it. But lookup(s) is one of the hottest methods, so I prefer formal tests :) Maybe we already have some benchmarks? 

## The status
```
$ jt test fast
```
<img width="748" alt="Screenshot 2020-06-11 at 15 00 43" src="https://user-images.githubusercontent.com/2331796/84384451-ab273780-abf6-11ea-8e23-8c0b510bd26f.png">

If you can run this PR on Oracle CI, please do it.

I hope this is not too verbose :) Feel free to any comments!

//cc @eregon