### PR TITLE
Fix refinements activation for eval binding scoping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Compatibility:
 * `File#path` now returns a new mutable String on every call like MRI (#2115).
 * Avoid infinite recursion when redefining `Warning#warn` and calling `Kernel#warn` (#2109).
 * Convert objects with `#to_path` in `$LOAD_PATH` (#2119).
+* Support refinements for eval with binding scoping (#2117, @ssnickolay)
 
 Performance:
 

--- a/spec/tags/core/module/using_tags.txt
+++ b/spec/tags/core/module/using_tags.txt
@@ -1,0 +1,1 @@
+slow:Module#using scope of refinement is active for eval with binding scope (main)

--- a/src/main/java/org/truffleruby/core/binding/BindingNodes.java
+++ b/src/main/java/org/truffleruby/core/binding/BindingNodes.java
@@ -414,4 +414,16 @@ public abstract class BindingNodes {
             return BindingNodes.createBinding(getContext(), callerFrame);
         }
     }
+
+    @Primitive(name = "caller_binding_with_new_frame")
+    public abstract static class CallerBindingWithNewFrameNode extends PrimitiveArrayArgumentsNode {
+
+        @Child ReadCallerFrameNode callerFrameNode = new ReadCallerFrameNode();
+
+        @Specialization
+        protected RubyBinding binding(VirtualFrame frame) {
+            final MaterializedFrame callerFrame = callerFrameNode.execute(frame);
+            return BindingNodes.createBinding(getContext(), newFrame(callerFrame));
+        }
+    }
 }

--- a/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
+++ b/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
@@ -798,9 +798,8 @@ public abstract class KernelNodes {
             final DeclarationContext declarationContext = RubyArguments.getDeclarationContext(frame);
             final FrameDescriptor descriptor = frame.getFrameDescriptor();
             RubyRootNode rootNode = buildRootNode(source, frame, file, line, false);
-            if (assignsNewUserVariables(descriptor)) {
-                binding.setFrame(frame);
-            }
+            binding.setFrame(frame);
+
             return getContext().getCodeLoader().prepareExecute(
                     ParserContext.EVAL,
                     declarationContext,

--- a/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
+++ b/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
@@ -696,45 +696,14 @@ public abstract class KernelNodes {
         public abstract Object execute(VirtualFrame frame, Object target, RubyString source, RubyBinding binding,
                 RubyString file, int line);
 
-        // If the source defines new local variables, those should be set in the Binding.
-        // So we have 2 specializations for whether or not the code defines new local variables.
-
         @Specialization(
                 guards = {
                         "equalNode.execute(source.rope, cachedSource)",
                         "equalNode.execute(file.rope, cachedFile)",
                         "line == cachedLine",
-                        "!assignsNewUserVariables(getDescriptor(cachedRootNode))",
                         "bindingDescriptor == getBindingDescriptor(binding)" },
                 limit = "getCacheLimit()")
-        protected Object evalBindingNoAddsVarsCached(
-                Object target,
-                RubyString source,
-                RubyBinding binding,
-                RubyString file,
-                int line,
-                @Cached("privatizeRope(source)") Rope cachedSource,
-                @Cached("privatizeRope(file)") Rope cachedFile,
-                @Cached("line") int cachedLine,
-                @Cached("getBindingDescriptor(binding)") FrameDescriptor bindingDescriptor,
-                @Cached("compileSource(cachedSource, getBindingFrame(binding), cachedFile, cachedLine)") RootNodeWrapper cachedRootNode,
-                @Cached("createCallTarget(cachedRootNode)") RootCallTarget cachedCallTarget,
-                @Cached("create(cachedCallTarget)") DirectCallNode callNode,
-                @Cached RopeNodes.EqualNode equalNode) {
-            final MaterializedFrame parentFrame = binding.getFrame();
-            return eval(target, cachedRootNode, cachedCallTarget, callNode, parentFrame);
-        }
-
-        @Specialization(
-                guards = {
-                        "equalNode.execute(source.rope, cachedSource)",
-                        "equalNode.execute(file.rope, cachedFile)",
-                        "line == cachedLine",
-                        "assignsNewUserVariables(getDescriptor(cachedRootNode))",
-                        "!assignsNewUserVariables(getDescriptor(rootNodeToEval))",
-                        "bindingDescriptor == getBindingDescriptor(binding)" },
-                limit = "getCacheLimit()")
-        protected Object evalBindingAddsVarsCached(
+        protected Object evalBindingCached(
                 Object target,
                 RubyString source,
                 RubyBinding binding,

--- a/src/main/java/org/truffleruby/language/methods/UsingNode.java
+++ b/src/main/java/org/truffleruby/language/methods/UsingNode.java
@@ -39,6 +39,16 @@ public abstract class UsingNode extends RubyContextNode {
         }
 
         final Frame callerFrame = getContext().getCallStack().getCallerFrameIgnoringSend(FrameAccess.READ_WRITE);
+        using(module, callerFrame);
+
+        if (RubyArguments.getMethod(callerFrame).toString().contains("(eval)")) {
+            final Frame evalFrame = RubyArguments.getDeclarationFrame(callerFrame);
+            using(module, evalFrame);
+        }
+    }
+
+    @TruffleBoundary
+    private void using(RubyModule module, Frame callerFrame) {
         final DeclarationContext declarationContext = RubyArguments.getDeclarationContext(callerFrame);
         final Map<RubyModule, RubyModule[]> newRefinements = usingModule(declarationContext, module);
         if (!newRefinements.isEmpty()) {

--- a/src/main/ruby/truffleruby/core/kernel.rb
+++ b/src/main/ruby/truffleruby/core/kernel.rb
@@ -319,7 +319,7 @@ module Kernel
       receiver = a_binding.receiver
     else
       receiver = self
-      a_binding = Primitive.caller_binding
+      a_binding = Primitive.caller_binding_with_new_frame
     end
 
     Primitive.kernel_eval(receiver, str, a_binding, file, line)

--- a/test/mri/excludes/TestRefinement.rb
+++ b/test/mri/excludes/TestRefinement.rb
@@ -1,4 +1,3 @@
-exclude :test_eval_scoping, "needs investigation"
 exclude :test_include_refinement, "needs investigation"
 exclude :test_prepend_after_refine, "needs investigation"
 exclude :test_refine_prepended_class, "needs investigation"

--- a/test/mri/excludes/TestRefinement.rb
+++ b/test/mri/excludes/TestRefinement.rb
@@ -1,4 +1,4 @@
-exclude :test_eval_with_binding_scoping, "needs investigation"
+exclude :test_eval_scoping, "needs investigation"
 exclude :test_include_refinement, "needs investigation"
 exclude :test_prepend_after_refine, "needs investigation"
 exclude :test_refine_prepended_class, "needs investigation"


### PR DESCRIPTION
_The fix almost works, but..._

The source of the issue is:
https://github.com/oracle/truffleruby/blob/d7043a7ed3a156307539ad2afc813386742e43d1/test/mri/excludes/TestRefinement.rb#L1

As we discussed on Slack, I ported the test to `ruby/spec` and extended slightly.

The problem is we store active refinements in the frame arguments, and it works for `using` caller frame, but if we pass `binding` via `eval` it should be activated for binding's frame too:

https://github.com/oracle/truffleruby/blob/d7043a7ed3a156307539ad2afc813386742e43d1/src/main/java/org/truffleruby/core/kernel/KernelNodes.java#L723 

In other words, refinements activation must occur several levels higher up the frame call stack too.

I am currently trying to find a solution that will not increase the footprint (does not require storing additional values). So I wanted to use `RubyArguments.getDeclarationFrame(callerFrame);` and it works if we run 
```sh
$ jt test spec/ruby/core/module/using_spec.rb
[- | ==================100%================== | 00:00:00]      0F      0E

Finished in 2.904000 seconds

7 files, 86 examples, 117 expectations, 0 failures, 0 errors, 0 tagged
```

but does not work if we run the test in as suite:
```sh
$ jt test spec/ruby/core/module
1)
Module#using scope of refinement is active for eval with binding scoping FAILED
Expected ["HELLO WORLD", "dlrow olleh", "HELLO WORLD", "HELLO WORLD", "HELLO WORLD"] == ["HELLO WORLD", "dlrow olleh", "dlrow olleh", "dlrow olleh", "HELLO WORLD"]
to be truthy but was false
/Users/ssnickolay/Projects/oss/graal/truffleruby-ws-2/truffleruby/spec/ruby/core/module/using_spec.rb:401:in `block (3 levels) in <top (required)>'
/Users/ssnickolay/Projects/oss/graal/truffleruby-ws-2/truffleruby/spec/ruby/core/module/using_spec.rb:3:in `<top (required)>'
[/ | ==================100%================== | 00:00:00]      1F      0E

Finished in 3.413000 seconds

55 files, 526 examples, 883 expectations, 1 failure, 0 errors, 12 tagged
```

I checked, and the reason is not in the test code -
- Using new class instead of String does not help
- Removing a part of `spec/ruby/core/module` helps only if we keep 1-2 random test files.

I guess the key reason here in some cache. If we run many specs, code is cached, and we get the error. (on the picture reasult of `Truffle.getRuntime().iterateFrames(new CallStackManager.FilterApplyVisitor<>(0, f -> true, o -> o))`)
![Untitled 3 001](https://user-images.githubusercontent.com/2331796/95312955-3c9e7180-0898-11eb-9896-9222b101b95d.jpeg)

You can see that running a bunch of tests `getDeclarationFrame` is look like new (no tags, etc.).

Any ideas on how to fix this? Or is this the wrong way to solve the problem anyway?
