### PR TITLE
Build with 2.3

### DIFF
--- a/doc/contributor/workflow.md
+++ b/doc/contributor/workflow.md
@@ -9,7 +9,7 @@ they might need to add `export SDKROOT=$(xcrun --show-sdk-path)` to their shell 
 
 Additionally, you will need:
 
-* Ruby >= 2.4
+* Ruby >= 2.3 (we stick at this version as it is available all the way back to for example Ubuntu 16.04)
 * [CMake](https://cmake.org/), for building Sulong (GraalVM's LLVM support)
   CMake can be installed via the usual methods: `dnf`, `apt-get`, `brew`, ...)
 

--- a/tool/generate-core-symbols.rb
+++ b/tool/generate-core-symbols.rb
@@ -104,7 +104,7 @@ public class CoreSymbols {
 <% ids[:token_op].uniq {|_, op| op}.each do |id, op, token| %><% if token %>
     public static final RubySymbol <%=token%> = createRubySymbol("<%=op%>", <%=index%>);<% index += 1 %><% end %><% end %>
 <% ids[:preserved].each do |token| %><% if ids[:predefined][token] %>
-    public static final RubySymbol <%=token.start_with?('_') ? token[1..].upcase : token.upcase%> = createRubySymbol("<%=token == 'NULL' ?  '' : ids[:predefined][token]%>", <%=index%>);<% index += 1 %><% else %>
+    public static final RubySymbol <%=token.start_with?('_') ? token[1..-1].upcase : token.upcase%> = createRubySymbol("<%=token == 'NULL' ?  '' : ids[:predefined][token]%>", <%=index%>);<% index += 1 %><% else %>
     // Skipped preserved token: `<%=token%>`<% index += 1 %><% end %><% end %>
     public static final int LAST_OP_ID = <%=index-1%>;
 <% types.each do |type| %><% tokens = ids[type] %><% tokens.each do |token| %>


### PR DESCRIPTION
Build with Ruby 2.3, because that's available on for example Ubuntu 16.04. I think it's a good goal to be able to keep building on this distribution without any custom packages.

https://github.com/Shopify/truffleruby/issues/1