### PR TITLE
Improve Time#inspect coverage in ruby/spec

### DIFF
--- a/spec/ruby/core/time/inspect_spec.rb
+++ b/spec/ruby/core/time/inspect_spec.rb
@@ -10,6 +10,11 @@ describe "Time#inspect" do
       t.inspect.should == "2007-11-01 15:25:00.123456 UTC"
     end
 
+    it "omits trailing zeros from microseconds" do
+      t = Time.utc(2007, 11, 1, 15, 25, 0, 100000)
+      t.inspect.should == "2007-11-01 15:25:00.1 UTC"
+    end
+
     it "preserves nanoseconds" do
       t = Time.utc(2007, 11, 1, 15, 25, 0, 123456.789r)
       t.inspect.should == "2007-11-01 15:25:00.123456789 UTC"

--- a/spec/ruby/core/time/inspect_spec.rb
+++ b/spec/ruby/core/time/inspect_spec.rb
@@ -5,7 +5,7 @@ describe "Time#inspect" do
   it_behaves_like :inspect, :inspect
 
   ruby_version_is "2.7" do
-    it "preserves milliseconds" do
+    it "preserves microseconds" do
       t = Time.utc(2007, 11, 1, 15, 25, 0, 123456)
       t.inspect.should == "2007-11-01 15:25:00.123456 UTC"
     end

--- a/spec/ruby/core/time/inspect_spec.rb
+++ b/spec/ruby/core/time/inspect_spec.rb
@@ -15,6 +15,18 @@ describe "Time#inspect" do
       t.inspect.should == "2007-11-01 15:25:00.1 UTC"
     end
 
+    it "uses the correct time zone without microseconds" do
+      t = Time.utc(2000, 1, 1)
+      t = t.localtime(9*3600)
+      t.inspect.should == "2000-01-01 09:00:00 +0900"
+    end
+
+    it "uses the correct time zone with microseconds" do
+      t = Time.utc(2000, 1, 1, 0, 0, 0, 123456)
+      t = t.localtime(9*3600)
+      t.inspect.should == "2000-01-01 09:00:00.123456 +0900"
+    end
+
     it "preserves nanoseconds" do
       t = Time.utc(2007, 11, 1, 15, 25, 0, 123456.789r)
       t.inspect.should == "2007-11-01 15:25:00.123456789 UTC"

--- a/spec/ruby/core/time/inspect_spec.rb
+++ b/spec/ruby/core/time/inspect_spec.rb
@@ -14,13 +14,5 @@ describe "Time#inspect" do
       t = Time.utc(2007, 11, 1, 15, 25, 0, 123456.789r)
       t.inspect.should == "2007-11-01 15:25:00.123456789 UTC"
     end
-
-    it "formats nanoseconds as a Rational" do
-      t = Time.utc(2007, 11, 1, 15, 25, 0, 123456.789)
-      t.nsec.should == 123456789
-      t.strftime("%N").should == "123456789"
-
-      t.inspect.should == "2007-11-01 15:25:00 8483885939586761/68719476736000000 UTC"
-    end
   end
 end

--- a/spec/ruby/core/time/inspect_spec.rb
+++ b/spec/ruby/core/time/inspect_spec.rb
@@ -10,6 +10,11 @@ describe "Time#inspect" do
       t.inspect.should == "2007-11-01 15:25:00.123456 UTC"
     end
 
+    it "preserves nanoseconds" do
+      t = Time.utc(2007, 11, 1, 15, 25, 0, 123456.789r)
+      t.inspect.should == "2007-11-01 15:25:00.123456789 UTC"
+    end
+
     it "formats nanoseconds as a Rational" do
       t = Time.utc(2007, 11, 1, 15, 25, 0, 123456.789)
       t.nsec.should == 123456789

--- a/spec/tags/core/time/inspect_tags.txt
+++ b/spec/tags/core/time/inspect_tags.txt
@@ -1,1 +1,0 @@
-fails:Time#inspect formats nanoseconds as a Rational


### PR DESCRIPTION
#2194 improved Ruby 2.7 compatibility by including fractional seconds in the output of `Time#inspect`. This PR adds more `Time#inspect` examples to ruby/spec to better characterise its behaviour.

I have also removed one sub-nanosecond example which, [according to Jeremy Evans](https://bugs.ruby-lang.org/issues/16470#note-18), was testing Ruby-implementation–specific behaviour. It’s impractical to make this example pass in TruffleRuby because [`java.time.ZonedDateTime`](https://docs.oracle.com/javase/8/docs/api/java/time/ZonedDateTime.html) only supports nanosecond precision, so removing it is the best way to bring us into full compliance with the Ruby 2.7 `Time#inspect` specs.

Shopify#1