### PR TITLE
Detect recursion

### DIFF
--- a/lib/truffle/truffle/cext.rb
+++ b/lib/truffle/truffle/cext.rb
@@ -1508,7 +1508,7 @@ module Truffle::CExt
   def rb_exec_recursive(func, obj, arg)
     result = nil
 
-    recursive = Thread.detect_recursion(obj) do
+    recursive = Truffle::ThreadOperations.detect_recursion(obj) do
       result = Primitive.cext_unwrap(Primitive.call_with_c_mutex(func, [Primitive.cext_wrap(obj), Primitive.cext_wrap(arg), 0]))
     end
 

--- a/spec/truffle/thread/detect_recursion_spec.rb
+++ b/spec/truffle/thread/detect_recursion_spec.rb
@@ -11,7 +11,7 @@ require_relative '../../ruby/spec_helper'
 module TruffleThreadDetectRecursionSpecFixtures
   def self.check_recursion_to_depth(obj, depth)
     # checks that obj recurses to a given depth
-    return false unless obj.class.method_defined? :each
+    return false unless obj.respond_to?(:each)
     Thread.detect_recursion(obj) do 
       if depth > 1
         obj.each do |el|
@@ -28,7 +28,7 @@ module TruffleThreadDetectRecursionSpecFixtures
     # (because detect_recursion on two objects is only used during object comparison,
     # and aborts after inequality is discovered)
     return false unless obj1.class == obj2.class
-    return false unless obj1.class.method_defined? :each
+    return false unless obj1.respond_to?(:each)
     return false unless obj1.size == obj2.size
 
     Thread.detect_recursion(obj1, obj2) do

--- a/spec/truffle/thread/detect_recursion_spec.rb
+++ b/spec/truffle/thread/detect_recursion_spec.rb
@@ -25,13 +25,13 @@ module TruffleThreadDetectRecursionSpecFixtures
 
   def self.check_double_recursion_equality_to_depth(obj1, obj2, depth)
     # checks that obj1 and obj2 are both recursive and equal structurally
-    # (because detect_recursion on two objects is only used during object comparison,
+    # (because detect_pair_recursion on two objects is only used during object comparison,
     # and aborts after inequality is discovered)
     return false unless obj1.class == obj2.class
     return false unless obj1.respond_to?(:each)
     return false unless obj1.size == obj2.size
 
-    Truffle::ThreadOperations.detect_recursion(obj1, obj2) do
+    Truffle::ThreadOperations.detect_pair_recursion(obj1, obj2) do
       if depth > 1
         if obj1.class == Hash
           obj1.each do |key, val|

--- a/spec/truffle/thread/detect_recursion_spec.rb
+++ b/spec/truffle/thread/detect_recursion_spec.rb
@@ -54,6 +54,24 @@ end
 
 describe "Thread#detect_recursion" do
 
+  describe "for empty arrays" do
+    it "returns false" do
+      a = []
+      10.times do |i|
+        TruffleThreadDetectRecursionSpecFixtures.check_recursion_to_depth(a, i).should be_false
+      end
+    end
+  end
+
+  describe "for empty hashes" do
+    it "returns false" do
+      a = {}
+      10.times do |i|
+        TruffleThreadDetectRecursionSpecFixtures.check_recursion_to_depth(a, i).should be_false
+      end
+    end
+  end
+
   describe "for single arrays" do
     it "for non-recursive arrays returns false" do
       a = [1,[2,[3], 4],[[[5,6,7]]]]

--- a/spec/truffle/thread/detect_recursion_spec.rb
+++ b/spec/truffle/thread/detect_recursion_spec.rb
@@ -12,7 +12,7 @@ module TruffleThreadDetectRecursionSpecFixtures
   def self.check_recursion_to_depth(obj, depth)
     # checks that obj recurses to a given depth
     return false unless obj.respond_to?(:each)
-    Thread.detect_recursion(obj) do 
+    Truffle::ThreadOperations.detect_recursion(obj) do 
       if depth > 1
         obj.each do |el|
           if check_recursion_to_depth(el, depth-1)
@@ -31,7 +31,7 @@ module TruffleThreadDetectRecursionSpecFixtures
     return false unless obj1.respond_to?(:each)
     return false unless obj1.size == obj2.size
 
-    Thread.detect_recursion(obj1, obj2) do
+    Truffle::ThreadOperations.detect_recursion(obj1, obj2) do
       if depth > 1
         if obj1.class == Hash
           obj1.each do |key, val|

--- a/spec/truffle/thread/detect_recursion_spec.rb
+++ b/spec/truffle/thread/detect_recursion_spec.rb
@@ -12,7 +12,7 @@ module TruffleThreadDetectRecursionSpecFixtures
   def self.check_recursion_to_depth(obj, depth)
     # checks that obj recurses to a given depth
     return false unless obj.respond_to?(:each)
-    Truffle::ThreadOperations.detect_recursion(obj) do 
+    Truffle::ThreadOperations.detect_recursion(obj) do
       if depth > 1
         obj.each do |el|
           if check_recursion_to_depth(el, depth-1)

--- a/spec/truffle/thread/detect_recursion_spec.rb
+++ b/spec/truffle/thread/detect_recursion_spec.rb
@@ -1,0 +1,225 @@
+# Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved. This
+# code is released under a tri EPL/GPL/LGPL license. You can use it,
+# redistribute it and/or modify it under the terms of the:
+#
+# Eclipse Public License version 2.0, or
+# GNU General Public License version 2, or
+# GNU Lesser General Public License version 2.1.
+
+require_relative '../../ruby/spec_helper'
+
+describe "Thread#detect_recursion" do
+
+  before :each do
+    def check_recursion_to_depth(obj, depth)
+      return false unless obj.class.method_defined? :each
+      Thread.detect_recursion obj do 
+        if depth > 1
+          obj.each do |el|
+            if check_recursion_to_depth(el, depth-1)
+              return true
+            end
+          end
+        end
+      end
+    end
+
+    def check_double_recursion_equality_to_depth(obj1, obj2, depth)
+      # checks that obj1 and obj2 are both recursive and equal structurally
+      # (because detect_recursion on two objects is only used during object comparison,
+      # and aborts after inequality is discovered)
+      return false unless obj1.class == obj2.class
+      return false unless obj1.class.method_defined? :each
+      return false unless obj1.size == obj2.size
+
+      Thread.detect_recursion obj1 obj2 do 
+        if depth > 1
+          if obj1.class == Hash
+            obj1.each do |key, val|
+              return false unless obj2.has_key?(key)
+              if check_double_recursion_equality_to_depth(val, obj2[key], depth-1)
+                return true
+              end
+            end
+          else
+            obj1.size.times do |i|
+              if check_double_recursion_equality_to_depth(obj1[i], obj2[i], depth-1)
+                return true
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+
+  describe "for single arrays" do
+    it "for non-recursive arrays returns false" do
+      a = [1,[2,[3], 4],[[[5,6,7]]]]
+
+      10.times do |i|
+        check_recursion_to_depth(a, i).should be_false
+      end
+    end
+    it "for recursive arrays returns true after sufficient depth to detect recursion" do
+      a = []
+      a << [[[a]]]
+
+      b = []
+      b << [1,[2,[3,b],4],5]
+
+      10.times do |i|
+        if i < 5
+          check_recursion_to_depth(a, i).should be_false
+          check_recursion_to_depth(b, i).should be_false
+        else
+          check_recursion_to_depth(a, i).should be_true
+          check_recursion_to_depth(b, i).should be_true
+        end
+      end
+    end
+  end
+
+  describe "for single hashes" do
+    it "for non-recursive hashes returns false" do
+      a = {:q => {:w => "qwe" }, :t => {:q => {:w => "qwe" }, :t => {:q => {:w => "qwe" }}}}
+
+      10.times do |i|
+        check_recursion_to_depth(a, i).should be_false
+      end
+    end
+    it "for recursive hashes returns true after sufficient depth to detect recursion" do
+      a = {:q => {:w => "qwe" }}
+      a[:t] = a
+
+      10.times do |i|
+        if i < 3
+          check_recursion_to_depth(a, i).should be_false
+        else
+          check_recursion_to_depth(a, i).should be_true
+        end
+      end
+    end
+  end
+
+  describe "for single structs" do
+    it "for recursive structs returns true after sufficient depth to detect recursion" do
+      car = Struct.new(:make, :model, :year)
+      a = car.new("Honda", "Accord", "1998")
+      a[:make] = a
+
+      10.times do |i|
+        if i < 2
+          check_recursion_to_depth(a, i).should be_false
+        else
+          check_recursion_to_depth(a, i).should be_true
+        end
+      end
+    end
+  end
+
+  describe "for single mixtures of types" do
+    it "for recursive structs returns true after sufficient depth to detect recursion" do
+      car = Struct.new(:make, :model, :year)
+      a = car.new("Honda", "Accord", "1998")
+      a[:make] = [{:car_make => ["a mess", {:here => a}]}]
+
+      10.times do |i|
+        if i < 8
+          check_recursion_to_depth(a, i).should be_false
+        else
+          check_recursion_to_depth(a, i).should be_true
+        end
+      end
+    end
+  end
+
+  describe "for a pair of arrays" do
+    it "returns false when structure differs" do
+      a = []
+      a << a
+
+      c = [[[[[[[[[a,1]]]]]]]]]
+
+      10.times do |i|
+        check_double_recursion_equality_to_depth(a, c, i).should be_false
+      end
+    end
+    it "returns true after sufficient depth to detect recursion and equivalent structure" do
+      a = []
+      a << a
+
+      b = []
+      b << [[[[[[b]]]]]]
+
+      10.times do |i|
+        if i < 8
+          check_double_recursion_equality_to_depth(a, b, i).should be_false
+        else
+          check_double_recursion_equality_to_depth(a, b, i).should be_true
+        end
+      end
+    end
+  end
+
+  describe "for a pair of hashes" do
+    it "returns false when structure differs" do
+      a = {:q => {:w => "qwe" }}
+      a[:t] = a
+
+      b = {:q => {:w => "qwe" }, :t => {:t => {:w => "qwe" }, :q => a}}
+
+      10.times do |i|
+        check_double_recursion_equality_to_depth(a, b, i).should be_false
+      end
+    end
+    it "returns true after sufficient depth to detect recursion and equivalent structure" do
+      a = {:q => {:w => "qwe" }}
+      a[:t] = a
+
+      b = {:q => {:w => "qwe" }, :t => {:q => {:w => "qwe" }, :t => a}}
+
+      10.times do |i|
+        if i < 4
+          check_double_recursion_equality_to_depth(a, b, i).should be_false
+        else
+          check_double_recursion_equality_to_depth(a, b, i).should be_true
+        end
+      end
+    end
+  end
+
+  describe "for a pair of  structs" do
+    it "returns true after sufficient depth to detect recursion and equivalent structure" do
+      car = Struct.new(:make, :model, :year)
+      a = car.new("Honda", "Accord", "1998")
+      a[:make] = a
+      b = car.new(a, "Accord", "1998")
+
+      10.times do |i|
+        if i < 3
+          check_double_recursion_equality_to_depth(a, b, i).should be_false
+        else
+          check_double_recursion_equality_to_depth(a, b, i).should be_true
+        end
+      end
+    end
+  end
+
+  describe "for a pair of mixtures of types" do
+    it "returns true after sufficient depth to detect recursion and equivalent structure" do
+      car = Struct.new(:make, :model, :year)
+      a = car.new("Honda", "Accord", "1998")
+      a[:make] = [{:car_make => ["a mess", {:here => a}]}]
+      b = car.new([{:car_make => ["a mess", {:here => a}]}], "Accord", "1998")
+
+      20.times do |i|
+        if i < 11
+          check_double_recursion_equality_to_depth(a, b, i).should be_false
+        else
+          check_double_recursion_equality_to_depth(a, b, i).should be_true
+        end
+      end
+    end
+  end
+end

--- a/src/main/java/org/truffleruby/core/CoreLibrary.java
+++ b/src/main/java/org/truffleruby/core/CoreLibrary.java
@@ -1064,6 +1064,7 @@ public class CoreLibrary {
             "/core/truffle/exception_operations.rb",
             "/core/truffle/feature_loader.rb",
             "/core/truffle/gem_util.rb",
+            "/core/truffle/thread_operations.rb",
             "/core/thread.rb",
             "/core/true.rb",
             "/core/type.rb",

--- a/src/main/ruby/truffleruby/core/array.rb
+++ b/src/main/ruby/truffleruby/core/array.rb
@@ -89,7 +89,7 @@ class Array
 
     total = other.size
 
-    Truffle::ThreadOperations.detect_recursion self, other do
+    Truffle::ThreadOperations.detect_pair_recursion self, other do
       i = 0
       count = Primitive.min(total, size)
 
@@ -132,7 +132,7 @@ class Array
 
     return false unless size == other.size
 
-    Truffle::ThreadOperations.detect_recursion self, other do
+    Truffle::ThreadOperations.detect_pair_recursion self, other do
       i = 0
       total = size
 
@@ -325,7 +325,7 @@ class Array
     return false unless other.kind_of?(Array)
     return false if size != other.size
 
-    Truffle::ThreadOperations.detect_recursion self, other do
+    Truffle::ThreadOperations.detect_pair_recursion self, other do
       i = 0
       each do |x|
         return false unless x.eql? other[i]

--- a/src/main/ruby/truffleruby/core/array.rb
+++ b/src/main/ruby/truffleruby/core/array.rb
@@ -509,12 +509,12 @@ class Array
         # the whole structure is recursive. In which case, abandon most of
         # the work and return a simple hash value.
       rescue Truffle::ThreadOperations::InnerRecursionDetected
-      return size
+        return size
       ensure
         objects.delete :__detect_outermost_recursion__
         objects.delete id
+      end
     end
-  end
 
     hash_val
   end

--- a/src/main/ruby/truffleruby/core/array.rb
+++ b/src/main/ruby/truffleruby/core/array.rb
@@ -89,7 +89,7 @@ class Array
 
     total = other.size
 
-    Thread.detect_recursion self, other do
+    Truffle::ThreadOperations.detect_recursion self, other do
       i = 0
       count = Primitive.min(total, size)
 
@@ -132,7 +132,7 @@ class Array
 
     return false unless size == other.size
 
-    Thread.detect_recursion self, other do
+    Truffle::ThreadOperations.detect_recursion self, other do
       i = 0
       total = size
 
@@ -325,7 +325,7 @@ class Array
     return false unless other.kind_of?(Array)
     return false if size != other.size
 
-    Thread.detect_recursion self, other do
+    Truffle::ThreadOperations.detect_recursion self, other do
       i = 0
       each do |x|
         return false unless x.eql? other[i]
@@ -484,7 +484,7 @@ class Array
 
       # If we've seen self, unwind back to the outer version
       if objects.key? id
-        raise Thread::InnerRecursionDetected
+        raise Truffle::ThreadOperations::InnerRecursionDetected
       end
 
       # .. or compute the hash value like normal
@@ -508,13 +508,13 @@ class Array
         # An inner version will raise to return back here, indicating that
         # the whole structure is recursive. In which case, abandon most of
         # the work and return a simple hash value.
-      rescue Thread::InnerRecursionDetected
-        return size
+      rescue Truffle::ThreadOperations::InnerRecursionDetected
+      return size
       ensure
         objects.delete :__detect_outermost_recursion__
         objects.delete id
-      end
     end
+  end
 
     hash_val
   end
@@ -549,7 +549,7 @@ class Array
     comma = ', '
     result = +'['
 
-    return +'[...]' if Thread.detect_recursion self do
+    return +'[...]' if Truffle::ThreadOperations.detect_recursion self do
       each_with_index do |element, index|
         temp = Truffle::Type.rb_inspect(element)
         result.force_encoding(temp.encoding) if index == 0
@@ -568,7 +568,7 @@ class Array
     return ''.encode(Encoding::US_ASCII) if size == 0
 
     out = +''
-    raise ArgumentError, 'recursive array join' if Thread.detect_recursion self do
+    raise ArgumentError, 'recursive array join' if Truffle::ThreadOperations.detect_recursion self do
       sep = Primitive.nil?(sep) ? $, : StringValue(sep)
 
       # We've manually unwound the first loop entry for performance
@@ -1263,7 +1263,7 @@ class Array
     end
 
     max_levels -= 1
-    recursion = Thread.detect_recursion(array) do
+    recursion = Truffle::ThreadOperations.detect_recursion(array) do
       array = Truffle::Type.coerce_to(array, Array, :to_ary)
 
       i = 0

--- a/src/main/ruby/truffleruby/core/comparable.rb
+++ b/src/main/ruby/truffleruby/core/comparable.rb
@@ -30,7 +30,7 @@ module Comparable
   def ==(other)
     return true if equal?(other)
 
-    return false if Thread.detect_recursion(self, other) do
+    return false if Truffle::ThreadOperations.detect_recursion(self, other) do
       unless comp = (self <=> other)
         return false
       end

--- a/src/main/ruby/truffleruby/core/comparable.rb
+++ b/src/main/ruby/truffleruby/core/comparable.rb
@@ -30,7 +30,7 @@ module Comparable
   def ==(other)
     return true if equal?(other)
 
-    return false if Truffle::ThreadOperations.detect_recursion(self, other) do
+    return false if Truffle::ThreadOperations.detect_pair_recursion(self, other) do
       unless comp = (self <=> other)
         return false
       end

--- a/src/main/ruby/truffleruby/core/enumerator.rb
+++ b/src/main/ruby/truffleruby/core/enumerator.rb
@@ -704,7 +704,7 @@ class Enumerator::Chain < Enumerator
   end
 
   def inspect
-    return "#<#{self.class.name}: ...>" if Thread.detect_recursion(self) do
+    return "#<#{self.class.name}: ...>" if Truffle::ThreadOperations.detect_recursion(self) do
       return "#<#{self.class.name}: #{@enums}>"
     end
   end

--- a/src/main/ruby/truffleruby/core/file.rb
+++ b/src/main/ruby/truffleruby/core/file.rb
@@ -733,7 +733,7 @@ class File < IO
     when String
       first = first.dup
     when Array
-      recursion = Thread.detect_recursion(first) do
+      recursion = Truffle::ThreadOperations.detect_recursion(first) do
         first = join(*first)
       end
 
@@ -754,7 +754,7 @@ class File < IO
       when String
         value = el
       when Array
-        recursion = Thread.detect_recursion(el) do
+        recursion = Truffle::ThreadOperations.detect_recursion(el) do
           value = join(*el)
         end
 

--- a/src/main/ruby/truffleruby/core/hash.rb
+++ b/src/main/ruby/truffleruby/core/hash.rb
@@ -137,7 +137,7 @@ class Hash
 
     return false unless other.size == size
 
-    Thread.detect_recursion self, other do
+    Truffle::ThreadOperations.detect_recursion self, other do
       each_pair do |key, value|
         other_value = other._get_or_undefined(key)
 
@@ -361,7 +361,7 @@ class Hash
   def hash
     val = Primitive.vm_hash_start CLASS_SALT
     val = Primitive.vm_hash_update val, size
-    Thread.detect_outermost_recursion self do
+    Truffle::ThreadOperations.detect_outermost_recursion self do
       each_pair do |key,value|
         entry_val = Primitive.vm_hash_start key.hash
         entry_val = Primitive.vm_hash_update entry_val, value.hash
@@ -406,7 +406,7 @@ class Hash
 
   def inspect
     out = []
-    return +'{...}' if Thread.detect_recursion self do
+    return +'{...}' if Truffle::ThreadOperations.detect_recursion self do
       each_pair do |key,value|
         str =  Truffle::Type.rb_inspect(key)
         str << '=>'

--- a/src/main/ruby/truffleruby/core/hash.rb
+++ b/src/main/ruby/truffleruby/core/hash.rb
@@ -137,7 +137,7 @@ class Hash
 
     return false unless other.size == size
 
-    Truffle::ThreadOperations.detect_recursion self, other do
+    Truffle::ThreadOperations.detect_pair_recursion self, other do
       each_pair do |key, value|
         other_value = other._get_or_undefined(key)
 

--- a/src/main/ruby/truffleruby/core/kernel.rb
+++ b/src/main/ruby/truffleruby/core/kernel.rb
@@ -380,18 +380,17 @@ module Kernel
       return Primitive.infect "#{prefix}>", self
     end
 
-    # If it's already been inspected, return the ...
-    return "#{prefix} ...>" if Thread.guarding? self
-
-    parts = Thread.recursion_guard self do
-      ivars.map do |var|
+    Truffle::ThreadOperations.detect_recursion(self) do
+      parts = ivars.map do |var|
         value = Primitive.object_ivar_get self, var
         "#{var}=#{value.inspect}"
       end
+      str = "#{prefix} #{parts.join(', ')}>"
+      return Primitive.infect str, self
     end
 
-    str = "#{prefix} #{parts.join(', ')}>"
-    Primitive.infect str, self
+    # If it's already been inspected, return the ...
+    "#{prefix} ...>"
   end
 
   def load(filename, wrap = false)

--- a/src/main/ruby/truffleruby/core/string.rb
+++ b/src/main/ruby/truffleruby/core/string.rb
@@ -1585,7 +1585,7 @@ class String
       return Primitive.string_cmp self, other
     end
 
-    Thread.detect_recursion self, other do
+    Truffle::ThreadOperations.detect_recursion self, other do
       if other.respond_to?(:<=>) && !other.respond_to?(:to_str)
         return nil unless tmp = (other <=> self)
       elsif other.respond_to?(:to_str)

--- a/src/main/ruby/truffleruby/core/string.rb
+++ b/src/main/ruby/truffleruby/core/string.rb
@@ -1585,7 +1585,7 @@ class String
       return Primitive.string_cmp self, other
     end
 
-    Truffle::ThreadOperations.detect_recursion self, other do
+    Truffle::ThreadOperations.detect_pair_recursion self, other do
       if other.respond_to?(:<=>) && !other.respond_to?(:to_str)
         return nil unless tmp = (other <=> self)
       elsif other.respond_to?(:to_str)

--- a/src/main/ruby/truffleruby/core/struct.rb
+++ b/src/main/ruby/truffleruby/core/struct.rb
@@ -130,9 +130,7 @@ class Struct
   end
 
   def to_s
-    return +'[...]' if Thread.guarding? self
-
-    Thread.recursion_guard self do
+    Truffle::ThreadOperations.detect_recursion(self) do
       values = []
 
       _attrs.each do |var|
@@ -143,11 +141,13 @@ class Struct
       name = self.class.name
 
       if Primitive.nil?(name) || name.empty?
-        "#<struct #{values.join(', ')}>"
+        return "#<struct #{values.join(', ')}>"
       else
-        "#<struct #{self.class.name} #{values.join(', ')}>"
+        return "#<struct #{self.class.name} #{values.join(', ')}>"
       end
     end
+
+    return +'[...]'
   end
   alias_method :inspect, :to_s
 
@@ -188,7 +188,7 @@ class Struct
   def ==(other)
     return false if self.class != other.class
 
-    Thread.detect_recursion self, other do
+    Truffle::ThreadOperations.detect_recursion self, other do
       return self.values == other.values
     end
 
@@ -270,7 +270,7 @@ class Struct
     return true if equal? other
     return false if self.class != other.class
 
-    Thread.detect_recursion self, other do
+    Truffle::ThreadOperations.detect_recursion self, other do
       _attrs.each do |var|
         mine =   Primitive.object_hidden_var_get(self, var)
         theirs = Primitive.object_hidden_var_get(other, var)
@@ -308,7 +308,7 @@ class Struct
   def hash
     val = Primitive.vm_hash_start(CLASS_SALT)
     val = Primitive.vm_hash_update(val, size)
-    return val if Thread.detect_outermost_recursion self do
+    return val if Truffle::ThreadOperations.detect_outermost_recursion self do
       _attrs.each do |var|
         val = Primitive.vm_hash_update(val, Primitive.object_hidden_var_get(self, var).hash)
       end
@@ -414,7 +414,7 @@ class Struct
         hash = Primitive.vm_hash_start CLASS_SALT
         hash = Primitive.vm_hash_update hash, #{hashes.size}
 
-        return hash if Thread.detect_outermost_recursion(self) do
+        return hash if Truffle::ThreadOperations.detect_outermost_recursion(self) do
           #{hash_calculation}
         end
 

--- a/src/main/ruby/truffleruby/core/struct.rb
+++ b/src/main/ruby/truffleruby/core/struct.rb
@@ -188,7 +188,7 @@ class Struct
   def ==(other)
     return false if self.class != other.class
 
-    Truffle::ThreadOperations.detect_recursion self, other do
+    Truffle::ThreadOperations.detect_pair_recursion self, other do
       return self.values == other.values
     end
 
@@ -270,7 +270,7 @@ class Struct
     return true if equal? other
     return false if self.class != other.class
 
-    Truffle::ThreadOperations.detect_recursion self, other do
+    Truffle::ThreadOperations.detect_pair_recursion self, other do
       _attrs.each do |var|
         mine =   Primitive.object_hidden_var_get(self, var)
         theirs = Primitive.object_hidden_var_get(other, var)

--- a/src/main/ruby/truffleruby/core/struct.rb
+++ b/src/main/ruby/truffleruby/core/struct.rb
@@ -147,7 +147,7 @@ class Struct
       end
     end
 
-    return +'[...]'
+    +'[...]'
   end
   alias_method :inspect, :to_s
 

--- a/src/main/ruby/truffleruby/core/truffle/interop.rb
+++ b/src/main/ruby/truffleruby/core/truffle/interop.rb
@@ -317,7 +317,7 @@ module Truffle
     end
 
     def self.foreign_inspect(object)
-      return recursive_string_for(object) if Thread.detect_recursion self do
+      return recursive_string_for(object) if Truffle::ThreadOperations.detect_recursion self do
         return foreign_inspect_nonrecursive(object)
       end
     end

--- a/src/main/ruby/truffleruby/core/truffle/io_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/io_operations.rb
@@ -32,13 +32,16 @@ module Truffle
           elsif arg.kind_of?(String)
             # might be a Foreign String we need to convert
             str = arg.to_str
-          elsif Thread.guarding? arg
-            str = '[...]'
           elsif (ary = Truffle::Type.rb_check_convert_type(arg, Array, :to_ary))
-            Thread.recursion_guard arg do
+            recursive = Truffle::ThreadOperations.detect_recursion(arg) do
               ary.each { |a| puts(io, a) }
             end
-            str = nil
+
+            if recursive
+              str = '[...]'
+            else
+              str = nil
+            end
           else
             str = arg.to_s
             str = Truffle::Type.rb_any_to_s(arg) unless Primitive.object_kind_of?(str, String)

--- a/src/main/ruby/truffleruby/core/truffle/thread_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/thread_operations.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2014, 2019 Oracle and/or its affiliates. All rights reserved. This
+# code is released under a tri EPL/GPL/LGPL license. You can use it,
+# redistribute it and/or modify it under the terms of the:
+#
+# Eclipse Public License version 2.0, or
+# GNU General Public License version 2, or
+# GNU Lesser General Public License version 2.1.
+
+# Copyright (c) 2007-2015, Evan Phoenix and contributors
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# * Neither the name of Rubinius nor the names of its contributors
+#   may be used to endorse or promote products derived from this software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# Copyright (c) 2011, Evan Phoenix
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# * Neither the name of the Evan Phoenix nor the names of its contributors
+#   may be used to endorse or promote products derived from this software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+module Truffle::ThreadOperations
+
+  # detect_recursion will return if there's a recursion
+  # on obj (or the pair obj+paired_obj).
+  # If there is one, it returns true.
+  # Otherwise, it will yield once and return false.
+  def self.detect_recursion(obj, paired_obj=nil)
+    unless Primitive.object_can_contain_object obj
+      yield
+      return false
+    end
+
+    id = obj.object_id
+    pair_id = paired_obj.object_id
+    objects = Primitive.thread_recursive_objects
+
+    case objects[id]
+
+    # Default case, we haven't seen +obj+ yet, so we add it and run the block.
+    when nil
+      objects[id] = pair_id
+      begin
+        yield
+      ensure
+        objects.delete id
+      end
+
+    # We've seen +obj+ before and it's got multiple paired objects associated
+    # with it, so check the pair and yield if there is no recursion.
+    when Hash
+      return true if objects[id][pair_id]
+
+      objects[id][pair_id] = true
+      begin
+        yield
+      ensure
+        objects[id].delete pair_id
+      end
+
+    # We've seen +obj+ with one paired object, so check the stored one for
+    # recursion.
+    #
+    # This promotes the value to a Hash since there is another new paired
+    # object.
+    else
+      previous = objects[id]
+      return true if previous == pair_id
+
+      objects[id] = { previous => true, pair_id => true }
+      begin
+        yield
+      ensure
+        objects[id] = previous
+      end
+    end
+
+    false
+  end
+  Truffle::Graal.always_split method(:detect_recursion)
+
+  class InnerRecursionDetected < Exception; end # rubocop:disable Lint/InheritException
+
+  # Similar to detect_recursion, but will short circuit all inner recursion levels
+  def self.detect_outermost_recursion(obj, paired_obj=nil, &block)
+    rec = Primitive.thread_recursive_objects
+
+    if rec[:__detect_outermost_recursion__]
+      if detect_recursion(obj, paired_obj, &block)
+        raise InnerRecursionDetected
+      end
+      false
+    else
+      rec[:__detect_outermost_recursion__] = true
+      begin
+        begin
+          detect_recursion(obj, paired_obj, &block)
+        rescue InnerRecursionDetected
+          return true
+        end
+        return nil
+      ensure
+        rec.delete :__detect_outermost_recursion__
+      end
+    end
+  end
+
+  def self.report_exception(thread, exception)
+    message = "#{thread.inspect} terminated with exception:\n#{exception.full_message}"
+    $stderr.write message
+  end
+
+end

--- a/src/main/ruby/truffleruby/core/truffle/thread_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/thread_operations.rb
@@ -123,11 +123,11 @@ module Truffle::ThreadOperations
   class InnerRecursionDetected < Exception; end # rubocop:disable Lint/InheritException
 
   # Similar to detect_recursion, but will short circuit all inner recursion levels
-  def self.detect_outermost_recursion(obj, paired_obj=nil, &block)
+  def self.detect_outermost_recursion(obj, &block)
     rec = Primitive.thread_recursive_objects
 
     if rec[:__detect_outermost_recursion__]
-      if detect_recursion(obj, paired_obj, &block)
+      if detect_recursion(obj, &block)
         raise InnerRecursionDetected
       end
       false
@@ -135,7 +135,7 @@ module Truffle::ThreadOperations
       rec[:__detect_outermost_recursion__] = true
       begin
         begin
-          detect_recursion(obj, paired_obj, &block)
+          detect_recursion(obj, &block)
         rescue InnerRecursionDetected
           return true
         end

--- a/test/truffle/compiler/pe/pe.rb
+++ b/test/truffle/compiler/pe/pe.rb
@@ -88,6 +88,7 @@ else
   require_relative 'core/encoding_pe'
   require_relative 'interop/interop_pe'
   require_relative 'truffle/engine_pe.rb'
+  require_relative 'truffle/thread_pe.rb'
   require_relative 'macro/pushing_pixels_pe.rb'
 
   if Truffle::Interop.mime_type_supported?('application/javascript')

--- a/test/truffle/compiler/pe/truffle/thread_pe.rb
+++ b/test/truffle/compiler/pe/truffle/thread_pe.rb
@@ -1,0 +1,27 @@
+# Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved. This
+# code is released under a tri EPL/GPL/LGPL license. You can use it,
+# redistribute it and/or modify it under the terms of the:
+# 
+# Eclipse Public License version 2.0, or
+# GNU General Public License version 2, or
+# GNU Lesser General Public License version 2.1.
+
+example "Thread.detect_recursion(Object.new) { }", false
+example "Thread.detect_recursion([]) { }", false
+example "Thread.detect_recursion({}) { }", false
+
+example "y = nil; Thread.detect_recursion(Object.new) { y = Thread.detect_recursion(Object.new) { } }; y", false
+example "x = Object.new; y = nil; Thread.detect_recursion(x) { y = Thread.detect_recursion(x) { } }; y", true
+
+def detect_recursion_recursive(method, object)
+  Thread.detect_recursion(object) do
+    object.send(method) do |child|
+      return detect_recursion_recursive(method, child)
+    end
+  end
+end
+
+example "detect_recursion_recursive(:each, [])", false
+example "detect_recursion_recursive(:each_value, {})", false
+example "a = []; a << a; detect_recursion_recursive(:each, a)", true
+example "a = {}; a[:a] = a; detect_recursion_recursive(:each_value, a)", true

--- a/test/truffle/compiler/pe/truffle/thread_pe.rb
+++ b/test/truffle/compiler/pe/truffle/thread_pe.rb
@@ -6,15 +6,15 @@
 # GNU General Public License version 2, or
 # GNU Lesser General Public License version 2.1.
 
-example "Thread.detect_recursion(Object.new) { }", false
-example "Thread.detect_recursion([]) { }", false
-example "Thread.detect_recursion({}) { }", false
+example "Truffle::ThreadOperations.detect_recursion(Object.new) { }", false
+example "Truffle::ThreadOperations.detect_recursion([]) { }", false
+example "Truffle::ThreadOperations.detect_recursion({}) { }", false
 
-example "y = nil; Thread.detect_recursion(Object.new) { y = Thread.detect_recursion(Object.new) { } }; y", false
-example "x = Object.new; y = nil; Thread.detect_recursion(x) { y = Thread.detect_recursion(x) { } }; y", true
+example "y = nil; Truffle::ThreadOperations.detect_recursion(Object.new) { y = Truffle::ThreadOperations.detect_recursion(Object.new) { } }; y", false
+example "x = Object.new; y = nil; Truffle::ThreadOperations.detect_recursion(x) { y = Truffle::ThreadOperations.detect_recursion(x) { } }; y", true
 
 def detect_recursion_recursive(method, object)
-  Thread.detect_recursion(object) do
+  Truffle::ThreadOperations.detect_recursion(object) do
     object.send(method) do |child|
       return detect_recursion_recursive(method, child)
     end


### PR DESCRIPTION
Trying to improve `detect_recursion` here with @LillianZ, as per https://github.com/oracle/truffleruby/issues/2011.

Here's what we've been trying to do:

* Wrote new specs and PE tests for `detect_recursion`.
* Moved the extra methods from `Thread` to `Truffle::ThreadOperations`.
* Replaced `recursion_guard` and `guarding?` with other primitives.
* `detect_outermost_recursion ` is never used with a paired object, so removed that option.
* `detect_recursion` has a lot of code not needed for the non-paired case, so split into `detect_recursion` and `detect_pair_recursion`.

That all keeps everything pretty much the same. I had hoped those changes would improve peak performance or compile time... but they didn't.

Then I tried:

* Reimplemented `detect_recursion` in Java.

Again I was sure this would improve compile time and maybe peak... but it didn't.

The benchmark I'm using is:

```ruby
require 'benchmark/ips'

empty = []
deep_nonrecursive = [[[[[[[[[[[[[[[[[[[[[[[[[[nil]]]]]]]]]]]]]]]]]]]]]]]]]]
deep_recursive = deep_nonrecursive.dup

def set_recursive(root, x)
  if x[0].nil?
    x[0] = root
  else
    set_recursive(root, x[0])
  end
end

set_recursive deep_recursive, deep_recursive

Benchmark.ips do |x|
  x.iterations = 3
  
  x.report 'empty' do
    empty.inspect
  end

  x.report 'deep_nonrecursive' do
    deep_nonrecursive.inspect
  end

  x.report 'deep_recursive' do
    deep_recursive.inspect
  end
end
```

Peak and compile time is not massively changed.

Does anyone have any thoughts on why simplifying this code so much as reimplementing the primitive in Java doesn't seem to achieve much? All the commits except the last one still make sense as the simplify and tidy the code.

The last commit causes one PE failure:

```
        FAILED: a = {}; a[:a] = a; detect_recursion_recursive(:each_value, a)
         wasn't constant
```

https://github.com/Shopify/truffleruby/issues/1