### PR TITLE
basic socket #send: cast the message to a string

### DIFF
--- a/lib/truffle/socket/basic_socket.rb
+++ b/lib/truffle/socket/basic_socket.rb
@@ -121,6 +121,7 @@ class BasicSocket < IO
   end
 
   def send(message, flags, dest_sockaddr = nil)
+    message    = StringValue(message)
     bytes      = message.bytesize
     bytes_sent = 0
 
@@ -166,7 +167,8 @@ class BasicSocket < IO
         end
       end
 
-      return buf.read_string(n_bytes)
+      str = buf.read_string(n_bytes)
+      buffer ? buffer.replace(str) : str
     end
   end
 

--- a/lib/truffle/socket/basic_socket.rb
+++ b/lib/truffle/socket/basic_socket.rb
@@ -154,8 +154,6 @@ class BasicSocket < IO
   end
 
   private def internal_recv(bytes_to_read, flags, buffer, exception)
-    raise ArgumentError, 'buffer argument not yet supported' if buffer
-
     Truffle::Socket::Foreign.memory_pointer(bytes_to_read) do |buf|
       n_bytes = Truffle::Socket::Foreign.recv(Primitive.io_fd(self), buf, bytes_to_read, flags)
 

--- a/lib/truffle/socket/ip_socket.rb
+++ b/lib/truffle/socket/ip_socket.rb
@@ -39,7 +39,7 @@ class IPSocket < BasicSocket
     Truffle::Socket.address_info(:getpeername, self, reverse_lookup)
   end
 
-  private def internal_recvfrom(maxlen, flags, exception)
+  private def internal_recvfrom(maxlen, flags, buffer, exception)
     message, addr = internal_recvmsg(maxlen, flags, nil, false, exception)
 
     return message if message == :wait_readable
@@ -58,11 +58,13 @@ class IPSocket < BasicSocket
       end
     end
 
+    message = buffer.replace(message) if buffer
+
     [message, [aname, addr.ip_port, hostname, addr.ip_address]]
   end
 
   def recvfrom(maxlen, flags = 0)
     flags = 0 if flags.nil?
-    internal_recvfrom(maxlen, flags, true)
+    internal_recvfrom(maxlen, flags, nil, true)
   end
 end

--- a/lib/truffle/socket/udp_socket.rb
+++ b/lib/truffle/socket/udp_socket.rb
@@ -73,12 +73,12 @@ class UDPSocket < IPSocket
     super(message, flags, addr)
   end
 
-  def recvfrom_nonblock(maxlen, flags = 0, exception: true)
+  def recvfrom_nonblock(maxlen, flags = 0, buffer = nil, exception: true)
     fcntl(Fcntl::F_SETFL, Fcntl::O_NONBLOCK)
 
     flags = 0 if flags.nil?
 
-    internal_recvfrom(maxlen, flags | Socket::MSG_DONTWAIT, exception)
+    internal_recvfrom(maxlen, flags | Socket::MSG_DONTWAIT, buffer, exception)
   end
 
   def inspect

--- a/spec/ruby/library/socket/basicsocket/send_spec.rb
+++ b/spec/ruby/library/socket/basicsocket/send_spec.rb
@@ -99,6 +99,17 @@ describe 'BasicSocket#send' do
         @server.close
       end
 
+      describe 'with an object implementing #to_str' do
+        it 'returns the amount of sent bytes' do
+          data = Class.new do
+            def to_str
+              'hello'
+            end
+          end.new
+          @client.send(data, 0, @server.getsockname).should == 5
+        end
+      end
+
       describe 'without a destination address' do
         it "raises #{SocketSpecs.dest_addr_req_error}" do
           -> { @client.send('hello', 0) }.should raise_error(SocketSpecs.dest_addr_req_error)


### PR DESCRIPTION
Fixes part of the issues described in #2209 , specifically in regards to the `BasicSocket#send`.

This solution is exactly the same implemented in the `IO#write_nonblock` layer which truffleruby inherited from rubinius.