### PR TITLE
Better build information automation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,7 +41,7 @@ src/main/c/*/Makefile
 src/main/c/*/extconf.h
 src/main/c/*/mkmf.log
 src/main/c/etc/constdefs.h
-src/main/c/spawn-helper/spawn-helper
+src/main/c/spawn-helper/spawn-helper*
 
 spec/ffi/.bundle/config
 

--- a/src/shared/java/org/truffleruby/shared/BuildInformation.java
+++ b/src/shared/java/org/truffleruby/shared/BuildInformation.java
@@ -14,9 +14,13 @@ import org.truffleruby.PopulateBuildInformation;
 @PopulateBuildInformation
 public interface BuildInformation {
 
+    String getBuildName();
+
     String getShortRevision();
 
     String getFullRevision();
+
+    String getCopyrightYear();
 
     String getCompileDate();
 

--- a/src/shared/java/org/truffleruby/shared/TruffleRuby.java
+++ b/src/shared/java/org/truffleruby/shared/TruffleRuby.java
@@ -21,24 +21,29 @@ public class TruffleRuby {
     public static final String LANGUAGE_VERSION = "2.7.2";
     public static final String LANGUAGE_REVISION = BuildInformationImpl.INSTANCE.getFullRevision();
     public static final String BOOT_SOURCE_NAME = "main_boot_source";
-    public static final String RUBY_COPYRIGHT = "truffleruby - Copyright (c) 2013-2019 Oracle and/or its affiliates";
+    public static final String RUBY_COPYRIGHT = "truffleruby - Copyright (c) 2013-" +
+            BuildInformationImpl.INSTANCE.getCopyrightYear() + " Oracle and/or its affiliates";
     public static final boolean PRE_INITIALIZE_CONTEXTS = System
             .getProperty("polyglot.image-build-time.PreinitializeContexts") != null;
 
     public static String getVersionString(String implementationName) {
-        final String vm;
-        if (ImageInfo.inImageCode()) {
-            vm = implementationName + " Native";
+        final String buildName = BuildInformationImpl.INSTANCE.getBuildName();
+        final String nameExtra;
+
+        if (buildName == null) {
+            nameExtra = "";
         } else {
-            vm = implementationName + " JVM";
+            nameExtra = String.format(" (%s)", BuildInformationImpl.INSTANCE.getBuildName());
         }
 
         return String.format(
-                "%s %s, like ruby %s, %s [%s-%s]",
+                "%s%s %s, like ruby %s, %s %s [%s-%s]",
                 ENGINE_ID,
+                nameExtra,
                 getEngineVersion(),
                 LANGUAGE_VERSION,
-                vm,
+                implementationName,
+                ImageInfo.inImageCode() ? "Native" : "JVM",
                 BasicPlatform.getArchName(),
                 BasicPlatform.getOSName());
     }

--- a/tool/jt.rb
+++ b/tool/jt.rb
@@ -48,6 +48,8 @@ RUBOCOP_INCLUDE_LIST = %w[
   spec/truffle
 ]
 
+RUBOCOP_VERSION = '0.66.0'
+
 DLEXT = RbConfig::CONFIG['DLEXT']
 
 # Expand GEM_HOME relative to cwd so it cannot be misinterpreted later.
@@ -2235,7 +2237,10 @@ module Commands
       env = { 'GEM_HOME' => gem_home, 'GEM_PATH' => gem_home }
       sh env, 'ruby', "#{gem_home}/bin/rubocop", *args
     else
-      sh 'rubocop', '_0.66.0_', *args
+      unless sh('rubocop', "_#{RUBOCOP_VERSION}_", *args, continue_on_failure: true)
+        sh 'gem', 'install', 'rubocop', '-v', RUBOCOP_VERSION
+        sh 'rubocop', "_#{RUBOCOP_VERSION}_", *args
+      end
     end
   end
 


### PR DESCRIPTION
In Shopify we like to tag builds with descriptive names in the version information. We find this is the best place to put info that we don't want getting separated from the build.

This lets you set `TRUFFLERUBY_BUILD_NAME` while building and then get that in `--version`. It's an alternative to what we currently do at Shopify, which is have a permanent diff in the version string. This way we can upstream it and have a clean diff.

I also automated the copyright year, and tried to automate the Ruby version - but I have a bug with this I've commented on the line can anyone help?

https://github.com/Shopify/truffleruby/issues/1