### PR TITLE
Minor improvements to Enumerator::Lazy#uniq and #chunk

### DIFF
--- a/spec/tags/core/enumerator/lazy/chunk_tags.txt
+++ b/spec/tags/core/enumerator/lazy/chunk_tags.txt
@@ -1,3 +1,2 @@
-fails:Enumerator::Lazy#chunk returns a new instance of Enumerator::Lazy
 fails:Enumerator::Lazy#chunk calls the block with gathered values when yield with multiple arguments
 fails:Enumerator::Lazy#chunk returns an Enumerator if called without a block

--- a/spec/tags/core/enumerator/lazy/uniq_tags.txt
+++ b/spec/tags/core/enumerator/lazy/uniq_tags.txt
@@ -1,6 +1,3 @@
-fails:Enumerator::Lazy#uniq without block returns a lazy enumerator
 fails:Enumerator::Lazy#uniq without block return same value after rewind
-fails:Enumerator::Lazy#uniq when yielded with an argument returns a lazy enumerator
 fails:Enumerator::Lazy#uniq when yielded with an argument return same value after rewind
 fails:Enumerator::Lazy#uniq when yielded with multiple arguments return same value after rewind
-fails:Enumerator::Lazy#uniq when yielded with multiple arguments returns all yield arguments as an array

--- a/src/main/ruby/truffleruby/core/enumerator.rb
+++ b/src/main/ruby/truffleruby/core/enumerator.rb
@@ -498,8 +498,11 @@ class Enumerator
       end
     end
 
+    def chunk(&original_block)
+      super.lazy
+    end
+
     # clone these methods from the superclass
-    alias_method :chunk, :chunk
     alias_method :chunk_while, :chunk_while
     alias_method :slice_after, :slice_after
     alias_method :slice_before, :slice_before

--- a/src/main/ruby/truffleruby/core/enumerator.rb
+++ b/src/main/ruby/truffleruby/core/enumerator.rb
@@ -293,6 +293,8 @@ class Enumerator
       self
     end
 
+    # TODO: rewind and/or to_a/force behave improperly on outputs of take, drop, uniq, possibly more
+
     alias_method :force, :to_a
 
     def take(n)
@@ -505,8 +507,8 @@ class Enumerator
 
     def uniq
       if block_given?
+        h = {}
         Lazy.new(self, nil) do |yielder, *args|
-          h = {}
           val = args.length >= 2 ? args : args.first
           comp = yield(val)
           unless h.key?(comp)
@@ -515,8 +517,8 @@ class Enumerator
           end
         end
       else
+        h = {}
         Lazy.new(self, nil) do |yielder, *args|
-          h = {}
           val = args.length >= 2 ? args : args.first
           unless h.key?(val)
             h[val] = true


### PR DESCRIPTION
Code for `Enumerator::Lazy#uniq` seems correct to me, but to pass the rest of the specs I think some of `rewind` and `to_a`/`force` or something more fundamental needs a fix. 

The pair of `rewind` and `to_a`/`force` behaves improperly on the outputs of `take`, `drop`, `uniq`, etc, but seemed okay on the output of `map`, and I couldn't determine the root cause.

https://github.com/Shopify/truffleruby/issues/1