### PR TITLE
Ruby 2.6: String#split with block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Compatibility:
 
 * Run `at_exit` handlers even if parsing the main script fails (#2047).
 * Load required libraries (`-r`) before parsing the main script (#2047).
+* `String#split` supports block (#2052, @ssnickolay)
 
 Performance:
 

--- a/spec/ruby/core/string/split_spec.rb
+++ b/spec/ruby/core/string/split_spec.rb
@@ -427,7 +427,7 @@ describe "String#split with Regexp" do
 
   ruby_version_is "2.6" do
     context "when a block is given" do
-      it "yields each split substrings with default pattern" do
+      it "yields each split substring with default pattern" do
         a = []
         returned_object = "chunky bacon".split { |str| a << str.capitalize }
 
@@ -443,7 +443,7 @@ describe "String#split with Regexp" do
         a.should == %w(C H U N K Y)
       end
 
-      it "yields each split substrings with a pattern" do
+      it "yields each split substring with a pattern" do
         a = []
         returned_object = "chunky-bacon".split("-", 0) { |str| a << str.capitalize }
 
@@ -451,7 +451,7 @@ describe "String#split with Regexp" do
         a.should == ["Chunky", "Bacon"]
       end
 
-      it "yields each split substrings with empty regexp pattern" do
+      it "yields each split substring with empty regexp pattern" do
         a = []
         returned_object = "chunky".split(//) { |str| a << str.capitalize }
 
@@ -459,7 +459,7 @@ describe "String#split with Regexp" do
         a.should == %w(C H U N K Y)
       end
 
-      it "yields each split substrings with empty regexp pattern and limit" do
+      it "yields each split substring with empty regexp pattern and limit" do
         a = []
         returned_object = "chunky".split(//, 3) { |str| a << str.capitalize }
 
@@ -467,7 +467,7 @@ describe "String#split with Regexp" do
         a.should == %w(C H Unky)
       end
 
-      it "yields each split substrings with a regexp pattern" do
+      it "yields each split substring with a regexp pattern" do
         a = []
         returned_object = "chunky:bacon".split(/:/) { |str| a << str.capitalize }
 

--- a/spec/ruby/core/string/split_spec.rb
+++ b/spec/ruby/core/string/split_spec.rb
@@ -435,6 +435,14 @@ describe "String#split with Regexp" do
         a.should == ["Chunky", "Bacon"]
       end
 
+      it "yields the string when limit is 1" do
+        a = []
+        returned_object = "chunky bacon".split("", 1) { |str| a << str.capitalize }
+
+        returned_object.should == "chunky bacon"
+        a.should == ["Chunky bacon"]
+      end
+
       it "yields each split letter" do
         a = []
         returned_object = "chunky".split("", 0) { |str| a << str.capitalize }

--- a/spec/ruby/core/string/split_spec.rb
+++ b/spec/ruby/core/string/split_spec.rb
@@ -426,12 +426,62 @@ describe "String#split with Regexp" do
   end
 
   ruby_version_is "2.6" do
-    it "yields each split substrings if a block is given" do
-      a = []
-      returned_object = "chunky bacon".split(" ") { |str| a << str.capitalize }
+    context "when a block is given" do
+      it "yields each split substrings with default pattern" do
+        a = []
+        returned_object = "chunky bacon".split { |str| a << str.capitalize }
 
-      returned_object.should == "chunky bacon"
-      a.should == ["Chunky", "Bacon"]
+        returned_object.should == "chunky bacon"
+        a.should == ["Chunky", "Bacon"]
+      end
+
+      it "yields each split letter" do
+        a = []
+        returned_object = "chunky".split("", 0) { |str| a << str.capitalize }
+
+        returned_object.should == "chunky"
+        a.should == %w(C H U N K Y)
+      end
+
+      it "yields each split substrings with a pattern" do
+        a = []
+        returned_object = "chunky-bacon".split("-", 0) { |str| a << str.capitalize }
+
+        returned_object.should == "chunky-bacon"
+        a.should == ["Chunky", "Bacon"]
+      end
+
+      it "yields each split substrings with empty regexp pattern" do
+        a = []
+        returned_object = "chunky".split(//) { |str| a << str.capitalize }
+
+        returned_object.should == "chunky"
+        a.should == %w(C H U N K Y)
+      end
+
+      it "yields each split substrings with empty regexp pattern and limit" do
+        a = []
+        returned_object = "chunky".split(//, 3) { |str| a << str.capitalize }
+
+        returned_object.should == "chunky"
+        a.should == %w(C H Unky)
+      end
+
+      it "yields each split substrings with a regexp pattern" do
+        a = []
+        returned_object = "chunky:bacon".split(/:/) { |str| a << str.capitalize }
+
+        returned_object.should == "chunky:bacon"
+        a.should == ["Chunky", "Bacon"]
+      end
+
+      it "returns a string as is (and doesn't call block) if it is empty" do
+        a = []
+        returned_object = "".split { |str| a << str.capitalize }
+
+        returned_object.should == ""
+        a.should == []
+      end
     end
 
     describe "for a String subclass" do

--- a/spec/tags/core/string/split_tags.txt
+++ b/spec/tags/core/string/split_tags.txt
@@ -1,2 +1,0 @@
-fails:String#split with Regexp yields each split substrings if a block is given
-fails:String#split with Regexp for a String subclass yields instances of the same subclass

--- a/spec/tags/truffle/methods_tags.txt
+++ b/spec/tags/truffle/methods_tags.txt
@@ -76,8 +76,6 @@ fails:Public methods on Proc should not include ruby_method=
 fails:Public methods on Proc should include hash
 fails:Public methods on MatchData should not include byte_begin
 fails:Public methods on MatchData should not include byte_end
-fails:Public methods on MatchData should not include collapsing?
-fails:Public methods on MatchData should not include pre_match_from
 fails:Public methods on MatchData should include hash
 fails:Public methods on Method should include clone
 fails:Public methods on Method should include original_name

--- a/src/main/ruby/truffleruby/core/regexp.rb
+++ b/src/main/ruby/truffleruby/core/regexp.rb
@@ -324,13 +324,6 @@ class MatchData
     names.collect { |name| [name, self[name]] }.to_h
   end
 
-  def pre_match_from(idx)
-    source = Primitive.match_data_get_source(self)
-    return source.byteslice(0, 0) if self.byte_begin(0) == 0
-    nd = self.byte_begin(0) - 1
-    source.byteslice(idx, nd-idx+1)
-  end
-
   def begin(index)
     backref = if String === index || Symbol === index
                 names_to_backref = Hash[Primitive.regexp_names(self.regexp)]
@@ -353,10 +346,6 @@ class MatchData
 
 
     Primitive.match_data_end(self, backref)
-  end
-
-  def collapsing?
-    self.byte_begin(0) == self.byte_end(0)
   end
 
   def inspect

--- a/src/main/ruby/truffleruby/core/splitter.rb
+++ b/src/main/ruby/truffleruby/core/splitter.rb
@@ -41,7 +41,7 @@ module Truffle
     class << self
       def split(string, pattern, limit, &block)
         # Odd edge case
-        return result(string, [], &block) if string.empty?
+        return (block ? string : []) if string.empty?
 
         if Primitive.undefined?(limit)
           limit = 0
@@ -53,7 +53,7 @@ module Truffle
           dup_string = string.dup
 
           ret = add_or_call([], dup_string, &block)
-          return result(dup_string, ret, &block)
+          return block ? dup_string : ret
         end
 
         pattern ||= ($; || DEFAULT_PATTERN)
@@ -102,7 +102,7 @@ module Truffle
         if limit > 0
           last = string.size > (limit - 1) ? string[(limit - 1)..-1] : empty_string(string)
 
-          if block_given?
+          if block
             string.each_char.each_with_index do |char, index|
               break if index == limit - 1
               block.call(char)
@@ -115,7 +115,7 @@ module Truffle
             string.chars.take(limit - 1) << last
           end
         else
-          if block_given?
+          if block
             string.each_char(&block)
 
             block.call(empty_string(string)) if tail_empty?(limit)
@@ -158,7 +158,7 @@ module Truffle
           add_empty(string, ret, empty_count, &block)
         end
 
-        result(string, ret, &block)
+        block ? string : ret
       end
 
       def split_type_regexp(string, pattern, limit, &block)
@@ -171,7 +171,7 @@ module Truffle
         last_match = nil
         last_match_end = 0
 
-        while match = Truffle::RegexpOperations.match(pattern, string, start)
+        while match = Truffle::RegexpOperations.match_from(pattern, string, start)
           break if limited && limit - count <= 1
 
           collapsed = Truffle::RegexpOperations.collapsing?(match)
@@ -209,7 +209,7 @@ module Truffle
           add_empty(string, ret, empty_count, &block)
         end
 
-        result(string, ret, &block)
+        block ? string : ret
       end
 
 
@@ -228,7 +228,7 @@ module Truffle
       end
 
       def add_or_call(array, element, &block)
-        if block_given?
+        if block
           block.call(element)
         else
           array << element
@@ -242,12 +242,6 @@ module Truffle
 
       def tail_empty?(limit)
         limit != 0
-      end
-
-      def result(string, res, &block)
-        return string if block_given?
-
-        res
       end
     end
   end

--- a/src/main/ruby/truffleruby/core/splitter.rb
+++ b/src/main/ruby/truffleruby/core/splitter.rb
@@ -77,7 +77,7 @@ module Truffle
         elsif pattern.kind_of?(Regexp)
           # Handle SPLIT_TYPE_REGEXP below
         else
-          pattern = StringValue(pattern) unless pattern.kind_of?(String)
+          pattern = StringValue(pattern)
 
           valid_encoding?(string)
           valid_encoding?(pattern)

--- a/src/main/ruby/truffleruby/core/string.rb
+++ b/src/main/ruby/truffleruby/core/string.rb
@@ -252,7 +252,7 @@ class String
     while match = pattern.match_from(self, index)
       fin = match.byte_end(0)
 
-      if match.collapsing?
+      if Truffle::RegexpOperations.collapsing?(match)
         if char = Primitive.string_find_character(self, fin)
           index = fin + char.bytesize
         else

--- a/src/main/ruby/truffleruby/core/string.rb
+++ b/src/main/ruby/truffleruby/core/string.rb
@@ -278,8 +278,8 @@ class String
     ret
   end
 
-  def split(pattern=nil, limit=undefined)
-    Truffle::Splitter.split(self, pattern, limit)
+  def split(pattern=nil, limit=undefined, &block)
+    Truffle::Splitter.split(self, pattern, limit, &block)
   end
 
   def squeeze(*strings)

--- a/src/main/ruby/truffleruby/core/truffle/regexp_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/regexp_operations.rb
@@ -42,5 +42,17 @@ module Truffle
     def self.match_stats
       Hash[*match_stats_array]
     end
+
+    def self.collapsing?(match)
+      match.byte_begin(0) == match.byte_end(0)
+    end
+
+    def self.pre_match_from(match, idx)
+      source = Primitive.match_data_get_source(match)
+      return source.byteslice(0, 0) if match.byte_begin(0) == 0
+
+      nd = match.byte_begin(0) - 1
+      source.byteslice(idx, nd-idx+1)
+    end
   end
 end

--- a/src/main/ruby/truffleruby/core/truffle/regexp_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/regexp_operations.rb
@@ -21,6 +21,12 @@ module Truffle
       re.search_region(str, pos, str.bytesize, true)
     end
 
+    def self.match_from(re, str, pos)
+      return nil unless str
+
+      re.search_region(str, pos, str.bytesize, true)
+    end
+
     def self.last_match(a_binding)
       Truffle::KernelOperations.frame_local_variable_get(:'$~', a_binding)
     end

--- a/src/main/ruby/truffleruby/core/truffle/string_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/string_operations.rb
@@ -89,7 +89,7 @@ module Truffle
       while match
         offset = match.byte_begin(0)
 
-        str = match.pre_match_from(last_end)
+        str = Truffle::RegexpOperations.pre_match_from(match, last_end)
         Primitive.string_append(ret, str) if str
 
         val = yield ret, match
@@ -98,7 +98,7 @@ module Truffle
         tainted ||= val.tainted?
         Primitive.string_append(ret, val)
 
-        if match.collapsing?
+        if Truffle::RegexpOperations.collapsing?(match)
           if (char = Primitive.string_find_character(orig, offset))
             offset += char.bytesize
           else


### PR DESCRIPTION
Closes #2050 

I had to change almost all `Splitter` to not create array when block is passed. Inspired by MRI implementation: https://github.com/ruby/ruby/blob/1020e120e060c00eca456d5a129c344daa472407/string.c#L7933-L7963

