### PR TITLE
Add specs for arity in C-ext methods 

### DIFF
--- a/spec/ruby/optional/capi/module_spec.rb
+++ b/spec/ruby/optional/capi/module_spec.rb
@@ -246,10 +246,22 @@ describe "CApiModule" do
       cls.new.test_method.should == :test_method
     end
 
+    it "returns the correct arity of the method in class" do
+      cls = Class.new
+      @m.rb_define_method(cls, "test_method")
+      cls.new.method(:test_method).arity.should == 0
+    end
+
     it "defines a method on a module" do
       mod = Module.new
       @m.rb_define_method(mod, "test_method")
       mod.should have_instance_method(:test_method)
+    end
+
+    it "returns the correct arity of the method in module" do
+      mod = Module.new
+      @m.rb_define_method(mod, "test_method")
+      mod.instance_method(:test_method).arity.should == 0
     end
   end
 
@@ -263,11 +275,22 @@ describe "CApiModule" do
       @mod.test_module_function.should == :test_method
     end
 
+    it "returns the correct arity of the module function" do
+      @mod.method(:test_module_function).arity.should == 0
+    end
+
     it "defines a private instance method" do
       cls = Class.new
       cls.include(@mod)
 
       cls.should have_private_instance_method(:test_module_function)
+    end
+
+    it "returns the correct arity for private instance method" do
+      cls = Class.new
+      cls.include(@mod)
+
+      @mod.instance_method(:test_module_function).arity.should == 0
     end
   end
 

--- a/spec/tags/optional/capi/module_tags.txt
+++ b/spec/tags/optional/capi/module_tags.txt
@@ -1,0 +1,4 @@
+fails:CApiModule rb_define_method returns the correct arity of the method in class
+fails:CApiModule rb_define_method returns the correct arity of the method in module
+fails:CApiModule rb_define_module_function returns the correct arity of the module function
+fails:CApiModule rb_define_module_function returns the correct arity for private instance method


### PR DESCRIPTION
Related to issue: https://github.com/oracle/truffleruby/issues/2268

Tagged these specs as it reflects the bug we described in the issue: 

```
1)
CApiModule rb_define_method returns the correct arity of the method in class FAILED
Expected -1 == 0
to be truthy but was false
/Users/mapleong/src/github.com/Shopify/truffleruby/spec/ruby/optional/capi/module_spec.rb:252:in `block (3 levels) in <top (required)>'
/Users/mapleong/src/github.com/Shopify/truffleruby/spec/ruby/optional/capi/module_spec.rb:7:in `<top (required)>'
```