### PR TITLE
Implement Module#const_source_location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Compatibility:
 * Fixed `Integer#digits` implementation to handle more bases (#2224, #2225).
 * Support the `inherit` parameter for `Module#{private, protected, public}_method_defined?`.
 * Implement `Thread.pending_interrupt?` and `Thread#pending_interrupt?` (#2219).
+* Implemented `Module#const_source_location` (#2212, @tomstuart and @wildmaples).
 
 Performance:
 

--- a/spec/tags/core/module/const_source_location_tags.txt
+++ b/spec/tags/core/module/const_source_location_tags.txt
@@ -1,25 +1,4 @@
-fails:Module#const_source_location raises a NameError if the name contains non-alphabetic characters except '_'
 fails:Module#const_source_location calls #to_str to convert the given name to a String
-fails:Module#const_source_location does not search the containing scope
-fails:Module#const_source_location searches into the receiver superclasses if the inherit flag is true
 fails:Module#const_source_location accepts a toplevel scope qualifier
 fails:Module#const_source_location accepts a scoped constant name
-fails:Module#const_source_location with dynamically assigned constants searches a path in a module included in the immediate class before the superclass
-fails:Module#const_source_location with dynamically assigned constants searches a path in the superclass before a module included in the superclass
-fails:Module#const_source_location with dynamically assigned constants searches a path in a module included in the superclass
-fails:Module#const_source_location with dynamically assigned constants searches a path in the superclass chain
-fails:Module#const_source_location with dynamically assigned constants returns path to a toplevel constant when the receiver is a Class
-fails:Module#const_source_location with dynamically assigned constants returns path to a toplevel constant when the receiver is a Module
-fails:Module#const_source_location with statically assigned constants searches location path a module included in the immediate class before the superclass
-fails:Module#const_source_location with statically assigned constants searches location path the superclass before a module included in the superclass
-fails:Module#const_source_location with statically assigned constants searches location path a module included in the superclass
-fails:Module#const_source_location with statically assigned constants searches location path the superclass chain
-fails:Module#const_source_location with statically assigned constants returns location path a toplevel constant when the receiver is a Class
-fails:Module#const_source_location with statically assigned constants returns location path a toplevel constant when the receiver is a Module
 fails:Module#const_source_location autoload returns the autoload location while not resolved
-fails:Module#const_source_location raises a NameError if the name does not start with a capital letter
-fails:Module#const_source_location raises a NameError if the name starts with a non-alphabetic character
-fails:Module#const_source_location raises a NameError if the name includes two successive scope separators
-fails:Module#const_source_location raises a NameError if only '::' is passed
-fails:Module#const_source_location raises a NameError if a Symbol has a toplevel scope qualifier
-fails:Module#const_source_location raises a NameError if a Symbol is a scoped constant name

--- a/spec/tags/core/module/const_source_location_tags.txt
+++ b/spec/tags/core/module/const_source_location_tags.txt
@@ -1,15 +1,9 @@
 fails:Module#const_source_location return empty path if constant defined in C code
 fails:Module#const_source_location accepts a String or Symbol name
-fails:Module#const_source_location returns nil if no constant is defined in the search path
 fails:Module#const_source_location raises a NameError if the name contains non-alphabetic characters except '_'
 fails:Module#const_source_location calls #to_str to convert the given name to a String
-fails:Module#const_source_location raises a TypeError if conversion to a String by calling #to_str fails
-fails:Module#const_source_location does not search the singleton class of a Class or Module
 fails:Module#const_source_location does not search the containing scope
-fails:Module#const_source_location returns nil if the constant is defined in the receiver's superclass and the inherit flag is false
 fails:Module#const_source_location searches into the receiver superclasses if the inherit flag is true
-fails:Module#const_source_location returns nil when the receiver is a Module, the constant is defined at toplevel and the inherit flag is false
-fails:Module#const_source_location returns nil when the receiver is a Class, the constant is defined at toplevel and the inherit flag is false
 fails:Module#const_source_location accepts a toplevel scope qualifier
 fails:Module#const_source_location accepts a scoped constant name
 fails:Module#const_source_location does search private constants path

--- a/spec/tags/core/module/const_source_location_tags.txt
+++ b/spec/tags/core/module/const_source_location_tags.txt
@@ -1,21 +1,15 @@
-fails:Module#const_source_location return empty path if constant defined in C code
-fails:Module#const_source_location accepts a String or Symbol name
 fails:Module#const_source_location raises a NameError if the name contains non-alphabetic characters except '_'
 fails:Module#const_source_location calls #to_str to convert the given name to a String
 fails:Module#const_source_location does not search the containing scope
 fails:Module#const_source_location searches into the receiver superclasses if the inherit flag is true
 fails:Module#const_source_location accepts a toplevel scope qualifier
 fails:Module#const_source_location accepts a scoped constant name
-fails:Module#const_source_location does search private constants path
-fails:Module#const_source_location with dynamically assigned constants searches a path in the immediate class or module first
 fails:Module#const_source_location with dynamically assigned constants searches a path in a module included in the immediate class before the superclass
 fails:Module#const_source_location with dynamically assigned constants searches a path in the superclass before a module included in the superclass
 fails:Module#const_source_location with dynamically assigned constants searches a path in a module included in the superclass
 fails:Module#const_source_location with dynamically assigned constants searches a path in the superclass chain
 fails:Module#const_source_location with dynamically assigned constants returns path to a toplevel constant when the receiver is a Class
 fails:Module#const_source_location with dynamically assigned constants returns path to a toplevel constant when the receiver is a Module
-fails:Module#const_source_location with dynamically assigned constants returns path to the updated value of a constant
-fails:Module#const_source_location with statically assigned constants searches location path the immediate class or module first
 fails:Module#const_source_location with statically assigned constants searches location path a module included in the immediate class before the superclass
 fails:Module#const_source_location with statically assigned constants searches location path the superclass before a module included in the superclass
 fails:Module#const_source_location with statically assigned constants searches location path a module included in the superclass
@@ -23,7 +17,6 @@ fails:Module#const_source_location with statically assigned constants searches l
 fails:Module#const_source_location with statically assigned constants returns location path a toplevel constant when the receiver is a Class
 fails:Module#const_source_location with statically assigned constants returns location path a toplevel constant when the receiver is a Module
 fails:Module#const_source_location autoload returns the autoload location while not resolved
-fails:Module#const_source_location autoload returns where the constant was resolved when resolved
 fails:Module#const_source_location raises a NameError if the name does not start with a capital letter
 fails:Module#const_source_location raises a NameError if the name starts with a non-alphabetic character
 fails:Module#const_source_location raises a NameError if the name includes two successive scope separators

--- a/spec/tags/core/module/const_source_location_tags.txt
+++ b/spec/tags/core/module/const_source_location_tags.txt
@@ -30,3 +30,9 @@ fails:Module#const_source_location with statically assigned constants returns lo
 fails:Module#const_source_location with statically assigned constants returns location path a toplevel constant when the receiver is a Module
 fails:Module#const_source_location autoload returns the autoload location while not resolved
 fails:Module#const_source_location autoload returns where the constant was resolved when resolved
+fails:Module#const_source_location raises a NameError if the name does not start with a capital letter
+fails:Module#const_source_location raises a NameError if the name starts with a non-alphabetic character
+fails:Module#const_source_location raises a NameError if the name includes two successive scope separators
+fails:Module#const_source_location raises a NameError if only '::' is passed
+fails:Module#const_source_location raises a NameError if a Symbol has a toplevel scope qualifier
+fails:Module#const_source_location raises a NameError if a Symbol is a scoped constant name

--- a/spec/tags/core/module/const_source_location_tags.txt
+++ b/spec/tags/core/module/const_source_location_tags.txt
@@ -1,4 +1,2 @@
 fails:Module#const_source_location calls #to_str to convert the given name to a String
-fails:Module#const_source_location accepts a toplevel scope qualifier
-fails:Module#const_source_location accepts a scoped constant name
 fails:Module#const_source_location autoload returns the autoload location while not resolved

--- a/src/main/java/org/truffleruby/core/module/ModuleNodes.java
+++ b/src/main/java/org/truffleruby/core/module/ModuleNodes.java
@@ -1092,12 +1092,13 @@ public abstract class ModuleNodes {
 
         @Specialization
         protected Object constSourceLocation(RubyModule module, String name, boolean inherit) {
-            final RubyConstant constant = module.fields.getConstant(name);
-            if (constant == null) {
+            final ConstantLookupResult lookupResult = ModuleOperations
+                    .lookupConstantWithInherit(getContext(), module, name, inherit, this, true);
+            if (!lookupResult.isFound()) {
                 return nil;
             }
 
-            final SourceSection sourceSection = constant.getSourceSection();
+            final SourceSection sourceSection = lookupResult.getConstant().getSourceSection();
             if (sourceSection == null || !sourceSection.isAvailable()) {
                 return createEmptyArray();
             } else {

--- a/src/main/java/org/truffleruby/core/module/ModuleNodes.java
+++ b/src/main/java/org/truffleruby/core/module/ModuleNodes.java
@@ -1072,6 +1072,29 @@ public abstract class ModuleNodes {
 
     }
 
+    @CoreMethod(names = "const_source_location", required = 1, optional = 1)
+    @NodeChild(value = "module", type = RubyNode.class)
+    @NodeChild(value = "name", type = RubyNode.class)
+    @NodeChild(value = "inherit", type = RubyNode.class)
+    public abstract static class ConstSourceLocationNode extends CoreMethodNode {
+
+        @CreateCast("name")
+        protected RubyNode coerceToString(RubyNode name) {
+            return NameToJavaStringNode.create(name);
+        }
+
+        @CreateCast("inherit")
+        protected RubyNode coerceToBoolean(RubyNode inherit) {
+            return BooleanCastWithDefaultNodeGen.create(true, inherit);
+        }
+
+        @Specialization
+        protected Object constSourceLocation(RubyModule module, String name, boolean inherit) {
+            return nil;
+        }
+
+    }
+
     @CoreMethod(names = "const_set", required = 2)
     @NodeChild(value = "module", type = RubyNode.class)
     @NodeChild(value = "name", type = RubyNode.class)

--- a/src/main/java/org/truffleruby/core/module/ModuleNodes.java
+++ b/src/main/java/org/truffleruby/core/module/ModuleNodes.java
@@ -1095,7 +1095,7 @@ public abstract class ModuleNodes {
         protected Object constSourceLocation(RubyModule module, Object name, boolean inherit,
                 @CachedLibrary(limit = "2") RubyStringLibrary strings) {
             final ConstantLookupResult lookupResult = ModuleOperations
-                    .lookupConstantWithInherit(getContext(), module, strings.getJavaString(name), inherit, this, true);
+                    .lookupScopedConstant(getContext(), module, strings.getJavaString(name), inherit, this, true);
 
             return getLocation(lookupResult);
         }

--- a/src/main/java/org/truffleruby/core/module/ModuleNodes.java
+++ b/src/main/java/org/truffleruby/core/module/ModuleNodes.java
@@ -1094,6 +1094,12 @@ public abstract class ModuleNodes {
         protected Object constSourceLocation(RubyModule module, String name, boolean inherit) {
             final ConstantLookupResult lookupResult = ModuleOperations
                     .lookupConstantWithInherit(getContext(), module, name, inherit, this, true);
+
+            return getLocation(lookupResult);
+        }
+
+        @TruffleBoundary
+        private Object getLocation(ConstantLookupResult lookupResult) {
             if (!lookupResult.isFound()) {
                 return nil;
             }


### PR DESCRIPTION
`Module#const_source_location` is one of the methods we need to implement for Ruby 2.7 support. This PR gets all but two of its associated Ruby specs passing.

On the remaining failures:

* I don’t understand why the “`calls #to_str to convert the given name to a String`” test is still failing. The `#to_str` assertion is working fine, but when I debugged this I could see that none of the constants in `ConstantSpecs::ClassA` had a `sourceSection` and I don’t know why.
* I think we should try to match MRI’s current behaviour for constants awaiting autoload. I don’t know how to get this working for the corresponding test (“`autoload returns the autoload location while not resolved`”) because the constant’s `sourceSection` points to the file to be autoloaded, not the `autoload` call site — the latter doesn’t appear to be stored anywhere.

Shopify#1