### PR TITLE
Implement Enumerator#produce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Compatibility:
 * Implement `Enumerable#tally` and `Enumerable#filter_map` (#2144 and #2152, @LillianZ).
 * Implement `Range#minmax`.
 * Pass more `Enumerator::Lazy#uniq` and `Enumerator::Lazy#chunk` specs (#2146, @LillianZ).
+* Implement `Enumerator#produce` (#2160, @zverok)
 
 Performance:
 

--- a/spec/tags/core/enumerator/produce_tags.txt
+++ b/spec/tags/core/enumerator/produce_tags.txt
@@ -1,4 +1,0 @@
-fails:Enumerator.produce creates an infinite enumerator
-fails:Enumerator.produce terminates iteration when block raises StopIteration exception
-fails:Enumerator.produce when initial value skipped uses nil instead
-fails:Enumerator.produce when initial value skipped starts enumerable from result of first block call

--- a/src/main/ruby/truffleruby/core/enumerator.rb
+++ b/src/main/ruby/truffleruby/core/enumerator.rb
@@ -216,6 +216,19 @@ class Enumerator
     Enumerator::Chain.new(self, other)
   end
 
+  def self.produce(initial = nil)
+    # Taken from https://github.com/zverok/enumerator_generate
+    raise ArgumentError, 'No block given' unless block_given?
+    Enumerator.new(Float::INFINITY) do |y|
+      val = initial == nil ? yield() : initial
+
+      loop do
+        y << val
+        val = yield(val)
+      end
+    end
+  end
+
   class Yielder
     def initialize(&block)
       raise LocalJumpError, 'Expected a block to be given' unless block_given?


### PR DESCRIPTION
Implements Enumerator#produce for Ruby 2.7 compatibility #2004

The reference implementation at https://github.com/zverok/enumerator_generate for the feature suggestion in https://bugs.ruby-lang.org/issues/14781 was in Ruby, so this is that (with default initial value set to nil and size set to Infinity).

The author agreed to make the code available under the same licence as Ruby(https://bugs.ruby-lang.org/issues/14781#note-27).

The major difference is the MRI has a Producer subclass, but MRI's Enumerator::Producer.new takes 0 arguments, so it should be fine that we don't have that method. 

Shopify#1 (?)