### PR TITLE
Pack missing block argument as nil instead of null

### DIFF
--- a/src/main/java/org/truffleruby/RubyContext.java
+++ b/src/main/java/org/truffleruby/RubyContext.java
@@ -63,6 +63,7 @@ import org.truffleruby.interop.InteropManager;
 import org.truffleruby.language.CallStackManager;
 import org.truffleruby.core.string.ImmutableRubyString;
 import org.truffleruby.language.LexicalScope;
+import org.truffleruby.language.Nil;
 import org.truffleruby.language.RubyBaseNode;
 import org.truffleruby.language.SafepointManager;
 import org.truffleruby.language.arguments.RubyArguments;
@@ -445,7 +446,7 @@ public class RubyContext {
 
         return IndirectCallNode.getUncached().call(
                 method.getCallTarget(),
-                RubyArguments.pack(null, null, method, null, object, null, arguments));
+                RubyArguments.pack(null, null, method, null, object, Nil.INSTANCE, arguments));
     }
 
     @TruffleBoundary

--- a/src/main/java/org/truffleruby/builtins/CoreMethodNodeManager.java
+++ b/src/main/java/org/truffleruby/builtins/CoreMethodNodeManager.java
@@ -26,7 +26,6 @@ import org.truffleruby.core.numeric.FixnumLowerNodeGen;
 import org.truffleruby.core.string.StringUtils;
 import org.truffleruby.core.support.TypeNodes;
 import org.truffleruby.language.LexicalScope;
-import org.truffleruby.language.Nil;
 import org.truffleruby.language.RubyNode;
 import org.truffleruby.language.RubyRootNode;
 import org.truffleruby.language.methods.Split;
@@ -308,7 +307,7 @@ public class CoreMethodNodeManager {
              * argument. The block coming into the method is actually always Nil or RubyProc, so here we check which and
              * convert Nil to NotProvided. */
             argumentsNodes[i++] = new ReadBlockFromCurrentFrameArgumentsNode.ConvertNilBlockToNotProvidedNode(
-                    new ReadBlockFromCurrentFrameArgumentsNode(Nil.INSTANCE));
+                    new ReadBlockFromCurrentFrameArgumentsNode());
         }
 
         if (!method.keywordAsOptional().isEmpty()) {

--- a/src/main/java/org/truffleruby/builtins/CoreMethodNodeManager.java
+++ b/src/main/java/org/truffleruby/builtins/CoreMethodNodeManager.java
@@ -26,7 +26,7 @@ import org.truffleruby.core.numeric.FixnumLowerNodeGen;
 import org.truffleruby.core.string.StringUtils;
 import org.truffleruby.core.support.TypeNodes;
 import org.truffleruby.language.LexicalScope;
-import org.truffleruby.language.NotProvided;
+import org.truffleruby.language.Nil;
 import org.truffleruby.language.RubyNode;
 import org.truffleruby.language.RubyRootNode;
 import org.truffleruby.language.methods.Split;
@@ -304,7 +304,11 @@ public class CoreMethodNodeManager {
         }
 
         if (method.needsBlock()) {
-            argumentsNodes[i++] = new ReadBlockFromCurrentFrameArgumentsNode(NotProvided.INSTANCE);
+            /* The way we write specializations for getting a block or not is that we use NotProvided like a missing
+             * argument. The block coming into the method is actually always Nil or RubyProc, so here we check which and
+             * convert Nil to NotProvided. */
+            argumentsNodes[i++] = new ReadBlockFromCurrentFrameArgumentsNode.ConvertNilBlockToNotProvidedNode(
+                    new ReadBlockFromCurrentFrameArgumentsNode(Nil.INSTANCE));
         }
 
         if (!method.keywordAsOptional().isEmpty()) {

--- a/src/main/java/org/truffleruby/builtins/EnumeratorSizeNode.java
+++ b/src/main/java/org/truffleruby/builtins/EnumeratorSizeNode.java
@@ -9,7 +9,6 @@
  */
 package org.truffleruby.builtins;
 
-import org.truffleruby.core.proc.RubyProc;
 import org.truffleruby.core.symbol.RubySymbol;
 import org.truffleruby.language.RubyContextSourceNode;
 import org.truffleruby.language.RubyNode;
@@ -38,7 +37,7 @@ public class EnumeratorSizeNode extends RubyContextSourceNode {
 
     @Override
     public Object execute(VirtualFrame frame) {
-        final RubyProc block = RubyArguments.getBlock(frame);
+        final Object block = RubyArguments.getBlock(frame);
 
         if (noBlockProfile.profile(block == null)) {
             if (toEnumWithSize == null) {

--- a/src/main/java/org/truffleruby/builtins/EnumeratorSizeNode.java
+++ b/src/main/java/org/truffleruby/builtins/EnumeratorSizeNode.java
@@ -39,7 +39,7 @@ public class EnumeratorSizeNode extends RubyContextSourceNode {
     public Object execute(VirtualFrame frame) {
         final Object block = RubyArguments.getBlock(frame);
 
-        if (noBlockProfile.profile(block == null)) {
+        if (noBlockProfile.profile(block == nil)) {
             if (toEnumWithSize == null) {
                 CompilerDirectives.transferToInterpreterAndInvalidate();
                 toEnumWithSize = insert(DispatchNode.create());

--- a/src/main/java/org/truffleruby/builtins/ReturnEnumeratorIfNoBlockNode.java
+++ b/src/main/java/org/truffleruby/builtins/ReturnEnumeratorIfNoBlockNode.java
@@ -38,7 +38,7 @@ public class ReturnEnumeratorIfNoBlockNode extends RubyContextSourceNode {
     public Object execute(VirtualFrame frame) {
         final Object block = RubyArguments.getBlock(frame);
 
-        if (noBlockProfile.profile(block == null)) {
+        if (noBlockProfile.profile(block == nil)) {
             if (toEnumNode == null) {
                 CompilerDirectives.transferToInterpreterAndInvalidate();
                 toEnumNode = insert(DispatchNode.create());

--- a/src/main/java/org/truffleruby/builtins/ReturnEnumeratorIfNoBlockNode.java
+++ b/src/main/java/org/truffleruby/builtins/ReturnEnumeratorIfNoBlockNode.java
@@ -10,7 +10,6 @@
 package org.truffleruby.builtins;
 
 import org.truffleruby.core.array.ArrayUtils;
-import org.truffleruby.core.proc.RubyProc;
 import org.truffleruby.core.symbol.RubySymbol;
 import org.truffleruby.language.RubyContextSourceNode;
 import org.truffleruby.language.RubyNode;
@@ -37,7 +36,7 @@ public class ReturnEnumeratorIfNoBlockNode extends RubyContextSourceNode {
 
     @Override
     public Object execute(VirtualFrame frame) {
-        final RubyProc block = RubyArguments.getBlock(frame);
+        final Object block = RubyArguments.getBlock(frame);
 
         if (noBlockProfile.profile(block == null)) {
             if (toEnumNode == null) {

--- a/src/main/java/org/truffleruby/core/inlined/InlinedDispatchNode.java
+++ b/src/main/java/org/truffleruby/core/inlined/InlinedDispatchNode.java
@@ -16,7 +16,6 @@ import com.oracle.truffle.api.frame.VirtualFrame;
 
 import org.truffleruby.RubyLanguage;
 import org.truffleruby.core.array.ArrayUtils;
-import org.truffleruby.core.proc.RubyProc;
 import org.truffleruby.language.RubyContextNode;
 import org.truffleruby.language.dispatch.DispatchNode;
 import org.truffleruby.language.dispatch.DispatchingNode;
@@ -53,11 +52,11 @@ public class InlinedDispatchNode extends RubyContextNode implements DispatchingN
         return dispatch(null, receiver, method, null, arguments);
     }
 
-    public Object callWithBlock(Object receiver, String method, RubyProc block, Object... arguments) {
+    public Object callWithBlock(Object receiver, String method, Object block, Object... arguments) {
         return dispatch(null, receiver, method, block, arguments);
     }
 
-    public Object dispatch(VirtualFrame frame, Object receiver, String methodName, RubyProc block, Object[] arguments) {
+    public Object dispatch(VirtualFrame frame, Object receiver, String methodName, Object block, Object[] arguments) {
         if ((lookupNode.lookupProtected(frame, receiver, methodName) != coreMethod()) ||
                 !Assumption.isValidAssumption(assumptions)) {
             return rewriteAndCallWithBlock(frame, receiver, methodName, block, arguments);
@@ -79,7 +78,7 @@ public class InlinedDispatchNode extends RubyContextNode implements DispatchingN
         }
     }
 
-    protected Object rewriteAndCallWithBlock(VirtualFrame frame, Object receiver, String methodName, RubyProc block,
+    protected Object rewriteAndCallWithBlock(VirtualFrame frame, Object receiver, String methodName, Object block,
             Object... arguments) {
         return rewriteToDispatchNode().dispatch(frame, receiver, methodName, block, arguments);
     }

--- a/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
+++ b/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
@@ -849,7 +849,7 @@ public abstract class KernelNodes {
                     method,
                     null,
                     target,
-                    null,
+                    nil,
                     EMPTY_ARGUMENTS));
         }
 

--- a/src/main/java/org/truffleruby/core/method/MethodNodes.java
+++ b/src/main/java/org/truffleruby/core/method/MethodNodes.java
@@ -295,7 +295,7 @@ public abstract class MethodNodes {
 
         private RubyProc createProc(RootCallTarget callTarget, InternalMethod method, Object receiver) {
             final Object[] packedArgs = RubyArguments
-                    .pack(null, null, method, null, receiver, null, EMPTY_ARGUMENTS);
+                    .pack(null, null, method, null, receiver, nil, EMPTY_ARGUMENTS);
             final MaterializedFrame declarationFrame = Truffle
                     .getRuntime()
                     .createMaterializedFrame(packedArgs, coreLibrary().emptyDeclarationDescriptor);

--- a/src/main/java/org/truffleruby/core/proc/ProcOperations.java
+++ b/src/main/java/org/truffleruby/core/proc/ProcOperations.java
@@ -13,6 +13,7 @@ import com.oracle.truffle.api.object.Shape;
 import org.truffleruby.RubyContext;
 import org.truffleruby.RubyLanguage;
 import org.truffleruby.core.klass.RubyClass;
+import org.truffleruby.language.Nil;
 import org.truffleruby.language.arguments.RubyArguments;
 import org.truffleruby.language.control.FrameOnStackMarker;
 import org.truffleruby.language.methods.DeclarationContext;
@@ -32,7 +33,7 @@ public abstract class ProcOperations {
                 proc.method,
                 proc.frameOnStackMarker,
                 getSelf(proc),
-                proc.block,
+                proc.block == null ? Nil.INSTANCE : proc.block,
                 args);
     }
 

--- a/src/main/java/org/truffleruby/core/proc/ProcOperations.java
+++ b/src/main/java/org/truffleruby/core/proc/ProcOperations.java
@@ -58,7 +58,7 @@ public abstract class ProcOperations {
             MaterializedFrame declarationFrame,
             SpecialVariableStorage variables,
             InternalMethod method,
-            RubyProc block,
+            Object block,
             FrameOnStackMarker frameOnStackMarker,
             DeclarationContext declarationContext) {
 

--- a/src/main/java/org/truffleruby/core/proc/RubyProc.java
+++ b/src/main/java/org/truffleruby/core/proc/RubyProc.java
@@ -42,7 +42,7 @@ public class RubyProc extends RubyDynamicObject implements ObjectGraphNode {
     public final MaterializedFrame declarationFrame;
     public final SpecialVariableStorage declarationVariables;
     public final InternalMethod method;
-    public final RubyProc block;
+    public final Object block;
     public final FrameOnStackMarker frameOnStackMarker;
     public final DeclarationContext declarationContext;
 
@@ -56,7 +56,7 @@ public class RubyProc extends RubyDynamicObject implements ObjectGraphNode {
             MaterializedFrame declarationFrame,
             SpecialVariableStorage declarationVariables,
             InternalMethod method,
-            RubyProc block,
+            Object block,
             FrameOnStackMarker frameOnStackMarker,
             DeclarationContext declarationContext) {
         super(rubyClass, shape);

--- a/src/main/java/org/truffleruby/core/symbol/SymbolNodes.java
+++ b/src/main/java/org/truffleruby/core/symbol/SymbolNodes.java
@@ -159,7 +159,7 @@ public abstract class SymbolNodes {
                     : new DeclarationContext(Visibility.PUBLIC, null, refinements);
 
             final Object[] args = RubyArguments
-                    .pack(null, null, method, declarationContext, null, nil, null, EMPTY_ARGUMENTS);
+                    .pack(null, null, method, declarationContext, null, nil, nil, EMPTY_ARGUMENTS);
             // MRI raises an error on Proc#binding if you attempt to access the binding of a Proc generated
             // by Symbol#to_proc. We generate a declaration frame here so that all procedures will have a
             // binding as this simplifies the logic elsewhere in the runtime.

--- a/src/main/java/org/truffleruby/debug/DebugHelpers.java
+++ b/src/main/java/org/truffleruby/debug/DebugHelpers.java
@@ -11,6 +11,7 @@ package org.truffleruby.debug;
 
 import org.truffleruby.RubyContext;
 import org.truffleruby.RubyLanguage;
+import org.truffleruby.language.Nil;
 import org.truffleruby.language.RubyNode;
 import org.truffleruby.language.RubyRootNode;
 import org.truffleruby.language.arguments.RubyArguments;
@@ -49,7 +50,7 @@ public abstract class DebugHelpers {
                 declarationContext,
                 null,
                 RubyArguments.getSelf(currentFrame),
-                null,
+                Nil.INSTANCE,
                 RubyNode.EMPTY_ARGUMENTS);
 
         final FrameDescriptor frameDescriptor = new FrameDescriptor(

--- a/src/main/java/org/truffleruby/extra/TruffleGraalNodes.java
+++ b/src/main/java/org/truffleruby/extra/TruffleGraalNodes.java
@@ -155,7 +155,7 @@ public abstract class TruffleGraalNodes {
                             RubyArguments.getMethod(proc.declarationFrame),
                             null,
                             nil,
-                            null,
+                            nil,
                             EMPTY_ARGUMENTS);
 
             // The Proc no longer needs the original declaration frame. However, all procs must have a

--- a/src/main/java/org/truffleruby/language/RubyParsingRequestNode.java
+++ b/src/main/java/org/truffleruby/language/RubyParsingRequestNode.java
@@ -82,7 +82,7 @@ public class RubyParsingRequestNode extends RubyBaseRootNode implements Internal
                     method,
                     null,
                     context.getCoreLibrary().mainObject,
-                    null,
+                    Nil.INSTANCE,
                     frame.getArguments()));
 
             // The return value will be leaked to Java, so share it if the Context API is used.

--- a/src/main/java/org/truffleruby/language/arguments/ReadBlockFromCurrentFrameArgumentsNode.java
+++ b/src/main/java/org/truffleruby/language/arguments/ReadBlockFromCurrentFrameArgumentsNode.java
@@ -24,7 +24,7 @@ public class ReadBlockFromCurrentFrameArgumentsNode extends RubyContextSourceNod
 
     @Override
     public Object execute(VirtualFrame frame) {
-        final Object block = RubyArguments.getBlockAssertType(frame);
+        final Object block = RubyArguments.getBlock(frame);
         return nullProfile.profile(block == null) ? nil : block;
     }
 

--- a/src/main/java/org/truffleruby/language/arguments/ReadBlockFromCurrentFrameArgumentsNode.java
+++ b/src/main/java/org/truffleruby/language/arguments/ReadBlockFromCurrentFrameArgumentsNode.java
@@ -20,12 +20,11 @@ import com.oracle.truffle.api.profiles.ConditionProfile;
 
 public class ReadBlockFromCurrentFrameArgumentsNode extends RubyContextSourceNode {
 
-    private final ConditionProfile nullProfile = ConditionProfile.create();
-
     @Override
     public Object execute(VirtualFrame frame) {
         final Object block = RubyArguments.getBlock(frame);
-        return nullProfile.profile(block == null) ? nil : block;
+        assert block instanceof Nil || block instanceof RubyProc : block;
+        return block;
     }
 
     public static class ConvertNilBlockToNotProvidedNode extends RubyContextSourceNode {

--- a/src/main/java/org/truffleruby/language/arguments/ReadBlockFromCurrentFrameArgumentsNode.java
+++ b/src/main/java/org/truffleruby/language/arguments/ReadBlockFromCurrentFrameArgumentsNode.java
@@ -20,18 +20,12 @@ import com.oracle.truffle.api.profiles.ConditionProfile;
 
 public class ReadBlockFromCurrentFrameArgumentsNode extends RubyContextSourceNode {
 
-    private final Object valueIfAbsent;
-
     private final ConditionProfile nullProfile = ConditionProfile.create();
-
-    public ReadBlockFromCurrentFrameArgumentsNode(Object valueIfAbsent) {
-        this.valueIfAbsent = valueIfAbsent;
-    }
 
     @Override
     public Object execute(VirtualFrame frame) {
         final Object block = RubyArguments.getBlockAssertType(frame);
-        return nullProfile.profile(block == null) ? valueIfAbsent : block;
+        return nullProfile.profile(block == null) ? nil : block;
     }
 
     public static class ConvertNilBlockToNotProvidedNode extends RubyContextSourceNode {

--- a/src/main/java/org/truffleruby/language/arguments/RubyArguments.java
+++ b/src/main/java/org/truffleruby/language/arguments/RubyArguments.java
@@ -154,14 +154,14 @@ public final class RubyArguments {
         return frame.getArguments()[ArgumentIndicies.SELF.ordinal()];
     }
 
-    public static RubyProc getBlock(Frame frame) {
-        return (RubyProc) frame.getArguments()[ArgumentIndicies.BLOCK.ordinal()];
+    public static Object getBlock(Frame frame) {
+        return frame.getArguments()[ArgumentIndicies.BLOCK.ordinal()];
     }
 
     /** A variant of getBlock() when the return type does not need to be RubyProc and which avoids the extra cast. */
     public static Object getBlockAssertType(Frame frame) {
         final Object block = frame.getArguments()[ArgumentIndicies.BLOCK.ordinal()];
-        assert block == null || block instanceof RubyProc : block;
+        assert block instanceof Nil || block instanceof RubyProc : block;
         return block;
     }
 

--- a/src/main/java/org/truffleruby/language/arguments/RubyArguments.java
+++ b/src/main/java/org/truffleruby/language/arguments/RubyArguments.java
@@ -155,12 +155,8 @@ public final class RubyArguments {
     }
 
     public static Object getBlock(Frame frame) {
-        return frame.getArguments()[ArgumentIndicies.BLOCK.ordinal()];
-    }
-
-    /** A variant of getBlock() when the return type does not need to be RubyProc and which avoids the extra cast. */
-    public static Object getBlockAssertType(Frame frame) {
         final Object block = frame.getArguments()[ArgumentIndicies.BLOCK.ordinal()];
+        /* We put into the arguments array either a Nil or RubyProc, so that's all we'll get out at this point. */
         assert block instanceof Nil || block instanceof RubyProc : block;
         return block;
     }

--- a/src/main/java/org/truffleruby/language/arguments/RubyArguments.java
+++ b/src/main/java/org/truffleruby/language/arguments/RubyArguments.java
@@ -12,6 +12,7 @@ package org.truffleruby.language.arguments;
 import org.truffleruby.core.array.ArrayUtils;
 import org.truffleruby.core.proc.RubyProc;
 import org.truffleruby.language.FrameAndVariables;
+import org.truffleruby.language.Nil;
 import org.truffleruby.language.control.FrameOnStackMarker;
 import org.truffleruby.language.methods.DeclarationContext;
 import org.truffleruby.language.methods.InternalMethod;
@@ -82,7 +83,14 @@ public final class RubyArguments {
         packed[ArgumentIndicies.DECLARATION_CONTEXT.ordinal()] = declarationContext;
         packed[ArgumentIndicies.FRAME_ON_STACK_MARKER.ordinal()] = frameOnStackMarker;
         packed[ArgumentIndicies.SELF.ordinal()] = self;
-        packed[ArgumentIndicies.BLOCK.ordinal()] = block;
+
+        /* The block in the arguments array is always either a Nil or RubyProc. The conversion from null if the caller
+         * doesn't want to provide a block is done at the caller, because it will know the type of values within its
+         * compilation unit.
+         *
+         * When you read the block back out in the callee, you'll therefore get a Nil or RubyProc. */
+        assert block == null || block instanceof Nil || block instanceof RubyProc : block;
+        packed[ArgumentIndicies.BLOCK.ordinal()] = block == null ? Nil.INSTANCE : block;
 
         ArrayUtils.arraycopy(arguments, 0, packed, RUNTIME_ARGUMENT_COUNT, arguments.length);
 

--- a/src/main/java/org/truffleruby/language/arguments/RubyArguments.java
+++ b/src/main/java/org/truffleruby/language/arguments/RubyArguments.java
@@ -44,7 +44,7 @@ public final class RubyArguments {
             InternalMethod method,
             FrameOnStackMarker frameOnStackMarker,
             Object self,
-            RubyProc block,
+            Object block,
             Object[] arguments) {
         return pack(
                 declarationFrame,
@@ -64,7 +64,7 @@ public final class RubyArguments {
             DeclarationContext declarationContext,
             FrameOnStackMarker frameOnStackMarker,
             Object self,
-            RubyProc block,
+            Object block,
             Object[] arguments) {
         assert method != null;
         assert declarationContext != null;

--- a/src/main/java/org/truffleruby/language/arguments/RubyArguments.java
+++ b/src/main/java/org/truffleruby/language/arguments/RubyArguments.java
@@ -84,13 +84,13 @@ public final class RubyArguments {
         packed[ArgumentIndicies.FRAME_ON_STACK_MARKER.ordinal()] = frameOnStackMarker;
         packed[ArgumentIndicies.SELF.ordinal()] = self;
 
-        /* The block in the arguments array is always either a Nil or RubyProc. The conversion from null if the caller
+        /* The block in the arguments array is always either a Nil or RubyProc. The provision of Nil if the caller
          * doesn't want to provide a block is done at the caller, because it will know the type of values within its
          * compilation unit.
          *
          * When you read the block back out in the callee, you'll therefore get a Nil or RubyProc. */
-        assert block == null || block instanceof Nil || block instanceof RubyProc : block;
-        packed[ArgumentIndicies.BLOCK.ordinal()] = block == null ? Nil.INSTANCE : block;
+        assert block instanceof Nil || block instanceof RubyProc : block;
+        packed[ArgumentIndicies.BLOCK.ordinal()] = block;
 
         ArrayUtils.arraycopy(arguments, 0, packed, RUNTIME_ARGUMENT_COUNT, arguments.length);
 

--- a/src/main/java/org/truffleruby/language/dispatch/DispatchNode.java
+++ b/src/main/java/org/truffleruby/language/dispatch/DispatchNode.java
@@ -138,7 +138,7 @@ public class DispatchNode extends FrameAndVariablesSendingNode implements Dispat
 
         final Object callerFrameOrStorage = getFrameOrStorageIfRequired(frame);
         final Object[] frameArguments = RubyArguments
-                .pack(null, callerFrameOrStorage, method, null, receiver, block, arguments);
+                .pack(null, callerFrameOrStorage, method, null, receiver, block == null ? nil : block, arguments);
 
         return callNode.execute(method, frameArguments);
     }

--- a/src/main/java/org/truffleruby/language/dispatch/DispatchNode.java
+++ b/src/main/java/org/truffleruby/language/dispatch/DispatchNode.java
@@ -109,15 +109,15 @@ public class DispatchNode extends FrameAndVariablesSendingNode implements Dispat
         return execute(null, receiver, method, null, arguments);
     }
 
-    public Object callWithBlock(Object receiver, String method, RubyProc block, Object... arguments) {
+    public Object callWithBlock(Object receiver, String method, Object block, Object... arguments) {
         return execute(null, receiver, method, block, arguments);
     }
 
-    public Object dispatch(VirtualFrame frame, Object receiver, String methodName, RubyProc block, Object[] arguments) {
+    public Object dispatch(VirtualFrame frame, Object receiver, String methodName, Object block, Object[] arguments) {
         return execute(frame, receiver, methodName, block, arguments);
     }
 
-    public Object execute(VirtualFrame frame, Object receiver, String methodName, RubyProc block, Object[] arguments) {
+    public Object execute(VirtualFrame frame, Object receiver, String methodName, Object block, Object[] arguments) {
         final RubyClass metaclass = metaclassNode.execute(receiver);
 
         final InternalMethod method = methodLookup.execute(frame, metaclass, methodName, config);
@@ -144,7 +144,7 @@ public class DispatchNode extends FrameAndVariablesSendingNode implements Dispat
     }
 
     private Object callMethodMissing(
-            VirtualFrame frame, Object receiver, String methodName, RubyProc block,
+            VirtualFrame frame, Object receiver, String methodName, Object block,
             Object[] arguments) {
 
         final RubySymbol symbolName = nameToSymbol(methodName);
@@ -166,7 +166,7 @@ public class DispatchNode extends FrameAndVariablesSendingNode implements Dispat
         return result;
     }
 
-    protected Object callForeign(Object receiver, String methodName, RubyProc block, Object[] arguments) {
+    protected Object callForeign(Object receiver, String methodName, Object block, Object[] arguments) {
         if (callForeign == null) {
             CompilerDirectives.transferToInterpreterAndInvalidate();
             callForeign = insert(CallForeignMethodNode.create());
@@ -175,7 +175,7 @@ public class DispatchNode extends FrameAndVariablesSendingNode implements Dispat
     }
 
     protected Object callMethodMissingNode(
-            VirtualFrame frame, Object receiver, RubyProc block, Object[] arguments) {
+            VirtualFrame frame, Object receiver, Object block, Object[] arguments) {
         if (callMethodMissing == null) {
             CompilerDirectives.transferToInterpreterAndInvalidate();
             callMethodMissing = insert(DispatchNode.create(DispatchConfiguration.PRIVATE_RETURN_MISSING));
@@ -240,13 +240,13 @@ public class DispatchNode extends FrameAndVariablesSendingNode implements Dispat
         }
 
         @Override
-        public Object execute(VirtualFrame frame, Object receiver, String methodName, RubyProc block,
+        public Object execute(VirtualFrame frame, Object receiver, String methodName, Object block,
                 Object[] arguments) {
             return super.execute(null, receiver, methodName, block, arguments);
         }
 
         @Override
-        protected Object callForeign(Object receiver, String methodName, RubyProc block, Object[] arguments) {
+        protected Object callForeign(Object receiver, String methodName, Object block, Object[] arguments) {
             if (callForeign == null) {
                 CompilerDirectives.transferToInterpreterAndInvalidate();
                 callForeign = insert(CallForeignMethodNode.getUncached());
@@ -257,7 +257,7 @@ public class DispatchNode extends FrameAndVariablesSendingNode implements Dispat
 
         @Override
         protected Object callMethodMissingNode(
-                VirtualFrame frame, Object receiver, RubyProc block, Object[] arguments) {
+                VirtualFrame frame, Object receiver, Object block, Object[] arguments) {
             if (callMethodMissing == null) {
                 CompilerDirectives.transferToInterpreterAndInvalidate();
                 callMethodMissing = insert(

--- a/src/main/java/org/truffleruby/language/dispatch/DispatchingNode.java
+++ b/src/main/java/org/truffleruby/language/dispatch/DispatchingNode.java
@@ -12,14 +12,12 @@ package org.truffleruby.language.dispatch;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.NodeInterface;
 
-import org.truffleruby.core.proc.RubyProc;
-
 public interface DispatchingNode extends NodeInterface {
 
     public Object call(Object receiver, String method, Object... arguments);
 
-    public Object callWithBlock(Object receiver, String method, RubyProc block, Object... arguments);
+    public Object callWithBlock(Object receiver, String method, Object block, Object... arguments);
 
-    public Object dispatch(VirtualFrame frame, Object receiver, String methodName, RubyProc block, Object[] arguments);
+    public Object dispatch(VirtualFrame frame, Object receiver, String methodName, Object block, Object[] arguments);
 
 }

--- a/src/main/java/org/truffleruby/language/loader/CodeLoader.java
+++ b/src/main/java/org/truffleruby/language/loader/CodeLoader.java
@@ -12,6 +12,7 @@ package org.truffleruby.language.loader;
 import org.truffleruby.RubyContext;
 import org.truffleruby.core.module.RubyModule;
 import org.truffleruby.language.LexicalScope;
+import org.truffleruby.language.Nil;
 import org.truffleruby.language.RubyNode;
 import org.truffleruby.language.RubyRootNode;
 import org.truffleruby.language.Visibility;
@@ -89,7 +90,7 @@ public class CodeLoader {
                 method,
                 null,
                 self,
-                null,
+                Nil.INSTANCE,
                 RubyNode.EMPTY_ARGUMENTS));
     }
 

--- a/src/main/java/org/truffleruby/language/methods/CallBoundMethodNode.java
+++ b/src/main/java/org/truffleruby/language/methods/CallBoundMethodNode.java
@@ -46,7 +46,7 @@ public abstract class CallBoundMethodNode extends RubyBaseNode {
                 internalMethod,
                 null,
                 method.receiver,
-                block,
+                block == null ? nil : block,
                 arguments);
     }
 }

--- a/src/main/java/org/truffleruby/language/methods/InternalMethod.java
+++ b/src/main/java/org/truffleruby/language/methods/InternalMethod.java
@@ -47,7 +47,7 @@ public class InternalMethod implements ObjectGraphNode {
 
     private final CachedSupplier<RootCallTarget> callTargetSupplier;
     @CompilationFinal private RootCallTarget callTarget;
-    private final RubyProc capturedBlock;
+    private final Object capturedBlock;
 
     public static InternalMethod fromProc(
             RubyContext context,
@@ -134,7 +134,7 @@ public class InternalMethod implements ObjectGraphNode {
             RubyProc proc,
             RootCallTarget callTarget,
             CachedSupplier<RootCallTarget> callTargetSupplier,
-            RubyProc capturedBlock) {
+            Object capturedBlock) {
         this(
                 sharedMethodInfo,
                 lexicalScope,
@@ -166,7 +166,7 @@ public class InternalMethod implements ObjectGraphNode {
             RubyProc proc,
             RootCallTarget callTarget,
             CachedSupplier<RootCallTarget> callTargetSupplier,
-            RubyProc capturedBlock) {
+            Object capturedBlock) {
         assert declaringModule != null;
         assert lexicalScope != null;
         assert !sharedMethodInfo.isBlock() : sharedMethodInfo;
@@ -428,7 +428,7 @@ public class InternalMethod implements ObjectGraphNode {
         }
     }
 
-    public RubyProc getCapturedBlock() {
+    public Object getCapturedBlock() {
         return capturedBlock;
     }
 

--- a/src/main/java/org/truffleruby/language/methods/ModuleBodyDefinitionNode.java
+++ b/src/main/java/org/truffleruby/language/methods/ModuleBodyDefinitionNode.java
@@ -14,7 +14,6 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.truffleruby.collections.ConcurrentOperations;
 import org.truffleruby.core.module.RubyModule;
-import org.truffleruby.core.proc.RubyProc;
 import org.truffleruby.language.LexicalScope;
 import org.truffleruby.language.RubyContextNode;
 import org.truffleruby.language.Visibility;
@@ -49,7 +48,7 @@ public class ModuleBodyDefinitionNode extends RubyContextNode {
     }
 
     public InternalMethod createMethod(VirtualFrame frame, LexicalScope staticLexicalScope, RubyModule module) {
-        final RubyProc capturedBlock;
+        final Object capturedBlock;
 
         if (captureBlock) {
             capturedBlock = RubyArguments.getBlock(frame);

--- a/src/main/java/org/truffleruby/language/methods/SymbolProcNode.java
+++ b/src/main/java/org/truffleruby/language/methods/SymbolProcNode.java
@@ -10,7 +10,6 @@
 package org.truffleruby.language.methods;
 
 import org.truffleruby.core.array.ArrayUtils;
-import org.truffleruby.core.proc.RubyProc;
 import org.truffleruby.language.RubyContextSourceNode;
 import org.truffleruby.language.arguments.RubyArguments;
 import org.truffleruby.language.control.RaiseException;
@@ -44,7 +43,7 @@ public class SymbolProcNode extends RubyContextSourceNode {
 
         final Object receiver = RubyArguments.getArgument(frame, 0);
         final Object[] arguments = ArrayUtils.extractRange(RubyArguments.getArguments(frame), 1, given);
-        final RubyProc block = RubyArguments.getBlock(frame);
+        final Object block = RubyArguments.getBlock(frame);
 
         return getCallNode().dispatch(frame, receiver, symbol, block, arguments);
     }

--- a/src/main/java/org/truffleruby/language/objects/RunModuleDefinitionNode.java
+++ b/src/main/java/org/truffleruby/language/objects/RunModuleDefinitionNode.java
@@ -49,7 +49,7 @@ public class RunModuleDefinitionNode extends RubyContextSourceNode {
                 definition,
                 null,
                 module,
-                null,
+                nil,
                 EMPTY_ARGUMENTS));
     }
 

--- a/src/main/java/org/truffleruby/language/supercall/CallSuperMethodNode.java
+++ b/src/main/java/org/truffleruby/language/supercall/CallSuperMethodNode.java
@@ -56,7 +56,7 @@ public class CallSuperMethodNode extends FrameAndVariablesSendingNode {
                         superMethod,
                         null,
                         self,
-                        block,
+                        block == null ? nil : block,
                         arguments);
 
         return callMethod(superMethod, frameArguments);

--- a/src/main/java/org/truffleruby/language/yield/CallBlockNode.java
+++ b/src/main/java/org/truffleruby/language/yield/CallBlockNode.java
@@ -38,7 +38,6 @@ public abstract class CallBlockNode extends RubyBaseNode {
     public abstract Object executeCallBlock(DeclarationContext declarationContext, RubyProc block, Object self,
             Object blockArgument, Object[] arguments);
 
-    // blockArgument is typed as Object below because it must accept "null".
     @Specialization(guards = "block.callTarget == cachedCallTarget", limit = "getCacheLimit()")
     protected Object callBlockCached(
             DeclarationContext declarationContext,

--- a/src/main/java/org/truffleruby/language/yield/CallBlockNode.java
+++ b/src/main/java/org/truffleruby/language/yield/CallBlockNode.java
@@ -74,7 +74,7 @@ public abstract class CallBlockNode extends RubyBaseNode {
                 declarationContext,
                 block.frameOnStackMarker,
                 self,
-                blockArgument,
+                blockArgument == null ? nil : blockArgument,
                 arguments);
     }
 

--- a/src/main/java/org/truffleruby/language/yield/CallBlockNode.java
+++ b/src/main/java/org/truffleruby/language/yield/CallBlockNode.java
@@ -74,7 +74,7 @@ public abstract class CallBlockNode extends RubyBaseNode {
                 declarationContext,
                 block.frameOnStackMarker,
                 self,
-                (RubyProc) blockArgument,
+                blockArgument,
                 arguments);
     }
 

--- a/src/main/java/org/truffleruby/language/yield/YieldExpressionNode.java
+++ b/src/main/java/org/truffleruby/language/yield/YieldExpressionNode.java
@@ -93,7 +93,7 @@ public class YieldExpressionNode extends RubyContextSourceNode {
 
     @Override
     public Object isDefined(VirtualFrame frame, RubyLanguage language, RubyContext context) {
-        if (RubyArguments.getBlock(frame) == null) {
+        if (RubyArguments.getBlock(frame) == nil) {
             return nil;
         } else {
             return coreStrings().YIELD.createInstance(context);

--- a/src/main/java/org/truffleruby/parser/LoadArgumentsTranslator.java
+++ b/src/main/java/org/truffleruby/parser/LoadArgumentsTranslator.java
@@ -357,7 +357,7 @@ public class LoadArgumentsTranslator extends Translator {
     }
 
     public RubyNode saveMethodBlockArg() {
-        final RubyNode readNode = new ReadBlockFromCurrentFrameArgumentsNode(Nil.INSTANCE);
+        final RubyNode readNode = new ReadBlockFromCurrentFrameArgumentsNode();
         final FrameSlot slot = methodBodyTranslator
                 .getEnvironment()
                 .getFrameDescriptor()
@@ -367,7 +367,7 @@ public class LoadArgumentsTranslator extends Translator {
 
     @Override
     public RubyNode visitBlockArgNode(BlockArgParseNode node) {
-        final RubyNode readNode = new ReadBlockFromCurrentFrameArgumentsNode(Nil.INSTANCE);
+        final RubyNode readNode = new ReadBlockFromCurrentFrameArgumentsNode();
         final FrameSlot slot = methodBodyTranslator.getEnvironment().getFrameDescriptor().findFrameSlot(node.getName());
         return new WriteLocalVariableNode(slot, readNode);
     }


### PR DESCRIPTION
As a step towards unifying the representations of block arguments (#2206) we’ve changed `RubyArguments.pack()` to convert a `null` block into `nil` at the point where it’s stored in the argument array. This allows us to remove the `null` check from `ReadBlockFromCurrentFrameArgumentsNode`, which now just returns the result of `getBlock()`.

Questions for reviewers:

* Is there a better return type for `getBlock()` than `Object`? We’re losing quite a lot of type safety here, given that we only ever expect the value to be `Nil.INSTANCE` or a `RubyProc`, but we don’t believe the overhead of e.g. `Optional<RubyProc>` is worthwhile.
* The type checker is satisfied and the specs all pass, but are there more lurking `null`s that need to be replaced with `nil`s as part of this change?

Shopify#1