### PR TITLE
Fix incorrect arity for C-extension methods

### DIFF
--- a/lib/truffle/truffle/cext_ruby.rb
+++ b/lib/truffle/truffle/cext_ruby.rb
@@ -43,7 +43,12 @@ module Truffle::CExt
       res
     end
 
-    mod.define_method(name, method_body)
+    # Even if the argc is -2, the arity number
+    # is still any number of arguments, -1
+    arity = argc == -2 ? -1 : argc
+
+    method_body_with_arity = Primitive.proc_specify_arity(method_body, arity)
+    mod.define_method(name, method_body_with_arity)
   end
 
   private

--- a/src/main/java/org/truffleruby/core/proc/RubyProc.java
+++ b/src/main/java/org/truffleruby/core/proc/RubyProc.java
@@ -74,6 +74,22 @@ public class RubyProc extends RubyDynamicObject implements ObjectGraphNode {
         this.declarationContext = declarationContext;
     }
 
+    public RubyProc withSharedMethodInfo(SharedMethodInfo newSharedMethodInfo, RubyClass newRubyClass, Shape newShape) {
+        return new RubyProc(
+                newRubyClass,
+                newShape,
+                type,
+                newSharedMethodInfo,
+                callTargets,
+                callTarget,
+                declarationFrame,
+                declarationVariables,
+                method,
+                block,
+                frameOnStackMarker,
+                declarationContext);
+    }
+
     @Override
     public void getAdjacentObjects(Set<Object> reachable) {
         ObjectGraph.getObjectsInFrame(declarationFrame, reachable);

--- a/src/main/java/org/truffleruby/language/methods/SharedMethodInfo.java
+++ b/src/main/java/org/truffleruby/language/methods/SharedMethodInfo.java
@@ -91,6 +91,18 @@ public class SharedMethodInfo {
                 newArgs);
     }
 
+    public SharedMethodInfo withArity(Arity newArity) {
+        return new SharedMethodInfo(
+                sourceSection,
+                lexicalScope,
+                newArity,
+                backtraceName,
+                blockDepth,
+                parseName,
+                notes,
+                argumentDescriptors);
+    }
+
     public SourceSection getSourceSection() {
         return sourceSection;
     }


### PR DESCRIPTION
Fix: https://github.com/oracle/truffleruby/issues/2268

Changes: 
* New helper contructor for `SharedMethodInfo` to modify Arity 
* Add and use primitive function for a Proc with "corrected" Arity
* Delete tags for the related specs

Questions: 

My assumptions for this logic is that when `argc` is -1 or less, there is a splat array (rest argument): 
```java
            if (argc <= -1) {
                newArity = new Arity(0, oldArity.getOptional(), true); // TRUE for hasRest
            } else {
                newArity = new Arity(argc, oldArity.getOptional(), false); // FALSE for hasRest
            }
```

The arity number then gets computed in `Arity#computeArityNumber`.

I am not sure if logic above is correct though.
