### PR TITLE
Represent missing block argument as nil instead of NotProvided

### DIFF
--- a/src/main/java/org/truffleruby/builtins/CoreMethodNodeManager.java
+++ b/src/main/java/org/truffleruby/builtins/CoreMethodNodeManager.java
@@ -306,8 +306,7 @@ public class CoreMethodNodeManager {
             /* The way we write specializations for getting a block or not is that we use NotProvided like a missing
              * argument. The block coming into the method is actually always Nil or RubyProc, so here we check which and
              * convert Nil to NotProvided. */
-            argumentsNodes[i++] = new ReadBlockFromCurrentFrameArgumentsNode.ConvertNilBlockToNotProvidedNode(
-                    new ReadBlockFromCurrentFrameArgumentsNode());
+            argumentsNodes[i++] = new ReadBlockFromCurrentFrameArgumentsNode();
         }
 
         if (!method.keywordAsOptional().isEmpty()) {

--- a/src/main/java/org/truffleruby/cext/CExtNodes.java
+++ b/src/main/java/org/truffleruby/cext/CExtNodes.java
@@ -68,7 +68,6 @@ import org.truffleruby.interop.ToJavaStringNode;
 import org.truffleruby.interop.TranslateInteropExceptionNode;
 import org.truffleruby.core.string.ImmutableRubyString;
 import org.truffleruby.language.LexicalScope;
-import org.truffleruby.language.NotProvided;
 import org.truffleruby.language.RubyContextNode;
 import org.truffleruby.language.RubyDynamicObject;
 import org.truffleruby.language.RubyGuards;
@@ -1119,7 +1118,7 @@ public class CExtNodes {
 
             RubyClass klass = (RubyClass) allocateNode
                     .call(getContext().getCoreLibrary().classClass, "__allocate__");
-            return initializeClassNode.executeInitialize(klass, superclass, NotProvided.INSTANCE);
+            return initializeClassNode.executeInitialize(klass, superclass, nil);
         }
 
     }

--- a/src/main/java/org/truffleruby/core/array/ArrayNodes.java
+++ b/src/main/java/org/truffleruby/core/array/ArrayNodes.java
@@ -697,7 +697,7 @@ public abstract class ArrayNodes {
                 array.size = i;
                 return found;
             } else {
-                if (maybeBlock == NotProvided.INSTANCE) {
+                if (maybeBlock == nil) {
                     return nil;
                 } else {
                     return yield((RubyProc) maybeBlock, value);

--- a/src/main/java/org/truffleruby/core/array/ArrayNodes.java
+++ b/src/main/java/org/truffleruby/core/array/ArrayNodes.java
@@ -961,7 +961,7 @@ public abstract class ArrayNodes {
         @Specialization(
                 guards = { "args.length == 1", "stores.acceptsValue(array.store, value(args))" },
                 limit = "storageStrategyLimit()")
-        protected RubyArray fill(RubyArray array, Object[] args, NotProvided block,
+        protected RubyArray fill(RubyArray array, Object[] args, Nil block,
                 @CachedLibrary("array.store") ArrayStoreLibrary stores,
                 @Cached PropagateSharingNode propagateSharingNode,
                 @Cached("createCountingProfile()") LoopConditionProfile loopProfile) {
@@ -983,7 +983,7 @@ public abstract class ArrayNodes {
         }
 
         @Specialization
-        protected Object fillFallback(VirtualFrame frame, RubyArray array, Object[] args, NotProvided block,
+        protected Object fillFallback(VirtualFrame frame, RubyArray array, Object[] args, Nil block,
                 @Cached DispatchNode callFillInternal) {
             return callFillInternal.call(array, "fill_internal", args);
         }
@@ -1066,14 +1066,10 @@ public abstract class ArrayNodes {
         @Child private KernelNodes.RespondToNode respondToToAryNode;
 
         protected abstract RubyArray executeInitialize(RubyArray array, Object size, Object fillingValue,
-                NotProvided block);
+                Nil block);
 
         @Specialization
-        protected RubyArray initializeNoArgs(
-                RubyArray array,
-                NotProvided size,
-                NotProvided fillingValue,
-                NotProvided block) {
+        protected RubyArray initializeNoArgs(RubyArray array, NotProvided size, NotProvided fillingValue, Nil block) {
             setStoreAndSize(array, ArrayStoreLibrary.INITIAL_STORE, 0);
             return array;
         }
@@ -1112,20 +1108,12 @@ public abstract class ArrayNodes {
 
         @TruffleBoundary
         @Specialization(guards = "size >= MAX_INT")
-        protected RubyArray initializeSizeTooBig(
-                RubyArray array,
-                long size,
-                NotProvided fillingValue,
-                NotProvided block) {
+        protected RubyArray initializeSizeTooBig(RubyArray array, long size, NotProvided fillingValue, Nil block) {
             throw new RaiseException(getContext(), coreExceptions().argumentError("array size too big", this));
         }
 
         @Specialization(guards = "size >= 0")
-        protected RubyArray initializeWithSizeNoValue(
-                RubyArray array,
-                int size,
-                NotProvided fillingValue,
-                NotProvided block) {
+        protected RubyArray initializeWithSizeNoValue(RubyArray array, int size, NotProvided fillingValue, Nil block) {
             final Object[] store = new Object[size];
             Arrays.fill(store, nil);
             setStoreAndSize(array, store, size);
@@ -1135,11 +1123,7 @@ public abstract class ArrayNodes {
         @Specialization(
                 guards = { "size >= 0", "wasProvided(fillingValue)" },
                 limit = "storageStrategyLimit()")
-        protected RubyArray initializeWithSizeAndValue(
-                RubyArray array,
-                int size,
-                Object fillingValue,
-                NotProvided block,
+        protected RubyArray initializeWithSizeAndValue(RubyArray array, int size, Object fillingValue, Nil block,
                 @CachedLibrary("array.store") ArrayStoreLibrary stores,
                 @CachedLibrary(limit = "1") ArrayStoreLibrary allocatedStores,
                 @Cached ConditionProfile needsFill,
@@ -1159,7 +1143,7 @@ public abstract class ArrayNodes {
 
         @Specialization(
                 guards = { "wasProvided(size)", "!isInteger(size)", "!isLong(size)", "wasProvided(fillingValue)" })
-        protected RubyArray initializeSizeOther(RubyArray array, Object size, Object fillingValue, NotProvided block) {
+        protected RubyArray initializeSizeOther(RubyArray array, Object size, Object fillingValue, Nil block) {
             int intSize = toInt(size);
             return executeInitialize(array, intSize, fillingValue, block);
         }
@@ -1202,7 +1186,7 @@ public abstract class ArrayNodes {
 
         @Specialization(
                 guards = { "!isInteger(object)", "!isLong(object)", "wasProvided(object)", "!isRubyArray(object)" })
-        protected RubyArray initialize(RubyArray array, Object object, NotProvided unusedValue, NotProvided block) {
+        protected RubyArray initialize(RubyArray array, Object object, NotProvided unusedValue, Nil block) {
             RubyArray copy = null;
             if (respondToToAry(getLanguage(), object)) {
                 Object toAryResult = callToAry(object);
@@ -1212,10 +1196,10 @@ public abstract class ArrayNodes {
             }
 
             if (copy != null) {
-                return executeInitialize(array, copy, NotProvided.INSTANCE, NotProvided.INSTANCE);
+                return executeInitialize(array, copy, NotProvided.INSTANCE, nil);
             } else {
                 int size = toInt(object);
-                return executeInitialize(array, size, NotProvided.INSTANCE, NotProvided.INSTANCE);
+                return executeInitialize(array, size, NotProvided.INSTANCE, nil);
             }
         }
 
@@ -2116,7 +2100,7 @@ public abstract class ArrayNodes {
         @Specialization(
                 guards = { "!isEmptyArray(array)", "isSmall(array)" },
                 limit = "storageStrategyLimit()")
-        protected RubyArray sortVeryShort(VirtualFrame frame, RubyArray array, NotProvided block,
+        protected RubyArray sortVeryShort(VirtualFrame frame, RubyArray array, Nil block,
                 @CachedLibrary("array.store") ArrayStoreLibrary originalStores,
                 @CachedLibrary(limit = "1") ArrayStoreLibrary stores,
                 @Cached DispatchNode compareDispatchNode,
@@ -2165,7 +2149,7 @@ public abstract class ArrayNodes {
                         "getLanguage().coreMethodAssumptions.integerCmpAssumption",
                         "getLanguage().coreMethodAssumptions.floatCmpAssumption" },
                 limit = "storageStrategyLimit()")
-        protected Object sortPrimitiveArrayNoBlock(RubyArray array, NotProvided block,
+        protected Object sortPrimitiveArrayNoBlock(RubyArray array, Nil block,
                 @CachedLibrary("array.store") ArrayStoreLibrary stores,
                 @CachedLibrary(limit = "1") ArrayStoreLibrary mutableStores) {
             final int size = array.size;
@@ -2179,7 +2163,7 @@ public abstract class ArrayNodes {
         @Specialization(
                 guards = { "!isEmptyArray(array)", "!isSmall(array)" },
                 limit = "storageStrategyLimit()")
-        protected Object sortArrayWithoutBlock(RubyArray array, NotProvided block,
+        protected Object sortArrayWithoutBlock(RubyArray array, Nil block,
                 @CachedLibrary("array.store") ArrayStoreLibrary stores,
                 @Cached DispatchNode fallbackNode) {
             return fallbackNode.call(array, "sort_fallback");

--- a/src/main/java/org/truffleruby/core/basicobject/BasicObjectNodes.java
+++ b/src/main/java/org/truffleruby/core/basicobject/BasicObjectNodes.java
@@ -493,17 +493,8 @@ public abstract class BasicObjectNodes {
         }
 
         @Specialization(guards = "wasProvided(name)")
-        protected Object methodMissingNoBlock(Object self, Object name, Object[] args, Nil block) {
-            return methodMissing(self, name, args, block);
-        }
-
-        @Specialization(guards = "wasProvided(name)")
-        protected Object methodMissingBlock(Object self, Object name, Object[] args, RubyProc block) {
-            return methodMissing(self, name, args, block);
-        }
-
-        private Object methodMissing(Object self, Object nameObject, Object[] args, Object block) {
-            throw new RaiseException(getContext(), buildMethodMissingException(self, nameObject, args, block));
+        protected Object methodMissing(Object self, Object name, Object[] args, Object block) {
+            throw new RaiseException(getContext(), buildMethodMissingException(self, name, args, block));
         }
 
         private static class FrameAndCallNode {
@@ -618,16 +609,7 @@ public abstract class BasicObjectNodes {
         @Child private NameToJavaStringNode nameToJavaString = NameToJavaStringNode.create();
 
         @Specialization
-        protected Object send(VirtualFrame frame, Object self, Object name, Object[] args, Nil block) {
-            return doSend(frame, self, name, args, block);
-        }
-
-        @Specialization
-        protected Object send(VirtualFrame frame, Object self, Object name, Object[] args, RubyProc block) {
-            return doSend(frame, self, name, args, block);
-        }
-
-        private Object doSend(VirtualFrame frame, Object self, Object name, Object[] args, Object block) {
+        protected Object send(VirtualFrame frame, Object self, Object name, Object[] args, Object block) {
             DeclarationContext context = RubyArguments.getDeclarationContext(readCallerFrame.execute(frame));
             RubyArguments.setDeclarationContext(frame, context);
 

--- a/src/main/java/org/truffleruby/core/basicobject/BasicObjectNodes.java
+++ b/src/main/java/org/truffleruby/core/basicobject/BasicObjectNodes.java
@@ -352,7 +352,7 @@ public abstract class BasicObjectNodes {
                 Object string,
                 Object fileName,
                 int line,
-                NotProvided block,
+                Nil block,
                 @CachedLibrary(limit = "2") RubyStringLibrary strings,
                 @CachedLibrary(limit = "2") RubyStringLibrary stringsFileName,
                 @Cached ReadCallerFrameNode callerFrameNode,
@@ -375,7 +375,7 @@ public abstract class BasicObjectNodes {
                 Object string,
                 Object fileName,
                 NotProvided line,
-                NotProvided block,
+                Nil block,
                 @CachedLibrary(limit = "2") RubyStringLibrary strings,
                 @CachedLibrary(limit = "2") RubyStringLibrary stringsFileName,
                 @Cached ReadCallerFrameNode callerFrameNode,
@@ -398,7 +398,7 @@ public abstract class BasicObjectNodes {
                 Object string,
                 NotProvided fileName,
                 NotProvided line,
-                NotProvided block,
+                Nil block,
                 @CachedLibrary(limit = "2") RubyStringLibrary strings,
                 @Cached ReadCallerFrameNode callerFrameNode,
                 @Cached IndirectCallNode callNode) {
@@ -478,7 +478,7 @@ public abstract class BasicObjectNodes {
         }
 
         @Specialization
-        protected Object instanceExec(Object receiver, Object[] arguments, NotProvided block) {
+        protected Object instanceExec(Object receiver, Object[] arguments, Nil block) {
             throw new RaiseException(getContext(), coreExceptions().localJumpError("no block given", this));
         }
 
@@ -488,13 +488,13 @@ public abstract class BasicObjectNodes {
     public abstract static class MethodMissingNode extends CoreMethodArrayArgumentsNode {
 
         @Specialization
-        protected Object methodMissingNoName(Object self, NotProvided name, Object[] args, NotProvided block) {
+        protected Object methodMissingNoName(Object self, NotProvided name, Object[] args, Nil block) {
             throw new RaiseException(getContext(), coreExceptions().argumentError("no id given", this));
         }
 
         @Specialization(guards = "wasProvided(name)")
-        protected Object methodMissingNoBlock(Object self, Object name, Object[] args, NotProvided block) {
-            return methodMissing(self, name, args, null);
+        protected Object methodMissingNoBlock(Object self, Object name, Object[] args, Nil block) {
+            return methodMissing(self, name, args, block);
         }
 
         @Specialization(guards = "wasProvided(name)")
@@ -502,7 +502,7 @@ public abstract class BasicObjectNodes {
             return methodMissing(self, name, args, block);
         }
 
-        private Object methodMissing(Object self, Object nameObject, Object[] args, RubyProc block) {
+        private Object methodMissing(Object self, Object nameObject, Object[] args, Object block) {
             throw new RaiseException(getContext(), buildMethodMissingException(self, nameObject, args, block));
         }
 
@@ -518,7 +518,7 @@ public abstract class BasicObjectNodes {
 
         @TruffleBoundary
         private RubyException buildMethodMissingException(Object self, Object nameObject, Object[] args,
-                RubyProc block) {
+                Object block) {
             final String name;
             if (nameObject instanceof RubySymbol) {
                 name = ((RubySymbol) nameObject).getString();
@@ -618,8 +618,8 @@ public abstract class BasicObjectNodes {
         @Child private NameToJavaStringNode nameToJavaString = NameToJavaStringNode.create();
 
         @Specialization
-        protected Object send(VirtualFrame frame, Object self, Object name, Object[] args, NotProvided block) {
-            return doSend(frame, self, name, args, nil);
+        protected Object send(VirtualFrame frame, Object self, Object name, Object[] args, Nil block) {
+            return doSend(frame, self, name, args, block);
         }
 
         @Specialization

--- a/src/main/java/org/truffleruby/core/hash/HashNodes.java
+++ b/src/main/java/org/truffleruby/core/hash/HashNodes.java
@@ -342,7 +342,7 @@ public abstract class HashNodes {
         @Child private YieldNode yieldNode = YieldNode.create();
 
         @Specialization(guards = "isNullHash(hash)")
-        protected Object deleteNull(RubyHash hash, Object key, NotProvided block) {
+        protected Object deleteNull(RubyHash hash, Object key, Nil block) {
             assert HashOperations.verifyStore(getContext(), hash);
 
             return nil;
@@ -512,7 +512,7 @@ public abstract class HashNodes {
     public abstract static class InitializeNode extends CoreMethodArrayArgumentsNode {
 
         @Specialization
-        protected RubyHash initialize(RubyHash hash, NotProvided defaultValue, NotProvided block) {
+        protected RubyHash initialize(RubyHash hash, NotProvided defaultValue, Nil block) {
             assert HashOperations.verifyStore(getContext(), hash);
             hash.defaultValue = nil;
             hash.defaultBlock = nil;
@@ -530,7 +530,7 @@ public abstract class HashNodes {
         }
 
         @Specialization(guards = "wasProvided(defaultValue)")
-        protected RubyHash initialize(RubyHash hash, Object defaultValue, NotProvided block,
+        protected RubyHash initialize(RubyHash hash, Object defaultValue, Nil block,
                 @Cached PropagateSharingNode propagateSharingNode) {
             assert HashOperations.verifyStore(getContext(), hash);
             propagateSharingNode.executePropagate(hash, defaultValue);

--- a/src/main/java/org/truffleruby/core/hash/HashNodes.java
+++ b/src/main/java/org/truffleruby/core/hash/HashNodes.java
@@ -382,7 +382,7 @@ public abstract class HashNodes {
 
             assert HashOperations.verifyStore(getContext(), hash);
 
-            if (maybeBlock == NotProvided.INSTANCE) {
+            if (maybeBlock == nil) {
                 return nil;
             } else {
                 return yieldNode.executeDispatch((RubyProc) maybeBlock, key);
@@ -397,7 +397,7 @@ public abstract class HashNodes {
             final Entry entry = lookupResult.getEntry();
 
             if (entry == null) {
-                if (maybeBlock == NotProvided.INSTANCE) {
+                if (maybeBlock == nil) {
                     return nil;
                 } else {
                     return yieldNode.executeDispatch((RubyProc) maybeBlock, key);

--- a/src/main/java/org/truffleruby/core/inlined/InlinedCallNode.java
+++ b/src/main/java/org/truffleruby/core/inlined/InlinedCallNode.java
@@ -16,7 +16,6 @@ import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.ExplodeLoop;
 
 import org.truffleruby.RubyLanguage;
-import org.truffleruby.language.NotProvided;
 import org.truffleruby.language.RubyNode;
 import org.truffleruby.language.dispatch.RubyCallNodeParameters;
 import org.truffleruby.language.methods.InternalMethod;
@@ -72,8 +71,7 @@ public class InlinedCallNode extends InlinedReplaceableNode {
 
     public Object executeWithArgumentsEvaluated(VirtualFrame frame, Object receiverObject, Object blockObject,
             Object[] argumentsObjects) {
-        final Object blockArgument = blockObject == nil ? NotProvided.INSTANCE : blockObject;
-        return inlinedMethod.inlineExecute(frame, receiverObject, argumentsObjects, blockArgument);
+        return inlinedMethod.inlineExecute(frame, receiverObject, argumentsObjects, blockObject);
     }
 
     private Object executeBlock(VirtualFrame frame) {

--- a/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
+++ b/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
@@ -1599,16 +1599,7 @@ public abstract class KernelNodes {
         @Child private NameToJavaStringNode nameToJavaString = NameToJavaStringNode.create();
 
         @Specialization
-        protected Object send(VirtualFrame frame, Object self, Object name, Object[] args, Nil block) {
-            return doSend(frame, self, name, args, block);
-        }
-
-        @Specialization
-        protected Object send(VirtualFrame frame, Object self, Object name, Object[] args, RubyProc block) {
-            return doSend(frame, self, name, args, block);
-        }
-
-        private Object doSend(VirtualFrame frame, Object self, Object name, Object[] args, Object block) {
+        protected Object send(VirtualFrame frame, Object self, Object name, Object[] args, Object block) {
             DeclarationContext context = RubyArguments.getDeclarationContext(readCallerFrame.execute(frame));
             RubyArguments.setDeclarationContext(frame, context);
 

--- a/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
+++ b/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
@@ -1261,7 +1261,7 @@ public abstract class KernelNodes {
     public abstract static class LambdaNode extends CoreMethodArrayArgumentsNode {
 
         @Specialization
-        protected RubyProc lambda(NotProvided block) {
+        protected RubyProc lambda(Nil block) {
             throw new RaiseException(getContext(), coreExceptions().argumentErrorProcWithoutBlock(this));
         }
 
@@ -1599,8 +1599,8 @@ public abstract class KernelNodes {
         @Child private NameToJavaStringNode nameToJavaString = NameToJavaStringNode.create();
 
         @Specialization
-        protected Object send(VirtualFrame frame, Object self, Object name, Object[] args, NotProvided block) {
-            return doSend(frame, self, name, args, nil);
+        protected Object send(VirtualFrame frame, Object self, Object name, Object[] args, Nil block) {
+            return doSend(frame, self, name, args, block);
         }
 
         @Specialization

--- a/src/main/java/org/truffleruby/core/klass/ClassNodes.java
+++ b/src/main/java/org/truffleruby/core/klass/ClassNodes.java
@@ -19,7 +19,6 @@ import org.truffleruby.core.basicobject.BasicObjectNodes;
 import org.truffleruby.core.inlined.InlinedDispatchNode;
 import org.truffleruby.core.inlined.InlinedMethodNode;
 import org.truffleruby.core.module.RubyModule;
-import org.truffleruby.core.proc.RubyProc;
 import org.truffleruby.language.Nil;
 import org.truffleruby.language.RubyDynamicObject;
 import org.truffleruby.language.Visibility;
@@ -283,13 +282,10 @@ public abstract class ClassNodes {
         public abstract Object execute(Object rubyClass, Object[] args, Object block);
 
         @Specialization(guards = "!rubyClass.isSingleton")
-        protected Object newInstance(RubyClass rubyClass, Object[] args, Nil block) {
-            return doNewInstance(rubyClass, args, block);
-        }
-
-        @Specialization(guards = "!rubyClass.isSingleton")
-        protected Object newInstance(RubyClass rubyClass, Object[] args, RubyProc block) {
-            return doNewInstance(rubyClass, args, block);
+        protected Object newInstance(RubyClass rubyClass, Object[] args, Object block) {
+            final Object instance = allocateNode().call(rubyClass, "__allocate__");
+            initialize().callWithBlock(instance, "initialize", block, args);
+            return instance;
         }
 
         @Specialization(guards = "rubyClass.isSingleton")
@@ -302,12 +298,6 @@ public abstract class ClassNodes {
         @Override
         public Object inlineExecute(Frame callerFrame, Object self, Object[] args, Object block) {
             return execute(self, args, block);
-        }
-
-        private Object doNewInstance(RubyClass rubyClass, Object[] args, Object block) {
-            final Object instance = allocateNode().call(rubyClass, "__allocate__");
-            initialize().callWithBlock(instance, "initialize", block, args);
-            return instance;
         }
 
         private DispatchingNode allocateNode() {

--- a/src/main/java/org/truffleruby/core/klass/ClassNodes.java
+++ b/src/main/java/org/truffleruby/core/klass/ClassNodes.java
@@ -21,7 +21,6 @@ import org.truffleruby.core.inlined.InlinedMethodNode;
 import org.truffleruby.core.module.RubyModule;
 import org.truffleruby.core.proc.RubyProc;
 import org.truffleruby.language.Nil;
-import org.truffleruby.language.NotProvided;
 import org.truffleruby.language.RubyDynamicObject;
 import org.truffleruby.language.Visibility;
 import org.truffleruby.language.control.RaiseException;
@@ -284,8 +283,8 @@ public abstract class ClassNodes {
         public abstract Object execute(Object rubyClass, Object[] args, Object block);
 
         @Specialization(guards = "!rubyClass.isSingleton")
-        protected Object newInstance(RubyClass rubyClass, Object[] args, NotProvided block) {
-            return doNewInstance(rubyClass, args, nil);
+        protected Object newInstance(RubyClass rubyClass, Object[] args, Nil block) {
+            return doNewInstance(rubyClass, args, block);
         }
 
         @Specialization(guards = "!rubyClass.isSingleton")

--- a/src/main/java/org/truffleruby/core/method/MethodNodes.java
+++ b/src/main/java/org/truffleruby/core/method/MethodNodes.java
@@ -31,7 +31,6 @@ import org.truffleruby.core.rope.CodeRange;
 import org.truffleruby.core.string.RubyString;
 import org.truffleruby.core.string.StringNodes;
 import org.truffleruby.core.symbol.RubySymbol;
-import org.truffleruby.language.NotProvided;
 import org.truffleruby.language.RubyContextSourceNode;
 import org.truffleruby.language.RubyRootNode;
 import org.truffleruby.language.Visibility;
@@ -134,7 +133,7 @@ public abstract class MethodNodes {
         @Specialization
         protected Object call(VirtualFrame frame, RubyMethod method, Object[] arguments, Object maybeBlock) {
             return callBoundMethodNode
-                    .execute(frame, method, arguments, maybeBlock == NotProvided.INSTANCE ? nil : maybeBlock);
+                    .execute(frame, method, arguments, maybeBlock);
         }
 
     }

--- a/src/main/java/org/truffleruby/core/module/ModuleNodes.java
+++ b/src/main/java/org/truffleruby/core/module/ModuleNodes.java
@@ -62,6 +62,7 @@ import org.truffleruby.core.support.TypeNodes;
 import org.truffleruby.core.symbol.RubySymbol;
 import org.truffleruby.core.symbol.SymbolTable;
 import org.truffleruby.language.LexicalScope;
+import org.truffleruby.language.Nil;
 import org.truffleruby.language.NotProvided;
 import org.truffleruby.language.RubyConstant;
 import org.truffleruby.language.RubyContextNode;
@@ -642,7 +643,7 @@ public abstract class ModuleNodes {
                 Object code,
                 NotProvided file,
                 NotProvided line,
-                NotProvided block,
+                Nil block,
                 @Cached IndirectCallNode callNode,
                 @CachedLibrary(limit = "2") RubyStringLibrary libCode) {
             return classEvalSource(frame, module, code, "(eval)", callNode);
@@ -655,7 +656,7 @@ public abstract class ModuleNodes {
                 Object code,
                 Object file,
                 NotProvided line,
-                NotProvided block,
+                Nil block,
                 @Cached IndirectCallNode callNode,
                 @CachedLibrary(limit = "2") RubyStringLibrary libCode,
                 @CachedLibrary(limit = "2") RubyStringLibrary libFile) {
@@ -663,13 +664,7 @@ public abstract class ModuleNodes {
         }
 
         @Specialization(guards = { "libCode.isRubyString(code)", "wasProvided(file)" })
-        protected Object classEval(
-                VirtualFrame frame,
-                RubyModule module,
-                Object code,
-                Object file,
-                int line,
-                NotProvided block,
+        protected Object classEval(VirtualFrame frame, RubyModule module, Object code, Object file, int line, Nil block,
                 @Cached IndirectCallNode callNode,
                 @CachedLibrary(limit = "2") RubyStringLibrary libCode,
                 @CachedLibrary(limit = "2") RubyStringLibrary libFile) {
@@ -689,7 +684,7 @@ public abstract class ModuleNodes {
                 Object code,
                 NotProvided file,
                 NotProvided line,
-                NotProvided block,
+                Nil block,
                 @Cached IndirectCallNode callNode) {
             return classEvalSource(frame, module, toStr(frame, code), "(eval)", callNode);
         }
@@ -701,7 +696,7 @@ public abstract class ModuleNodes {
                 Object code,
                 Object file,
                 NotProvided line,
-                NotProvided block,
+                Nil block,
                 @CachedLibrary(limit = "2") RubyStringLibrary stringLibrary,
                 @Cached IndirectCallNode callNode,
                 @CachedLibrary(limit = "2") RubyStringLibrary libCode) {
@@ -761,12 +756,7 @@ public abstract class ModuleNodes {
         }
 
         @Specialization
-        protected Object classEval(
-                RubyModule self,
-                NotProvided code,
-                NotProvided file,
-                NotProvided line,
-                NotProvided block) {
+        protected Object classEval(RubyModule self, NotProvided code, NotProvided file, NotProvided line, Nil block) {
             throw new RaiseException(getContext(), coreExceptions().argumentError(0, 1, 2, this));
         }
 
@@ -799,7 +789,7 @@ public abstract class ModuleNodes {
         }
 
         @Specialization
-        protected Object classExec(RubyModule self, Object[] args, NotProvided block) {
+        protected Object classExec(RubyModule self, Object[] args, Nil block) {
             throw new RaiseException(getContext(), coreExceptions().noBlockGiven(this));
         }
 
@@ -1223,7 +1213,7 @@ public abstract class ModuleNodes {
 
         @TruffleBoundary
         @Specialization
-        protected RubySymbol defineMethod(RubyModule module, String name, NotProvided proc, NotProvided block) {
+        protected RubySymbol defineMethod(RubyModule module, String name, NotProvided proc, Nil block) {
             throw new RaiseException(getContext(), coreExceptions().argumentError("needs either proc or block", this));
         }
 
@@ -1243,17 +1233,13 @@ public abstract class ModuleNodes {
                 RubyModule module,
                 String name,
                 RubyProc proc,
-                NotProvided block) {
+                Nil block) {
             return defineMethod(module, name, proc, readCallerFrame.execute(frame));
         }
 
         @TruffleBoundary
         @Specialization
-        protected RubySymbol defineMethodMethod(
-                RubyModule module,
-                String name,
-                RubyMethod methodObject,
-                NotProvided block,
+        protected RubySymbol defineMethodMethod(RubyModule module, String name, RubyMethod methodObject, Nil block,
                 @Cached CanBindMethodToModuleNode canBindMethodToModuleNode) {
             final InternalMethod method = methodObject.method;
 
@@ -1280,7 +1266,7 @@ public abstract class ModuleNodes {
                 RubyModule module,
                 String name,
                 RubyUnboundMethod method,
-                NotProvided block) {
+                Nil block) {
             final MaterializedFrame callerFrame = readCallerFrame.execute(frame);
             return defineMethodInternal(module, name, method, callerFrame);
         }
@@ -1405,7 +1391,7 @@ public abstract class ModuleNodes {
         }
 
         @Specialization
-        protected RubyModule initialize(RubyModule module, NotProvided block) {
+        protected RubyModule initialize(RubyModule module, Nil block) {
             return module;
         }
 
@@ -2156,7 +2142,7 @@ public abstract class ModuleNodes {
         @Child private CallBlockNode callBlockNode = CallBlockNode.create();
 
         @Specialization
-        protected RubyModule refine(RubyModule self, Object moduleToRefine, NotProvided block) {
+        protected RubyModule refine(RubyModule self, Object moduleToRefine, Nil block) {
             throw new RaiseException(getContext(), coreExceptions().argumentError("no block given", this));
         }
 

--- a/src/main/java/org/truffleruby/core/module/ModuleNodes.java
+++ b/src/main/java/org/truffleruby/core/module/ModuleNodes.java
@@ -1224,7 +1224,7 @@ public abstract class ModuleNodes {
                 String name,
                 NotProvided proc,
                 RubyProc block) {
-            return defineMethodProc(frame, module, name, block, NotProvided.INSTANCE);
+            return defineMethodProc(frame, module, name, block, nil);
         }
 
         @Specialization

--- a/src/main/java/org/truffleruby/core/objectspace/WeakMapNodes.java
+++ b/src/main/java/org/truffleruby/core/objectspace/WeakMapNodes.java
@@ -19,7 +19,7 @@ import org.truffleruby.collections.WeakValueCache;
 import org.truffleruby.core.array.RubyArray;
 import org.truffleruby.core.klass.RubyClass;
 import org.truffleruby.core.proc.RubyProc;
-import org.truffleruby.language.NotProvided;
+import org.truffleruby.language.Nil;
 import org.truffleruby.language.Visibility;
 import org.truffleruby.language.control.RaiseException;
 
@@ -103,7 +103,7 @@ public abstract class WeakMapNodes {
     public abstract static class EachKeyNode extends YieldingCoreMethodNode {
 
         @Specialization
-        protected RubyWeakMap eachKey(RubyWeakMap map, NotProvided block) {
+        protected RubyWeakMap eachKey(RubyWeakMap map, Nil block) {
             return eachNoBlockProvided(this, map);
         }
 
@@ -120,7 +120,7 @@ public abstract class WeakMapNodes {
     public abstract static class EachValueNode extends YieldingCoreMethodNode {
 
         @Specialization
-        protected RubyWeakMap eachValue(RubyWeakMap map, NotProvided block) {
+        protected RubyWeakMap eachValue(RubyWeakMap map, Nil block) {
             return eachNoBlockProvided(this, map);
         }
 
@@ -137,7 +137,7 @@ public abstract class WeakMapNodes {
     public abstract static class EachNode extends YieldingCoreMethodNode {
 
         @Specialization
-        protected RubyWeakMap each(RubyWeakMap map, NotProvided block) {
+        protected RubyWeakMap each(RubyWeakMap map, Nil block) {
             return eachNoBlockProvided(this, map);
         }
 

--- a/src/main/java/org/truffleruby/core/proc/ProcNodes.java
+++ b/src/main/java/org/truffleruby/core/proc/ProcNodes.java
@@ -190,17 +190,7 @@ public abstract class ProcNodes {
         @Child private CallBlockNode callBlockNode = CallBlockNode.create();
 
         @Specialization
-        protected Object call(RubyProc proc, Object[] args, Nil block) {
-            return callBlockNode.executeCallBlock(
-                    proc.declarationContext,
-                    proc,
-                    ProcOperations.getSelf(proc),
-                    block,
-                    args);
-        }
-
-        @Specialization
-        protected Object call(RubyProc proc, Object[] args, RubyProc block) {
+        protected Object call(RubyProc proc, Object[] args, Object block) {
             return callBlockNode.executeCallBlock(
                     proc.declarationContext,
                     proc,

--- a/src/main/java/org/truffleruby/core/proc/ProcNodes.java
+++ b/src/main/java/org/truffleruby/core/proc/ProcNodes.java
@@ -25,7 +25,7 @@ import org.truffleruby.core.rope.CodeRange;
 import org.truffleruby.core.string.RubyString;
 import org.truffleruby.core.string.StringNodes;
 import org.truffleruby.core.symbol.SymbolNodes;
-import org.truffleruby.language.NotProvided;
+import org.truffleruby.language.Nil;
 import org.truffleruby.language.Visibility;
 import org.truffleruby.language.WarnNode;
 import org.truffleruby.language.arguments.ArgumentDescriptorUtils;
@@ -69,7 +69,7 @@ public abstract class ProcNodes {
         public abstract RubyProc executeProcNew(VirtualFrame frame, RubyClass procClass, Object[] args, Object block);
 
         @Specialization
-        protected RubyProc proc(VirtualFrame frame, RubyClass procClass, Object[] args, NotProvided block,
+        protected RubyProc proc(VirtualFrame frame, RubyClass procClass, Object[] args, Nil block,
                 @Cached FindAndReadDeclarationVariableNode readNode,
                 @Cached ReadCallerFrameNode readCaller,
                 @Cached ProcNewNode recurseNode,
@@ -190,12 +190,12 @@ public abstract class ProcNodes {
         @Child private CallBlockNode callBlockNode = CallBlockNode.create();
 
         @Specialization
-        protected Object call(RubyProc proc, Object[] args, NotProvided block) {
+        protected Object call(RubyProc proc, Object[] args, Nil block) {
             return callBlockNode.executeCallBlock(
                     proc.declarationContext,
                     proc,
                     ProcOperations.getSelf(proc),
-                    nil,
+                    block,
                     args);
         }
 

--- a/src/main/java/org/truffleruby/core/range/RangeNodes.java
+++ b/src/main/java/org/truffleruby/core/range/RangeNodes.java
@@ -25,7 +25,7 @@ import org.truffleruby.core.cast.BooleanCastWithDefaultNodeGen;
 import org.truffleruby.core.cast.ToIntNode;
 import org.truffleruby.core.klass.RubyClass;
 import org.truffleruby.core.proc.RubyProc;
-import org.truffleruby.language.NotProvided;
+import org.truffleruby.language.Nil;
 import org.truffleruby.language.RubyContextNode;
 import org.truffleruby.language.RubyGuards;
 import org.truffleruby.language.RubyNode;
@@ -137,7 +137,7 @@ public abstract class RangeNodes {
             return range;
         }
 
-        private Object eachInternal(VirtualFrame frame, RubyRange range, RubyProc block) {
+        private Object eachInternal(VirtualFrame frame, RubyRange range, Object block) {
             if (eachInternalCall == null) {
                 CompilerDirectives.transferToInterpreterAndInvalidate();
                 eachInternalCall = insert(DispatchNode.create());
@@ -147,13 +147,13 @@ public abstract class RangeNodes {
         }
 
         @Specialization
-        protected Object eachObject(VirtualFrame frame, RubyLongRange range, NotProvided block) {
-            return eachInternal(frame, range, null);
+        protected Object eachObject(VirtualFrame frame, RubyLongRange range, Nil block) {
+            return eachInternal(frame, range, block);
         }
 
         @Specialization
-        protected Object each(VirtualFrame frame, RubyObjectRange range, NotProvided block) {
-            return eachInternal(frame, range, null);
+        protected Object each(VirtualFrame frame, RubyObjectRange range, Nil block) {
+            return eachInternal(frame, range, block);
         }
 
         @Specialization

--- a/src/main/java/org/truffleruby/core/range/RangeNodes.java
+++ b/src/main/java/org/truffleruby/core/range/RangeNodes.java
@@ -152,12 +152,7 @@ public abstract class RangeNodes {
         }
 
         @Specialization
-        protected Object each(VirtualFrame frame, RubyObjectRange range, Nil block) {
-            return eachInternal(frame, range, block);
-        }
-
-        @Specialization
-        protected Object each(VirtualFrame frame, RubyObjectRange range, RubyProc block) {
+        protected Object each(VirtualFrame frame, RubyObjectRange range, Object block) {
             return eachInternal(frame, range, block);
         }
     }

--- a/src/main/java/org/truffleruby/core/string/StringNodes.java
+++ b/src/main/java/org/truffleruby/core/string/StringNodes.java
@@ -831,7 +831,7 @@ public abstract class StringNodes {
         @Child private RopeNodes.BytesNode bytesNode = RopeNodes.BytesNode.create();
 
         @Specialization
-        protected RubyArray bytes(Object string, NotProvided block,
+        protected RubyArray bytes(Object string, Nil block,
                 @CachedLibrary(limit = "2") RubyStringLibrary strings) {
             final Rope rope = strings.getRope(string);
             final byte[] bytes = bytesNode.execute(rope);

--- a/src/main/java/org/truffleruby/core/tracepoint/TracePointNodes.java
+++ b/src/main/java/org/truffleruby/core/tracepoint/TracePointNodes.java
@@ -30,7 +30,7 @@ import org.truffleruby.core.string.RubyString;
 import org.truffleruby.core.string.StringNodes.MakeStringNode;
 import org.truffleruby.core.symbol.RubySymbol;
 import org.truffleruby.core.thread.GetCurrentRubyThreadNode;
-import org.truffleruby.language.NotProvided;
+import org.truffleruby.language.Nil;
 import org.truffleruby.language.Visibility;
 import org.truffleruby.language.arguments.RubyArguments;
 import org.truffleruby.language.control.RaiseException;
@@ -119,7 +119,7 @@ public abstract class TracePointNodes {
     public abstract static class EnableNode extends YieldingCoreMethodNode {
 
         @Specialization
-        protected boolean enable(RubyTracePoint tracePoint, NotProvided block) {
+        protected boolean enable(RubyTracePoint tracePoint, Nil block) {
             boolean setupDone = createEventBindings(getContext(), getLanguage(), tracePoint);
             return !setupDone;
         }
@@ -141,7 +141,7 @@ public abstract class TracePointNodes {
     public abstract static class DisableNode extends YieldingCoreMethodNode {
 
         @Specialization
-        protected Object disable(RubyTracePoint tracePoint, NotProvided block) {
+        protected Object disable(RubyTracePoint tracePoint, Nil block) {
             return disposeEventBindings(tracePoint);
         }
 

--- a/src/main/java/org/truffleruby/debug/TruffleDebugNodes.java
+++ b/src/main/java/org/truffleruby/debug/TruffleDebugNodes.java
@@ -59,6 +59,7 @@ import org.truffleruby.interop.BoxedValue;
 import org.truffleruby.interop.ToJavaStringNode;
 import org.truffleruby.language.ImmutableRubyObject;
 import org.truffleruby.core.string.ImmutableRubyString;
+import org.truffleruby.language.Nil;
 import org.truffleruby.language.NotProvided;
 import org.truffleruby.language.RubyDynamicObject;
 import org.truffleruby.language.RubyRootNode;
@@ -205,21 +206,21 @@ public abstract class TruffleDebugNodes {
 
         @TruffleBoundary
         @Specialization
-        protected Object astMethod(RubyMethod method, NotProvided block) {
+        protected Object astMethod(RubyMethod method, Nil block) {
             ast(method.method);
             return nil;
         }
 
         @TruffleBoundary
         @Specialization
-        protected Object astUnboundMethod(RubyUnboundMethod method, NotProvided block) {
+        protected Object astUnboundMethod(RubyUnboundMethod method, Nil block) {
             ast(method.method);
             return nil;
         }
 
         @TruffleBoundary
         @Specialization
-        protected Object astProc(RubyProc proc, NotProvided block) {
+        protected Object astProc(RubyProc proc, Nil block) {
             ast(proc.callTarget);
             return nil;
         }
@@ -267,21 +268,21 @@ public abstract class TruffleDebugNodes {
 
         @TruffleBoundary
         @Specialization
-        protected Object astMethod(RubyMethod method, NotProvided block) {
+        protected Object astMethod(RubyMethod method, Nil block) {
             printAst(method.method);
             return nil;
         }
 
         @TruffleBoundary
         @Specialization
-        protected Object astUnboundMethod(RubyUnboundMethod method, NotProvided block) {
+        protected Object astUnboundMethod(RubyUnboundMethod method, Nil block) {
             printAst(method.method);
             return nil;
         }
 
         @TruffleBoundary
         @Specialization
-        protected Object astProc(RubyProc proc, NotProvided block) {
+        protected Object astProc(RubyProc proc, Nil block) {
             printAst(proc.callTarget);
             return nil;
         }

--- a/src/main/java/org/truffleruby/language/arguments/ReadBlockFromCurrentFrameArgumentsNode.java
+++ b/src/main/java/org/truffleruby/language/arguments/ReadBlockFromCurrentFrameArgumentsNode.java
@@ -11,12 +11,9 @@ package org.truffleruby.language.arguments;
 
 import org.truffleruby.core.proc.RubyProc;
 import org.truffleruby.language.Nil;
-import org.truffleruby.language.NotProvided;
 import org.truffleruby.language.RubyContextSourceNode;
-import org.truffleruby.language.RubyNode;
 
 import com.oracle.truffle.api.frame.VirtualFrame;
-import com.oracle.truffle.api.profiles.ConditionProfile;
 
 public class ReadBlockFromCurrentFrameArgumentsNode extends RubyContextSourceNode {
 
@@ -25,31 +22,6 @@ public class ReadBlockFromCurrentFrameArgumentsNode extends RubyContextSourceNod
         final Object block = RubyArguments.getBlock(frame);
         assert block instanceof Nil || block instanceof RubyProc : block;
         return block;
-    }
-
-    public static class ConvertNilBlockToNotProvidedNode extends RubyContextSourceNode {
-
-        @Child RubyNode child;
-
-        private final ConditionProfile nilProfile = ConditionProfile.createBinaryProfile();
-
-        public ConvertNilBlockToNotProvidedNode(RubyNode child) {
-            this.child = child;
-        }
-
-        @Override
-        public Object execute(VirtualFrame frame) {
-            final Object block = child.execute(frame);
-
-            assert block instanceof Nil || block instanceof RubyProc : block;
-
-            if (nilProfile.profile(block instanceof Nil)) {
-                return NotProvided.INSTANCE;
-            } else {
-                return block;
-            }
-        }
-
     }
 
 }

--- a/src/main/java/org/truffleruby/language/objects/InitializeClassNode.java
+++ b/src/main/java/org/truffleruby/language/objects/InitializeClassNode.java
@@ -14,6 +14,7 @@ import org.truffleruby.core.klass.RubyClass;
 import org.truffleruby.core.module.ModuleNodes;
 import org.truffleruby.core.module.ModuleNodesFactory;
 import org.truffleruby.core.proc.RubyProc;
+import org.truffleruby.language.Nil;
 import org.truffleruby.language.NotProvided;
 import org.truffleruby.language.RubyContextNode;
 import org.truffleruby.language.control.RaiseException;
@@ -38,7 +39,7 @@ public abstract class InitializeClassNode extends RubyContextNode {
     public abstract RubyClass executeInitialize(RubyClass rubyClass, Object superclass, Object block);
 
     @Specialization
-    protected RubyClass initialize(RubyClass rubyClass, NotProvided superclass, NotProvided block) {
+    protected RubyClass initialize(RubyClass rubyClass, NotProvided superclass, Nil block) {
         return initializeGeneralWithoutBlock(rubyClass, coreLibrary().objectClass, false);
     }
 
@@ -48,7 +49,7 @@ public abstract class InitializeClassNode extends RubyContextNode {
     }
 
     @Specialization
-    protected RubyClass initialize(RubyClass rubyClass, RubyClass superclass, NotProvided block) {
+    protected RubyClass initialize(RubyClass rubyClass, RubyClass superclass, Nil block) {
         return initializeGeneralWithoutBlock(rubyClass, superclass, true);
     }
 


### PR DESCRIPTION
This PR completes the work on #2206 by removing the `ConvertNilBlockToNotProvidedNode` introduced in #2232 and updating all the relevant specializations to expect a `Nil block` rather than a `NotProvided block`. This creates the opportunity to merge pairs of now-identical specializations into a single one expecting an `Object block`.

Shopify#1