### PR TITLE
Extra whitespace in squiggly heredoc with escaped newline

### DIFF
--- a/spec/tags/language/heredoc_tags.txt
+++ b/spec/tags/language/heredoc_tags.txt
@@ -1,2 +1,1 @@
 fails:Heredoc string prints a warning if quoted HEREDOC identifier is ending not on same line
-fails:Heredoc string allows HEREDOC with <<~'identifier', no interpolation, with backslash

--- a/src/main/java/org/truffleruby/parser/ast/ParseNode.java
+++ b/src/main/java/org/truffleruby/parser/ast/ParseNode.java
@@ -64,6 +64,11 @@ public abstract class ParseNode {
         this.newline = true;
     }
 
+    // Used by heredoc dedent processing.  It gets unset so we do not liter line events because of it.
+    public void unsetNewline() {
+        this.newline = false;
+    }
+
     public boolean isNewline() {
         return newline;
     }

--- a/src/main/java/org/truffleruby/parser/lexer/StringTerm.java
+++ b/src/main/java/org/truffleruby/parser/lexer/StringTerm.java
@@ -40,6 +40,7 @@ import static org.truffleruby.parser.lexer.RubyLexer.STR_FUNC_LIST;
 import static org.truffleruby.parser.lexer.RubyLexer.STR_FUNC_QWORDS;
 import static org.truffleruby.parser.lexer.RubyLexer.STR_FUNC_REGEXP;
 import static org.truffleruby.parser.lexer.RubyLexer.STR_FUNC_SYMBOL;
+import static org.truffleruby.parser.lexer.RubyLexer.STR_FUNC_INDENT;
 import static org.truffleruby.parser.lexer.RubyLexer.STR_FUNC_TERM;
 import static org.truffleruby.parser.lexer.RubyLexer.isHexChar;
 import static org.truffleruby.parser.lexer.RubyLexer.isOctChar;
@@ -250,6 +251,7 @@ public class StringTerm extends StrTerm {
         boolean escape = (flags & STR_FUNC_ESCAPE) != 0;
         boolean regexp = (flags & STR_FUNC_REGEXP) != 0;
         boolean symbol = (flags & STR_FUNC_SYMBOL) != 0;
+        boolean indent = (flags & STR_FUNC_INDENT) != 0;
         boolean hasNonAscii = false;
         int c;
 
@@ -283,6 +285,13 @@ public class StringTerm extends StrTerm {
                             break;
                         }
                         if (expand) {
+                            if (!(indent || lexer.getHeredocIndent() >= 0)) continue;
+                            if (c == end) {
+                                c = '\\';
+                                // goto terminate
+                                if (enc != null) buffer.setEncoding(lexer.getEncoding());
+                                return c;
+                            }
                             continue;
                         }
                         buffer.append('\\');

--- a/src/main/java/org/truffleruby/parser/parser/RubyParser.java
+++ b/src/main/java/org/truffleruby/parser/parser/RubyParser.java
@@ -3238,7 +3238,7 @@ states[501] = (support, lexer, yyVal, yyVals, yyTop) -> {
     return yyVal;
 };
 states[502] = (support, lexer, yyVal, yyVals, yyTop) -> {
-    yyVal = null;
+    yyVal = lexer.createStr(RopeOperations.emptyRope(lexer.getEncoding()), 0);
     return yyVal;
 };
 states[503] = (support, lexer, yyVal, yyVals, yyTop) -> {
@@ -3304,6 +3304,7 @@ states[514] = (support, lexer, yyVal, yyVals, yyTop) -> {
     lexer.setHeredocIndent(((Integer)yyVals[-2+yyTop]));
     lexer.setHeredocLineIndent(-1);
 
+    if (((ParseNode)yyVals[-1+yyTop]) != null) ((ParseNode)yyVals[-1+yyTop]).unsetNewline();
     yyVal = support.newEvStrNode(support.getPosition(((ParseNode)yyVals[-1+yyTop])), ((ParseNode)yyVals[-1+yyTop]));
     return yyVal;
 };
@@ -3949,7 +3950,7 @@ states[669] = (support, lexer, yyVal, yyVals, yyTop) -> {
     return yyVal;
 };
 }
-// line 2805 "RubyParser.y"
+// line 2806 "RubyParser.y"
 
     /** The parse method use an lexer stream and parse it to an AST node 
      * structure
@@ -3966,4 +3967,4 @@ states[669] = (support, lexer, yyVal, yyVals, yyTop) -> {
 }
 // CheckStyle: stop generated
 // @formatter:on
-// line 10891 "-"
+// line 10892 "-"

--- a/src/main/java/org/truffleruby/parser/parser/RubyParser.y
+++ b/src/main/java/org/truffleruby/parser/parser/RubyParser.y
@@ -2167,7 +2167,7 @@ string_contents : /* none */ {
                 }
 
 xstring_contents: /* none */ {
-                    $$ = null;
+                    $$ = lexer.createStr(RopeOperations.emptyRope(lexer.getEncoding()), 0);
                 }
                 | xstring_contents string_content {
                     $$ = support.literal_concat($1, $<ParseNode>2);
@@ -2217,6 +2217,7 @@ string_content  : tSTRING_CONTENT {
                    lexer.setHeredocIndent($<Integer>6);
                    lexer.setHeredocLineIndent(-1);
 
+                   if ($7 != null) $7.unsetNewline();
                    $$ = support.newEvStrNode(support.getPosition($7), $7);
                 }
 


### PR DESCRIPTION
### Issue

Extra whitespace in squiggly heredoc with escaped newline https://github.com/oracle/truffleruby/issues/2238 


### Changes in this PR 

This commit is pretty much identical to [this commit from JRuby](https://github.com/jruby/jruby/commit/fb1ac0824fa24e1ef1bda1b7ea1be24e61c815f8) as it solves the issue for JRuby. 

The change I have here currently does fix the issue, but breaks one other test, namely this test: 

```
1)
Heredoc string selects the least-indented line and removes its indentation from all the lines for <<~'identifier' FAILED
Expected
"a
        b
          c
" ==
"a
  b
    c
"
to be truthy but was false
/Users/mapleong/src/github.com/Shopify/truffleruby/spec/ruby/language/heredoc_spec.rb:116:in `block (2 levels) in <top (required)>'
/Users/mapleong/src/github.com/Shopify/truffleruby/spec/ruby/language/heredoc_spec.rb:5:in `<top (required)>'
```

### Questions for Reviewers

Soooo, because I haven't worked with lexers before and they are difficult to debug and understand -- I am hoping that someone who knows what they are doing give a better direction or perhaps a different solution altogether. 

There are many changes happening all at once in one commit, perhaps we can also try to isolate the changes so we can only fix the original issue. 