### PR TITLE
Remove debugging print

### DIFF
--- a/src/main/ruby/truffleruby/core/truffle/range_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/range_operations.rb
@@ -110,9 +110,6 @@ module Truffle
       # Check upper bound.
       if !Primitive.nil?(range.end)
         cmp = (value <=> range.end)
-        if Primitive.nil? cmp
-          p range, value
-        end
         if range.exclude_end?
           return false if Comparable.compare_int(cmp) >= 0
         else


### PR DESCRIPTION
I added an untaken if statement for debugging during this commit; https://github.com/oracle/truffleruby/pull/2211/commits/8f8eaea592578656f95343661766fc585063f30c

I just noticed I forgot to remove it, so this PR does so.