### PR TITLE
Ruby 2.7: Refinements take place at Object#method and Module#instance_method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Compatibility:
 * Implement `rb_lastline_set` (#2170).
 * Implemented `Module#const_source_location` (#2212, @tomstuart and @wildmaples).
 * Do not call `File.exist?` in `Dir.glob` as `File.exist?` is often mocked (#2236, @gogainda).
+* Refinements take place at `Object#method` and `Module#instance_method` (#2004, @ssnickolay).
 
 Performance:
 

--- a/lib/cext/include/ruby/intern.h
+++ b/lib/cext/include/ruby/intern.h
@@ -441,7 +441,6 @@ VALUE rb_eval_cmd(VALUE, VALUE, int);
 VALUE rb_eval_cmd_kw(VALUE, VALUE, int);
 int rb_obj_respond_to(VALUE, ID, int);
 int rb_respond_to(VALUE, ID);
-VALUE rb_method_to(VALUE, ID);
 NORETURN(VALUE rb_f_notimplement(int argc, const VALUE *argv, VALUE obj, VALUE marker));
 #if !defined(RUBY_EXPORT) && defined(_WIN32)
 RUBY_EXTERN VALUE (*const rb_f_notimplement_)(int, const VALUE *, VALUE, VALUE marker);
@@ -487,7 +486,6 @@ VALUE rb_method_call_with_block(int, const VALUE *, VALUE, VALUE);
 VALUE rb_method_call_with_block_kw(int, const VALUE *, VALUE, VALUE, int);
 int rb_mod_method_arity(VALUE, ID);
 int rb_obj_method_arity(VALUE, ID);
-VALUE rb_obj_method(VALUE, VALUE);
 VALUE rb_protect(VALUE (*)(VALUE), VALUE, int*);
 void rb_set_end_proc(void (*)(VALUE), VALUE);
 void rb_thread_schedule(void);

--- a/lib/cext/include/ruby/intern.h
+++ b/lib/cext/include/ruby/intern.h
@@ -441,6 +441,7 @@ VALUE rb_eval_cmd(VALUE, VALUE, int);
 VALUE rb_eval_cmd_kw(VALUE, VALUE, int);
 int rb_obj_respond_to(VALUE, ID, int);
 int rb_respond_to(VALUE, ID);
+VALUE rb_method_to(VALUE, ID);
 NORETURN(VALUE rb_f_notimplement(int argc, const VALUE *argv, VALUE obj, VALUE marker));
 #if !defined(RUBY_EXPORT) && defined(_WIN32)
 RUBY_EXTERN VALUE (*const rb_f_notimplement_)(int, const VALUE *, VALUE, VALUE marker);
@@ -486,6 +487,7 @@ VALUE rb_method_call_with_block(int, const VALUE *, VALUE, VALUE);
 VALUE rb_method_call_with_block_kw(int, const VALUE *, VALUE, VALUE, int);
 int rb_mod_method_arity(VALUE, ID);
 int rb_obj_method_arity(VALUE, ID);
+VALUE rb_obj_method(VALUE, VALUE);
 VALUE rb_protect(VALUE (*)(VALUE), VALUE, int*);
 void rb_set_end_proc(void (*)(VALUE), VALUE);
 void rb_thread_schedule(void);

--- a/lib/truffle/truffle/cext.rb
+++ b/lib/truffle/truffle/cext.rb
@@ -423,6 +423,10 @@ module Truffle::CExt
     object.method(id).arity
   end
 
+  def rb_obj_method(object, id)
+    object.method(id)
+  end
+
   def rb_ivar_defined(object, id)
     Primitive.object_ivar_defined?(object, id)
   end

--- a/spec/ruby/core/kernel/fixtures/classes.rb
+++ b/spec/ruby/core/kernel/fixtures/classes.rb
@@ -362,18 +362,19 @@ module KernelSpecs
   class RespondViaMissing
     def respond_to_missing?(method, priv=false)
       case method
-        when :handled_publicly
-          true
-        when :handled_privately
-          priv
-        when :not_handled
-          false
-        else
-          raise "Typo in method name"
+      when :handled_publicly
+        true
+      when :handled_privately
+        priv
+      when :not_handled
+        false
+      else
+        raise "Typo in method name: #{method.inspect}"
       end
     end
 
     def method_missing(method, *args)
+      raise "the method name should be a Symbol" unless Symbol === method
       "Done #{method}(#{args})"
     end
   end

--- a/spec/ruby/core/kernel/shared/method.rb
+++ b/spec/ruby/core/kernel/shared/method.rb
@@ -15,8 +15,14 @@ describe :kernel_method, shared: true do
     m.call.should == 'class done'
   end
 
-  it "returns a method object if we repond_to_missing? method" do
+  it "returns a method object if respond_to_missing?(method) is true" do
     m = KernelSpecs::RespondViaMissing.new.send(@method, :handled_publicly)
+    m.should be_an_instance_of Method
+    m.call(42).should == "Done handled_publicly([42])"
+  end
+
+  it "the returned method object if respond_to_missing?(method) calls #method_missing with a Symbol name" do
+    m = KernelSpecs::RespondViaMissing.new.send(@method, "handled_publicly")
     m.should be_an_instance_of Method
     m.call(42).should == "Done handled_publicly([42])"
   end

--- a/spec/ruby/core/module/refine_spec.rb
+++ b/spec/ruby/core/module/refine_spec.rb
@@ -574,6 +574,43 @@ describe "Module#refine" do
     end
 
     ruby_version_is "" ... "2.7" do
+      it "is not honored by Kernel#public_method" do
+        klass = Class.new
+        refinement = Module.new do
+          refine klass do
+            def foo; end
+          end
+        end
+
+        -> {
+          Module.new do
+            using refinement
+            klass.new.public_method(:foo)
+          end
+        }.should raise_error(NameError, /undefined method `foo'/)
+      end
+    end
+
+    ruby_version_is "2.7" do
+      it "is honored by Kernel#public_method" do
+        klass = Class.new
+        refinement = Module.new do
+          refine klass do
+            def foo; end
+          end
+        end
+
+        result = nil
+        Module.new do
+          using refinement
+          result = klass.new.public_method(:foo).class
+        end
+
+        result.should == Method
+      end
+    end
+
+    ruby_version_is "" ... "2.7" do
       it "is not honored by Kernel#instance_method" do
         klass = Class.new
         refinement = Module.new do
@@ -592,7 +629,7 @@ describe "Module#refine" do
     end
 
     ruby_version_is "2.7" do
-      it "is honored by Kernel#method" do
+      it "is honored by Kernel#instance_method" do
         klass = Class.new
         refinement = Module.new do
           refine klass do

--- a/spec/ruby/optional/capi/ext/kernel_spec.c
+++ b/spec/ruby/optional/capi/ext/kernel_spec.c
@@ -310,10 +310,6 @@ static VALUE kernel_spec_rb_make_backtrace(VALUE self) {
   return rb_make_backtrace();
 }
 
-static VALUE kernel_spec_rb_obj_method(VALUE self, VALUE obj, VALUE method) {
-  return rb_obj_method(obj, method);
-}
-
 static VALUE kernel_spec_rb_funcall3(VALUE self, VALUE obj, VALUE method) {
   return rb_funcall3(obj, SYM2ID(method), 0, NULL);
 }
@@ -366,7 +362,6 @@ void Init_kernel_spec(void) {
   rb_define_method(cls, "rb_set_end_proc", kernel_spec_rb_set_end_proc, 1);
   rb_define_method(cls, "rb_f_sprintf", kernel_spec_rb_f_sprintf, 1);
   rb_define_method(cls, "rb_make_backtrace", kernel_spec_rb_make_backtrace, 0);
-  rb_define_method(cls, "rb_obj_method", kernel_spec_rb_obj_method, 2);
   rb_define_method(cls, "rb_funcall3", kernel_spec_rb_funcall3, 2);
   rb_define_method(cls, "rb_funcall_many_args", kernel_spec_rb_funcall_many_args, 2);
   rb_define_method(cls, "rb_funcall_with_block", kernel_spec_rb_funcall_with_block, 3);

--- a/spec/ruby/optional/capi/ext/object_spec.c
+++ b/spec/ruby/optional/capi/ext/object_spec.c
@@ -142,6 +142,10 @@ static VALUE object_specs_rb_obj_method_arity(VALUE self, VALUE obj, VALUE mid) 
   return INT2FIX(rb_obj_method_arity(obj, SYM2ID(mid)));
 }
 
+static VALUE object_specs_rb_obj_method(VALUE self, VALUE obj, VALUE method) {
+  return rb_obj_method(obj, method);
+}
+
 static VALUE object_spec_rb_obj_taint(VALUE self, VALUE obj) {
   return rb_obj_taint(obj);
 }
@@ -413,6 +417,7 @@ void Init_object_spec(void) {
   rb_define_method(cls, "rb_obj_is_instance_of", so_instance_of, 2);
   rb_define_method(cls, "rb_obj_is_kind_of", so_kind_of, 2);
   rb_define_method(cls, "rb_obj_method_arity", object_specs_rb_obj_method_arity, 2);
+  rb_define_method(cls, "rb_obj_method", object_specs_rb_obj_method, 2);
   rb_define_method(cls, "rb_obj_taint", object_spec_rb_obj_taint, 1);
   rb_define_method(cls, "rb_require", so_require, 0);
   rb_define_method(cls, "rb_respond_to", so_respond_to, 2);

--- a/spec/ruby/optional/capi/kernel_spec.rb
+++ b/spec/ruby/optional/capi/kernel_spec.rb
@@ -559,20 +559,6 @@ describe "C-API Kernel function" do
     end
   end
 
-  describe "rb_obj_method" do
-    it "returns the method object for a symbol" do
-      method = @s.rb_obj_method("test", :size)
-      method.owner.should == String
-      method.name.to_sym.should == :size
-    end
-
-    it "returns the method object for a string" do
-      method = @s.rb_obj_method("test", "size")
-      method.owner.should == String
-      method.name.to_sym.should == :size
-    end
-  end
-
   describe "rb_funcall3" do
     before :each do
       @obj = Object.new

--- a/spec/ruby/optional/capi/object_spec.rb
+++ b/spec/ruby/optional/capi/object_spec.rb
@@ -161,6 +161,20 @@ describe "CApiObject" do
     end
   end
 
+  describe "rb_obj_method" do
+    it "returns the method object for a symbol" do
+      method = @o.rb_obj_method("test", :size)
+      method.owner.should == String
+      method.name.to_sym.should == :size
+    end
+
+    it "returns the method object for a string" do
+      method = @o.rb_obj_method("test", "size")
+      method.owner.should == String
+      method.name.to_sym.should == :size
+    end
+  end
+
   describe "rb_method_boundp" do
     it "returns true when the given method is bound" do
       @o.rb_method_boundp(Object, :class, true).should == true

--- a/spec/tags/core/module/refine_tags.txt
+++ b/spec/tags/core/module/refine_tags.txt
@@ -1,2 +1,1 @@
 slow:Module#refine method lookup looks in the included modules for builtin methods
-fails:Module#refine for methods accessed indirectly is honored by Kernel#method

--- a/src/main/.checkstyle_checks.xml
+++ b/src/main/.checkstyle_checks.xml
@@ -144,7 +144,7 @@
     </module>
     <module name="RegexpSinglelineJava">
       <property name="format" value="CompilerAsserts.neverPartOfCompilation\(\)"/>
-      <property name="message" value="Use a @TruffleBoundary instead, which does not fail compilation if called in PE code."/>
+      <property name="message" value="Pass a String argument explaining what to use instead in PE code."/>
     </module>
     <module name="RegexpSinglelineJava">
       <property name="format" value=",\s*@Cached"/>

--- a/src/main/c/cext/call.c
+++ b/src/main/c/cext/call.c
@@ -190,6 +190,10 @@ int rb_obj_method_arity(VALUE object, ID id) {
   return polyglot_as_i32(RUBY_CEXT_INVOKE_NO_WRAP("rb_obj_method_arity", object, ID2SYM(id)));
 }
 
+VALUE rb_obj_method(VALUE object, VALUE id) {
+  return RUBY_CEXT_INVOKE("rb_obj_method", object, id);
+}
+
 int rb_obj_respond_to(VALUE object, ID id, int priv) {
   return polyglot_as_boolean(polyglot_invoke(RUBY_CEXT, "rb_obj_respond_to", rb_tr_unwrap(object), rb_tr_id2sym(id), priv));
 }

--- a/src/main/c/cext/object.c
+++ b/src/main/c/cext/object.c
@@ -136,10 +136,6 @@ const char *rb_obj_classname(VALUE object) {
   }
 }
 
-VALUE rb_obj_method(VALUE obj, VALUE vid) {
-  return RUBY_INVOKE(obj, "method", ID2SYM(rb_intern_str(vid)));
-}
-
 // taint status
 
 VALUE rb_obj_tainted(VALUE obj) {

--- a/src/main/java/org/truffleruby/RubyContext.java
+++ b/src/main/java/org/truffleruby/RubyContext.java
@@ -533,7 +533,7 @@ public class RubyContext {
 
     public RubyLanguage getLanguageSlow() {
         CompilerAsserts.neverPartOfCompilation(
-                "@CachedLanguage or a final field in the node should be used so the RubyLanguage instance is constant in PE code");
+                "Use getLanguage() or @CachedLanguage instead, so the RubyLanguage instance is constant in PE code");
         return language;
     }
 

--- a/src/main/java/org/truffleruby/RubyLanguage.java
+++ b/src/main/java/org/truffleruby/RubyLanguage.java
@@ -14,6 +14,7 @@ import java.util.Objects;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReentrantLock;
 
+import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.instrumentation.AllocationReporter;
 import com.oracle.truffle.api.object.Shape;
@@ -327,10 +328,12 @@ public final class RubyLanguage extends TruffleLanguage<RubyContext> {
     }
 
     public static RubyContext getCurrentContext() {
+        CompilerAsserts.neverPartOfCompilation("Use getContext() or @CachedContext instead in PE code");
         return getCurrentContext(RubyLanguage.class);
     }
 
     public static RubyLanguage getCurrentLanguage() {
+        CompilerAsserts.neverPartOfCompilation("Use getLanguage() or @CachedLanguage instead in PE code");
         return getCurrentLanguage(RubyLanguage.class);
     }
 

--- a/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
+++ b/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
@@ -1310,8 +1310,7 @@ public abstract class KernelNodes {
 
         @Specialization
         protected RubyMethod method(VirtualFrame frame, Object self, Object name) {
-            return getMethodObjectNode
-                    .get(frame, self, name, PRIVATE, readCallerFrame.execute(frame));
+            return getMethodObjectNode.execute(frame, self, name, PRIVATE, readCallerFrame.execute(frame));
         }
 
     }
@@ -1453,8 +1452,7 @@ public abstract class KernelNodes {
 
         @Specialization
         protected RubyMethod publicMethod(VirtualFrame frame, Object self, Object name) {
-            return getMethodObjectNode
-                    .get(frame, self, name, PUBLIC, readCallerFrame.execute(frame));
+            return getMethodObjectNode.execute(frame, self, name, PUBLIC, readCallerFrame.execute(frame));
         }
 
     }

--- a/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
+++ b/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
@@ -1311,7 +1311,7 @@ public abstract class KernelNodes {
         @Specialization
         protected RubyMethod method(VirtualFrame frame, Object self, Object name) {
             return getMethodObjectNode
-                    .executeGetMethodObject(frame, self, name, PRIVATE, readCallerFrame.execute(frame));
+                    .get(frame, self, name, PRIVATE, readCallerFrame.execute(frame));
         }
 
     }
@@ -1454,7 +1454,7 @@ public abstract class KernelNodes {
         @Specialization
         protected RubyMethod publicMethod(VirtualFrame frame, Object self, Object name) {
             return getMethodObjectNode
-                    .executeGetMethodObject(frame, self, name, PUBLIC, readCallerFrame.execute(frame));
+                    .get(frame, self, name, PUBLIC, readCallerFrame.execute(frame));
         }
 
     }

--- a/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
+++ b/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
@@ -60,7 +60,6 @@ import org.truffleruby.core.inlined.InlinedDispatchNode;
 import org.truffleruby.core.inlined.InlinedMethodNode;
 import org.truffleruby.core.kernel.KernelNodesFactory.CopyNodeFactory;
 import org.truffleruby.core.kernel.KernelNodesFactory.DupNodeFactory;
-import org.truffleruby.core.kernel.KernelNodesFactory.GetMethodObjectNodeGen;
 import org.truffleruby.core.kernel.KernelNodesFactory.InitializeCopyNodeFactory;
 import org.truffleruby.core.kernel.KernelNodesFactory.SameOrEqualNodeFactory;
 import org.truffleruby.core.kernel.KernelNodesFactory.SingletonMethodsNodeFactory;
@@ -96,8 +95,6 @@ import org.truffleruby.core.string.ImmutableRubyString;
 import org.truffleruby.language.ImmutableRubyObject;
 import org.truffleruby.language.Nil;
 import org.truffleruby.language.NotProvided;
-import org.truffleruby.language.RubyContextNode;
-import org.truffleruby.language.RubyContextSourceNode;
 import org.truffleruby.language.RubyDynamicObject;
 import org.truffleruby.language.RubyGuards;
 import org.truffleruby.language.RubyNode;
@@ -110,7 +107,6 @@ import org.truffleruby.language.arguments.RubyArguments;
 import org.truffleruby.language.backtrace.Backtrace;
 import org.truffleruby.language.backtrace.BacktraceFormatter;
 import org.truffleruby.language.control.RaiseException;
-import org.truffleruby.language.dispatch.DispatchConfiguration;
 import org.truffleruby.language.dispatch.DispatchNode;
 import org.truffleruby.language.dispatch.DispatchingNode;
 import org.truffleruby.language.dispatch.InternalRespondToNode;
@@ -124,10 +120,8 @@ import org.truffleruby.language.loader.RequireNode;
 import org.truffleruby.language.loader.RequireNodeGen;
 import org.truffleruby.language.locals.FindDeclarationVariableNodes.FindAndReadDeclarationVariableNode;
 import org.truffleruby.language.methods.DeclarationContext;
+import org.truffleruby.language.methods.GetMethodObjectNode;
 import org.truffleruby.language.methods.InternalMethod;
-import org.truffleruby.language.methods.LookupMethodOnSelfNode;
-import org.truffleruby.language.methods.SharedMethodInfo;
-import org.truffleruby.language.methods.Split;
 import org.truffleruby.language.objects.AllocationTracing;
 import org.truffleruby.language.objects.CheckIVarNameNode;
 import org.truffleruby.language.objects.IsANode;
@@ -1306,7 +1300,8 @@ public abstract class KernelNodes {
     @NodeChild(value = "name", type = RubyNode.class)
     public abstract static class MethodNode extends CoreMethodNode {
 
-        @Child private GetMethodObjectNode getMethodObjectNode = GetMethodObjectNode.create(true);
+        @Child private GetMethodObjectNode getMethodObjectNode = GetMethodObjectNode.create();
+        @Child private ReadCallerFrameNode readCallerFrame = ReadCallerFrameNode.create();
 
         @CreateCast("name")
         protected RubyNode coerceToString(RubyNode name) {
@@ -1315,112 +1310,8 @@ public abstract class KernelNodes {
 
         @Specialization
         protected RubyMethod method(VirtualFrame frame, Object self, Object name) {
-            return getMethodObjectNode.executeGetMethodObject(frame, self, name);
-        }
-
-    }
-
-    public abstract static class GetMethodObjectNode extends RubyContextNode {
-
-        public static GetMethodObjectNode create(boolean ignoreVisibility) {
-            return GetMethodObjectNodeGen.create(ignoreVisibility);
-        }
-
-        private final DispatchConfiguration dispatchConfig;
-
-        @Child private NameToJavaStringNode nameToJavaStringNode = NameToJavaStringNode.create();
-        @Child private LookupMethodOnSelfNode lookupMethodNode;
-        @Child private DispatchNode respondToMissingNode = DispatchNode.create();
-        @Child private BooleanCastNode booleanCastNode = BooleanCastNode.create();
-
-        public GetMethodObjectNode(boolean ignoreVisibility) {
-            this.dispatchConfig = ignoreVisibility ? PRIVATE : PUBLIC;
-            lookupMethodNode = LookupMethodOnSelfNode.create();
-        }
-
-        public abstract RubyMethod executeGetMethodObject(VirtualFrame frame, Object self, Object name);
-
-        @Specialization
-        protected RubyMethod method(VirtualFrame frame, Object self, Object name,
-                @Cached ConditionProfile notFoundProfile,
-                @Cached ConditionProfile respondToMissingProfile,
-                @Cached LogicalClassNode logicalClassNode) {
-            final String normalizedName = nameToJavaStringNode.execute(name);
-            InternalMethod method = lookupMethodNode.execute(frame, self, normalizedName, dispatchConfig);
-
-            if (notFoundProfile.profile(method == null)) {
-                final Object respondToMissing = respondToMissingNode
-                        .call(self, "respond_to_missing?", name, dispatchConfig.ignoreVisibility);
-                if (respondToMissingProfile.profile(booleanCastNode.executeToBoolean(respondToMissing))) {
-                    final InternalMethod methodMissing = lookupMethodNode
-                            .execute(frame, self, "method_missing", dispatchConfig);
-                    method = createMissingMethod(self, name, normalizedName, methodMissing);
-                } else {
-                    throw new RaiseException(
-                            getContext(),
-                            coreExceptions().nameErrorUndefinedMethod(
-                                    normalizedName,
-                                    logicalClassNode.execute(self),
-                                    this));
-                }
-            }
-            final RubyMethod instance = new RubyMethod(
-                    coreLibrary().methodClass,
-                    getLanguage().methodShape,
-                    self,
-                    method);
-            AllocationTracing.trace(instance, this);
-            return instance;
-        }
-
-        @TruffleBoundary
-        private InternalMethod createMissingMethod(Object self, Object name, String normalizedName,
-                InternalMethod methodMissing) {
-            final SharedMethodInfo info = methodMissing
-                    .getSharedMethodInfo()
-                    .convertMethodMissingToMethod(methodMissing.getDeclaringModule(), normalizedName);
-
-            final RubyNode newBody = new CallMethodMissingWithStaticName(name);
-            final RubyRootNode newRootNode = new RubyRootNode(
-                    getLanguage(),
-                    info.getSourceSection(),
-                    new FrameDescriptor(nil),
-                    info,
-                    newBody,
-                    Split.HEURISTIC);
-            final RootCallTarget newCallTarget = Truffle.getRuntime().createCallTarget(newRootNode);
-
-            final RubyClass module = MetaClassNode.getUncached().execute(self);
-            return new InternalMethod(
-                    getContext(),
-                    info,
-                    methodMissing.getLexicalScope(),
-                    DeclarationContext.NONE,
-                    normalizedName,
-                    module,
-                    Visibility.PUBLIC,
-                    newCallTarget);
-        }
-
-        private static class CallMethodMissingWithStaticName extends RubyContextSourceNode {
-
-            private final Object methodName;
-            @Child private DispatchNode methodMissing = DispatchNode.create();
-
-            public CallMethodMissingWithStaticName(Object methodName) {
-                this.methodName = methodName;
-            }
-
-            @Override
-            public Object execute(VirtualFrame frame) {
-                final Object[] originalUserArguments = RubyArguments.getArguments(frame);
-                final Object[] newUserArguments = ArrayUtils.unshift(originalUserArguments, methodName);
-                return methodMissing.callWithBlock(
-                        RubyArguments.getSelf(frame),
-                        "method_missing",
-                        RubyArguments.getBlock(frame),
-                        newUserArguments);
-            }
+            return getMethodObjectNode
+                    .executeGetMethodObject(frame, self, name, PRIVATE, readCallerFrame.execute(frame));
         }
 
     }
@@ -1552,7 +1443,8 @@ public abstract class KernelNodes {
     @NodeChild(value = "name", type = RubyNode.class)
     public abstract static class PublicMethodNode extends CoreMethodNode {
 
-        @Child private GetMethodObjectNode getMethodObjectNode = GetMethodObjectNode.create(false);
+        @Child private GetMethodObjectNode getMethodObjectNode = GetMethodObjectNode.create();
+        @Child private ReadCallerFrameNode readCallerFrame = ReadCallerFrameNode.create();
 
         @CreateCast("name")
         protected RubyNode coerceToString(RubyNode name) {
@@ -1561,7 +1453,8 @@ public abstract class KernelNodes {
 
         @Specialization
         protected RubyMethod publicMethod(VirtualFrame frame, Object self, Object name) {
-            return getMethodObjectNode.executeGetMethodObject(frame, self, name);
+            return getMethodObjectNode
+                    .executeGetMethodObject(frame, self, name, PUBLIC, readCallerFrame.execute(frame));
         }
 
     }

--- a/src/main/java/org/truffleruby/core/module/ModuleNodes.java
+++ b/src/main/java/org/truffleruby/core/module/ModuleNodes.java
@@ -1836,6 +1836,7 @@ public abstract class ModuleNodes {
     @NodeChild(value = "module", type = RubyNode.class)
     @NodeChild(value = "name", type = RubyNode.class)
     public abstract static class InstanceMethodNode extends CoreMethodNode {
+        @Child private ReadCallerFrameNode readCallerFrame = ReadCallerFrameNode.create();
 
         @CreateCast("name")
         protected RubyNode coerceToString(RubyNode name) {
@@ -1843,9 +1844,9 @@ public abstract class ModuleNodes {
         }
 
         @Specialization
-        protected RubyUnboundMethod instanceMethod(RubyModule module, String name,
+        protected RubyUnboundMethod instanceMethod(VirtualFrame frame, RubyModule module, String name,
                 @Cached BranchProfile errorProfile) {
-            final Frame callerFrame = getContext().getCallStack().getCallerFrameIgnoringSend(FrameAccess.READ_ONLY);
+            final Frame callerFrame = readCallerFrame.execute(frame);
             final DeclarationContext declarationContext = RubyArguments.getDeclarationContext(callerFrame);
 
             // TODO(CS, 11-Jan-15) cache this lookup

--- a/src/main/java/org/truffleruby/core/module/ModuleNodes.java
+++ b/src/main/java/org/truffleruby/core/module/ModuleNodes.java
@@ -1845,8 +1845,11 @@ public abstract class ModuleNodes {
         @Specialization
         protected RubyUnboundMethod instanceMethod(RubyModule module, String name,
                 @Cached BranchProfile errorProfile) {
+            final Frame callerFrame = getContext().getCallStack().getCallerFrameIgnoringSend(FrameAccess.READ_ONLY);
+            final DeclarationContext declarationContext = RubyArguments.getDeclarationContext(callerFrame);
+
             // TODO(CS, 11-Jan-15) cache this lookup
-            final InternalMethod method = ModuleOperations.lookupMethodUncached(module, name, null);
+            final InternalMethod method = ModuleOperations.lookupMethodUncached(module, name, declarationContext);
 
             if (method == null || method.isUndefined()) {
                 errorProfile.enter();

--- a/src/main/java/org/truffleruby/interop/TranslateInteropRubyExceptionNode.java
+++ b/src/main/java/org/truffleruby/interop/TranslateInteropRubyExceptionNode.java
@@ -9,6 +9,7 @@
  */
 package org.truffleruby.interop;
 
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import org.truffleruby.RubyContext;
 import org.truffleruby.RubyLanguage;
 import org.truffleruby.core.cast.IntegerCastNode;
@@ -159,6 +160,7 @@ public abstract class TranslateInteropRubyExceptionNode extends RubyBaseNode {
         throw exception;
     }
 
+    @TruffleBoundary
     protected AssertionError handleBadErrorType(InteropException e, RaiseException rubyException) {
         RubyContext context = RubyLanguage.getCurrentContext();
         final RubyException exception = context.getCoreExceptions().runtimeError(

--- a/src/main/java/org/truffleruby/language/RubyDynamicObject.java
+++ b/src/main/java/org/truffleruby/language/RubyDynamicObject.java
@@ -376,7 +376,7 @@ public abstract class RubyDynamicObject extends DynamicObject {
                 return iVar;
             } else if (definedNode.execute(null, this, name)) {
                 return getMethodObjectNode
-                        .executeGetMethodObject(null, this, rubyName, DispatchConfiguration.PRIVATE, null);
+                        .get(null, this, rubyName, DispatchConfiguration.PRIVATE, null);
             } else {
                 errorProfile.enter();
                 throw UnknownIdentifierException.create(name);

--- a/src/main/java/org/truffleruby/language/RubyDynamicObject.java
+++ b/src/main/java/org/truffleruby/language/RubyDynamicObject.java
@@ -375,8 +375,7 @@ public abstract class RubyDynamicObject extends DynamicObject {
             if (ivarFoundProfile.profile(iVar != null)) {
                 return iVar;
             } else if (definedNode.execute(null, this, name)) {
-                return getMethodObjectNode
-                        .get(null, this, rubyName, DispatchConfiguration.PRIVATE, null);
+                return getMethodObjectNode.execute(null, this, rubyName, DispatchConfiguration.PRIVATE, null);
             } else {
                 errorProfile.enter();
                 throw UnknownIdentifierException.create(name);

--- a/src/main/java/org/truffleruby/language/SafepointManager.java
+++ b/src/main/java/org/truffleruby/language/SafepointManager.java
@@ -106,6 +106,8 @@ public final class SafepointManager {
         final Assumption safepointAssumption = language.getSafepointAssumption();
         CompilerAsserts.partialEvaluationConstant(safepointAssumption);
         if (!safepointAssumption.isValid()) {
+            // For the TruffleCheckNeverPartOfCompilation check, isValid() deopts anyway
+            CompilerDirectives.transferToInterpreterAndInvalidate();
             final SafepointManager safepointManager = RubyLanguage.getCurrentContext().getSafepointManager();
             if (safepointManager.active) {
                 CompilerDirectives.transferToInterpreterAndInvalidate();

--- a/src/main/java/org/truffleruby/language/methods/GetMethodObjectNode.java
+++ b/src/main/java/org/truffleruby/language/methods/GetMethodObjectNode.java
@@ -81,7 +81,7 @@ public abstract class GetMethodObjectNode extends RubyBaseNode {
 
         final String normalizedName = nameToJavaStringNode.execute(name);
         InternalMethod method = lookupMethodNode
-                .lookup(frame, self, normalizedName, dispatchConfig);
+                .execute(frame, self, normalizedName, dispatchConfig);
 
         if (notFoundProfile.profile(method == null)) {
             final Object respondToMissing = respondToMissingNode
@@ -90,7 +90,7 @@ public abstract class GetMethodObjectNode extends RubyBaseNode {
                 /** refinements should not affect BasicObject#method_missing */
                 RubyArguments.setDeclarationContext(frame, originalDeclarationContext);
                 final InternalMethod methodMissing = lookupMethodNode
-                        .lookup(frame, self, "method_missing", dispatchConfig);
+                        .execute(frame, self, "method_missing", dispatchConfig);
                 method = createMissingMethod(self, name, normalizedName, methodMissing, context);
             } else {
                 throw new RaiseException(

--- a/src/main/java/org/truffleruby/language/methods/GetMethodObjectNode.java
+++ b/src/main/java/org/truffleruby/language/methods/GetMethodObjectNode.java
@@ -47,12 +47,7 @@ public abstract class GetMethodObjectNode extends RubyBaseNode {
         return GetMethodObjectNodeGen.create();
     }
 
-    public RubyMethod get(VirtualFrame frame, Object self, Object name,
-            DispatchConfiguration config, MaterializedFrame callerFrame) {
-        return execute(frame, self, name, config, callerFrame);
-    }
-
-    protected abstract RubyMethod execute(Frame frame, Object self, Object name,
+    public abstract RubyMethod execute(Frame frame, Object self, Object name,
             DispatchConfiguration dispatchConfig, MaterializedFrame callerFrame);
 
     @Specialization

--- a/src/main/java/org/truffleruby/language/methods/GetMethodObjectNode.java
+++ b/src/main/java/org/truffleruby/language/methods/GetMethodObjectNode.java
@@ -60,7 +60,7 @@ public abstract class GetMethodObjectNode extends RubyBaseNode {
             "name.equals(cachedName)",
             "contextReference.get() == cachedContext"
     }, limit = "getCacheLimit()")
-    public RubyMethod doCached(Frame frame, Object self, Object name,
+    protected RubyMethod doCached(Frame frame, Object self, Object name,
             DispatchConfiguration dispatchConfig,
             Frame callerFrame,
             @Cached("self") Object cachedSelf,
@@ -81,7 +81,7 @@ public abstract class GetMethodObjectNode extends RubyBaseNode {
 
 
     @Specialization(replaces = "doCached")
-    public RubyMethod doGeneric(Frame frame, Object self, Object name,
+    protected RubyMethod doGeneric(Frame frame, Object self, Object name,
             DispatchConfiguration dispatchConfig,
             Frame callerFrame,
             @CachedContext(RubyLanguage.class) RubyContext context,

--- a/src/main/java/org/truffleruby/language/methods/GetMethodObjectNode.java
+++ b/src/main/java/org/truffleruby/language/methods/GetMethodObjectNode.java
@@ -56,7 +56,10 @@ public abstract class GetMethodObjectNode extends RubyBaseNode {
             DispatchConfiguration dispatchConfig, MaterializedFrame callerFrame);
 
     @Specialization
-    protected RubyMethod getMethodObject(Frame frame, Object self, Object name,
+    protected RubyMethod getMethodObject(
+            Frame frame,
+            Object self,
+            Object name,
             DispatchConfiguration dispatchConfig,
             MaterializedFrame callerFrame,
             @CachedContext(RubyLanguage.class) RubyContext context,

--- a/src/main/java/org/truffleruby/language/methods/GetMethodObjectNode.java
+++ b/src/main/java/org/truffleruby/language/methods/GetMethodObjectNode.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright (c) 2013, 2020 Oracle and/or its affiliates. All rights reserved. This
+ * code is released under a tri EPL/GPL/LGPL license. You can use it,
+ * redistribute it and/or modify it under the terms of the:
+ *
+ * Eclipse Public License version 2.0, or
+ * GNU General Public License version 2, or
+ * GNU Lesser General Public License version 2.1.
+ */
+package org.truffleruby.language.methods;
+
+import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
+import com.oracle.truffle.api.RootCallTarget;
+import com.oracle.truffle.api.Truffle;
+import com.oracle.truffle.api.TruffleLanguage;
+import com.oracle.truffle.api.dsl.Cached;
+import com.oracle.truffle.api.dsl.CachedContext;
+import com.oracle.truffle.api.dsl.GenerateUncached;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.frame.Frame;
+import com.oracle.truffle.api.frame.FrameDescriptor;
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.profiles.ConditionProfile;
+import org.truffleruby.RubyContext;
+import org.truffleruby.RubyLanguage;
+import org.truffleruby.core.array.ArrayUtils;
+import org.truffleruby.core.cast.BooleanCastNode;
+import org.truffleruby.core.cast.NameToJavaStringNode;
+import org.truffleruby.core.klass.RubyClass;
+import org.truffleruby.core.method.RubyMethod;
+import org.truffleruby.language.RubyBaseNode;
+import org.truffleruby.language.RubyContextSourceNode;
+import org.truffleruby.language.RubyNode;
+import org.truffleruby.language.RubyRootNode;
+import org.truffleruby.language.Visibility;
+import org.truffleruby.language.arguments.RubyArguments;
+import org.truffleruby.language.control.RaiseException;
+import org.truffleruby.language.dispatch.DispatchConfiguration;
+import org.truffleruby.language.dispatch.DispatchNode;
+import org.truffleruby.language.objects.AllocationTracing;
+import org.truffleruby.language.objects.LogicalClassNode;
+import org.truffleruby.language.objects.MetaClassNode;
+
+@GenerateUncached
+public abstract class GetMethodObjectNode extends RubyBaseNode {
+    public static GetMethodObjectNode create() {
+        return GetMethodObjectNodeGen.create();
+    }
+
+    public abstract RubyMethod executeGetMethodObject(Frame frame, Object self, Object name,
+            DispatchConfiguration dispatchConfig, Frame callerFrame);
+
+    protected int getCacheLimit() {
+        return RubyLanguage.getCurrentLanguage().options.METHOD_LOOKUP_CACHE;
+    }
+
+    @Specialization(guards = {
+            "dispatchConfig == cachedDispatchConfig",
+            "self == cachedSelf",
+            "name.equals(cachedName)",
+            "contextReference.get() == cachedContext"
+    }, limit = "getCacheLimit()")
+    public RubyMethod doCached(Frame frame, Object self, Object name,
+            DispatchConfiguration dispatchConfig,
+            Frame callerFrame,
+            @Cached("self") Object cachedSelf,
+            @Cached("name") Object cachedName,
+            @Cached("dispatchConfig") DispatchConfiguration cachedDispatchConfig,
+            @CachedContext(RubyLanguage.class) TruffleLanguage.ContextReference<RubyContext> contextReference,
+            @Cached("contextReference.get()") RubyContext cachedContext,
+            @Cached NameToJavaStringNode nameToJavaStringNode,
+            @Cached LookupMethodOnSelfNode lookupMethodNode,
+            @Cached DispatchNode respondToMissingNode,
+            @Cached BooleanCastNode booleanCastNode,
+            @Cached ConditionProfile notFoundProfile,
+            @Cached ConditionProfile respondToMissingProfile,
+            @Cached LogicalClassNode logicalClassNode,
+            @Cached("getMethodObject(frame, self, cachedName, cachedDispatchConfig, callerFrame, cachedContext, nameToJavaStringNode, lookupMethodNode, respondToMissingNode, booleanCastNode, notFoundProfile, respondToMissingProfile, logicalClassNode)") RubyMethod cachedRubyMethod) {
+        return cachedRubyMethod;
+    }
+
+
+    @Specialization(replaces = "doCached")
+    public RubyMethod doGeneric(Frame frame, Object self, Object name,
+            DispatchConfiguration dispatchConfig,
+            Frame callerFrame,
+            @CachedContext(RubyLanguage.class) RubyContext context,
+            @Cached NameToJavaStringNode nameToJavaStringNode,
+            @Cached LookupMethodOnSelfNode lookupMethodNode,
+            @Cached DispatchNode respondToMissingNode,
+            @Cached BooleanCastNode booleanCastNode,
+            @Cached ConditionProfile notFoundProfile,
+            @Cached ConditionProfile respondToMissingProfile,
+            @Cached LogicalClassNode logicalClassNode) {
+        assert this != GetMethodObjectNodeGen.getUncached() || frame == null;
+
+        return getMethodObject(
+                frame,
+                self,
+                name,
+                dispatchConfig,
+                callerFrame,
+                context,
+                nameToJavaStringNode,
+                lookupMethodNode,
+                respondToMissingNode,
+                booleanCastNode,
+                notFoundProfile,
+                respondToMissingProfile,
+                logicalClassNode);
+    }
+
+    protected RubyMethod getMethodObject(Frame frame, Object self, Object name,
+            DispatchConfiguration dispatchConfig,
+            Frame callerFrame,
+            RubyContext context,
+            NameToJavaStringNode nameToJavaStringNode,
+            LookupMethodOnSelfNode lookupMethodNode,
+            DispatchNode respondToMissingNode,
+            BooleanCastNode booleanCastNode,
+            ConditionProfile notFoundProfile,
+            ConditionProfile respondToMissingProfile,
+            LogicalClassNode logicalClassNode) {
+        DeclarationContext originalDeclarationContext = null;
+
+        if (frame != null) {
+            originalDeclarationContext = RubyArguments.getDeclarationContext(frame);
+
+            final DeclarationContext declarationContext = RubyArguments.getDeclarationContext(callerFrame);
+            if (declarationContext != null) {
+                RubyArguments.setDeclarationContext(frame, declarationContext);
+            }
+        }
+
+        final String normalizedName = nameToJavaStringNode.execute(name);
+        InternalMethod method = lookupMethodNode
+                .lookup(frame, self, normalizedName, dispatchConfig);
+
+        if (notFoundProfile.profile(method == null)) {
+            final Object respondToMissing = respondToMissingNode
+                    .call(self, "respond_to_missing?", name, dispatchConfig.ignoreVisibility);
+            if (respondToMissingProfile.profile(booleanCastNode.executeToBoolean(respondToMissing))) {
+                /** refinements should not affect BasicObject#method_missing */
+                RubyArguments.setDeclarationContext(frame, originalDeclarationContext);
+                final InternalMethod methodMissing = lookupMethodNode
+                        .lookup(frame, self, "method_missing", dispatchConfig);
+                method = createMissingMethod(self, name, normalizedName, methodMissing, context);
+            } else {
+                throw new RaiseException(
+                        context,
+                        context.getCoreExceptions().nameErrorUndefinedMethod(
+                                normalizedName,
+                                logicalClassNode.execute(self),
+                                this));
+            }
+        }
+        final RubyMethod instance = new RubyMethod(
+                context.getCoreLibrary().methodClass,
+                RubyLanguage.getCurrentLanguage().methodShape,
+                self,
+                method);
+        AllocationTracing.trace(RubyLanguage.getCurrentLanguage(), context, instance, this);
+        return instance;
+    }
+
+    @TruffleBoundary
+    private InternalMethod createMissingMethod(Object self, Object name, String normalizedName,
+            InternalMethod methodMissing,
+            RubyContext context) {
+        final SharedMethodInfo info = methodMissing
+                .getSharedMethodInfo()
+                .convertMethodMissingToMethod(methodMissing.getDeclaringModule(), normalizedName);
+
+        final RubyNode newBody = new CallMethodMissingWithStaticName(name);
+        final RubyRootNode newRootNode = new RubyRootNode(
+                RubyLanguage.getCurrentLanguage(),
+                info.getSourceSection(),
+                new FrameDescriptor(nil),
+                info,
+                newBody,
+                Split.HEURISTIC);
+        final RootCallTarget newCallTarget = Truffle.getRuntime().createCallTarget(newRootNode);
+
+        final RubyClass module = MetaClassNode.getUncached().execute(self);
+        return new InternalMethod(
+                context,
+                info,
+                methodMissing.getLexicalScope(),
+                DeclarationContext.NONE,
+                normalizedName,
+                module,
+                Visibility.PUBLIC,
+                newCallTarget);
+    }
+
+    private static class CallMethodMissingWithStaticName extends RubyContextSourceNode {
+        private final Object methodName;
+        @Child private DispatchNode methodMissing = DispatchNode.create();
+
+        public CallMethodMissingWithStaticName(Object methodName) {
+            this.methodName = methodName;
+        }
+
+        @Override
+        public Object execute(VirtualFrame frame) {
+            final Object[] originalUserArguments = RubyArguments.getArguments(frame);
+            final Object[] newUserArguments = ArrayUtils.unshift(originalUserArguments, methodName);
+            return methodMissing.callWithBlock(
+                    RubyArguments.getSelf(frame),
+                    "method_missing",
+                    RubyArguments.getBlock(frame),
+                    newUserArguments);
+        }
+    }
+}


### PR DESCRIPTION
Related to #2004 

A few notes:
1. Refinements for `#method` is similar to `#respond_to?` (see: https://github.com/oracle/truffleruby/pull/2120/files) where we used  `ReadCallerFrameNode`. In this PR I don't use `ReadCallerFrameNode`, but instead directly call: 
```
getContext().getCallStack().getCallerFrameIgnoringSend(FrameInstance.FrameAccess.READ_ONLY);
```

to avoid frame materialization. However, we discussed the possible optimization of `ReadCallerFrameNode` so maybe we should repeat the `RespondToNode` approach (with `@Child private ReadCallerFrameNode readCallerFrame`) to be more consistent. 

I didn't find `#method` or `#instance_method` uses via Primitive (so there are no needs in : https://github.com/oracle/truffleruby/commit/d84da65fc8531aca9e1e397e1a75eee83834b655).

There were also options with AST-inlining, but we haven't done that yet.

2. The following behavior seems a little confusing
```ruby
# $ ruby -v
# => ruby 2.7.1p83 (2020-03-31 revision a0c7c23c9c) [x86_64-darwin19]

klass = Class.new

refinement = Module.new do
  refine klass do
    def foo; end
  end
end

result = nil
result2 = nil

Module.new do
  using refinement

  result = klass.instance_method(:foo)
  result2 = klass.method_defined?(:foo)
end

puts result
# => #<UnboundMethod: #<Class:0x00007fa2df849688>(#<refinement:#<Class:0x00007fa2df849688>@#<Module:0x00007fa2df8494d0>>)#foo() test.rb:5>
puts result2
# => false
```

How do you think this is expected?