### PR TITLE
Add missing spec for squiggly heredoc with backslash

### DIFF
--- a/spec/ruby/language/fixtures/squiggly_heredoc.rb
+++ b/spec/ruby/language/fixtures/squiggly_heredoc.rb
@@ -29,6 +29,14 @@ module SquigglyHeredocSpecs
     HERE
   end
 
+  def self.backslash
+    <<~HERE
+      a
+      b\
+      c
+    HERE
+  end
+
   def self.least_indented_on_the_first_line
     <<~HERE
       a

--- a/spec/ruby/language/heredoc_spec.rb
+++ b/spec/ruby/language/heredoc_spec.rb
@@ -100,6 +100,11 @@ HERE
     SquigglyHeredocSpecs.singlequoted.should == "singlequoted \#{\"interpolated\"}\n"
   end
 
+  it "allows HEREDOC with <<~'identifier', no interpolation, with backslash" do
+    require_relative 'fixtures/squiggly_heredoc'
+    SquigglyHeredocSpecs.backslash.should == "a\nbc\n"
+  end
+
   it "selects the least-indented line and removes its indentation from all the lines" do
     require_relative 'fixtures/squiggly_heredoc'
     SquigglyHeredocSpecs.least_indented_on_the_first_line.should == "a\n  b\n    c\n"

--- a/spec/tags/language/heredoc_tags.txt
+++ b/spec/tags/language/heredoc_tags.txt
@@ -1,1 +1,2 @@
 fails:Heredoc string prints a warning if quoted HEREDOC identifier is ending not on same line
+fails:Heredoc string allows HEREDOC with <<~'identifier', no interpolation, with backslash


### PR DESCRIPTION
Related to this issue: https://github.com/oracle/truffleruby/issues/2238