### PR TITLE
Implement and untag Enumerable#filter_map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Compatibility:
 
 * Implement `String#undump` (#2131, @kustosz)
 * `Errno` constants with the same `errno` number are now the same class.
+* Implement `Enumerable#tally` and `Enumerable#filter_map` (#2144 and #2152, @LillianZ).
 
 Performance:
 

--- a/spec/tags/core/enumerable/filter_map_tags.txt
+++ b/spec/tags/core/enumerable/filter_map_tags.txt
@@ -1,3 +1,0 @@
-fails:Enumerable#filter_map returns an empty array if there are no elements
-fails:Enumerable#filter_map returns an array with truthy results of passing each element to block
-fails:Enumerable#filter_map returns an enumerator when no block given

--- a/src/main/ruby/truffleruby/core/enumerable.rb
+++ b/src/main/ruby/truffleruby/core/enumerable.rb
@@ -924,6 +924,19 @@ module Enumerable
     ary
   end
 
+  def filter_map
+    return to_enum(:filter_map) { enumerator_size } unless block_given?
+
+    ary = []
+    each do
+      o = Primitive.single_block_arg
+      v = yield(o)
+      ary << v if v
+    end
+
+    ary
+  end
+
   def reverse_each(&block)
     return to_enum(:reverse_each) { enumerator_size } unless block_given?
 


### PR DESCRIPTION
Implements Enumerable#filter_map for Ruby 2.7 compatibility #2004

Also, after this and https://github.com/oracle/truffleruby/pull/2145 are merged, we'll be totally compliant with Enumerable specs!

https://github.com/Shopify/truffleruby/issues/1