### PR TITLE
Fix String#scrub!

### DIFF
--- a/spec/ruby/core/string/scrub_spec.rb
+++ b/spec/ruby/core/string/scrub_spec.rb
@@ -105,4 +105,18 @@ describe "String#scrub!" do
     input.scrub! { |b| "<?>" }
     input.should == "a<?>"
   end
+
+  it "maintains the state of frozen strings that are already valid" do
+    input = "a"
+    input.freeze
+    input.scrub!
+    input.frozen?.should be_true
+  end
+
+  it "preserves the instance variables of already valid strings" do
+    input = "a"
+    input.instance_variable_set(:@a, 'b')
+    input.scrub!
+    input.instance_variable_get(:@a).should == 'b'
+  end
 end

--- a/src/main/ruby/truffleruby/core/string.rb
+++ b/src/main/ruby/truffleruby/core/string.rb
@@ -1019,6 +1019,7 @@ class String
   end
 
   def scrub!(replace = nil, &block)
+    return self if valid_encoding?
     replace(scrub(replace, &block))
     self
   end


### PR DESCRIPTION
Sometimes the TR `string#scrub! ` returns nil when the MRI implementation and the TR `string#scrub`  return a scrubbed string. This PR  fixes the behaviour of `string#scrub! ` without  impacting the behaviour of `string#scrub` (on the test suite that surfaced the issue with `string#scrub! `); and now calls `scrub!` in `scrub`, which seems more common than the other way around,  though I'm not entirely why that ordering would cause this issue.