### PR TITLE
Update to Joni 2.1.40 and JCodings 1.0.55

### DIFF
--- a/3rd_party_licenses.txt
+++ b/3rd_party_licenses.txt
@@ -41,7 +41,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SU
 ================================================================================
 
-JONI 2.1.30
+JONI 2.1.40
 
 /*
 * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -365,7 +365,7 @@ OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 SUCH DAMAGE.
 ================================================================================
 
-JCodings 1.0.45
+JCodings 1.0.55
 
 /*
 * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ Compatibility:
 * Convert objects with `#to_path` in `$LOAD_PATH` (#2119).
 * Handle the functions being native for `rb_thread_call_without_gvl()` (#2090).
 * Support refinements for Kernel#respond_to? (#2120, @ssnickolay)
+* JCodings has been updated from 1.0.45 to 1.0.55.
+* Joni has been updated from 2.1.30 to 2.1.40.
 
 Performance:
 

--- a/mx.truffleruby/suite.py
+++ b/mx.truffleruby/suite.py
@@ -51,9 +51,9 @@ suite = {
             "maven": {
                 "groupId": "org.jruby.joni",
                 "artifactId": "joni",
-                "version": "2.1.30"
+                "version": "2.1.40"
             },
-            "sha1": "a23a567521996c2a412688763892cddbca7c3bd6",
+            "sha1": "18766fa1b624d615d3a1cac513bf729adfd6b38f",
             "sourceSha1": "a1444342fc0c275613d43ca3d0a71ce919d85b18",
             "license": ["MIT"],
         },
@@ -62,9 +62,9 @@ suite = {
             "maven": {
                 "groupId": "org.jruby.jcodings",
                 "artifactId": "jcodings",
-                "version": "1.0.45"
+                "version": "1.0.55"
             },
-            "sha1": "029404c013b3d51a8c60fac80409bb3d64dfb816",
+            "sha1": "57169ef6964f44aef67b247cb87f053d93182488",
             "sourceSha1": "702693ea01e006385f2834ad56dad54b7a4ca248",
             "license": ["MIT"],
         },


### PR DESCRIPTION
sourceSha1 in suite.py ignored because I couldn't determine what it was; if change needed please advise. Thanks!

It's been 10 subsubreleases and almost a year since an update for each, and there's been at least one relevant bug fix since then (https://github.com/jruby/jcodings/issues/39, possibly fixed by https://github.com/jruby/jcodings/commit/408210ce852febb2959f2bcdc460f2c91c195117). 