### PR TITLE
Considers an autoload constant as loaded when autoload is called for/from the current file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Compatibility:
 * Update `Range#cover?` to handle `Range` parameter.
 * Fix `String#{casecmp, casecmp?}` parameter conversion.
 * Fix `Regexp` issue which raised syntax error instead of `RegexpError` (#2066).
+* Handle `Object#autoload` when autoload itself (#1616, @ssnickolay)
 
 Performance:
 

--- a/spec/ruby/core/module/autoload_spec.rb
+++ b/spec/ruby/core/module/autoload_spec.rb
@@ -210,6 +210,13 @@ describe "Module#autoload" do
     ModuleSpecs::Autoload.use_ex1.should == :good
   end
 
+  it "considers an autoload constant as loaded when autoload is called for/from the current file" do
+    filename = fixture(__FILE__, "autoload_during_require_current_file.rb")
+    require filename
+
+    ScratchPad.recorded.should be_nil
+  end
+
   describe "interacting with defined?" do
     it "does not load the file when referring to the constant in defined?" do
       module ModuleSpecs::Autoload::Dog

--- a/spec/ruby/core/module/fixtures/autoload_during_require_current_file.rb
+++ b/spec/ruby/core/module/fixtures/autoload_during_require_current_file.rb
@@ -1,0 +1,5 @@
+module ModuleSpecs::Autoload
+  autoload(:AutoloadCurrentFile, __FILE__)
+
+  ScratchPad.record autoload?(:AutoloadCurrentFile)
+end

--- a/src/main/java/org/truffleruby/core/module/ModuleFields.java
+++ b/src/main/java/org/truffleruby/core/module/ModuleFields.java
@@ -334,7 +334,7 @@ public class ModuleFields extends ModuleChain implements ObjectGraphNode {
         final ReentrantLock lock = fileLocks.get(filename.toString());
         if (lock.isLocked()) {
             // We need to handle the new autoload constant immediately
-            // if Object.autolaod(name, filename) is executed from filename.rb
+            // if Object.autoload(name, filename) is executed from filename.rb
             GetConstantNode.autoloadConstantStart(autoloadConstant);
         }
 

--- a/src/main/java/org/truffleruby/core/module/ModuleFields.java
+++ b/src/main/java/org/truffleruby/core/module/ModuleFields.java
@@ -19,6 +19,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.truffleruby.RubyContext;
 import org.truffleruby.RubyLanguage;
@@ -32,8 +33,10 @@ import org.truffleruby.core.symbol.RubySymbol;
 import org.truffleruby.language.RubyConstant;
 import org.truffleruby.language.RubyDynamicObject;
 import org.truffleruby.language.RubyGuards;
+import org.truffleruby.language.constants.GetConstantNode;
 import org.truffleruby.language.control.RaiseException;
 import org.truffleruby.language.library.RubyLibrary;
+import org.truffleruby.language.loader.ReentrantLockFreeingMap;
 import org.truffleruby.language.methods.InternalMethod;
 import org.truffleruby.language.objects.ObjectGraph;
 import org.truffleruby.language.objects.ObjectGraphNode;
@@ -327,6 +330,14 @@ public class ModuleFields extends ModuleChain implements ObjectGraphNode {
                     autoloadConstant,
                     filename));
         }
+        final ReentrantLockFreeingMap<String> fileLocks = getContext().getFeatureLoader().getFileLocks();
+        final ReentrantLock lock = fileLocks.get(filename.toString());
+        if (lock.isLocked()) {
+            // We need to handle the new autoload constant immediately
+            // if Object.autolaod(name, filename) is executed from filename.rb
+            GetConstantNode.autoloadConstantStart(autoloadConstant);
+        }
+
         context.getFeatureLoader().addAutoload(autoloadConstant);
     }
 

--- a/src/main/java/org/truffleruby/language/constants/GetConstantNode.java
+++ b/src/main/java/org/truffleruby/language/constants/GetConstantNode.java
@@ -139,10 +139,10 @@ public abstract class GetConstantNode extends RubyContextNode {
 
     /** Subset of {@link #autoloadResolveConstant} which does not try to resolve the constant. */
     @TruffleBoundary
-    public static void autoloadUndefineConstantIfStillAutoload(RubyConstant autoloadConstant) {
+    public static boolean autoloadUndefineConstantIfStillAutoload(RubyConstant autoloadConstant) {
         final RubyModule autoloadConstantModule = autoloadConstant.getDeclaringModule();
         final ModuleFields fields = autoloadConstantModule.fields;
-        fields.undefineConstantIfStillAutoload(autoloadConstant);
+        return fields.undefineConstantIfStillAutoload(autoloadConstant);
     }
 
     @TruffleBoundary

--- a/src/main/java/org/truffleruby/language/constants/GetConstantNode.java
+++ b/src/main/java/org/truffleruby/language/constants/GetConstantNode.java
@@ -27,6 +27,7 @@ import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.profiles.ConditionProfile;
+import com.oracle.truffle.api.source.SourceSection;
 
 public abstract class GetConstantNode extends RubyContextNode {
 
@@ -146,6 +147,19 @@ public abstract class GetConstantNode extends RubyContextNode {
     }
 
     @TruffleBoundary
+    public static void logAutoloadResult(RubyContext context, RubyConstant constant, boolean undefined) {
+        if (context.getOptions().LOG_AUTOLOAD) {
+            final SourceSection section = context.getCallStack().getTopMostUserSourceSection();
+            final String message = RubyContext.fileLine(section) + ": " + constant + " " +
+                    (undefined
+                            ? "was marked as undefined as it was not assigned in "
+                            : "was successfully autoloaded from ") +
+                    constant.getAutoloadConstant().getAutoloadPath();
+            RubyLanguage.LOGGER.info(message);
+        }
+    }
+
+    @TruffleBoundary
     public Object autoloadResolveConstant(LexicalScope lexicalScope, RubyModule module, String name,
             RubyConstant autoloadConstant, LookupConstantInterface lookupConstantNode) {
         final RubyModule autoloadConstantModule = autoloadConstant.getDeclaringModule();
@@ -158,9 +172,11 @@ public abstract class GetConstantNode extends RubyContextNode {
                 (ModuleOperations.inAncestorsOf(resolvedConstant.getDeclaringModule(), autoloadConstantModule) ||
                         resolvedConstant.getDeclaringModule() == coreLibrary().objectClass)) {
             // all is good, just return that constant
+            logAutoloadResult(getContext(), autoloadConstant, false);
         } else {
             // If the autoload constant was not set in the ancestors, undefine the constant
-            fields.undefineConstantIfStillAutoload(autoloadConstant);
+            boolean undefined = fields.undefineConstantIfStillAutoload(autoloadConstant);
+            logAutoloadResult(getContext(), autoloadConstant, undefined);
 
             // redo lookup, to consider the undefined constant
             resolvedConstant = lookupConstantNode.lookupConstant(lexicalScope, module, name);

--- a/src/main/java/org/truffleruby/language/loader/FeatureLoader.java
+++ b/src/main/java/org/truffleruby/language/loader/FeatureLoader.java
@@ -12,6 +12,7 @@ package org.truffleruby.language.loader;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -124,12 +125,7 @@ public class FeatureLoader {
             final String expandedAutoloadPath = findFeature(entry.getKey());
 
             if (expandedPath.equals(expandedAutoloadPath)) {
-                for (RubyConstant constant : entry.getValue()) {
-                    // Do not autoload recursively from the #require call in GetConstantNode
-                    if (!constant.getAutoloadConstant().isAutoloading()) {
-                        constants.add(constant);
-                    }
-                }
+                constants.addAll(Arrays.asList(entry.getValue()));
             }
         }
 

--- a/src/main/java/org/truffleruby/language/loader/FeatureLoader.java
+++ b/src/main/java/org/truffleruby/language/loader/FeatureLoader.java
@@ -13,6 +13,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -108,7 +109,7 @@ public class FeatureLoader {
         try {
             final Map<String, List<RubyConstant>> constantsMap = registeredAutoloads.get(basename);
             if (constantsMap == null || constantsMap.isEmpty()) {
-                return null;
+                return Collections.emptyList();
             }
 
             // Deep-copy constantsMap so we can call findFeature() outside the lock
@@ -129,11 +130,7 @@ public class FeatureLoader {
             }
         }
 
-        if (constants.isEmpty()) {
-            return null;
-        } else {
-            return constants;
-        }
+        return constants;
     }
 
     public void removeAutoload(RubyConstant constant) {

--- a/src/main/java/org/truffleruby/language/loader/RequireNode.java
+++ b/src/main/java/org/truffleruby/language/loader/RequireNode.java
@@ -79,37 +79,60 @@ public abstract class RequireNode extends RubyContextNode {
         }
     }
 
+    /** During the require operation we need to load constants marked as autoloaded for the expandedPath (see
+     * {@link FeatureLoader#registeredAutoloads}) and mark them as started loading (via locks). After require we
+     * re-select autoload constants (because their list can be supplemented with constants that are loaded themselves
+     * (i.e. Object.autoload(:C, __FILE__))) and remove them from autoload registry. More details here:
+     * https://github.com/oracle/truffleruby/pull/2060#issuecomment-668627142 **/
     private boolean requireConsideringAutoload(String feature, String expandedPath, RubyString pathString) {
         final FeatureLoader featureLoader = getContext().getFeatureLoader();
         final List<RubyConstant> autoloadConstants = featureLoader.getAutoloadConstants(expandedPath);
-        if (autoloadConstants != null) {
-            if (getContext().getOptions().LOG_AUTOLOAD) {
-                String info = autoloadConstants
-                        .stream()
-                        .map(c -> c + " with " + c.getAutoloadConstant().getAutoloadPath())
-                        .collect(Collectors.joining(" and "));
-                RubyLanguage.LOGGER
-                        .info(() -> String.format(
-                                "%s: requiring %s which is registered as an autoload for %s",
-                                RubyContext.fileLine(getContext().getCallStack().getTopMostUserSourceSection()),
-                                feature,
-                                info));
-            }
+        try {
+            if (autoloadConstants != null) {
+                if (getContext().getOptions().LOG_AUTOLOAD) {
+                    String info = autoloadConstants
+                            .stream()
+                            .map(c -> c + " with " + c.getAutoloadConstant().getAutoloadPath())
+                            .collect(Collectors.joining(" and "));
+                    RubyLanguage.LOGGER
+                            .info(() -> String.format(
+                                    "%s: requiring %s which is registered as an autoload for %s",
+                                    RubyContext.fileLine(getContext().getCallStack().getTopMostUserSourceSection()),
+                                    feature,
+                                    info));
+                }
 
-            for (RubyConstant autoloadConstant : autoloadConstants) {
-                GetConstantNode.autoloadConstantStart(autoloadConstant);
-            }
-            try {
-                return doRequire(feature, expandedPath, pathString);
-            } finally {
                 for (RubyConstant autoloadConstant : autoloadConstants) {
-                    GetConstantNode.autoloadUndefineConstantIfStillAutoload(autoloadConstant);
-                    GetConstantNode.autoloadConstantStop(autoloadConstant);
-                    featureLoader.removeAutoload(autoloadConstant);
+                    GetConstantNode.autoloadConstantStart(autoloadConstant);
                 }
             }
-        } else {
+
             return doRequire(feature, expandedPath, pathString);
+        } finally {
+            final List<RubyConstant> releasedConstants = featureLoader.getAutoloadConstants(expandedPath);
+            if (releasedConstants != null) {
+                if (getContext().getOptions().LOG_AUTOLOAD) {
+                    String info = autoloadConstants
+                            .stream()
+                            .filter(c -> c.getAutoloadConstant().isAutoloading())
+                            .map(c -> c + " with " + c.getAutoloadConstant().getAutoloadPath())
+                            .collect(Collectors.joining(" and "));
+                    RubyLanguage.LOGGER
+                            .info(() -> String.format(
+                                    "%s: during requiring %s was successfully autoloaded %s",
+                                    RubyContext.fileLine(getContext().getCallStack().getTopMostUserSourceSection()),
+                                    feature,
+                                    info));
+                }
+
+                for (RubyConstant autoloadConstant : releasedConstants) {
+                    if (autoloadConstant.getAutoloadConstant().isAutoloading()) {
+                        GetConstantNode.autoloadUndefineConstantIfStillAutoload(autoloadConstant);
+                        GetConstantNode.autoloadConstantStop(autoloadConstant);
+                        featureLoader.removeAutoload(autoloadConstant);
+                    }
+                }
+            }
         }
     }
 

--- a/src/main/java/org/truffleruby/language/loader/RequireNode.java
+++ b/src/main/java/org/truffleruby/language/loader/RequireNode.java
@@ -128,15 +128,7 @@ public abstract class RequireNode extends RubyContextNode {
                 if (constant.getAutoloadConstant().isAutoloadingThread() && !alreadyAutoloading.contains(constant)) {
                     final boolean undefined = GetConstantNode
                             .autoloadUndefineConstantIfStillAutoload(constant);
-                    if (getContext().getOptions().LOG_AUTOLOAD) {
-                        final SourceSection section = getContext().getCallStack().getTopMostUserSourceSection();
-                        final String message = RubyContext.fileLine(section) + ": " + constant + " " +
-                                (undefined
-                                        ? "was marked as undefined as it was not assigned in "
-                                        : "was successfully autoloaded from ") +
-                                constant.getAutoloadConstant().getAutoloadPath();
-                        RubyLanguage.LOGGER.info(message);
-                    }
+                    GetConstantNode.logAutoloadResult(getContext(), constant, undefined);
                     GetConstantNode.autoloadConstantStop(constant);
                     featureLoader.removeAutoload(constant);
                 }

--- a/src/main/java/org/truffleruby/language/loader/RequireNode.java
+++ b/src/main/java/org/truffleruby/language/loader/RequireNode.java
@@ -102,7 +102,10 @@ public abstract class RequireNode extends RubyContextNode {
             }
 
             for (RubyConstant autoloadConstant : autoloadConstants) {
-                GetConstantNode.autoloadConstantStart(autoloadConstant);
+                // Do not autoload recursively from the #require call in GetConstantNode
+                if (!autoloadConstant.getAutoloadConstant().isAutoloading()) {
+                    GetConstantNode.autoloadConstantStart(autoloadConstant);
+                }
             }
         }
 


### PR DESCRIPTION
Related to #1616 (you could assign the issue on me, but I prefer not to close it until we get a green zeitwerk CI build with TruffleRuby `head`. I'll do a PR to zeitwerk when this PR will be merged)

The initial idea was not to add a constant to autoload if the autoload file is the same as the current feature (see the test). However, I debugged [MRI function](https://github.com/ruby/ruby/blob/d2bf6133f6f37279505ab8f9b1dcfc5a48b70345/variable.c#L1998) and didn't find the code associated with the current file. As far as I understand, this is part of the specification. We cannot ignore the autoload call, even if it is within the current file.

I continued searching and found a place executed when we call `#autoload?` after `autoload(:CONST, __FILE)`: https://github.com/ruby/ruby/blob/d2bf6133f6f37279505ab8f9b1dcfc5a48b70345/load.c#L481-L484

In TruffleRuby, we already have this logic in `#autoload?` and need to properly handle such kind of constants during the `#autoload` execution. The only thing that confuses me is how to process and remove these constants from `featureLoader`. I added (and disabled) the code that should handle this case (we wrap required file node with lock and remove logic), but it breaks some autoload specs (related to threads synchronization). Maybe I'm missing something ... 

**UPD**: I made another attempt with a fresh mind and it seems to be working as it should now (see the last commit)