### PR TITLE
Update unicode emoji ver from 12.0 to 12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Compatibility:
 * `Kernel#lambda` with no block in a method called with a block raises an exception (#2004, @ssnickolay).
 * Implemented `BigDecimal` as C extension to improve compatibility.
 * Comment lines can be placed between fluent dot now (#2004, @ssnickolay).
+* Updated the Unicode Emoji version (#2173, @wildmaples).
 
 Performance:
 

--- a/lib/truffle/rbconfig.rb
+++ b/lib/truffle/rbconfig.rb
@@ -192,7 +192,7 @@ module RbConfig
     'target_cpu'        => host_cpu,
     'target_os'         => host_os,
     'UNICODE_VERSION'   => '12.0.0',
-    'UNICODE_EMOJI_VERSION' => '12.0',
+    'UNICODE_EMOJI_VERSION' => '12.1',
     'warnflags'         => warnflags,
   }
 


### PR DESCRIPTION
Looks like a funny change, but see https://github.com/ruby/ruby/commit/c54635c08b.

By @wildmaples.

https://github.com/Shopify/truffleruby/issues/1