### PR TITLE
Improve random number generation performance by avoiding synchronization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Compatibility:
 Performance:
 
 * Improve the performance of checks for recursion (#2189, @LillianZ).
+* Improve random number generation performance by avoiding synchronization (#2190, @ivoanjo).
 
 Changes:
 

--- a/bench/micro/random/random.rb
+++ b/bench/micro/random/random.rb
@@ -1,0 +1,11 @@
+# Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved. This
+# code is released under a tri EPL/GPL/LGPL license. You can use it,
+# redistribute it and/or modify it under the terms of the:
+#
+# Eclipse Public License version 2.0, or
+# GNU General Public License version 2, or
+# GNU Lesser General Public License version 2.1.
+
+benchmark 'random' do
+  Kernel.rand
+end

--- a/bench/micro/random/random_object.rb
+++ b/bench/micro/random/random_object.rb
@@ -1,0 +1,13 @@
+# Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved. This
+# code is released under a tri EPL/GPL/LGPL license. You can use it,
+# redistribute it and/or modify it under the terms of the:
+#
+# Eclipse Public License version 2.0, or
+# GNU General Public License version 2, or
+# GNU Lesser General Public License version 2.1.
+
+THE_RANDOM = Random.new
+
+benchmark 'random object' do
+  THE_RANDOM.rand
+end

--- a/src/main/java/org/truffleruby/algorithms/Randomizer.java
+++ b/src/main/java/org/truffleruby/algorithms/Randomizer.java
@@ -26,8 +26,6 @@
  ***** END LICENSE BLOCK *****/
 package org.truffleruby.algorithms;
 
-import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
-
 public class Randomizer {
 
     private static final int N = 624;
@@ -40,23 +38,21 @@ public class Randomizer {
     private int left = 1;
 
     private final Object seed;
-    private final boolean threadSafe;
 
-    public Randomizer(boolean threadSafe) {
-        this(0L, 0, threadSafe);
+    public Randomizer() {
+        this(0L, 0);
     }
 
-    public Randomizer(Object seed, int s, boolean threadSafe) {
+    public Randomizer(Object seed, int s) {
         this.seed = seed;
-        this.threadSafe = threadSafe;
         state[0] = s;
         for (int j = 1; j < N; j++) {
             state[j] = (1812433253 * (state[j - 1] ^ (state[j - 1] >>> 30)) + j);
         }
     }
 
-    public Randomizer(Object seed, int[] initKey, boolean threadSafe) {
-        this(seed, 19650218, threadSafe);
+    public Randomizer(Object seed, int[] initKey) {
+        this(seed, 19650218);
         int len = initKey.length;
         int i = 1;
         int j = 0;
@@ -88,25 +84,12 @@ public class Randomizer {
         return seed;
     }
 
-    @TruffleBoundary
     public int genrandInt32() {
-        int y;
-
-        if (threadSafe) {
-            synchronized (this) {
-                if (--left <= 0) {
-                    nextState();
-                }
-
-                y = state[N - left];
-            }
-        } else {
-            if (--left <= 0) {
-                nextState();
-            }
-
-            y = state[N - left];
+        if (--left <= 0) {
+            nextState();
         }
+
+        int y = state[N - left];
 
         /* Tempering */
         y ^= (y >>> 11);

--- a/src/main/java/org/truffleruby/algorithms/Randomizer.java
+++ b/src/main/java/org/truffleruby/algorithms/Randomizer.java
@@ -84,7 +84,7 @@ public class Randomizer {
         return seed;
     }
 
-    public int genrandInt32() {
+    public int unsynchronizedGenrandInt32() {
         if (--left <= 0) {
             nextState();
         }

--- a/src/main/java/org/truffleruby/core/support/RubyRandomizer.java
+++ b/src/main/java/org/truffleruby/core/support/RubyRandomizer.java
@@ -18,10 +18,12 @@ import com.oracle.truffle.api.object.Shape;
 public final class RubyRandomizer extends RubyDynamicObject {
 
     public Randomizer randomizer;
+    public final boolean threadSafe; // Used to configure new Randomizer instances, e.g. when setting seed manually
 
-    public RubyRandomizer(RubyClass rubyClass, Shape shape, Randomizer randomizer) {
+    public RubyRandomizer(RubyClass rubyClass, Shape shape, Randomizer randomizer, boolean threadSafe) {
         super(rubyClass, shape);
         this.randomizer = randomizer;
+        this.threadSafe = threadSafe;
     }
 
 }

--- a/src/main/java/org/truffleruby/core/support/RubyRandomizer.java
+++ b/src/main/java/org/truffleruby/core/support/RubyRandomizer.java
@@ -38,10 +38,10 @@ public final class RubyRandomizer extends RubyDynamicObject {
     public int genrandInt32() {
         if (threadSafe) {
             synchronized (this) {
-                return randomizer.genrandInt32();
+                return randomizer.unsynchronizedGenrandInt32();
             }
         } else {
-            return randomizer.genrandInt32();
+            return randomizer.unsynchronizedGenrandInt32();
         }
     }
 

--- a/src/main/java/org/truffleruby/core/thread/RubyThread.java
+++ b/src/main/java/org/truffleruby/core/thread/RubyThread.java
@@ -79,7 +79,10 @@ public class RubyThread extends RubyDynamicObject implements ObjectGraphNode {
         this.recursiveObjects = HashOperations.newEmptyHash(context, language);
         this.recursiveObjectsSingle = HashOperations.newEmptyHash(context, language);
         this.recursiveObjectsSingle.compareByIdentity = true;
-        this.randomizer = RandomizerNodes.newRandomizer(context, language);
+        this.randomizer = RandomizerNodes.newRandomizer(
+                context,
+                language,
+                false); // This random instance is only for this thread and thus does not need to be thread-safe
         this.tracePointState = new TracePointState();
         this.reportOnException = reportOnException;
         this.abortOnException = abortOnException;


### PR DESCRIPTION
As discussed in #2176, prior to this change, random number generation
included grabbing a lock. This was especially expensive when running
in native mode, even being slower than MRI.

In the common case of `Kernel.rand` calls, threads already used
thread-local `RubyRandomizer` instances, so for those we can skip the
lock safely.

Thus, in this change I:

* Added a `threadSafe` field to `Randomizer` that is used to decide if
  a lock needs to be grabbed or not during generation
* Added a `threadSafe` field to `RubyRandomizer` that is used to track
  if that object should or not contain a `threadSafe` instance of
  `Randomizer`. This is useful whenever a `Randomizer` instance is
  recreated for an existing `RubyRandomizer` -- currently this happens
  whenever the seed is changed
* Added a microbenchmark to validate the change

Results using `jt ... benchmark bench/micro/random/random.rb --simple`
on my Intel i5-8250U laptop using Ubuntu 20.04.1 LTS:

| Ruby                      | Iterations/s | Speedup relative to MRI |
|---------------------------|-------------:|------------------------:|
| MRI 2.7.2                 |     13,188,053 |                Baseline |
| TruffleRuby native before |      9,156,314 |                    0.69 |
| ~~TruffleRuby JVM before~~ (Wrong value posted initially)   |     ~~18,233,405~~ |                    ~~1.38~~ |
| TruffleRuby JVM before (master) | 30,341,583 |  2.30 |
| TruffleRuby native after  |     35,622,402 |                    2.70 |
| TruffleRuby JVM after     |     49,584,760 |                    3.76 |

---

**Note**: While benchmarking using regular ruby `Random` objects, I've
noticed a regression when this change is applied. I've investigated a
bit, and it seems like the addition of `if (threadSafe)` in
`Randomizer.java::genrandInt32` seems to cause a non-trivial impact to
the benchmark performance.

I don't know enough truffle-foo to investigate why, but here's the
results I'm getting with
`jt ... benchmark bench/micro/random/random_object.rb --simple`:

| Ruby                                 | Iterations/s | Slowdown relative to before |
|--------------------------------------|-------------:|-----------------------------|
| TruffleRuby Random obj native before |    9,125,906 |                    Baseline |
| TruffleRuby Random obj JVM before    |   46,542,201 |                    Baseline |
| TruffleRuby Random obj native after  |    8,938,364 |                        0.98 |
| TruffleRuby Random obj JVM after     |   43,711,568 |                        0.94 |

It's not a big difference, but it's definitely measurable.

Any thoughts?

Fixes #2176