### PR TITLE
Correct arity value for Proc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ Compatibility:
 * Verify that gem paths are correct before loading RubyGems (#2075).
 * Implement `rb_ivar_count`.
 * Implemented `rb_yield_values2`.
+* Fix arity for arguments with optional kwargs (#1669, @ssnickolay)
+* Fix arity for `Proc` (#2098, @ssnickolay)
 
 Performance:
 

--- a/spec/tags/core/proc/arity_tags.txt
+++ b/spec/tags/core/proc/arity_tags.txt
@@ -1,6 +1,0 @@
-fails:"Proc#arity for instances created with proc { || } returns zero for definition \n    @a = proc { |a=1| }\n    @b = proc { |a=1, b=2| }"
-fails:"Proc#arity for instances created with proc { || } returns zero for definition \n    @a = proc { |a: 1| }\n    @b = proc { |a: 1, b: 2| }"
-fails:"Proc#arity for instances created with proc { || } returns zero for definition \n    @a = proc { |**k, &l| }\n    @b = proc { |a: 1, b: 2, **k| }"
-fails:"Proc#arity for instances created with proc { || } returns zero for definition \n    @a = proc { |a=1, b: 2| }\n    @b = proc { |a=1, b: 2| }"
-fails:"Proc#arity for instances created with proc { || } returns positive values for definition \n    @a = proc { |a, b=1| }\n    @b = proc { |a, b, c=1, d=2| }"
-fails:"Proc#arity for instances created with proc { || } returns positive values for definition \n    @a = proc { |(a, (*b, c)), d=1| }\n    @b = proc { |a, (*b, c), d, (*e), (*), **k| }"

--- a/src/main/java/org/truffleruby/core/hash/HashNodes.java
+++ b/src/main/java/org/truffleruby/core/hash/HashNodes.java
@@ -501,7 +501,8 @@ public abstract class HashNodes {
 
         private Object yieldPair(RubyProc block, Object key, Object value) {
             // MRI behavior, see rb_hash_each_pair()
-            if (arityMoreThanOne.profile(block.getArityNumber() > 1)) {
+            // We use getMethodArityNumber() here since for non-lambda the semantics are the same for both branches
+            if (arityMoreThanOne.profile(block.sharedMethodInfo.getArity().getMethodArityNumber() > 1)) {
                 return yield(block, key, value);
             } else {
                 return yield(block, createArray(new Object[]{ key, value }));
@@ -722,7 +723,8 @@ public abstract class HashNodes {
 
         private Object yieldPair(RubyProc block, Object key, Object value) {
             // MRI behavior, see rb_hash_each_pair()
-            if (arityMoreThanOne.profile(block.getArityNumber() > 1)) {
+            // We use getMethodArityNumber() here since for non-lambda the semantics are the same for both branches
+            if (arityMoreThanOne.profile(block.sharedMethodInfo.getArity().getMethodArityNumber() > 1)) {
                 return yield(block, key, value);
             } else {
                 return yield(block, createArray(new Object[]{ key, value }));

--- a/src/main/java/org/truffleruby/core/hash/HashNodes.java
+++ b/src/main/java/org/truffleruby/core/hash/HashNodes.java
@@ -501,7 +501,7 @@ public abstract class HashNodes {
 
         private Object yieldPair(RubyProc block, Object key, Object value) {
             // MRI behavior, see rb_hash_each_pair()
-            if (arityMoreThanOne.profile(block.sharedMethodInfo.getArity().getArityNumber() > 1)) {
+            if (arityMoreThanOne.profile(block.getArityNumber() > 1)) {
                 return yield(block, key, value);
             } else {
                 return yield(block, createArray(new Object[]{ key, value }));
@@ -722,7 +722,7 @@ public abstract class HashNodes {
 
         private Object yieldPair(RubyProc block, Object key, Object value) {
             // MRI behavior, see rb_hash_each_pair()
-            if (arityMoreThanOne.profile(block.sharedMethodInfo.getArity().getArityNumber() > 1)) {
+            if (arityMoreThanOne.profile(block.getArityNumber() > 1)) {
                 return yield(block, key, value);
             } else {
                 return yield(block, createArray(new Object[]{ key, value }));

--- a/src/main/java/org/truffleruby/core/method/MethodNodes.java
+++ b/src/main/java/org/truffleruby/core/method/MethodNodes.java
@@ -97,7 +97,7 @@ public abstract class MethodNodes {
 
         @Specialization
         protected int arity(RubyMethod method) {
-            return method.method.getSharedMethodInfo().getArity().getArityNumber();
+            return method.method.getArityNumber();
         }
 
     }

--- a/src/main/java/org/truffleruby/core/method/UnboundMethodNodes.java
+++ b/src/main/java/org/truffleruby/core/method/UnboundMethodNodes.java
@@ -66,7 +66,7 @@ public abstract class UnboundMethodNodes {
 
         @Specialization
         protected int arity(RubyUnboundMethod unboundMethod) {
-            return unboundMethod.method.getSharedMethodInfo().getArity().getArityNumber();
+            return unboundMethod.method.getArityNumber();
         }
 
     }

--- a/src/main/java/org/truffleruby/core/proc/ProcNodes.java
+++ b/src/main/java/org/truffleruby/core/proc/ProcNodes.java
@@ -160,9 +160,8 @@ public abstract class ProcNodes {
 
         @Specialization
         protected int arity(RubyProc proc) {
-            return proc.sharedMethodInfo.getArity().getArityNumber();
+            return proc.getArityNumber();
         }
-
     }
 
     @CoreMethod(names = "binding")

--- a/src/main/java/org/truffleruby/core/proc/RubyProc.java
+++ b/src/main/java/org/truffleruby/core/proc/RubyProc.java
@@ -86,6 +86,10 @@ public class RubyProc extends RubyDynamicObject implements ObjectGraphNode {
     }
     // endregion
 
+    public int getArityNumber() {
+        return sharedMethodInfo.getArity().getArityNumber(type);
+    }
+
     // region Executable
     @ExportMessage
     public boolean isExecutable() {

--- a/src/main/java/org/truffleruby/language/globals/IsDefinedGlobalVariableNode.java
+++ b/src/main/java/org/truffleruby/language/globals/IsDefinedGlobalVariableNode.java
@@ -59,7 +59,7 @@ public abstract class IsDefinedGlobalVariableNode extends RubyContextNode {
     }
 
     protected int isDefinedArity(GlobalVariableStorage storage) {
-        return storage.getIsDefined().sharedMethodInfo.getArity().getArityNumber();
+        return storage.getIsDefined().getArityNumber();
     }
 
     protected GlobalVariableStorage getStorage() {

--- a/src/main/java/org/truffleruby/language/globals/ReadGlobalVariableNode.java
+++ b/src/main/java/org/truffleruby/language/globals/ReadGlobalVariableNode.java
@@ -53,7 +53,7 @@ public abstract class ReadGlobalVariableNode extends RubyContextSourceNode {
     }
 
     protected int getterArity(GlobalVariableStorage storage) {
-        return storage.getGetter().sharedMethodInfo.getArity().getArityNumber();
+        return storage.getGetter().getArityNumber();
     }
 
     protected GlobalVariableStorage getStorage() {

--- a/src/main/java/org/truffleruby/language/globals/WriteGlobalVariableNode.java
+++ b/src/main/java/org/truffleruby/language/globals/WriteGlobalVariableNode.java
@@ -59,7 +59,7 @@ public abstract class WriteGlobalVariableNode extends RubyContextSourceNode {
     }
 
     protected int setterArity(GlobalVariableStorage storage) {
-        return storage.getSetter().sharedMethodInfo.getArity().getArityNumber();
+        return storage.getSetter().getArityNumber();
     }
 
     protected GlobalVariableStorage getStorage() {

--- a/src/main/java/org/truffleruby/language/methods/Arity.java
+++ b/src/main/java/org/truffleruby/language/methods/Arity.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import org.truffleruby.core.proc.ProcType;
 import org.truffleruby.core.string.StringUtils;
 import org.truffleruby.parser.ArgumentDescriptor;
 import org.truffleruby.parser.ArgumentType;
@@ -30,7 +31,10 @@ public class Arity {
     private final boolean allKeywordsOptional;
     private final boolean hasKeywordsRest;
     private final String[] keywordArguments;
+    /** During parsing we cannot know if this Arity object belongs to proc or to lambda. So we calculate the arity
+     * number for both cases and provide a ProcType-dependent interface. */
     private final int arityNumber;
+    private final int procArityNumber;
 
     public Arity(int preRequired, int optional, boolean hasRest) {
         this(preRequired, optional, hasRest, 0, NO_KEYWORDS, true, false);
@@ -52,7 +56,8 @@ public class Arity {
         this.keywordArguments = keywordArguments;
         this.allKeywordsOptional = allKeywordsOptional;
         this.hasKeywordsRest = hasKeywordsRest;
-        this.arityNumber = computeArityNumber();
+        this.arityNumber = computeArityNumber(false);
+        this.procArityNumber = computeArityNumber(true);
 
         assert keywordArguments != null && preRequired >= 0 && optional >= 0 && postRequired >= 0 : toString();
     }
@@ -107,22 +112,22 @@ public class Arity {
         return hasKeywordsRest;
     }
 
-    private int computeArityNumber() {
+    private int computeArityNumber(boolean isProc) {
         int count = getRequired();
 
         if (acceptsKeywords() && !allKeywordsOptional) {
             count++;
         }
 
-        if (optional > 0 || hasRest || (acceptsKeywords() && allKeywordsOptional)) {
+        if (hasRest || (!isProc && (optional > 0 || (acceptsKeywords() && allKeywordsOptional)))) {
             count = -count - 1;
         }
 
         return count;
     }
 
-    public int getArityNumber() {
-        return arityNumber;
+    public int getArityNumber(ProcType type) {
+        return type == ProcType.PROC ? procArityNumber : arityNumber;
     }
 
     public String[] getKeywordArguments() {

--- a/src/main/java/org/truffleruby/language/methods/Arity.java
+++ b/src/main/java/org/truffleruby/language/methods/Arity.java
@@ -130,6 +130,10 @@ public class Arity {
         return type == ProcType.PROC ? procArityNumber : arityNumber;
     }
 
+    public int getMethodArityNumber() {
+        return arityNumber;
+    }
+
     public String[] getKeywordArguments() {
         return keywordArguments;
     }

--- a/src/main/java/org/truffleruby/language/methods/InternalMethod.java
+++ b/src/main/java/org/truffleruby/language/methods/InternalMethod.java
@@ -14,7 +14,6 @@ import java.util.Set;
 import org.truffleruby.RubyContext;
 import org.truffleruby.core.klass.RubyClass;
 import org.truffleruby.core.module.RubyModule;
-import org.truffleruby.core.proc.ProcType;
 import org.truffleruby.core.proc.RubyProc;
 import org.truffleruby.language.LexicalScope;
 import org.truffleruby.language.Visibility;
@@ -184,7 +183,7 @@ public class InternalMethod implements ObjectGraphNode {
     }
 
     public int getArityNumber() {
-        return sharedMethodInfo.getArity().getArityNumber(ProcType.LAMBDA);
+        return sharedMethodInfo.getArity().getMethodArityNumber();
     }
 
     public RootCallTarget getCallTarget() {

--- a/src/main/java/org/truffleruby/language/methods/InternalMethod.java
+++ b/src/main/java/org/truffleruby/language/methods/InternalMethod.java
@@ -14,6 +14,7 @@ import java.util.Set;
 import org.truffleruby.RubyContext;
 import org.truffleruby.core.klass.RubyClass;
 import org.truffleruby.core.module.RubyModule;
+import org.truffleruby.core.proc.ProcType;
 import org.truffleruby.core.proc.RubyProc;
 import org.truffleruby.language.LexicalScope;
 import org.truffleruby.language.Visibility;
@@ -180,6 +181,10 @@ public class InternalMethod implements ObjectGraphNode {
 
     public boolean isBuiltIn() {
         return builtIn;
+    }
+
+    public int getArityNumber() {
+        return sharedMethodInfo.getArity().getArityNumber(ProcType.LAMBDA);
     }
 
     public RootCallTarget getCallTarget() {


### PR DESCRIPTION
The logic for calculating arity is different for proc\lambda. Unfortunately, at the `Arity#computeArityNumber()` level we don't know the `isProc` value (and we cannot change it easily). 

@eregon proposed to figure out how to compute the correct arity value for procs and optimize it after 