### PR TITLE
make MatchData#length faster

### DIFF
--- a/src/main/java/org/truffleruby/core/regexp/MatchDataNodes.java
+++ b/src/main/java/org/truffleruby/core/regexp/MatchDataNodes.java
@@ -564,11 +564,9 @@ public abstract class MatchDataNodes {
     @CoreMethod(names = { "length", "size" })
     public abstract static class LengthNode extends CoreMethodArrayArgumentsNode {
 
-        @Child private ValuesNode getValues = ValuesNode.create();
-
         @Specialization
         protected int length(RubyMatchData matchData) {
-            return getValues.execute(matchData).length;
+            return matchData.region.numRegs;
         }
 
     }


### PR DESCRIPTION
Tested as part of a larger RegEx benchmark, this modification noticeably improved the runtime. Unfortunately I lost the numbers, but they could be reproduced if needed. 

https://github.com/Shopify/truffleruby/issues/1