### PR TITLE
Pass activated ancestors refinements for super lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@ Compatibility:
 * Implemented `Digest::Instance#new` (#2040).
 * Implemented `ONIGENC_MBC_CASE_FOLD`.
 * Fixed `Thread#raise` to call the exception class' constructor with no arguments when given no message (#2045).
-* Fixed `refine + super` compatibility (#2039, @ssnickolay)
+* Fixed `refine + super` compatibility (#2039, #2048, @ssnickolay)
 
 Performance:
 

--- a/spec/ruby/core/module/refine_spec.rb
+++ b/spec/ruby/core/module/refine_spec.rb
@@ -736,7 +736,7 @@ describe "Module#refine" do
 
       a = Module.new do
         def foo
-           [:A] + super
+          [:A] + super
         end
       end
 
@@ -751,6 +751,32 @@ describe "Module#refine" do
         using refinement
 
         result = refined_class.new.foo
+      end
+
+      result.should == [:A, :C]
+    end
+
+    it "looks in the refined ancestors from included module" do
+      refined_class = ModuleSpecs.build_refined_class(for_super: true)
+      subclass = Class.new(refined_class)
+
+      a = Module.new do
+        def foo
+          [:A] + super
+        end
+      end
+
+      refinement = Module.new do
+        refine refined_class do
+          include a
+        end
+      end
+
+      result = nil
+      Module.new do
+        using refinement
+
+        result = subclass.new.foo
       end
 
       result.should == [:A, :C]

--- a/src/main/java/org/truffleruby/cext/CExtNodes.java
+++ b/src/main/java/org/truffleruby/cext/CExtNodes.java
@@ -877,9 +877,8 @@ public class CExtNodes {
             final InternalMethod callingMethod = RubyArguments.getMethod(callingMethodFrame);
             final Object callingSelf = RubyArguments.getSelf(callingMethodFrame);
             final DynamicObject callingMetaclass = metaClassNode.executeMetaClass(callingSelf);
-            final DeclarationContext declarationContext = RubyArguments.getDeclarationContext(frame);
             final MethodLookupResult superMethodLookup = ModuleOperations
-                    .lookupSuperMethod(callingMethod, callingMetaclass, declarationContext);
+                    .lookupSuperMethod(callingMethod, callingMetaclass);
             final InternalMethod superMethod = superMethodLookup.getMethod();
             return callSuperMethodNode.executeCallSuperMethod(frame, callingSelf, superMethod, args, null);
         }

--- a/src/main/java/org/truffleruby/core/array/ArrayUtils.java
+++ b/src/main/java/org/truffleruby/core/array/ArrayUtils.java
@@ -100,8 +100,8 @@ public abstract class ArrayUtils {
     }
 
     public static boolean contains(int[] array, int value) {
-        for (int n = 0; n < array.length; n++) {
-            if (array[n] == value) {
+        for (int element : array) {
+            if (element == value) {
                 return true;
             }
         }
@@ -109,9 +109,10 @@ public abstract class ArrayUtils {
         return false;
     }
 
+    /** Compares by identity using Java {@code ==} */
     public static <T> boolean contains(T[] array, T value) {
-        for (int n = 0; n < array.length; n++) {
-            if (array[n] == value) {
+        for (T element : array) {
+            if (element == value) {
                 return true;
             }
         }

--- a/src/main/java/org/truffleruby/core/method/MethodNodes.java
+++ b/src/main/java/org/truffleruby/core/method/MethodNodes.java
@@ -206,7 +206,7 @@ public abstract class MethodNodes {
             Object receiver = Layouts.METHOD.getReceiver(method);
             InternalMethod internalMethod = Layouts.METHOD.getMethod(method);
             DynamicObject selfMetaClass = metaClassNode.executeMetaClass(receiver);
-            MethodLookupResult superMethod = ModuleOperations.lookupSuperMethod(internalMethod, selfMetaClass, null);
+            MethodLookupResult superMethod = ModuleOperations.lookupSuperMethod(internalMethod, selfMetaClass);
             if (!superMethod.isDefined()) {
                 return nil;
             } else {

--- a/src/main/java/org/truffleruby/core/method/UnboundMethodNodes.java
+++ b/src/main/java/org/truffleruby/core/method/UnboundMethodNodes.java
@@ -203,7 +203,7 @@ public abstract class UnboundMethodNodes {
         protected Object superMethod(DynamicObject unboundMethod) {
             InternalMethod internalMethod = Layouts.UNBOUND_METHOD.getMethod(unboundMethod);
             DynamicObject origin = Layouts.UNBOUND_METHOD.getOrigin(unboundMethod);
-            MethodLookupResult superMethod = ModuleOperations.lookupSuperMethod(internalMethod, origin, null);
+            MethodLookupResult superMethod = ModuleOperations.lookupSuperMethod(internalMethod, origin);
             if (!superMethod.isDefined()) {
                 return nil;
             } else {

--- a/src/main/java/org/truffleruby/core/module/ModuleOperations.java
+++ b/src/main/java/org/truffleruby/core/module/ModuleOperations.java
@@ -10,6 +10,7 @@
 package org.truffleruby.core.module;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -608,7 +609,7 @@ public abstract class ModuleOperations {
         System.arraycopy(callerRefinements, 0, array, 0, callerRefinements.length);
         System.arraycopy(lexicalRefinements, 0, array, callerRefinements.length, lexicalRefinements.length);
 
-        return array;
+        return Arrays.stream(array).distinct().toArray(DynamicObject[]::new);
     }
 
     private static DynamicObject[] getRefinementsFor(DeclarationContext declarationContext, DynamicObject module) {

--- a/src/main/java/org/truffleruby/core/module/ModuleOperations.java
+++ b/src/main/java/org/truffleruby/core/module/ModuleOperations.java
@@ -577,9 +577,6 @@ public abstract class ModuleOperations {
 
     private static InternalMethod rememberUsedRefinements(InternalMethod method,
             DeclarationContext declarationContext) {
-        if (declarationContext == null) {
-            return method;
-        }
         return method.withActiveRefinements(declarationContext);
     }
 
@@ -591,7 +588,7 @@ public abstract class ModuleOperations {
                 declarationContext.getRefinements());
         currentRefinements.put(ancestor, refinements);
 
-        return rememberUsedRefinements(method, declarationContext.withRefinements(currentRefinements));
+        return method.withActiveRefinements(declarationContext.withRefinements(currentRefinements));
     }
 
     private static DynamicObject[] getRefinementsFor(DeclarationContext declarationContext,

--- a/src/main/java/org/truffleruby/language/methods/InternalMethod.java
+++ b/src/main/java/org/truffleruby/language/methods/InternalMethod.java
@@ -248,8 +248,6 @@ public class InternalMethod implements ObjectGraphNode {
     }
 
     public InternalMethod withActiveRefinements(DeclarationContext context) {
-        assert context != null;
-
         if (context == activeRefinements) {
             return this;
         } else {

--- a/src/main/java/org/truffleruby/language/methods/InternalMethod.java
+++ b/src/main/java/org/truffleruby/language/methods/InternalMethod.java
@@ -113,7 +113,7 @@ public class InternalMethod implements ObjectGraphNode {
                 undefined,
                 false,
                 !context.getCoreLibrary().isLoaded(),
-                DeclarationContext.NONE,
+                null,
                 proc,
                 callTarget,
                 capturedBlock);
@@ -248,6 +248,8 @@ public class InternalMethod implements ObjectGraphNode {
     }
 
     public InternalMethod withActiveRefinements(DeclarationContext context) {
+        assert context != null;
+
         if (context == activeRefinements) {
             return this;
         } else {

--- a/src/main/java/org/truffleruby/language/methods/UsingNode.java
+++ b/src/main/java/org/truffleruby/language/methods/UsingNode.java
@@ -70,7 +70,7 @@ public abstract class UsingNode extends RubyContextNode {
         return newRefinements;
     }
 
-    public static void applyRefinements(DynamicObject refinedModule, DynamicObject refinementModule,
+    private static void applyRefinements(DynamicObject refinedModule, DynamicObject refinementModule,
             Map<DynamicObject, DynamicObject[]> newRefinements) {
         final DynamicObject[] refinements = newRefinements.get(refinedModule);
         if (refinements == null) {

--- a/src/main/java/org/truffleruby/language/supercall/LookupSuperMethodNode.java
+++ b/src/main/java/org/truffleruby/language/supercall/LookupSuperMethodNode.java
@@ -68,14 +68,10 @@ public abstract class LookupSuperMethodNode extends RubyContextNode {
     }
 
     @TruffleBoundary
-    protected MethodLookupResult doLookup(InternalMethod currentMethod,
-            DynamicObject selfMetaClass) {
+    protected MethodLookupResult doLookup(InternalMethod currentMethod, DynamicObject selfMetaClass) {
         assert RubyGuards.isRubyClass(selfMetaClass);
 
-        MethodLookupResult superMethod = ModuleOperations
-                .lookupSuperMethod(
-                        currentMethod,
-                        selfMetaClass);
+        MethodLookupResult superMethod = ModuleOperations.lookupSuperMethod(currentMethod, selfMetaClass);
         // TODO (eregon, 12 June 2015): Is this correct?
         if (!superMethod.isDefined()) {
             return superMethod.withNoMethod();

--- a/src/main/java/org/truffleruby/language/supercall/LookupSuperMethodNode.java
+++ b/src/main/java/org/truffleruby/language/supercall/LookupSuperMethodNode.java
@@ -14,9 +14,7 @@ import org.truffleruby.core.module.ModuleOperations;
 import org.truffleruby.language.RubyContextNode;
 import org.truffleruby.language.RubyGuards;
 import org.truffleruby.language.arguments.RubyArguments;
-import org.truffleruby.language.methods.DeclarationContext;
 import org.truffleruby.language.methods.InternalMethod;
-import org.truffleruby.language.methods.UsingNode;
 import org.truffleruby.language.objects.MetaClassNode;
 
 import com.oracle.truffle.api.CompilerDirectives;
@@ -25,9 +23,6 @@ import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.object.DynamicObject;
-
-import java.util.HashMap;
-import java.util.Map;
 
 /** Caches {@link ModuleOperations#lookupSuperMethod} on an actual instance. */
 public abstract class LookupSuperMethodNode extends RubyContextNode {
@@ -80,8 +75,7 @@ public abstract class LookupSuperMethodNode extends RubyContextNode {
         MethodLookupResult superMethod = ModuleOperations
                 .lookupSuperMethod(
                         currentMethod,
-                        selfMetaClass,
-                        getDeclarationContext(currentMethod, selfMetaClass));
+                        selfMetaClass);
         // TODO (eregon, 12 June 2015): Is this correct?
         if (!superMethod.isDefined()) {
             return superMethod.withNoMethod();
@@ -91,31 +85,5 @@ public abstract class LookupSuperMethodNode extends RubyContextNode {
 
     protected int getCacheLimit() {
         return getContext().getOptions().METHOD_LOOKUP_CACHE;
-    }
-
-    private DeclarationContext getDeclarationContext(InternalMethod currentMethod,
-            DynamicObject selfMetaClass) {
-        final DeclarationContext context = currentMethod.getDeclarationContext();
-        final DeclarationContext callerContext = currentMethod.getActiveRefinements();
-
-        if (callerContext != null) {
-            // super from the refined method has access to the parent's active refinements for the selfMetaClass
-            final DynamicObject[] activeRefinements = callerContext.getRefinementsFor(selfMetaClass);
-
-            if (activeRefinements == null) {
-                return context;
-            } else {
-                final Map<DynamicObject, DynamicObject[]> newRefinements = new HashMap<>(context.getRefinements());
-
-                // add class refinements in reverse order to keep the original positions
-                for (int i = activeRefinements.length - 1; i >= 0; i--) {
-                    UsingNode.applyRefinements(selfMetaClass, activeRefinements[i], newRefinements);
-                }
-
-                return context.withRefinements(newRefinements);
-            }
-        } else {
-            return context;
-        }
     }
 }


### PR DESCRIPTION
Inspired by https://github.com/palkan/ruby-compatibility-examples/blob/d36eae2d2ed3a76dd86172b28254e2be0b3ed56c/examples/refine_include_super.rb

When a method is called from `Kernel` we actually not execute `Kernel.foo`, but do it on new class based on Kernel (`objectMetaClass #<Class:#<Module:0x28>>`). In this case refinements are activated for `Kernel` do not work.
To fix it we need to go over `objectMetaClass` ancestors and take all proper refinements.