### PR TITLE
Add instructions to add a manual GraalVM install to asdf

### DIFF
--- a/doc/user/installing-graalvm.md
+++ b/doc/user/installing-graalvm.md
@@ -32,6 +32,13 @@ Whichever edition you get you will get a tarball which you can extract. There
 will be a `bin` directory (`Contents/Home/bin` on macOS) which you can add to
 your `$PATH` if you want to.
 
+### Installing with asdf
+
+Using [asdf](https://github.com/asdf-vm/asdf) and
+[asdf-java](https://github.com/halcyon/asdf-java) installation is as easy as
+`asdf install java graalvm-20.1.0+java11` (look up versions via
+`asdf list-all java | grep graalvm`)
+
 ## Installing Ruby and Other Languages
 
 After installing GraalVM you then need to install the Ruby language into it.

--- a/doc/user/ruby-managers.md
+++ b/doc/user/ruby-managers.md
@@ -147,6 +147,17 @@ $ rvm use ext-truffleruby
 $ ruby --version
 ```
 
+### asdf (with asdf-ruby plugin)
+
+Adding Truffleruby to asdf functions much like `rbenv` or `chruby`, create a symbolic link in the `.installs/ruby` directory but you also need to reshim:
+
+```bash
+ln -s "$ruby_home" "$HOME/.asdf/installs/ruby/truffleruby"
+asdf reshim ruby truffleruby
+asdf local ruby truffleruby
+ruby --version
+```
+
 ## Using TruffleRuby without a Ruby Manager
 
 If you are using a Ruby manager like `rvm`, `rbenv`, or `chruby` and wish not to


### PR DESCRIPTION
Basic instructions that at least worked for me :+1: 

[asdf](https://github.com/asdf-vm/asdf) is a great version manager, [asdf-ruby](https://github.com/asdf-vm/asdf-ruby) uses ruby-build under the hood. 

Btw. getting GraalVM with it is as simple as `asdf install java graalvm-20.1.0+java11` - happy to add docs about this as well if wanted.

Thanks for your excellent work!