### PR TITLE
Make File.extname return '.' if the path ends with one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Compatibility:
 * Updated `Regexp.last_match` to support `Symbol` and `String` parameter (#2179).
 * Added support for numbered block parameters (`_1` etc).
 * Fixed `String#upto` issue with non-ascii strings (#2183).
+* Make `File.extname` return `'.'` if the path ends with one (#2192, @tomstuart).
 
 Performance:
 

--- a/spec/tags/core/file/extname_tags.txt
+++ b/spec/tags/core/file/extname_tags.txt
@@ -1,1 +1,0 @@
-fails:File.extname for a filename ending with a dot returns '.'

--- a/src/main/ruby/truffleruby/core/file.rb
+++ b/src/main/ruby/truffleruby/core/file.rb
@@ -475,6 +475,7 @@ class File < IO
   #
   #  File.extname("test.rb")         #=> ".rb"
   #  File.extname("a/b/d/test.rb")   #=> ".rb"
+  #  File.extname("foo.")            #=> "."
   #  File.extname("test")            #=> ""
   #  File.extname(".profile")        #=> ""
   def self.extname(path)
@@ -497,8 +498,15 @@ class File < IO
     # last component starts with a .
     return +'' if dot_idx == slash_idx + 1
 
-    # last component ends with a .
-    return +'' if dot_idx == path_size - 1
+    if dot_idx == path_size - 1
+      last_component = path.byteslice(slash_idx + 1, path_size - (slash_idx + 1))
+
+      # last component is entirely . characters
+      return +'' if last_component.each_char.all? { |c| c == '.' }
+
+      # last component ends with a .
+      return +'.'
+    end
 
     path.byteslice(dot_idx, path_size - dot_idx)
   end


### PR DESCRIPTION
`File.basename(path, '.*') + File.extname(path)` should always correctly reconstruct `File.basename(path)`, but [Ruby bug 15267](https://bugs.ruby-lang.org/issues/15267) is that this doesn’t hold for paths which end in a dot:

```ruby
>> path = 'a/b/c/foo.'
=> "a/b/c/foo."
>> File.basename(path, '.*')
=> "foo"
>> File.extname(path)
=> ""
>> File.basename(path, '.*') + File.extname(path)
=> "foo"
>> File.basename(path)
=> "foo."
```

This was fixed in MRI v2_7_0.preview2 by ruby/ruby#2565 but not yet in TruffleRuby (#2004). This PR updates TruffleRuby’s `File.extname` behaviour to return `'.'` for paths ending in a dot, while preserving the existing edge case behaviour of still returning the empty string when the last path component consists entirely of dots (e.g. `'..'`).

Shopify#1