### PR TITLE
Fix wrong constant/identifier detection in lexer for non-ascii encodings

### DIFF
--- a/spec/ruby/language/variables_spec.rb
+++ b/spec/ruby/language/variables_spec.rb
@@ -796,3 +796,29 @@ describe 'Local variable shadowing' do
     end
   end
 end
+
+describe 'Allowed characters' do
+  it 'does not allow non-ASCII upcased characters at the beginning' do
+    -> do
+      eval <<-CODE
+        def test
+           ἍBB = 1
+         end
+      CODE
+    end.should raise_error(SyntaxError, /dynamic constant assignment/)
+  end
+
+  it 'allows non-ASCII lowercased characters at the beginning' do
+    result = nil
+
+    eval <<-CODE
+      def test
+        μ = 1
+      end
+
+      result = test
+    CODE
+
+    result.should == 1
+  end
+end

--- a/spec/ruby/language/variables_spec.rb
+++ b/spec/ruby/language/variables_spec.rb
@@ -798,14 +798,17 @@ describe 'Local variable shadowing' do
 end
 
 describe 'Allowed characters' do
-  it 'does not allow non-ASCII upcased characters at the beginning' do
-    -> do
-      eval <<-CODE
-        def test
-           ἍBB = 1
-         end
-      CODE
-    end.should raise_error(SyntaxError, /dynamic constant assignment/)
+  ruby_version_is "2.6" do
+    # new feature in 2.6 -- https://bugs.ruby-lang.org/issues/13770
+    it 'does not allow non-ASCII upcased characters at the beginning' do
+      -> do
+        eval <<-CODE
+          def test
+            ἍBB = 1
+          end
+        CODE
+      end.should raise_error(SyntaxError, /dynamic constant assignment/)
+    end
   end
 
   it 'allows non-ASCII lowercased characters at the beginning' do

--- a/src/main/java/org/truffleruby/parser/lexer/RubyLexer.java
+++ b/src/main/java/org/truffleruby/parser/lexer/RubyLexer.java
@@ -1798,7 +1798,7 @@ public class RubyLexer implements MagicCommentHandler {
             }
             tempVal = createTokenRope();
 
-            if (result == 0 && Character.isUpperCase(tempVal.get(0) & 0xFF)) {
+            if (result == 0 && Character.isUpperCase(tempVal.getString().charAt(0))) {
                 result = RubyParser.tCONSTANT;
             } else {
                 result = RubyParser.tIDENTIFIER;
@@ -3493,7 +3493,7 @@ public class RubyLexer implements MagicCommentHandler {
     }
 
     public void validateFormalIdentifier(Rope identifier) {
-        int first = identifier.get(0) & 0xFF;
+        int first = identifier.getString().charAt(0);
 
         if (Character.isUpperCase(first)) {
             compile_error("formal argument cannot be a constant");

--- a/src/main/java/org/truffleruby/parser/lexer/RubyLexer.java
+++ b/src/main/java/org/truffleruby/parser/lexer/RubyLexer.java
@@ -3497,7 +3497,7 @@ public class RubyLexer implements MagicCommentHandler {
             compile_error("formal argument cannot be a constant");
         }
 
-        int first = identifier.getString().charAt(0);
+        int first = identifier.get(0) & 0xFF;
 
         switch (first) {
             case '@':

--- a/src/main/java/org/truffleruby/parser/lexer/RubyLexer.java
+++ b/src/main/java/org/truffleruby/parser/lexer/RubyLexer.java
@@ -1798,7 +1798,7 @@ public class RubyLexer implements MagicCommentHandler {
             }
             tempVal = createTokenRope();
 
-            if (result == 0 && isFirstCharacterEncodingAwareUppercase(tempVal)) {
+            if (result == 0 && isFirstCodepointUppercase(tempVal)) {
                 result = RubyParser.tCONSTANT;
             } else {
                 result = RubyParser.tIDENTIFIER;
@@ -3493,7 +3493,7 @@ public class RubyLexer implements MagicCommentHandler {
     }
 
     public void validateFormalIdentifier(Rope identifier) {
-        if (isFirstCharacterEncodingAwareUppercase(identifier)) {
+        if (isFirstCodepointUppercase(identifier)) {
             compile_error("formal argument cannot be a constant");
         }
 
@@ -3665,9 +3665,9 @@ public class RubyLexer implements MagicCommentHandler {
         return isARG() && spaceSeen && !Character.isWhitespace(c);
     }
 
-    /** Encoding-aware (including multi-byte encodings) check of first character of a given rope, usually to determine
+    /** Encoding-aware (including multi-byte encodings) check of first codepoint of a given rope, usually to determine
      * if it is a constant */
-    private boolean isFirstCharacterEncodingAwareUppercase(Rope rope) {
+    private boolean isFirstCodepointUppercase(Rope rope) {
         byte[] ropeBytes = rope.getBytes();
         int firstCharacter = rope.encoding.mbcToCode(ropeBytes, 0, ropeBytes.length);
         return rope.encoding.isUpper(firstCharacter);

--- a/src/main/java/org/truffleruby/parser/lexer/RubyLexer.java
+++ b/src/main/java/org/truffleruby/parser/lexer/RubyLexer.java
@@ -1798,7 +1798,7 @@ public class RubyLexer implements MagicCommentHandler {
             }
             tempVal = createTokenRope();
 
-            if (result == 0 && Character.isUpperCase(tempVal.getString().charAt(0))) {
+            if (result == 0 && isFirstCharacterEncodingAwareUppercase(tempVal)) {
                 result = RubyParser.tCONSTANT;
             } else {
                 result = RubyParser.tIDENTIFIER;
@@ -3493,11 +3493,11 @@ public class RubyLexer implements MagicCommentHandler {
     }
 
     public void validateFormalIdentifier(Rope identifier) {
-        int first = identifier.getString().charAt(0);
-
-        if (Character.isUpperCase(first)) {
+        if (isFirstCharacterEncodingAwareUppercase(identifier)) {
             compile_error("formal argument cannot be a constant");
         }
+
+        int first = identifier.getString().charAt(0);
 
         switch (first) {
             case '@':
@@ -3665,4 +3665,11 @@ public class RubyLexer implements MagicCommentHandler {
         return isARG() && spaceSeen && !Character.isWhitespace(c);
     }
 
+    /** Encoding-aware (including multi-byte encodings) check of first character of a given rope, usually to determine
+     * if it is a constant */
+    private boolean isFirstCharacterEncodingAwareUppercase(Rope rope) {
+        byte[] ropeBytes = rope.getBytes();
+        int firstCharacter = rope.encoding.mbcToCode(ropeBytes, 0, ropeBytes.length);
+        return rope.encoding.isUpper(firstCharacter);
+    }
 }

--- a/src/main/java/org/truffleruby/parser/lexer/RubyLexer.java
+++ b/src/main/java/org/truffleruby/parser/lexer/RubyLexer.java
@@ -3668,8 +3668,15 @@ public class RubyLexer implements MagicCommentHandler {
     /** Encoding-aware (including multi-byte encodings) check of first codepoint of a given rope, usually to determine
      * if it is a constant */
     private boolean isFirstCodepointUppercase(Rope rope) {
-        byte[] ropeBytes = rope.getBytes();
-        int firstCharacter = rope.encoding.mbcToCode(ropeBytes, 0, ropeBytes.length);
-        return rope.encoding.isUpper(firstCharacter);
+        Encoding ropeEncoding = rope.encoding;
+        int firstByte = rope.get(0) & 0xFF;
+
+        if (ropeEncoding.isAsciiCompatible() && isASCII(firstByte)) {
+            return StringSupport.isAsciiUppercase((byte) firstByte);
+        } else {
+            byte[] ropeBytes = rope.getBytes();
+            int firstCharacter = ropeEncoding.mbcToCode(ropeBytes, 0, ropeBytes.length);
+            return ropeEncoding.isUpper(firstCharacter);
+        }
     }
 }

--- a/src/main/java/org/truffleruby/parser/parser/ParserSupport.java
+++ b/src/main/java/org/truffleruby/parser/parser/ParserSupport.java
@@ -1459,7 +1459,7 @@ public class ParserSupport {
 
     // ENEBO: Totally weird naming (in MRI is not allocated and is a local var name) [1.9]
     public boolean is_local_id(Rope name) {
-        return lexer.isIdentifierChar(name.get(0) & 0xFF);
+        return lexer.isIdentifierChar(name.getString().charAt(0));
     }
 
     // 1.9

--- a/src/main/java/org/truffleruby/parser/parser/ParserSupport.java
+++ b/src/main/java/org/truffleruby/parser/parser/ParserSupport.java
@@ -1459,7 +1459,7 @@ public class ParserSupport {
 
     // ENEBO: Totally weird naming (in MRI is not allocated and is a local var name) [1.9]
     public boolean is_local_id(Rope name) {
-        return lexer.isIdentifierChar(name.getString().charAt(0));
+        return lexer.isIdentifierChar(name.get(0) & 0xFF);
     }
 
     // 1.9


### PR DESCRIPTION
During lexing/parsing, a token is determined to be an identifier or a constant by looking at its first byte and determining if it is an uppercase character: Constants start with an uppercase character, identifiers start with a lowercase one.

But as previously implemented, only the first byte of a token was used when checking if a character is an upper or lowercase one, which breaks under multibyte encodings, such as UTF-8.

For instance, in #2079 a user reported that

```ruby
def variance
  μ = mean
  reduce(0) { |m, i| m + (i - μ).square } / (length - 1)
end
```

caused a `SyntaxError: dynamic constant assignment` because `μ` ([Greek Small Letter Mu](https://www.compart.com/en/unicode/U+03BC)) is encoded with UTF-8 as (206, 188), and `Character.isUpperCase(206) == true`. Thus, the code was considering it a constant, even though the character is considered a lowercase letter by the unicode standard (and thus by MRI).

Interestingly enough, the reverse can happen.

```ruby
def foo
  Ⴀ = 1
end
```

The character `Ⴀ` ([Georgian Capital Letter An](https://www.compart.com/en/unicode/U+10A0)) is encoded with UTF-8 as (225, 130, 160) and `isUpperCase(225) == false` making TruffleRuby accept it as an identifier in the example, where MRI rejects it with `SyntaxError: dynamic constant assignment` because it considers it to be a constant.

The fix is thus to extract the entire character on multi-byte encodings, and thus the `isUpperCase` check becomes correct.

To discuss before merging:

* This extracts the first character in a rather heavy-handed way -- it converts the entire `Rope` representation of the token into a `String` instance, and then extracts the `String`'s first character.

  This is definitely correct but it's a rather expensive conversion just to grab the first character -- especially given that most of the time Ruby sources are only the ASCII subset of UTF-8 and thus are not using multibyte characters.

  I was digging through the `Rope` implementation and could not find a nice way of getting only a single character that can be used by the lexer/parser. One low-hanging improvement is to add a fast path for   ASCII/UTF-8 single-byte characters, and in other cases fall back to the heaver approach. Thoughts?

* What's the best way to add a regression test for this? I was looking through the codebase and there doesn't seem to be a a lot of TruffleRuby-specific tests, but I'm not sure if this would fit within ruby/spec.

fixes #2079