### PR TITLE
Several gems need at least some value for total_allocated_objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ Compatibility:
 * Implemented the `Time.at` `in:` parameter.
 * Implemented `Kernel#raise` `cause` parameter.
 * Improved compatibility of `Signal.trap` and `Kernel#trap` (#2287, @chrisseaton).
+* Implemented `GC.stat(:total_allocated_objects)` as `0` (#2292, @chrisseaton).
 
 Performance:
 

--- a/doc/user/compatibility.md
+++ b/doc/user/compatibility.md
@@ -157,6 +157,10 @@ Additionally, `FPE`, `ILL`, `KILL`, `SEGV`, `STOP`, and `VTALRM` cannot be trapp
 
 When TruffleRuby is run as part of a polyglot application, any signals that are handled by another language become unavailable for TruffleRuby to trap.
 
+### GC statistics
+
+TruffleRuby provides similar `GC.stat` statistics to MRI, but not all statistics are available, and some statistics may be approximations. Use `GC.stat.keys` to see which are provided with real or approximate values. Missing values will return `0`.
+
 ## Features with Very Low Performance
 
 ### `ObjectSpace`

--- a/spec/ruby/core/gc/stat_spec.rb
+++ b/spec/ruby/core/gc/stat_spec.rb
@@ -11,6 +11,10 @@ describe "GC.stat" do
     GC.stat(:count).should be_kind_of(Integer)
   end
 
+  it "returns nil for a non-existent stat" do
+    GC.stat(:does_not_exist).should be_nil
+  end
+
   it "increases count after GC is run" do
     count = GC.stat(:count)
     GC.start

--- a/spec/ruby/core/gc/stat_spec.rb
+++ b/spec/ruby/core/gc/stat_spec.rb
@@ -11,10 +11,6 @@ describe "GC.stat" do
     GC.stat(:count).should be_kind_of(Integer)
   end
 
-  it "returns nil for a non-existent stat" do
-    GC.stat(:does_not_exist).should be_nil
-  end
-
   it "increases count after GC is run" do
     count = GC.stat(:count)
     GC.start

--- a/spec/ruby/core/gc/stat_spec.rb
+++ b/spec/ruby/core/gc/stat_spec.rb
@@ -1,17 +1,14 @@
 require_relative '../../spec_helper'
 
 describe "GC.stat" do
-  it "supports access by key" do
-    keys = [:heap_free_slots, :total_allocated_objects, :count]
-    keys.each do |key|
-      GC.stat(key).should be_kind_of(Integer)
-    end
-  end
-
   it "returns hash of values" do
     stat = GC.stat
     stat.should be_kind_of(Hash)
     stat.keys.should include(:count)
+  end
+
+  it "can return a single value" do
+    GC.stat(:count).should be_kind_of(Integer)
   end
 
   it "increases count after GC is run" do
@@ -24,5 +21,17 @@ describe "GC.stat" do
     count = GC.stat(:major_gc_count)
     GC.start
     GC.stat(:major_gc_count).should > count
+  end
+
+  it "provides some number for count" do
+    GC.stat(:count).should be_kind_of(Integer)
+  end
+
+  it "provides some number for heap_free_slots" do
+    GC.stat(:heap_free_slots).should be_kind_of(Integer)
+  end
+
+  it "provides some number for total_allocated_objects" do
+    GC.stat(:total_allocated_objects).should be_kind_of(Integer)
   end
 end

--- a/src/main/ruby/truffleruby/core/gc.rb
+++ b/src/main/ruby/truffleruby/core/gc.rb
@@ -130,12 +130,10 @@ module GC
       end
     end
 
-    return stat unless option
-
-    if stat[option]
+    if option
       stat[option]
     else
-      0
+      stat
     end
   end
 

--- a/src/main/ruby/truffleruby/core/gc.rb
+++ b/src/main/ruby/truffleruby/core/gc.rb
@@ -89,20 +89,12 @@ module GC
       heap_available_slots: committed,
       heap_live_slots: used,
       heap_free_slots: committed - used,
-      total_allocated_objects: 0,
       used: used,
       committed: committed,
       init: init,
       max: max,
-      peak_used: 0,
-      peak_committed: 0,
-      peak_init: 0,
-      peak_max: 0,
-      last_used: 0,
-      last_committed: 0,
-      last_init: 0,
-      last_max: 0,
     }
+    stat.default = 0
 
     memory_pool_names.each_with_index do |memory_pool_name, i|
       # Populate memory pool specific stats

--- a/src/main/ruby/truffleruby/core/gc.rb
+++ b/src/main/ruby/truffleruby/core/gc.rb
@@ -76,10 +76,10 @@ module GC
   end
 
   def self.stat(option = nil)
-    time, count, minor_count, major_count, unknown_count, heap, memory_pool_names, memory_pool_info = Primitive.gc_stat()
+    time, count, minor_count, major_count, unknown_count, heap, memory_pool_names, memory_pool_info = Primitive.gc_stat
     used, committed, init, max = heap
 
-    # Initialize stat for statistics that come from memory pools, and populate it with some final stats
+    # Initialize stat for statistics that come from memory pools, and populate it with some final stats (ordering similar to MRI)
     stat = {
       count: count,
       time: time,
@@ -89,6 +89,7 @@ module GC
       heap_available_slots: committed,
       heap_live_slots: used,
       heap_free_slots: committed - used,
+      total_allocated_objects: 0,
       used: used,
       committed: committed,
       init: init,


### PR DESCRIPTION
Fixes #1681.

For example `activesupport` and `shopify_metrics` (internal gem). `activesupport` has logic to detect JRuby and give it the value `0`, so we might as well just report `0` in the first place.