### PR TITLE
Make interpolated strings frozen

### DIFF
--- a/spec/ruby/language/string_spec.rb
+++ b/spec/ruby/language/string_spec.rb
@@ -308,4 +308,14 @@ describe "Ruby String interpolation" do
       eval(code).should_not.frozen?
     end
   end
+
+  ruby_version_is ""..."3.0" do
+    it "creates a frozen String when # frozen-string-literal: true is used" do
+      code = <<~'RUBY'
+      # frozen-string-literal: true
+      "a#{6*7}c"
+      RUBY
+      eval(code).should.frozen?
+    end
+  end
 end

--- a/src/main/java/org/truffleruby/core/string/InterpolatedStringNode.java
+++ b/src/main/java/org/truffleruby/core/string/InterpolatedStringNode.java
@@ -28,10 +28,13 @@ public final class InterpolatedStringNode extends RubyContextSourceNode {
 
     private final Rope emptyRope;
 
-    public InterpolatedStringNode(ToSNode[] children, Encoding encoding) {
+    private final boolean frozen;
+
+    public InterpolatedStringNode(ToSNode[] children, Encoding encoding, boolean frozen) {
         assert children.length > 0;
         this.children = children;
         this.emptyRope = RopeOperations.emptyRope(encoding);
+        this.frozen = frozen;
     }
 
     @ExplodeLoop
@@ -47,6 +50,9 @@ public final class InterpolatedStringNode extends RubyContextSourceNode {
             builder = executeStringAppend(builder, toInterpolate);
         }
 
+        if (frozen) {
+            builder.freeze();
+        }
 
         return builder;
     }

--- a/src/main/java/org/truffleruby/parser/ast/DStrParseNode.java
+++ b/src/main/java/org/truffleruby/parser/ast/DStrParseNode.java
@@ -39,14 +39,24 @@ import org.truffleruby.parser.ast.visitor.NodeVisitor;
 
 /** A string which contains some dynamic elements which needs to be evaluated (introduced by #). */
 public class DStrParseNode extends DParseNode implements ILiteralNode {
+    private boolean frozen;
 
-    public DStrParseNode(SourceIndexLength position, Encoding encoding) {
+    public DStrParseNode(SourceIndexLength position, Encoding encoding, boolean frozen) {
         super(position, encoding);
+        setFrozen(frozen);
     }
 
     @Override
     public NodeType getNodeType() {
         return NodeType.DSTRNODE;
+    }
+
+    public boolean isFrozen() {
+        return frozen;
+    }
+
+    public void setFrozen(boolean frozen) {
+        this.frozen = frozen;
     }
 
     /** Accept for the visitor pattern.

--- a/src/main/java/org/truffleruby/parser/parser/ParserSupport.java
+++ b/src/main/java/org/truffleruby/parser/parser/ParserSupport.java
@@ -1212,8 +1212,8 @@ public class ParserSupport {
         this.lexer = lexer;
     }
 
-    public DStrParseNode createDStrNode(SourceIndexLength position) {
-        return new DStrParseNode(position, lexer.getEncoding());
+    public DStrParseNode createDStrNode(SourceIndexLength position, boolean frozen) {
+        return new DStrParseNode(position, lexer.getEncoding(), frozen);
     }
 
     public ParseNodeTuple createKeyValue(ParseNode key, ParseNode value) {
@@ -1269,12 +1269,12 @@ public class ParserSupport {
         }
 
         if (head instanceof EvStrParseNode) {
-            head = createDStrNode(head.getPosition()).add(head);
+            head = createDStrNode(head.getPosition(), false).add(head);
         }
 
         if (lexer.getHeredocIndent() > 0) {
             if (head instanceof StrParseNode) {
-                head = createDStrNode(head.getPosition()).add(head);
+                head = createDStrNode(head.getPosition(), false).add(head);
                 return list_append(head, tail);
             } else if (head instanceof DStrParseNode) {
                 return list_append(head, tail);
@@ -1297,7 +1297,10 @@ public class ParserSupport {
 
         } else if (tail instanceof DStrParseNode) {
             if (head instanceof StrParseNode) { // Str + oDStr -> Dstr(Str, oDStr.contents)
-                DStrParseNode newDStr = new DStrParseNode(head.getPosition(), ((DStrParseNode) tail).getEncoding());
+                DStrParseNode newDStr = new DStrParseNode(
+                        head.getPosition(),
+                        ((DStrParseNode) tail).getEncoding(),
+                        false);
                 newDStr.add(head);
                 newDStr.add(tail);
                 return newDStr;
@@ -1308,12 +1311,15 @@ public class ParserSupport {
 
         // tail must be EvStrParseNode at this point
         if (head instanceof StrParseNode) {
-
+            StrParseNode front = (StrParseNode) head;
             //Do not add an empty string node
-            if (((StrParseNode) head).getValue().byteLength() == 0) {
-                head = createDStrNode(head.getPosition());
+            if (front.getValue().byteLength() == 0) {
+                head = createDStrNode(
+                        head.getPosition(),
+                        front.isFrozen());
             } else {
-                head = createDStrNode(head.getPosition()).add(head);
+                head = createDStrNode(head.getPosition(), front.isFrozen())
+                        .add(head);
             }
         }
         return ((DStrParseNode) head).add(tail);

--- a/src/main/java/org/truffleruby/parser/parser/RubyParser.java
+++ b/src/main/java/org/truffleruby/parser/parser/RubyParser.java
@@ -3119,7 +3119,7 @@ states[477] = (support, lexer, yyVal, yyVals, yyTop) -> {
     return yyVal;
 };
 states[479] = (support, lexer, yyVal, yyVals, yyTop) -> {
-    yyVal = ((ParseNode)yyVals[0+yyTop]) instanceof EvStrParseNode ? new DStrParseNode(((ParseNode)yyVals[0+yyTop]).getPosition(), lexer.getEncoding()).add(((ParseNode)yyVals[0+yyTop])) : ((ParseNode)yyVals[0+yyTop]);
+    yyVal = ((ParseNode)yyVals[0+yyTop]) instanceof EvStrParseNode ? new DStrParseNode(((ParseNode)yyVals[0+yyTop]).getPosition(), lexer.getEncoding(), support.getConfiguration().isFrozenStringLiteral()).add(((ParseNode)yyVals[0+yyTop])) : ((ParseNode)yyVals[0+yyTop]);
     /*
     NODE *node = $1;
     if (!node) {
@@ -3181,7 +3181,7 @@ states[487] = (support, lexer, yyVal, yyVals, yyTop) -> {
     return yyVal;
 };
 states[488] = (support, lexer, yyVal, yyVals, yyTop) -> {
-    yyVal = ((ListParseNode)yyVals[-2+yyTop]).add(((ParseNode)yyVals[-1+yyTop]) instanceof EvStrParseNode ? new DStrParseNode(((ListParseNode)yyVals[-2+yyTop]).getPosition(), lexer.getEncoding()).add(((ParseNode)yyVals[-1+yyTop])) : ((ParseNode)yyVals[-1+yyTop]));
+    yyVal = ((ListParseNode)yyVals[-2+yyTop]).add(((ParseNode)yyVals[-1+yyTop]) instanceof EvStrParseNode ? new DStrParseNode(((ListParseNode)yyVals[-2+yyTop]).getPosition(), lexer.getEncoding(), false).add(((ParseNode)yyVals[-1+yyTop])) : ((ParseNode)yyVals[-1+yyTop]));
     return yyVal;
 };
 states[489] = (support, lexer, yyVal, yyVals, yyTop) -> {
@@ -3856,7 +3856,7 @@ states[636] = (support, lexer, yyVal, yyVals, yyTop) -> {
 };
 states[637] = (support, lexer, yyVal, yyVals, yyTop) -> {
     if (((ParseNode)yyVals[-2+yyTop]) instanceof StrParseNode) {
-        DStrParseNode dnode = new DStrParseNode(support.getPosition(((ParseNode)yyVals[-2+yyTop])), lexer.getEncoding());
+        DStrParseNode dnode = new DStrParseNode(support.getPosition(((ParseNode)yyVals[-2+yyTop])), lexer.getEncoding(), false);
         dnode.add(((ParseNode)yyVals[-2+yyTop]));
         yyVal = support.createKeyValue(new DSymbolParseNode(support.getPosition(((ParseNode)yyVals[-2+yyTop])), dnode), ((ParseNode)yyVals[0+yyTop]));
     } else if (((ParseNode)yyVals[-2+yyTop]) instanceof DStrParseNode) {

--- a/src/main/java/org/truffleruby/parser/parser/RubyParser.y
+++ b/src/main/java/org/truffleruby/parser/parser/RubyParser.y
@@ -2054,7 +2054,7 @@ literal         : numeric {
                 | dsym
 
 strings         : string {
-                    $$ = $1 instanceof EvStrParseNode ? new DStrParseNode($1.getPosition(), lexer.getEncoding()).add($1) : $1;
+                    $$ = $1 instanceof EvStrParseNode ? new DStrParseNode($1.getPosition(), lexer.getEncoding(), support.getConfiguration().isFrozenStringLiteral()).add($1) : $1;
                     /*
                     NODE *node = $1;
                     if (!node) {
@@ -2114,7 +2114,7 @@ word_list       : /* none */ {
                     $$ = new ArrayParseNode(lexer.getPosition());
                 }
                 | word_list word ' ' {
-                     $$ = $1.add($2 instanceof EvStrParseNode ? new DStrParseNode($1.getPosition(), lexer.getEncoding()).add($2) : $2);
+                     $$ = $1.add($2 instanceof EvStrParseNode ? new DStrParseNode($1.getPosition(), lexer.getEncoding(), false).add($2) : $2);
                 }
 
 word            : string_content {
@@ -2711,7 +2711,7 @@ assoc           : arg_value tASSOC arg_value {
                 }
                 | tSTRING_BEG string_contents tLABEL_END arg_value {
                     if ($2 instanceof StrParseNode) {
-                        DStrParseNode dnode = new DStrParseNode(support.getPosition($2), lexer.getEncoding());
+                        DStrParseNode dnode = new DStrParseNode(support.getPosition($2), lexer.getEncoding(), false);
                         dnode.add($2);
                         $$ = support.createKeyValue(new DSymbolParseNode(support.getPosition($2), dnode), $4);
                     } else if ($2 instanceof DStrParseNode) {


### PR DESCRIPTION
This PR attempts to solve https://github.com/oracle/truffleruby/issues/2303 by making strings that were built using interpolation frozen.

```
# frozen_string_literal: true
p "foo #{14}".frozen?
```

Before this patch, the line above printed `false`. With this patch it prints `true`. We think this better aligns with Ruby 2.7 behaviour, given that's the one that TruffleRuby aims to target: `truffleruby 21.1.0-dev-90afa7e8, like ruby 2.7.2`.