### PR TITLE
Ruby 2.7: Comment lines can be placed between fluent dot now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Compatibility:
 * Updated `Dir.{glob,[]}` to raise `ArgumentError` for nul-separated strings.
 * `Kernel#lambda` with no block in a method called with a block raises an exception (#2004, @ssnickolay).
 * Implemented `BigDecimal` as C extension to improve compatibility.
+* Comment lines can be placed between fluent dot now (#2004, @ssnickolay).
 
 Performance:
 

--- a/spec/tags/language/comment_tags.txt
+++ b/spec/tags/language/comment_tags.txt
@@ -1,1 +1,0 @@
-fails:The comment can be placed between fluent dot now

--- a/src/main/java/org/truffleruby/parser/lexer/RubyLexer.java
+++ b/src/main/java/org/truffleruby/parser/lexer/RubyLexer.java
@@ -880,6 +880,9 @@ public class RubyLexer implements MagicCommentHandler {
                             case '\13': /* '\v' */
                                 spaceSeen = true;
                                 continue;
+                            case '#':
+                                pushback(c);
+                                continue loop;
                             case '&':
                             case '.': {
                                 if (peek('.') == (c == '&')) {


### PR DESCRIPTION
Related to #2004 

The MRI commit: https://github.com/ruby/ruby/commit/3a3f48fb8fbdbb810d9b675159529970015316b9

Btw, should we unexclude `test_syntax.rb` (tag only individual failed tests)? The file completely disabled by `failing.exclude` but it is runnable:

```ruby
jt test test/mri/tests/ruby/test_syntax.rb

Finished tests in 106.157000s, 1.0550 tests/s, 10.3620 assertions/s.
112 tests, 1100 assertions, 26 failures, 3 errors, 0 skips
```