### PR TITLE
Warn deprecation when yield is used in singleton class

### DIFF
--- a/spec/tags/language/singleton_class_tags.txt
+++ b/spec/tags/language/singleton_class_tags.txt
@@ -1,1 +1,0 @@
-fails:Defining yield in singleton class emits a deprecation warning

--- a/src/main/java/org/truffleruby/language/yield/YieldExpressionNode.java
+++ b/src/main/java/org/truffleruby/language/yield/YieldExpressionNode.java
@@ -16,6 +16,7 @@ import org.truffleruby.core.array.ArrayToObjectArrayNodeGen;
 import org.truffleruby.core.proc.RubyProc;
 import org.truffleruby.language.RubyContextSourceNode;
 import org.truffleruby.language.RubyNode;
+import org.truffleruby.language.WarnNode;
 import org.truffleruby.language.arguments.RubyArguments;
 import org.truffleruby.language.control.RaiseException;
 
@@ -27,24 +28,35 @@ import com.oracle.truffle.api.profiles.BranchProfile;
 public class YieldExpressionNode extends RubyContextSourceNode {
 
     private final boolean unsplat;
+    private final boolean warnInModuleBody;
 
     @Children private final RubyNode[] arguments;
     @Child private YieldNode yieldNode;
     @Child private ArrayToObjectArrayNode unsplatNode;
     @Child private RubyNode readBlockNode;
+    @Child private WarnNode warnNode;
 
     private final BranchProfile useCapturedBlock = BranchProfile.create();
     private final BranchProfile noCapturedBlock = BranchProfile.create();
 
-    public YieldExpressionNode(boolean unsplat, RubyNode[] arguments, RubyNode readBlockNode) {
+    public YieldExpressionNode(
+            boolean unsplat,
+            RubyNode[] arguments,
+            RubyNode readBlockNode,
+            boolean warnInModuleBody) {
         this.unsplat = unsplat;
         this.arguments = arguments;
         this.readBlockNode = readBlockNode;
+        this.warnInModuleBody = warnInModuleBody;
     }
 
     @ExplodeLoop
     @Override
     public final Object execute(VirtualFrame frame) {
+        if (warnInModuleBody) {
+            warnIfYieldInSingletonClass();
+        }
+
         Object[] argumentsObjects = new Object[arguments.length];
 
         for (int i = 0; i < arguments.length; i++) {
@@ -97,4 +109,15 @@ public class YieldExpressionNode extends RubyContextSourceNode {
         return yieldNode;
     }
 
+    private void warnIfYieldInSingletonClass() {
+        if (warnNode == null) {
+            CompilerDirectives.transferToInterpreterAndInvalidate();
+            warnNode = insert(new WarnNode());
+        }
+        if (warnNode.shouldWarnForDeprecation()) {
+            warnNode.warningMessage(
+                    getSourceSection(),
+                    "`yield' in class syntax will not be supported from Ruby 3.0. [Feature #15575]");
+        }
+    }
 }

--- a/src/main/java/org/truffleruby/parser/BodyTranslator.java
+++ b/src/main/java/org/truffleruby/parser/BodyTranslator.java
@@ -3306,7 +3306,13 @@ public class BodyTranslator extends Translator {
 
         RubyNode readBlock = environment
                 .findLocalVarOrNilNode(TranslatorEnvironment.METHOD_BLOCK_NAME, node.getPosition());
-        final RubyNode ret = new YieldExpressionNode(unsplat, argumentsTranslated, readBlock);
+
+        final RubyNode ret = new YieldExpressionNode(
+                unsplat,
+                argumentsTranslated,
+                readBlock,
+                environment.shouldWarnYieldInModuleBody());
+
         ret.unsafeSetSourceSection(node.getPosition());
         return addNewlineIfNeeded(node, ret);
     }

--- a/src/main/java/org/truffleruby/parser/BodyTranslator.java
+++ b/src/main/java/org/truffleruby/parser/BodyTranslator.java
@@ -1950,10 +1950,7 @@ public class BodyTranslator extends Translator {
 
         final boolean isProc = !isLambda;
 
-        TranslatorEnvironment methodParent = environment;
-        while (methodParent.isBlock()) {
-            methodParent = methodParent.getParent();
-        }
+        TranslatorEnvironment methodParent = environment.getSurroundingMethodEnvironment();
         final String methodName = methodParent.getMethodName();
 
         final int blockDepth = environment.getBlockDepth() + 1;

--- a/src/main/java/org/truffleruby/parser/TranslatorEnvironment.java
+++ b/src/main/java/org/truffleruby/parser/TranslatorEnvironment.java
@@ -252,4 +252,12 @@ public class TranslatorEnvironment {
     public LexicalScope unsafeGetLexicalScope() {
         return parseEnvironment.getLexicalScope();
     }
+
+    public TranslatorEnvironment getSurroundingMethodEnvironment() {
+        TranslatorEnvironment methodParent = this;
+        while (methodParent.isBlock()) {
+            methodParent = methodParent.getParent();
+        }
+        return methodParent;
+    }
 }

--- a/src/main/java/org/truffleruby/parser/TranslatorEnvironment.java
+++ b/src/main/java/org/truffleruby/parser/TranslatorEnvironment.java
@@ -260,4 +260,8 @@ public class TranslatorEnvironment {
         }
         return methodParent;
     }
+
+    public boolean shouldWarnYieldInModuleBody() {
+        return getSurroundingMethodEnvironment().isModuleBody();
+    }
 }


### PR DESCRIPTION
Obligatory: I've been working on this PR since last year. 

This PR contains: 

* The compatibility update for ruby 2.7 [#15575](https://bugs.ruby-lang.org/issues/15575): Add deprecation warning when yield is used in a singleton class
* A hack to fix a DSL processing problem, which causes this exception when we try to build: 

```
/Users/mapleong/src/github.com/Shopify/truffleruby-shopify/src/main/java/org/truffleruby/language/yield/YieldNode.java:47: error: Incompatible return type YieldNode. The expression type must be equal to the parameter type WarnNode.
                              @Cached(allowUncached = true) WarnNode warnNode) {
```