### PR TITLE
Implement beginless range

### DIFF
--- a/spec/ruby/core/array/element_set_spec.rb
+++ b/spec/ruby/core/array/element_set_spec.rb
@@ -439,7 +439,6 @@ end
 
 ruby_version_is "2.6" do
   describe "Array#[]= with [m..]" do
-
     it "just sets the section defined by range to nil even if the rhs is nil" do
       a = [1, 2, 3, 4, 5]
       a[eval("(2..)")] = nil
@@ -472,6 +471,53 @@ ruby_version_is "2.6" do
       a.should == [1, 2, 3, 4]
       a[eval("(5..)")] = [6]
       a.should == [1, 2, 3, 4, nil, 6]
+    end
+  end
+end
+
+ruby_version_is "2.7" do
+  describe "Array#[]= with [..n] and [...n]" do
+    it "just sets the section defined by range to nil even if the rhs is nil" do
+      a = [1, 2, 3, 4, 5]
+      a[eval("(..2)")] = nil
+      a.should == [nil, 4, 5]
+      a[eval("(...2)")] = nil
+      a.should == [nil, 5]
+    end
+
+    it "just sets the section defined by range to nil if n < 0 and the rhs is nil" do
+      a = [1, 2, 3, 4, 5]
+      a[eval("(..-3)")] = nil
+      a.should == [nil, 4, 5]
+      a[eval("(...-1)")] = [nil, 5]
+    end
+
+    it "replaces the section defined by range" do
+      a = [6, 5, 4, 3, 2, 1]
+      a[eval("(...3)")] = 9
+      a.should == [9, 3, 2, 1]
+      a[eval("(..2)")] = [7, 7, 7, 7, 7]
+      a.should == [7, 7, 7, 7, 7, 1]
+    end
+
+    it "replaces the section if n < 0" do
+      a = [1, 2, 3, 4, 5]
+      a[eval("(..-2)")] = [7, 8, 9]
+      a.should == [7, 8, 9, 5]
+    end
+
+    it "replaces everything if n > the array size" do
+      a = [1, 2, 3]
+      a[eval("(...7)")] = [4]
+      a.should == [4]
+    end
+
+    it "inserts at the beginning if n < negative the array size" do
+      a = [1, 2, 3]
+      a[eval("(..-7)")] = [4]
+      a.should == [4, 1, 2, 3]
+      a[eval("(...-10)")] = [6]
+      a.should == [6, 4, 1, 2, 3]
     end
   end
 end

--- a/spec/ruby/core/array/fill_spec.rb
+++ b/spec/ruby/core/array/fill_spec.rb
@@ -327,8 +327,8 @@ describe "Array#fill with (filler, range)" do
 
   ruby_version_is "2.7" do
     it "works with beginless ranges" do
-      [1, 2, 3, 4].fill('x', eval("(nil..2)")).should == ["x", "x", "x", 4]
-      [1, 2, 3, 4].fill(eval("(nil...2)")) { |x| x + 2 }.should == [2, 3, 3, 4]
+      [1, 2, 3, 4].fill('x', eval("(..2)")).should == ["x", "x", "x", 4]
+      [1, 2, 3, 4].fill(eval("(...2)")) { |x| x + 2 }.should == [2, 3, 3, 4]
     end
   end
 end

--- a/spec/ruby/core/array/fill_spec.rb
+++ b/spec/ruby/core/array/fill_spec.rb
@@ -327,8 +327,8 @@ describe "Array#fill with (filler, range)" do
 
   ruby_version_is "2.7" do
     it "works with beginless ranges" do
-      [1, 2, 3, 4].fill('x', Range.new(nil, 2)).should == ["x", "x", "x", 4]
-      [1, 2, 3, 4].fill(Range.new(nil, 2, true)) { |x| x + 2 }.should == [2, 3, 3, 4]
+      [1, 2, 3, 4].fill('x', eval("(nil..2)")).should == ["x", "x", "x", 4]
+      [1, 2, 3, 4].fill(eval("(nil...2)")) { |x| x + 2 }.should == [2, 3, 3, 4]
     end
   end
 end

--- a/spec/ruby/core/array/fill_spec.rb
+++ b/spec/ruby/core/array/fill_spec.rb
@@ -324,4 +324,11 @@ describe "Array#fill with (filler, range)" do
       [1, 2, 3, 4].fill(eval("(3...)")) { |x| x + 2 }.should == [1, 2, 3, 5]
     end
   end
+
+  ruby_version_is "2.7" do
+    it "works with beginless ranges" do
+      [1, 2, 3, 4].fill('x', Range.new(nil, 2)).should == ["x", "x", "x", 4]
+      [1, 2, 3, 4].fill(Range.new(nil, 2, true)) { |x| x + 2 }.should == [2, 3, 3, 4]
+    end
+  end
 end

--- a/spec/ruby/core/array/shared/slice.rb
+++ b/spec/ruby/core/array/shared/slice.rb
@@ -520,4 +520,40 @@ describe :array_slice, shared: true do
     -> { "hello".send(@method, bignum_value..(bignum_value + 1)) }.should raise_error(RangeError)
     -> { "hello".send(@method, 0..bignum_value) }.should raise_error(RangeError)
   end
+
+  ruby_version_is "2.6" do
+    it "can accept endless ranges" do
+      a = [0, 1, 2, 3, 4, 5]
+      a.send(@method, Range.new(2, nil, false)).should == [2, 3, 4, 5]
+      a.send(@method, Range.new(2, nil, true)).should == [2, 3, 4, 5]
+      a.send(@method, Range.new(-2, nil, false)).should == [4, 5]
+      a.send(@method, Range.new(-2, nil, true)).should == [4, 5]
+      a.send(@method, Range.new(9, nil, false)).should == nil
+      a.send(@method, Range.new(9, nil, true)).should == nil
+      a.send(@method, Range.new(-9, nil, false)).should == nil
+      a.send(@method, Range.new(-9, nil, true)).should == nil
+    end
+  end
+
+  ruby_version_is "2.7" do
+    it "can accept beginless ranges" do
+      a = [0, 1, 2, 3, 4, 5]
+      a.send(@method, Range.new(nil, 3, false)).should == [0, 1, 2, 3]
+      a.send(@method, Range.new(nil, 3, true)).should == [0, 1, 2]
+      a.send(@method, Range.new(nil, -3, false)).should == [0, 1, 2, 3]
+      a.send(@method, Range.new(nil, -3, true)).should == [0, 1, 2]
+      a.send(@method, Range.new(nil, 0, false)).should == [0]
+      a.send(@method, Range.new(nil, 0, true)).should == []
+      a.send(@method, Range.new(nil, 9, false)).should == [0, 1, 2, 3, 4, 5]
+      a.send(@method, Range.new(nil, 9, true)).should == [0, 1, 2, 3, 4, 5]
+      a.send(@method, Range.new(nil, -9, false)).should == []
+      a.send(@method, Range.new(nil, -9, true)).should == []
+    end
+
+    it "can accept nil...nil ranges" do
+      a = [0, 1, 2, 3, 4, 5]
+      a.send(@method, Range.new(nil, nil, false)).should == a
+      a.send(@method, Range.new(nil, nil, true)).should == a
+    end
+  end
 end

--- a/spec/ruby/core/array/shared/slice.rb
+++ b/spec/ruby/core/array/shared/slice.rb
@@ -524,30 +524,30 @@ describe :array_slice, shared: true do
   ruby_version_is "2.6" do
     it "can accept endless ranges" do
       a = [0, 1, 2, 3, 4, 5]
-      a.send(@method, eval("(2..nil)")).should == [2, 3, 4, 5]
-      a.send(@method, eval("(2...nil)")).should == [2, 3, 4, 5]
-      a.send(@method, eval("(-2..nil)")).should == [4, 5]
-      a.send(@method, eval("(-2...nil)")).should == [4, 5]
-      a.send(@method, eval("(9..nil)")).should == nil
-      a.send(@method, eval("(9...nil)")).should == nil
-      a.send(@method, eval("(-9..nil)")).should == nil
-      a.send(@method, eval("(-9...nil)")).should == nil
+      a.send(@method, eval("(2..)")).should == [2, 3, 4, 5]
+      a.send(@method, eval("(2...)")).should == [2, 3, 4, 5]
+      a.send(@method, eval("(-2..)")).should == [4, 5]
+      a.send(@method, eval("(-2...)")).should == [4, 5]
+      a.send(@method, eval("(9..)")).should == nil
+      a.send(@method, eval("(9...)")).should == nil
+      a.send(@method, eval("(-9..)")).should == nil
+      a.send(@method, eval("(-9...)")).should == nil
     end
   end
 
   ruby_version_is "2.7" do
     it "can accept beginless ranges" do
       a = [0, 1, 2, 3, 4, 5]
-      a.send(@method, eval("(nil..3)")).should == [0, 1, 2, 3]
-      a.send(@method, eval("(nil...3)")).should == [0, 1, 2]
-      a.send(@method, eval("(nil..-3)")).should == [0, 1, 2, 3]
-      a.send(@method, eval("(nil...-3)")).should == [0, 1, 2]
-      a.send(@method, eval("(nil..0)")).should == [0]
-      a.send(@method, eval("(nil...0)")).should == []
-      a.send(@method, eval("(nil..9)")).should == [0, 1, 2, 3, 4, 5]
-      a.send(@method, eval("(nil...9)")).should == [0, 1, 2, 3, 4, 5]
-      a.send(@method, eval("(nil..-9)")).should == []
-      a.send(@method, eval("(nil...-9)")).should == []
+      a.send(@method, eval("(..3)")).should == [0, 1, 2, 3]
+      a.send(@method, eval("(...3)")).should == [0, 1, 2]
+      a.send(@method, eval("(..-3)")).should == [0, 1, 2, 3]
+      a.send(@method, eval("(...-3)")).should == [0, 1, 2]
+      a.send(@method, eval("(..0)")).should == [0]
+      a.send(@method, eval("(...0)")).should == []
+      a.send(@method, eval("(..9)")).should == [0, 1, 2, 3, 4, 5]
+      a.send(@method, eval("(...9)")).should == [0, 1, 2, 3, 4, 5]
+      a.send(@method, eval("(..-9)")).should == []
+      a.send(@method, eval("(...-9)")).should == []
     end
 
     it "can accept nil...nil ranges" do

--- a/spec/ruby/core/array/shared/slice.rb
+++ b/spec/ruby/core/array/shared/slice.rb
@@ -524,36 +524,37 @@ describe :array_slice, shared: true do
   ruby_version_is "2.6" do
     it "can accept endless ranges" do
       a = [0, 1, 2, 3, 4, 5]
-      a.send(@method, Range.new(2, nil, false)).should == [2, 3, 4, 5]
-      a.send(@method, Range.new(2, nil, true)).should == [2, 3, 4, 5]
-      a.send(@method, Range.new(-2, nil, false)).should == [4, 5]
-      a.send(@method, Range.new(-2, nil, true)).should == [4, 5]
-      a.send(@method, Range.new(9, nil, false)).should == nil
-      a.send(@method, Range.new(9, nil, true)).should == nil
-      a.send(@method, Range.new(-9, nil, false)).should == nil
-      a.send(@method, Range.new(-9, nil, true)).should == nil
+      a.send(@method, eval("(2..nil)")).should == [2, 3, 4, 5]
+      a.send(@method, eval("(2...nil)")).should == [2, 3, 4, 5]
+      a.send(@method, eval("(-2..nil)")).should == [4, 5]
+      a.send(@method, eval("(-2...nil)")).should == [4, 5]
+      a.send(@method, eval("(9..nil)")).should == nil
+      a.send(@method, eval("(9...nil)")).should == nil
+      a.send(@method, eval("(-9..nil)")).should == nil
+      a.send(@method, eval("(-9...nil)")).should == nil
     end
   end
 
   ruby_version_is "2.7" do
     it "can accept beginless ranges" do
       a = [0, 1, 2, 3, 4, 5]
-      a.send(@method, Range.new(nil, 3, false)).should == [0, 1, 2, 3]
-      a.send(@method, Range.new(nil, 3, true)).should == [0, 1, 2]
-      a.send(@method, Range.new(nil, -3, false)).should == [0, 1, 2, 3]
-      a.send(@method, Range.new(nil, -3, true)).should == [0, 1, 2]
-      a.send(@method, Range.new(nil, 0, false)).should == [0]
-      a.send(@method, Range.new(nil, 0, true)).should == []
-      a.send(@method, Range.new(nil, 9, false)).should == [0, 1, 2, 3, 4, 5]
-      a.send(@method, Range.new(nil, 9, true)).should == [0, 1, 2, 3, 4, 5]
-      a.send(@method, Range.new(nil, -9, false)).should == []
-      a.send(@method, Range.new(nil, -9, true)).should == []
+      a.send(@method, eval("(nil..3)")).should == [0, 1, 2, 3]
+      a.send(@method, eval("(nil...3)")).should == [0, 1, 2]
+      a.send(@method, eval("(nil..-3)")).should == [0, 1, 2, 3]
+      a.send(@method, eval("(nil...-3)")).should == [0, 1, 2]
+      a.send(@method, eval("(nil..0)")).should == [0]
+      a.send(@method, eval("(nil...0)")).should == []
+      a.send(@method, eval("(nil..9)")).should == [0, 1, 2, 3, 4, 5]
+      a.send(@method, eval("(nil...9)")).should == [0, 1, 2, 3, 4, 5]
+      a.send(@method, eval("(nil..-9)")).should == []
+      a.send(@method, eval("(nil...-9)")).should == []
     end
 
     it "can accept nil...nil ranges" do
       a = [0, 1, 2, 3, 4, 5]
-      a.send(@method, Range.new(nil, nil, false)).should == a
-      a.send(@method, Range.new(nil, nil, true)).should == a
+      a.send(@method, eval("(nil...nil)")).should == a
+      a.send(@method, eval("(...nil)")).should == a
+      a.send(@method, eval("(nil..)")).should == a
     end
   end
 end

--- a/spec/ruby/core/array/slice_spec.rb
+++ b/spec/ruby/core/array/slice_spec.rb
@@ -165,6 +165,18 @@ describe "Array#slice!" do
       a.should == [1, 2]
     end
   end
+
+  ruby_version_is "2.7" do
+    it "works with beginless ranges" do
+      a = [0,1,2,3,4]
+      a.slice!(Range.new(nil, 3)).should == [0, 1, 2, 3]
+      a.should == [4]
+
+      a = [0,1,2,3,4]
+      a.slice!(Range.new(nil, -2, true)).should == [0, 1, 2]
+      a.should == [3, 4]
+    end
+  end
 end
 
 describe "Array#slice" do

--- a/spec/ruby/core/array/slice_spec.rb
+++ b/spec/ruby/core/array/slice_spec.rb
@@ -169,11 +169,11 @@ describe "Array#slice!" do
   ruby_version_is "2.7" do
     it "works with beginless ranges" do
       a = [0,1,2,3,4]
-      a.slice!(Range.new(nil, 3)).should == [0, 1, 2, 3]
+      a.slice!(eval("(nil..3)")).should == [0, 1, 2, 3]
       a.should == [4]
 
       a = [0,1,2,3,4]
-      a.slice!(Range.new(nil, -2, true)).should == [0, 1, 2]
+      a.slice!(eval("(nil...-2)")).should == [0, 1, 2]
       a.should == [3, 4]
     end
   end

--- a/spec/ruby/core/array/slice_spec.rb
+++ b/spec/ruby/core/array/slice_spec.rb
@@ -169,11 +169,11 @@ describe "Array#slice!" do
   ruby_version_is "2.7" do
     it "works with beginless ranges" do
       a = [0,1,2,3,4]
-      a.slice!(eval("(nil..3)")).should == [0, 1, 2, 3]
+      a.slice!(eval("(..3)")).should == [0, 1, 2, 3]
       a.should == [4]
 
       a = [0,1,2,3,4]
-      a.slice!(eval("(nil...-2)")).should == [0, 1, 2]
+      a.slice!(eval("(...-2)")).should == [0, 1, 2]
       a.should == [3, 4]
     end
   end

--- a/spec/ruby/core/array/values_at_spec.rb
+++ b/spec/ruby/core/array/values_at_spec.rb
@@ -67,4 +67,11 @@ describe "Array#values_at" do
       [1, 2, 3, 4].values_at(eval("(3...)")).should == [4]
     end
   end
+
+  ruby_version_is "2.7" do
+    it "works when given beginless ranges" do
+      [1, 2, 3, 4].values_at(Range.new(nil, 2)).should == [1, 2, 3]
+      [1, 2, 3, 4].values_at(Range.new(nil, 2, true)).should == [1, 2]
+    end
+  end
 end

--- a/spec/ruby/core/array/values_at_spec.rb
+++ b/spec/ruby/core/array/values_at_spec.rb
@@ -70,8 +70,8 @@ describe "Array#values_at" do
 
   ruby_version_is "2.7" do
     it "works when given beginless ranges" do
-      [1, 2, 3, 4].values_at(eval("(nil..2)")).should == [1, 2, 3]
-      [1, 2, 3, 4].values_at(eval("(nil...2)")).should == [1, 2]
+      [1, 2, 3, 4].values_at(eval("(..2)")).should == [1, 2, 3]
+      [1, 2, 3, 4].values_at(eval("(...2)")).should == [1, 2]
     end
   end
 end

--- a/spec/ruby/core/array/values_at_spec.rb
+++ b/spec/ruby/core/array/values_at_spec.rb
@@ -70,8 +70,8 @@ describe "Array#values_at" do
 
   ruby_version_is "2.7" do
     it "works when given beginless ranges" do
-      [1, 2, 3, 4].values_at(Range.new(nil, 2)).should == [1, 2, 3]
-      [1, 2, 3, 4].values_at(Range.new(nil, 2, true)).should == [1, 2]
+      [1, 2, 3, 4].values_at(eval("(nil..2)")).should == [1, 2, 3]
+      [1, 2, 3, 4].values_at(eval("(nil...2)")).should == [1, 2]
     end
   end
 end

--- a/spec/ruby/core/range/bsearch_spec.rb
+++ b/spec/ruby/core/range/bsearch_spec.rb
@@ -126,8 +126,8 @@ describe "Range#bsearch" do
         inf = Float::INFINITY
         (0..inf).bsearch { |x| x == inf }.should == inf
         (0...inf).bsearch { |x| x == inf }.should == nil
-        (-inf..0).bsearch { |x| x == -inf }.should == nil
-        (-inf...0).bsearch { |x| x == -inf }.should == nil
+        (-inf..0).bsearch { |x| x != -inf }.should == -Float::MAX
+        (-inf...0).bsearch { |x| x != -inf }.should == -Float::MAX
         (inf..inf).bsearch { |x| true }.should == inf
         (inf...inf).bsearch { |x| true }.should == nil
         (-inf..-inf).bsearch { |x| true }.should == -inf
@@ -194,10 +194,10 @@ describe "Range#bsearch" do
 
       it "works with infinity bounds" do
         inf = Float::INFINITY
-        (0..inf).bsearch { |x| x == inf ? 0 : -1 }.should == nil
-        (0...inf).bsearch { |x| x == inf ? 0 : -1 }.should == nil
-        (-inf...0).bsearch { |x| x == -inf ? 0 : 1 }.should == nil
-        (-inf..0).bsearch { |x| x == -inf ? 0 : 1 }.should == nil
+        (0..inf).bsearch { |x| x == inf ? 0 : 1 }.should == inf
+        (0...inf).bsearch { |x| x == inf ? 0 : 1 }.should == nil
+        (-inf...0).bsearch { |x| x == -inf ? 0 : -1 }.should == -inf
+        (-inf..0).bsearch { |x| x == -inf ? 0 : -1 }.should == -inf
         (inf..inf).bsearch { 0 }.should == inf
         (inf...inf).bsearch { 0 }.should == nil
         (-inf..-inf).bsearch { 0 }.should == -inf

--- a/spec/ruby/core/range/bsearch_spec.rb
+++ b/spec/ruby/core/range/bsearch_spec.rb
@@ -248,7 +248,7 @@ describe "Range#bsearch" do
 
         it "returns an element at an index for which block returns 0" do
           result = eval("(0..)").bsearch { |x| x < 1 ? 1 : x > 3 ? -1 : 0 }
-          [1, 2].should include(result)
+          [1, 2, 3].should include(result)
         end
       end
     end
@@ -326,6 +326,113 @@ describe "Range#bsearch" do
           eval("(-inf..)").bsearch { |x| 3 - x }.should == 3
           eval("(-inf...)").bsearch { |x| 3 - x }.should == 3
           eval("(0.0...)").bsearch { 0 }.should != inf
+        end
+      end
+    end
+  end
+
+
+  ruby_version_is "2.7" do
+    context "with beginless ranges and Integer values" do
+      context "with a block returning true or false" do
+        it "returns the smallest element for which block returns true" do
+          eval("(..10)").bsearch { |x| x >= 2 }.should == 2
+          eval("(...-1)").bsearch { |x| x >= -10 }.should == -10
+        end
+      end
+
+      context "with a block returning negative, zero, positive numbers" do
+        it "returns nil if the block returns greater than zero for every element" do
+          eval("(..0)").bsearch { |x| 1 }.should be_nil
+        end
+
+        it "returns nil if the block never returns zero" do
+          eval("(..0)").bsearch { |x| x > 5 ? -1 : 1 }.should be_nil
+        end
+
+        it "accepts Float::INFINITY from the block" do
+          eval("(..0)").bsearch { |x| Float::INFINITY }.should be_nil
+        end
+
+        it "returns an element at an index for which block returns 0.0" do
+          result = eval("(..10)").bsearch { |x| x < 2 ? 1.0 : x > 2 ? -1.0 : 0.0 }
+          result.should == 2
+        end
+
+        it "returns an element at an index for which block returns 0" do
+          result = eval("(...10)").bsearch { |x| x < 1 ? 1 : x > 3 ? -1 : 0 }
+          [1, 2, 3].should include(result)
+        end
+      end
+    end
+
+    context "with beginless ranges and Float values" do
+      context "with a block returning true or false" do
+        it "returns nil if the block returns true for every element" do
+          eval("(..-0.1)").bsearch { |x| x > 0.0 }.should be_nil
+          eval("(...-0.1)").bsearch { |x| x > 0.0 }.should be_nil
+        end
+
+        it "returns nil if the block returns nil for every element" do
+          eval("(..-0.1)").bsearch { |x| nil }.should be_nil
+          eval("(...-0.1)").bsearch { |x| nil }.should be_nil
+        end
+
+        it "returns the smallest element for which block returns true" do
+          eval("(..10)").bsearch { |x| x >= 2 }.should == 2
+          eval("(..10)").bsearch { |x| x >= 1 }.should == 1
+        end
+
+        it "works with infinity bounds" do
+          inf = Float::INFINITY
+          eval("(..inf)").bsearch { |x| true }.should == -inf
+          eval("(...inf)").bsearch { |x| true }.should == -inf
+          eval("(..-inf)").bsearch { |x| true }.should == -inf
+          eval("(...-inf)").bsearch { |x| true }.should == nil
+        end
+      end
+
+      context "with a block returning negative, zero, positive numbers" do
+        it "returns nil if the block returns less than zero for every element" do
+          eval("(..5.0)").bsearch { |x| -1 }.should be_nil
+          eval("(...5.0)").bsearch { |x| -1 }.should be_nil
+        end
+
+        it "returns nil if the block returns greater than zero for every element" do
+          eval("(..1.1)").bsearch { |x| 1 }.should be_nil
+          eval("(...1.1)").bsearch { |x| 1 }.should be_nil
+        end
+
+        it "returns nil if the block never returns zero" do
+          eval("(..6.3)").bsearch { |x| x < 2 ? 1 : -1 }.should be_nil
+        end
+
+        it "accepts (+/-)Float::INFINITY from the block" do
+          eval("(..5.0)").bsearch { |x| Float::INFINITY }.should be_nil
+          eval("(..7.0)").bsearch { |x| -Float::INFINITY }.should be_nil
+        end
+
+        it "returns an element at an index for which block returns 0.0" do
+          result = eval("(..8.0)").bsearch { |x| x < 2 ? 1.0 : x > 2 ? -1.0 : 0.0 }
+          result.should == 2
+        end
+
+        it "returns an element at an index for which block returns 0" do
+          result = eval("(..8.0)").bsearch { |x| x < 1 ? 1 : x > 3 ? -1 : 0 }
+          result.should >= 1
+          result.should <= 3
+        end
+
+        it "works with infinity bounds" do
+          inf = Float::INFINITY
+          eval("(..-inf)").bsearch { |x| 1 }.should == nil
+          eval("(...-inf)").bsearch { |x| 1 }.should == nil
+          eval("(..inf)").bsearch { |x| x == inf ? 0 : 1 }.should == inf
+          eval("(...inf)").bsearch { |x| x == inf ? 0 : 1 }.should == nil
+          eval("(..-inf)").bsearch { |x| x == -inf ? 0 : -1 }.should == -inf
+          eval("(...-inf)").bsearch { |x| x == -inf ? 0 : -1 }.should == nil
+          eval("(..inf)").bsearch { |x| 3 - x }.should == 3
+          eval("(...inf)").bsearch { |x| 3 - x }.should == 3
         end
       end
     end

--- a/spec/ruby/core/range/count_spec.rb
+++ b/spec/ruby/core/range/count_spec.rb
@@ -1,0 +1,20 @@
+require_relative '../../spec_helper'
+
+describe "Range#count" do
+  ruby_version_is "2.6" do
+    it "returns Infinity for endless ranges without arguments or blocks" do
+      inf = Float::INFINITY
+      eval("('a'...)").count.should == inf
+      eval("(7..)").count.should == inf
+    end
+  end
+
+  ruby_version_is "2.7" do
+    it "returns Infinity for beginless ranges without arguments or blocks" do
+      inf = Float::INFINITY
+      eval("(...'a')").count.should == inf
+      eval("(...nil)").count.should == inf
+      eval("(..10.0)").count.should == inf
+    end
+  end
+end

--- a/spec/ruby/core/range/count_spec.rb
+++ b/spec/ruby/core/range/count_spec.rb
@@ -1,17 +1,11 @@
 require_relative '../../spec_helper'
 
 describe "Range#count" do
-  ruby_version_is "2.6" do
-    it "returns Infinity for endless ranges without arguments or blocks" do
-      inf = Float::INFINITY
-      eval("('a'...)").count.should == inf
-      eval("(7..)").count.should == inf
-    end
-  end
-
   ruby_version_is "2.7" do
     it "returns Infinity for beginless ranges without arguments or blocks" do
       inf = Float::INFINITY
+      eval("('a'...)").count.should == inf
+      eval("(7..)").count.should == inf
       eval("(...'a')").count.should == inf
       eval("(...nil)").count.should == inf
       eval("(..10.0)").count.should == inf

--- a/spec/ruby/core/range/each_spec.rb
+++ b/spec/ruby/core/range/each_spec.rb
@@ -54,6 +54,12 @@ describe "Range#each" do
     end
   end
 
+  ruby_version_is "2.7" do
+    it "raises a TypeError beginless ranges" do
+      -> { eval("(..2)").each { |x| x } }.should raise_error(TypeError)
+    end
+  end
+
   it "raises a TypeError if the first element does not respond to #succ" do
     -> { (0.5..2.4).each { |i| i } }.should raise_error(TypeError)
 

--- a/spec/ruby/core/range/equal_value_spec.rb
+++ b/spec/ruby/core/range/equal_value_spec.rb
@@ -13,4 +13,10 @@ describe "Range#==" do
       eval("(1.0..)").should == eval("(1.0..)")
     end
   end
+
+  ruby_version_is "2.7" do
+    it "returns true if the endpoints are == for beginless ranges" do
+      eval("(...10)").should == eval("(...10)")
+    end
+  end
 end

--- a/spec/ruby/core/range/first_spec.rb
+++ b/spec/ruby/core/range/first_spec.rb
@@ -46,4 +46,10 @@ describe "Range#first" do
   it "raises a TypeError when passed a String" do
     -> { (2..3).first("1") }.should raise_error(TypeError)
   end
+
+  ruby_version_is "2.7" do
+    it "raises a RangeError when called on an beginless range" do
+      -> { eval("(..1)").first }.should raise_error(RangeError)
+    end
+  end
 end

--- a/spec/ruby/core/range/inspect_spec.rb
+++ b/spec/ruby/core/range/inspect_spec.rb
@@ -19,6 +19,18 @@ describe "Range#inspect" do
     end
   end
 
+  ruby_version_is '2.7' do
+    it "works for beginless ranges" do
+      eval("(..1)").inspect.should ==  "..1"
+      eval("(...0.1)").inspect.should ==  "...0.1"
+    end
+
+    it "works for nil ... nil ranges" do
+      eval("(..nil)").inspect.should ==  "nil..nil"
+      eval("(nil...)").inspect.should ==  "nil...nil"
+    end
+  end
+
   ruby_version_is ''...'2.7' do
     it "returns a tainted string if either end is tainted" do
       (("a".taint)..."c").inspect.tainted?.should be_true

--- a/spec/ruby/core/range/max_spec.rb
+++ b/spec/ruby/core/range/max_spec.rb
@@ -51,6 +51,14 @@ describe "Range#max" do
       -> { eval("(1..)").max }.should raise_error(RangeError)
     end
   end
+
+  ruby_version_is "2.7.2" do
+    it "returns the end point (or one less) for beginless ranges" do
+      eval("(...1)").max.should == 0
+      eval("(..1)").max.should == 1
+      eval("(..1.0)").max.should == 1.0
+    end
+  end
 end
 
 describe "Range#max given a block" do
@@ -84,5 +92,11 @@ describe "Range#max given a block" do
     (100..10).max {|x,y| x <=> y}.should be_nil
     ('z'..'l').max {|x,y| x <=> y}.should be_nil
     (5...5).max {|x,y| x <=> y}.should be_nil
+  end
+
+  ruby_version_is "2.7" do
+    it "raises RangeError when called with custom comparison method on an beginless range" do
+      -> { eval("(..1)").max {|a, b| a} }.should raise_error(RangeError)
+    end
   end
 end

--- a/spec/ruby/core/range/max_spec.rb
+++ b/spec/ruby/core/range/max_spec.rb
@@ -52,7 +52,7 @@ describe "Range#max" do
     end
   end
 
-  ruby_version_is "2.7.2" do
+  ruby_version_is "3.0" do
     it "returns the end point (or one less) for beginless ranges" do
       eval("(...1)").max.should == 0
       eval("(..1)").max.should == 1

--- a/spec/ruby/core/range/min_spec.rb
+++ b/spec/ruby/core/range/min_spec.rb
@@ -38,6 +38,19 @@ describe "Range#min" do
     time_end = Time.now + 1.0
     (time_start...time_end).min.should equal(time_start)
   end
+
+  ruby_version_is "2.6" do
+    it "returns the start point for endless ranges" do
+      eval("(1..)").min.should == 1
+      eval("(1.0...)").min.should == 1.0
+    end
+  end
+
+  ruby_version_is "2.7" do
+    it "raises RangeError when called on an beginless range" do
+      -> { eval("(..1)").min }.should raise_error(RangeError)
+    end
+  end
 end
 
 describe "Range#min given a block" do
@@ -74,9 +87,8 @@ describe "Range#min given a block" do
   end
 
   ruby_version_is "2.6" do
-    it "returns the start point for endless ranges" do
-      eval("(1..)").min.should == 1
-      eval("(1.0...)").min.should == 1.0
+    it "raises RangeError when called with custom comparison method on an endless range" do
+      -> { eval("(1..)").min {|a, b| a} }.should raise_error(RangeError)
     end
   end
 end

--- a/spec/ruby/core/range/size_spec.rb
+++ b/spec/ruby/core/range/size_spec.rb
@@ -25,9 +25,23 @@ describe "Range#size" do
   end
 
   ruby_version_is "2.6" do
-    it 'returns Float::INFINITY for endless ranges' do
+    it 'returns Float::INFINITY for endless ranges if the start is numeric' do
       eval("(1..)").size.should == Float::INFINITY
       eval("(0.5...)").size.should == Float::INFINITY
+    end
+
+    it 'returns nil for endless ranges if the start is not numeric' do
+      eval("('z'..)").size.should == nil
+      eval("([]...)").size.should == nil
+    end
+  end
+
+  ruby_version_is "2.7" do
+    it 'returns Float::INFINITY for all beginless ranges' do
+      eval("(..1)").size.should == Float::INFINITY
+      eval("(...0.5)").size.should == Float::INFINITY
+      eval("(..nil)").size.should == Float::INFINITY
+      eval("(...'o')").size.should == Float::INFINITY
     end
   end
 

--- a/spec/ruby/core/range/to_a_spec.rb
+++ b/spec/ruby/core/range/to_a_spec.rb
@@ -25,4 +25,10 @@ describe "Range#to_a" do
       -> { eval("(1..)").to_a }.should raise_error(RangeError)
     end
   end
+
+  ruby_version_is "2.7" do
+    it "throws an exception for beginless ranges" do
+      -> { eval("(..1)").to_a }.should raise_error(TypeError)
+    end
+  end
 end

--- a/spec/tags/core/range/new_tags.txt
+++ b/spec/tags/core/range/new_tags.txt
@@ -1,2 +1,0 @@
-fails:Range.new beginless/endless range allows beginless left boundary
-fails:Range.new beginless/endless range distinguishes ranges with included and excluded right boundary

--- a/spec/tags/language/range_tags.txt
+++ b/spec/tags/language/range_tags.txt
@@ -1,1 +1,0 @@
-fails:Literal Ranges creates beginless ranges

--- a/src/main/java/org/truffleruby/core/range/RangeNodes.java
+++ b/src/main/java/org/truffleruby/core/range/RangeNodes.java
@@ -364,10 +364,17 @@ public abstract class RangeNodes {
             return toAInternalCall.call(range, "to_a_internal");
         }
 
-        @Specialization(guards = "range.isEndless()")
+        @Specialization(guards = "range.isEndless() || range.isNilNil()")
         protected Object endlessToA(RubyObjectRange range) {
             throw new RaiseException(getContext(), coreExceptions().rangeError(
                     "cannot convert endless range to an array",
+                    this));
+        }
+
+        @Specialization(guards = "range.isBeginless()")
+        protected Object beginlessToA(RubyObjectRange range) {
+            throw new RaiseException(getContext(), coreExceptions().typeError(
+                    "can't iterate from NilClass",
                     this));
         }
     }

--- a/src/main/java/org/truffleruby/core/range/RangeNodes.java
+++ b/src/main/java/org/truffleruby/core/range/RangeNodes.java
@@ -419,6 +419,30 @@ public abstract class RangeNodes {
                     end);
         }
 
+        @Specialization(guards = "range.isBeginless()")
+        protected RubyIntRange beginlessObjectRange(RubyObjectRange range, RubyArray array) {
+            int begin = 0;
+            int end = toInt(range.end);
+            return new RubyIntRange(
+                    coreLibrary().rangeClass,
+                    getLanguage().intRangeShape,
+                    range.excludedEnd,
+                    begin,
+                    end);
+        }
+
+        @Specialization(guards = "range.isNilNil()")
+        protected RubyIntRange nilNilObjectRange(RubyObjectRange range, RubyArray array) {
+            int begin = 0;
+            int end = array.size;
+            return new RubyIntRange(
+                    coreLibrary().rangeClass,
+                    getLanguage().intRangeShape,
+                    false,
+                    begin,
+                    end);
+        }
+
         private int toInt(Object indexObject) {
             if (toIntNode == null) {
                 CompilerDirectives.transferToInterpreterAndInvalidate();
@@ -585,6 +609,18 @@ public abstract class RangeNodes {
         protected int[] normalizeObjectRange(RubyObjectRange range, int size,
                 @Cached ToIntNode toInt) {
             return normalize(toInt.execute(range.begin), toInt.execute(range.end), range.excludedEnd, size);
+        }
+
+        @Specialization(guards = "range.isBeginless()")
+        protected int[] normalizeBeginlessRange(RubyObjectRange range, int size,
+                @Cached ToIntNode toInt) {
+            return normalize(0, toInt.execute(range.end), range.excludedEnd, size);
+        }
+
+        @Specialization(guards = "range.isNilNil()")
+        protected int[] normalizeNilNilRange(RubyObjectRange range, int size,
+                @Cached ToIntNode toInt) {
+            return new int[]{ 0, size };
         }
 
         private int[] normalize(int begin, int end, boolean excludedEnd, int size) {

--- a/src/main/java/org/truffleruby/core/range/RangeNodes.java
+++ b/src/main/java/org/truffleruby/core/range/RangeNodes.java
@@ -497,7 +497,7 @@ public abstract class RangeNodes {
                 @Cached AllocateHelperNode allocateHelperNode,
                 @Cached DispatchNode compare) {
 
-            if (compare.call(begin, "<=>", end) == nil && end != nil) {
+            if (compare.call(begin, "<=>", end) == nil && end != nil && begin != nil) {
                 throw new RaiseException(getContext(), coreExceptions().argumentError("bad value for range", this));
             }
 

--- a/src/main/java/org/truffleruby/core/range/RubyObjectRange.java
+++ b/src/main/java/org/truffleruby/core/range/RubyObjectRange.java
@@ -29,12 +29,20 @@ public final class RubyObjectRange extends RubyRange implements ObjectGraphNode 
         this.end = end;
     }
 
+    public boolean isNilNil() {
+        return begin == Nil.INSTANCE && end == Nil.INSTANCE;
+    }
+
     public boolean isEndless() {
-        return end == Nil.INSTANCE;
+        return begin != Nil.INSTANCE && end == Nil.INSTANCE;
+    }
+
+    public boolean isBeginless() {
+        return begin == Nil.INSTANCE && end != Nil.INSTANCE;
     }
 
     public boolean isBounded() {
-        return end != Nil.INSTANCE;
+        return begin != Nil.INSTANCE && end != Nil.INSTANCE;
     }
 
     @Override

--- a/src/main/ruby/truffleruby/core/range.rb
+++ b/src/main/ruby/truffleruby/core/range.rb
@@ -364,7 +364,14 @@ class Range
   end
 
   def inspect
-    "#{self.begin.inspect}#{exclude_end? ? "..." : ".."}#{Truffle::RangeOperations.endless?(self) ? "" : self.end.inspect}"
+    sep = exclude_end? ? '...' : '..'
+    if (Primitive.nil?(self.begin) && Primitive.nil?(self.end))
+      result = "nil#{sep}nil"
+    else
+      result = (Primitive.nil?(self.begin) ? '' : self.begin.inspect) + sep +
+               (Primitive.nil?(self.end) ? '' : self.end.inspect)
+    end
+    Primitive.infect(result, self)
   end
 
   def last(n=undefined)

--- a/src/main/ruby/truffleruby/core/range.rb
+++ b/src/main/ruby/truffleruby/core/range.rb
@@ -99,7 +99,7 @@ class Range
   end
 
   private def bsearch_float(&block)
-    normalized_begin = Primitive.nil?(self.begin) ? -Float::INFINITY : self.begin.to_f
+    normalized_begin = Truffle::RangeOperations.beginless?(self) ? -Float::INFINITY : self.begin.to_f
     normalized_end = Truffle::RangeOperations.endless?(self) ? Float::INFINITY : self.end.to_f
     normalized_end = normalized_end.prev_float if self.exclude_end?
     min = normalized_begin
@@ -262,6 +262,16 @@ class Range
     last_admissible
   end
 
+  def count(item = undefined)
+    if Truffle::RangeOperations.beginless?(self) || Truffle::RangeOperations.endless?(self)
+      return Float::INFINITY unless block_given? || !Primitive.undefined?(item)
+    end
+
+    p "count for here"
+
+    super
+  end
+
   private def each_internal(&block)
     return to_enum { size } unless block_given?
     first, last = self.begin, self.end
@@ -325,6 +335,7 @@ class Range
   end
 
   def first(n=undefined)
+    raise RangeError, 'cannot get the first element of beginless range' if Primitive.nil?(self.begin)
     return self.begin if Primitive.undefined? n
 
     super
@@ -383,6 +394,10 @@ class Range
 
   def max
     raise RangeError, 'cannot get the maximum of endless range' if Truffle::RangeOperations.endless?(self)
+    if Truffle::RangeOperations.beginless?(self)
+      raise RangeError, 'cannot get the maximum of beginless range with custom comparison method' if block_given?
+      return exclude_end? ? self.end - 1 : self.end
+    end
     return super if block_given? || (exclude_end? && !self.end.kind_of?(Numeric))
     return nil if Comparable.compare_int(self.end <=> self.begin) < 0
     return nil if exclude_end? && Comparable.compare_int(self.end <=> self.begin) == 0
@@ -400,8 +415,13 @@ class Range
   end
 
   def min
+    raise RangeError, 'cannot get the minimum of beginless range' if Truffle::RangeOperations.beginless?(self)
+    if Truffle::RangeOperations.endless?(self)
+      raise RangeError, 'cannot get the minimum of endless range with custom comparison method' if block_given?
+      return self.begin
+    end
     return super if block_given?
-    if !Truffle::RangeOperations.endless?(self) && Comparable.compare_int(self.end <=> self.begin) < 0
+    if Comparable.compare_int(self.end <=> self.begin) < 0
       return nil
     elsif exclude_end? && self.end == self.begin
       return nil
@@ -499,6 +519,7 @@ class Range
   end
 
   def size
+    return Float::INFINITY if Truffle::RangeOperations.beginless?(self)
     return nil unless self.begin.kind_of?(Numeric)
     return Float::INFINITY if Truffle::RangeOperations.endless?(self)
 

--- a/src/main/ruby/truffleruby/core/range.rb
+++ b/src/main/ruby/truffleruby/core/range.rb
@@ -375,12 +375,10 @@ class Range
   def inspect
     sep = exclude_end? ? '...' : '..'
     if (Primitive.nil?(self.begin) && Primitive.nil?(self.end))
-      result = "nil#{sep}nil"
+      "nil#{sep}nil"
     else
-      result = (Primitive.nil?(self.begin) ? '' : self.begin.inspect) + sep +
-               (Primitive.nil?(self.end) ? '' : self.end.inspect)
+      (Primitive.nil?(self.begin) ? '' : self.begin.inspect) + sep + (Primitive.nil?(self.end) ? '' : self.end.inspect)
     end
-    Primitive.infect(result, self)
   end
 
   def last(n=undefined)

--- a/src/main/ruby/truffleruby/core/range.rb
+++ b/src/main/ruby/truffleruby/core/range.rb
@@ -99,8 +99,8 @@ class Range
   end
 
   private def bsearch_float(&block)
-    normalized_begin = Truffle::RangeOperations.beginless?(self) ? -Float::INFINITY : self.begin.to_f
-    normalized_end = Truffle::RangeOperations.endless?(self) ? Float::INFINITY : self.end.to_f
+    normalized_begin = Primitive.nil?(self.begin) ? -Float::INFINITY : self.begin.to_f
+    normalized_end = Primitive.nil?(self.end) ? Float::INFINITY : self.end.to_f
     normalized_end = normalized_end.prev_float if self.exclude_end?
     min = normalized_begin
     max = normalized_end
@@ -263,11 +263,9 @@ class Range
   end
 
   def count(item = undefined)
-    if Truffle::RangeOperations.beginless?(self) || Truffle::RangeOperations.endless?(self)
+    if Primitive.nil?(self.begin) || Primitive.nil?(self.end)
       return Float::INFINITY unless block_given? || !Primitive.undefined?(item)
     end
-
-    p "count for here"
 
     super
   end
@@ -386,15 +384,15 @@ class Range
   end
 
   def last(n=undefined)
-    raise RangeError, 'cannot get the last element of endless range' if Truffle::RangeOperations.endless?(self)
+    raise RangeError, 'cannot get the last element of endless range' if Primitive.nil? self.end
     return self.end if Primitive.undefined? n
 
     to_a.last(n)
   end
 
   def max
-    raise RangeError, 'cannot get the maximum of endless range' if Truffle::RangeOperations.endless?(self)
-    if Truffle::RangeOperations.beginless?(self)
+    raise RangeError, 'cannot get the maximum of endless range' if Primitive.nil? self.end
+    if Primitive.nil? self.begin
       raise RangeError, 'cannot get the maximum of beginless range with custom comparison method' if block_given?
       return exclude_end? ? self.end - 1 : self.end
     end
@@ -415,8 +413,8 @@ class Range
   end
 
   def min
-    raise RangeError, 'cannot get the minimum of beginless range' if Truffle::RangeOperations.beginless?(self)
-    if Truffle::RangeOperations.endless?(self)
+    raise RangeError, 'cannot get the minimum of beginless range' if Primitive.nil? self.begin
+    if Primitive.nil? self.end
       raise RangeError, 'cannot get the minimum of endless range with custom comparison method' if block_given?
       return self.begin
     end
@@ -519,9 +517,9 @@ class Range
   end
 
   def size
-    return Float::INFINITY if Truffle::RangeOperations.beginless?(self)
+    return Float::INFINITY if Primitive.nil? self.begin
     return nil unless self.begin.kind_of?(Numeric)
-    return Float::INFINITY if Truffle::RangeOperations.endless?(self)
+    return Float::INFINITY if Primitive.nil? self.end
 
     delta = self.end - self.begin
     return 0 if delta < 0

--- a/src/main/ruby/truffleruby/core/truffle/range_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/range_operations.rb
@@ -126,6 +126,10 @@ module Truffle
       false
     end
 
+    def self.beginless?(range)
+      Primitive.nil? range.begin
+    end
+
     def self.endless?(range)
       Primitive.nil? range.end
     end

--- a/src/main/ruby/truffleruby/core/truffle/range_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/range_operations.rb
@@ -113,7 +113,7 @@ module Truffle
       return false unless beg_compare
 
       if Comparable.compare_int(beg_compare) <= 0
-        return true if endless?(range)
+        return true if Primitive.nil? range.end
         end_compare = (value <=> range.end)
 
         if range.exclude_end?
@@ -124,14 +124,6 @@ module Truffle
       end
 
       false
-    end
-
-    def self.beginless?(range)
-      Primitive.nil? range.begin
-    end
-
-    def self.endless?(range)
-      Primitive.nil? range.end
     end
 
     # MRI: r_less


### PR DESCRIPTION
Starting to implement beginless ranges for Ruby 2.7 compatibility https://github.com/oracle/truffleruby/issues/2004

So far:
Implemented or added specs for Range#{new, bsearch, count, each, equal_value, first, inspect, max, min, size} regarding beginless range compatibility
Implemented or added specs for Array#{[], []=, slice, slice!, to_a, fill, values_at} regarding beginless range compatibility

To do:
Range#cover?/include/===
some or all of Range#{entires, eql?, hash, last, member?, minmax, step/%, to_s}
Methods outside of Array and Range, such as String methods.

https://github.com/Shopify/truffleruby/issues/1
