### PR TITLE
Add spec for small Rational passed to Time::at

### DIFF
--- a/spec/ruby/core/time/at_spec.rb
+++ b/spec/ruby/core/time/at_spec.rb
@@ -38,6 +38,14 @@ describe "Time.at" do
         Time.at(BigDecimal('1.1')).to_f.should == 1.1
       end
     end
+
+    describe "passed Rational" do
+      it "returns Time with correct nanosecond and microsecond" do
+        t = Time.at(Rational(1_486_570_508_539_759, 1_000_000))
+        t.usec.should == 539_759
+        t.nsec.should == 539_759_000
+      end
+    end
   end
 
   describe "passed Time" do

--- a/src/main/ruby/truffleruby/core/time.rb
+++ b/src/main/ruby/truffleruby/core/time.rb
@@ -336,7 +336,17 @@ class Time
           raise ArgumentError, "unexpected unit: #{unit}"
         end
 
-      usec = 0 if Primitive.undefined?(usec)
+      if Primitive.undefined?(usec) && Primitive.object_kind_of?(sec, Rational)
+        rational = Truffle::Type.coerce_to_exact_num(sec)
+        seconds, fractional_seconds = rational.divmod(1)
+        nano_fractional_seconds = fractional_seconds * 1_000_000_000
+
+        time = Primitive.time_at self, seconds.to_i, nano_fractional_seconds.to_i
+        time = Primitive.time_localtime(time, offset) if offset
+        return time
+      elsif Primitive.undefined?(usec)
+        usec = 0
+      end
 
       s = Truffle::Type.coerce_to_exact_num(sec)
       u = Truffle::Type.coerce_to_exact_num(usec)


### PR DESCRIPTION
Fix: https://github.com/oracle/truffleruby/issues/2286

Changes: 
* Add a spec covering small Rational objects
* Add a fix:
  * Reassigns the `sec` and `usec` variables within the method so it continues to evaluate in the same fashion as `Time::at(seconds, microseconds_with_frac)`.
  * The Rational object is `divmod` into the denominator and numerator. The numerator is the `sec` and the denominator is the fractional seconds which is then converted into `usec` accordingly. 
