### PR TITLE
Fix rehash functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Bug fixes:
 * Fix `Thread.handle_interrupt` to defer non-pure interrupts until the end of the `handle_interrupt` block (#2219).
 * Clear and restore errinfo on entry and normal return from methods in C extensions (#2227).
 * Fix extra whitespace in squiggly heredoc with escaped newline (#2238, @wildmaples and @norswap).
-
+* Fix `Hash#rehash` to remove duplicate keys after modifications (#2266, @MattAlp)
 Compatibility:
 
 * Implemented `$LOAD_PATH.resolve_feature_path`.


### PR DESCRIPTION
Working on #2263- `Hash#rehash` currently recalculates hashes, but does not remove duplicate as described in the spec. This PR addresses this by unlinking duplicate entries within a hash when a hash collision and equal values are detected.