### PR TITLE
Add spec for keyword argument caller to allocate/reuse hash object

### DIFF
--- a/spec/ruby/language/method_spec.rb
+++ b/spec/ruby/language/method_spec.rb
@@ -817,6 +817,17 @@ describe "A method" do
         m(1, a: 2, b: 3).should == [1, {a: 2, b: 3}]
         -> { m("a" => 1, b: 2) }.should raise_error(ArgumentError)
       end
+
+      evaluate <<-ruby do
+          def m(a)
+            a.delete(:one); a
+          end
+        ruby
+        h = { one: 1, two: 2 }
+
+        m(**h).should == { two: 2 }
+        m(**h).should equal(h)
+      end
     end
 
     evaluate <<-ruby do

--- a/spec/ruby/language/method_spec.rb
+++ b/spec/ruby/language/method_spec.rb
@@ -777,7 +777,18 @@ describe "A method" do
           m("a" => 1, b: 2).should == [{"a" => 1, b: 2}, {}]
         end
       end
+
+      evaluate <<-ruby do
+        def m(a)
+          a.delete(:one); a
+        end
+      ruby
+      h = { one: 1, two: 2 }
+
+      m(**h).should == { two: 2 }
+      m(**h).should_not equal(h)
     end
+  end
 
     ruby_version_is "3.0" do
       evaluate <<-ruby do

--- a/spec/tags/language/method_tags.txt
+++ b/spec/tags/language/method_tags.txt
@@ -1,5 +1,6 @@
 fails:A method assigns local variables from method parameters for definition 'def m() end'
 fails:A method assigns local variables from method parameters for definition 'def m(*a) a end'
+fails:"A method assigns local variables from method parameters for definition \n    def m(a)\n      a.delete(:one); a\n    end"
 fails:A method assigns local variables from method parameters for definition 'def m(a = nil, **k) [a, k] end'
 fails:A method assigns local variables from method parameters for definition 'def m(*a, **k) [a, k] end'
 fails:A method assigns local variables from method parameters for definition 'def m(a, **nil); a end;'


### PR DESCRIPTION
Issue: https://github.com/oracle/truffleruby/issues/2282

I've tested this on MRI versions: 
* 2.4.10, 2.5.8, 2.6.6, 2.7.2 
* And 3.0.0 which has a different behaviour than the previous versions 


I've created two spec cases: 
* For <3.0.0: ensures that a new Hash is allocated when the method is called with `**hsh` argument.
* 3.0.0: ensures that the same hash is reused.

