### PR TITLE
Support refinemnets for String#to_s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ Compatibility:
 * Fix arity for `Proc` (#2098, @ssnickolay)
 * Check bounds for `FFI::Pointer` accesses when the size of the memory behind is known. 
 * Implement negative line numbers for eval (#1482).
-* Support refinements for `String#to_s` (#2110, @ssnickolay)
+* Support refinements for `#to_s` called by string interpolation (#2110, @ssnickolay)
 
 Performance:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Compatibility:
 * Fix arity for `Proc` (#2098, @ssnickolay)
 * Check bounds for `FFI::Pointer` accesses when the size of the memory behind is known. 
 * Implement negative line numbers for eval (#1482).
+* Support refinements for `String#to_s` (#2110, @ssnickolay)
 
 Performance:
 

--- a/spec/tags/core/module/refine_tags.txt
+++ b/spec/tags/core/module/refine_tags.txt
@@ -1,3 +1,2 @@
-fails:Module#refine for methods accessed indirectly is honored by string interpolation
 fails:Module#refine for methods accessed indirectly is honored by Kernel#respond_to?
 slow:Module#refine method lookup looks in the included modules for builtin methods

--- a/src/main/java/org/truffleruby/core/cast/ToSNode.java
+++ b/src/main/java/org/truffleruby/core/cast/ToSNode.java
@@ -34,7 +34,7 @@ public abstract class ToSNode extends RubyContextSourceNode {
     @Specialization(guards = "!isRubyString(object)")
     protected RubyString toSFallback(VirtualFrame frame, Object object,
             @Cached DispatchNode callToSNode) {
-        final Object value = callToSNode.call(object, "to_s");
+        final Object value = callToSNode.dispatch(frame, object, "to_s", null, EMPTY_ARGUMENTS);
 
         if (value instanceof RubyString) {
             return (RubyString) value;


### PR DESCRIPTION
FYI  we cannot untag `exclude :test_tostring, "needs investigation"` from `TestRefinements.rb` because we have some issue with `String.taint + refinements`. I'll take a look at it later