### PR TITLE
Showing fractional seconds in Time#inspect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Compatibility:
 * Updated `Regexp.last_match` to support `Symbol` and `String` parameter (#2179).
 * Added support for numbered block parameters (`_1` etc).
 * Fixed `String#upto` issue with non-ascii strings (#2183).
+* Include fractional seconds in `Time#inspect` output (#2194, @tomstuart).
 
 Performance:
 

--- a/spec/tags/core/time/inspect_tags.txt
+++ b/spec/tags/core/time/inspect_tags.txt
@@ -1,2 +1,1 @@
-fails:Time#inspect preserves milliseconds
 fails:Time#inspect formats nanoseconds as a Rational

--- a/src/main/ruby/truffleruby/core/time.rb
+++ b/src/main/ruby/truffleruby/core/time.rb
@@ -50,7 +50,15 @@ class Time
     end
     str.force_encoding Encoding::US_ASCII
   end
-  alias_method :to_s, :inspect
+
+  def to_s
+    if gmt?
+      str = strftime('%Y-%m-%d %H:%M:%S UTC')
+    else
+      str = strftime('%Y-%m-%d %H:%M:%S %z')
+    end
+    str.force_encoding Encoding::US_ASCII
+  end
 
   def subsec
     if nsec == 0

--- a/src/main/ruby/truffleruby/core/time.rb
+++ b/src/main/ruby/truffleruby/core/time.rb
@@ -44,6 +44,12 @@ class Time
 
   def inspect
     str = strftime('%Y-%m-%d %H:%M:%S')
+
+    if nsec != 0
+      str << sprintf(".%09d", nsec)
+      str.chop! while str.end_with?('0')
+    end
+
     str << (gmt? ? ' UTC' : strftime(' %z'))
     str.force_encoding Encoding::US_ASCII
   end

--- a/src/main/ruby/truffleruby/core/time.rb
+++ b/src/main/ruby/truffleruby/core/time.rb
@@ -43,11 +43,8 @@ class Time
   }
 
   def inspect
-    if gmt?
-      str = strftime('%Y-%m-%d %H:%M:%S UTC')
-    else
-      str = strftime('%Y-%m-%d %H:%M:%S %z')
-    end
+    str = strftime('%Y-%m-%d %H:%M:%S')
+    str << (gmt? ? ' UTC' : strftime(' %z'))
     str.force_encoding Encoding::US_ASCII
   end
 


### PR DESCRIPTION
Creating on behalf of @tomstuart.

Showing fractional seconds in Time#inspect is Ruby feature #15958, required for Ruby 2.7 compatibility per oracle/truffleruby#2004. This PR satisfies one of the two ruby/spec tests for Time#inspect.

The other spec is probably too MRI specific. We'll address that elsewhere.

https://github.com/Shopify/truffleruby/issues/1