### PR TITLE
Fix `String#dump` formatting of escaped unicode characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Compatibility:
 * Allow `Range#include?` and `#member?` with `Time` (#2202, @wildmaples).
 * Implemented `Comparable#clamp(Range)` (#2200, @wildmaples).
 * Added a `Array#minmax` to override `Enumerable#minmax` (#2199, @wildmaples).
+* Fixed `String#dump`'s formatting of escaped unicode characters (#2217, @meganniu).
 
 Performance:
 

--- a/spec/tags/core/string/dump_tags.txt
+++ b/spec/tags/core/string/dump_tags.txt
@@ -1,2 +1,1 @@
 fails:String#dump returns a string with multi-byte UTF-8 characters replaced by \u{} notation with lower-case hex digits
-fails:String#dump returns a string with multi-byte UTF-8 characters replaced by \u{} notation with upper-case hex digits

--- a/src/main/java/org/truffleruby/core/string/StringNodes.java
+++ b/src/main/java/org/truffleruby/core/string/StringNodes.java
@@ -2187,7 +2187,7 @@ public abstract class StringNodes {
                             int cc = codePointX(enc, cr, bytes, p - 1, end);
                             p += n;
                             outBytes.setLength(q);
-                            outBytes.append(StringUtils.formatASCIIBytes("u{%x}", cc));
+                            outBytes.append(StringUtils.formatASCIIBytes("u%04X", cc));
                             q = outBytes.getLength();
                             continue;
                         }


### PR DESCRIPTION
With this PR, `"\u0080".dump` correctly returns `"\u0080"` instead of `"\u{80}"`.