### PR TITLE
Fix String#encode with options issue

### DIFF
--- a/spec/ruby/core/string/encode_spec.rb
+++ b/spec/ruby/core/string/encode_spec.rb
@@ -19,13 +19,17 @@ describe "String#encode" do
     it "returns a copy when Encoding.default_internal is nil" do
       Encoding.default_internal = nil
       str = "あ"
-      str.encode.should_not equal(str)
+      encoded = str.encode
+      encoded.should_not equal(str)
+      encoded.should eql(str)
     end
 
     it "returns a copy for a ASCII-only String when Encoding.default_internal is nil" do
       Encoding.default_internal = nil
       str = "abc"
-      str.encode.should_not equal(str)
+      encoded = str.encode
+      encoded.should_not equal(str)
+      encoded.should eql(str)
     end
 
     it "encodes an ascii substring of a binary string to UTF-8" do
@@ -39,7 +43,9 @@ describe "String#encode" do
   describe "when passed to encoding" do
     it "returns a copy when passed the same encoding as the String" do
       str = "あ"
-      str.encode(Encoding::UTF_8).should_not equal(str)
+      encoded = str.encode(Encoding::UTF_8)
+      encoded.should_not equal(str)
+      encoded.should eql(str)
     end
 
     it "round trips a String" do
@@ -75,6 +81,7 @@ describe "String#encode" do
       encoded = str.encode("utf-8", "utf-8")
 
       encoded.should_not equal(str)
+      encoded.should eql(str.force_encoding("utf-8"))
       encoded.encoding.should == Encoding::UTF_8
     end
 
@@ -87,14 +94,28 @@ describe "String#encode" do
   describe "when passed to, options" do
     it "returns a copy when the destination encoding is the same as the String encoding" do
       str = "あ"
-      str.encode(Encoding::UTF_8, undef: :replace).should_not equal(str)
+      encoded = str.encode(Encoding::UTF_8, undef: :replace)
+      encoded.should_not equal(str)
+      encoded.should eql(str)
     end
   end
 
   describe "when passed to, from, options" do
     it "returns a copy when both encodings are the same" do
       str = "あ"
-      str.encode("utf-8", "utf-8", invalid: :replace).should_not equal(str)
+      encoded = str.encode("utf-8", "utf-8", invalid: :replace)
+      encoded.should_not equal(str)
+      encoded.should eql(str)
+    end
+
+    it "returns a copy in the destination encoding when both encodings are the same" do
+      str = "あ"
+      str.force_encoding("binary")
+      encoded = str.encode("utf-8", "utf-8", invalid: :replace)
+
+      encoded.should_not equal(str)
+      encoded.should eql(str.force_encoding("utf-8"))
+      encoded.encoding.should == Encoding::UTF_8
     end
   end
 end

--- a/src/main/ruby/truffleruby/core/string.rb
+++ b/src/main/ruby/truffleruby/core/string.rb
@@ -457,7 +457,7 @@ class String
         status = ec.primitive_convert self.dup, dest, nil, nil, ec.options
         raise ec.last_error unless status == :finished
         return replace(dest)
-      elsif options == 0
+      else
         force_encoding to_enc
       end
     end


### PR DESCRIPTION
Fixes and adds specs for https://github.com/oracle/truffleruby/issues/2091#issuecomment-689111429
which is the String#encode case where source == destination directory, with options.
(Also adds a check that values are expected in specs where copies should occur; but this check does not cause any new failures)

Example Code:

``` ruby
string = "Gl\xC3\xBCck".force_encoding(Encoding::ASCII_8BIT)
encoded = string.encode(Encoding.find('filesystem'), Encoding.default_external, invalid: :replace, undef: :replace)
p encoded
p encoded.encoding

```

MRI output
```
"Glück"
#<Encoding:UTF-8>
```

TruffleRuby output after fix
```
"Glück"
#<Encoding:UTF-8>
```

TruffleRuby output before fix
```
"Gl\xC3\xBCck"
#<Encoding:ASCII-8BIT> 
```
