### PR TITLE
Refactor Kernel#respond_to? specializations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ New features:
 
 Bug fixes:
 
+* Fix error message when the method name is not a Symbol or String for `Kernel#respond_to?` (#2132, @ssnickolay)
+
 
 Compatibility:
 

--- a/spec/ruby/core/kernel/respond_to_spec.rb
+++ b/spec/ruby/core/kernel/respond_to_spec.rb
@@ -25,7 +25,7 @@ describe "Kernel#respond_to?" do
   end
 
   it "throws a type error if argument can't be coerced into a Symbol" do
-    -> { @a.respond_to?(Object.new) }.should raise_error(TypeError)
+    -> { @a.respond_to?(Object.new) }.should raise_error(TypeError, /is not a symbol nor a string/)
   end
 
   it "returns false if obj responds to the given protected method" do
@@ -69,5 +69,4 @@ describe "Kernel#respond_to?" do
     KernelSpecs::Foo.new.respond_to?(:bar).should == true
     KernelSpecs::Foo.new.respond_to?(:invalid_and_silly_method_name).should == false
   end
-
 end

--- a/src/main/java/org/truffleruby/core/exception/CoreExceptions.java
+++ b/src/main/java/org/truffleruby/core/exception/CoreExceptions.java
@@ -505,6 +505,14 @@ public class CoreExceptions {
     }
 
     @TruffleBoundary
+    public RubyException typeErrorIsNotAOrB(String value, String expectedTypeA, String expectedTypeB,
+            Node currentNode) {
+        return typeError(
+                StringUtils.format("%s is not a %s nor a %s", value, expectedTypeA, expectedTypeB),
+                currentNode);
+    }
+
+    @TruffleBoundary
     public RubyException typeErrorIsNotAClassModule(Object value, Node currentNode) {
         return typeError(inspectReceiver(value) + " is not a class/module", currentNode);
     }

--- a/src/main/java/org/truffleruby/core/exception/CoreExceptions.java
+++ b/src/main/java/org/truffleruby/core/exception/CoreExceptions.java
@@ -505,10 +505,10 @@ public class CoreExceptions {
     }
 
     @TruffleBoundary
-    public RubyException typeErrorIsNotAOrB(String value, String expectedTypeA, String expectedTypeB,
+    public RubyException typeErrorIsNotAOrB(Object value, String expectedTypeA, String expectedTypeB,
             Node currentNode) {
         return typeError(
-                StringUtils.format("%s is not a %s nor a %s", value, expectedTypeA, expectedTypeB),
+                StringUtils.format("%s is not a %s nor a %s", inspectReceiver(value), expectedTypeA, expectedTypeB),
                 currentNode);
     }
 

--- a/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
+++ b/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
@@ -1596,7 +1596,7 @@ public abstract class KernelNodes {
             if (notSymbolOrStringProfile.profile(!RubyGuards.isRubySymbolOrString(name))) {
                 throw new RaiseException(
                         getContext(),
-                        coreExceptions().typeErrorIsNotAOrB(object.toString(), "symbol", "string", this));
+                        coreExceptions().typeErrorIsNotAOrB(object, "symbol", "string", this));
             }
 
             final boolean ret;

--- a/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
+++ b/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
@@ -46,6 +46,7 @@ import org.truffleruby.core.cast.BooleanCastWithDefaultNodeGen;
 import org.truffleruby.core.cast.DurationToMillisecondsNodeGen;
 import org.truffleruby.core.cast.NameToJavaStringNode;
 import org.truffleruby.core.cast.ToStringOrSymbolNodeGen;
+import org.truffleruby.core.cast.ToSymbolNode;
 import org.truffleruby.core.exception.GetBacktraceException;
 import org.truffleruby.core.format.BytesResult;
 import org.truffleruby.core.format.FormatExceptionTranslator;
@@ -1584,12 +1585,20 @@ public abstract class KernelNodes {
         }
 
         @Specialization
-        protected boolean doesRespondToString(
+        protected boolean doesRespondTo(
                 VirtualFrame frame,
                 Object object,
-                RubyString name,
+                Object name,
                 boolean includeProtectedAndPrivate,
-                @Cached ToJavaStringNode toJavaString) {
+                @Cached ConditionProfile notSymbolOrStringProfile,
+                @Cached ToJavaStringNode toJavaString,
+                @Cached ToSymbolNode toSymbolNode) {
+            if (notSymbolOrStringProfile.profile(!RubyGuards.isRubySymbolOrString(name))) {
+                throw new RaiseException(
+                        getContext(),
+                        coreExceptions().typeErrorIsNotAOrB(object.toString(), "symbol", "string", this));
+            }
+
             final boolean ret;
             useCallerRefinements(frame);
 
@@ -1603,33 +1612,7 @@ public abstract class KernelNodes {
                 return true;
             } else if (respondToMissingProfile
                     .profile(dispatchRespondToMissing.execute(frame, object, "respond_to_missing?"))) {
-                return respondToMissing(object, getSymbol(name.rope), includeProtectedAndPrivate);
-            } else {
-                return false;
-            }
-        }
-
-        @Specialization
-        protected boolean doesRespondToSymbol(
-                VirtualFrame frame,
-                Object object,
-                RubySymbol name,
-                boolean includeProtectedAndPrivate,
-                @Cached ToJavaStringNode toJavaString) {
-            final boolean ret;
-            useCallerRefinements(frame);
-
-            if (ignoreVisibilityProfile.profile(includeProtectedAndPrivate)) {
-                ret = dispatchIgnoreVisibility.execute(frame, object, toJavaString.executeToJavaString(name));
-            } else {
-                ret = dispatch.execute(frame, object, toJavaString.executeToJavaString(name));
-            }
-
-            if (isTrueProfile.profile(ret)) {
-                return true;
-            } else if (respondToMissingProfile
-                    .profile(dispatchRespondToMissing.execute(frame, object, "respond_to_missing?"))) {
-                return respondToMissing(object, name, includeProtectedAndPrivate);
+                return respondToMissing(object, toSymbolNode.execute(name), includeProtectedAndPrivate);
             } else {
                 return false;
             }


### PR DESCRIPTION
Related to https://github.com/oracle/truffleruby/pull/2120#discussion_r502441639

The test output before the PR changes:
```ruby
1)
Kernel#respond_to? throws a type error if argument can't be coerced into a Symbol ERROR
Expected TypeError ((?-mix:is not a symbol nor a string))
but got: TypeError (TruffleRuby doesn't have a case for the org.truffleruby.core.kernel.KernelNodesFactory$RespondToNodeFactory$RespondToNodeGen node with values of type KernelSpecs::A(org.truffleruby.core.basicobject.RubyBasicObject) Object(org.truffleruby.core.basicobject.RubyBasicObject) java.lang.Boolean=false
	from org.truffleruby.core.kernel.KernelNodesFactory$RespondToNodeFactory$RespondToNodeGen.executeAndSpecialize(KernelNodesFactory.java:5238)
	from org.truffleruby.core.kernel.KernelNodesFactory$RespondToNodeFactory$RespondToNodeGen.execute(KernelNodesFactory.java:5210)
	from org.truffleruby.language.arguments.CheckArityNode.execute(CheckArityNode.java:41)
	from org.truffleruby.language.methods.ExceptionTranslatingNode.execute(ExceptionTranslatingNode.java:33)
	from org.truffleruby.language.RubyRootNode.execute(RubyRootNode.java:64)
	from com.oracle.truffle.api.impl.DefaultCallTarget.callDirectOrIndirect(DefaultCallTarget.java:84))
/Users/ssnickolay/Projects/oss/graal/truffleruby-ws-2/truffleruby/spec/ruby/core/kernel/respond_to_spec.rb:28:in `respond_to?'
```

Not sure if I should add a note to the Changelog