### PR TITLE
Do not rely on exceptions in Struct#dig

### DIFF
--- a/spec/ruby/core/struct/dig_spec.rb
+++ b/spec/ruby/core/struct/dig_spec.rb
@@ -10,6 +10,12 @@ describe "Struct#dig" do
     @instance.dig(:a, :a).should == { b: [1, 2, 3] }
   end
 
+  it "returns the value by the index" do
+    instance = Struct.new(:a, :b).new(:one, :two)
+    instance.dig(0).should == :one
+    instance.dig(1).should == :two
+  end
+
   it "returns the nested value specified if the sequence includes an index" do
     @instance.dig(:a, :a, :b, 0).should == 1
   end

--- a/src/main/ruby/truffleruby/core/struct.rb
+++ b/src/main/ruby/truffleruby/core/struct.rb
@@ -252,13 +252,22 @@ class Struct
     _attrs[var]
   end
 
-  def dig(key, *more)
-    result = nil
-    begin
-      result = self[key]
-    rescue IndexError, NameError
-      nil # nothing found with key
+  private def read_or_nil(var)
+    case var
+    when Symbol, String
+      return unless _attrs.include?(var.to_sym)
+    else
+      var = Integer(var)
+      a_len = _attrs.length
+      return if (var > a_len - 1) || (var < -a_len)
+      var = _attrs[var]
     end
+
+    Primitive.object_hidden_var_get(self, var)
+  end
+
+  def dig(key, *more)
+    result = read_or_nil(key)
     if Primitive.nil?(result) || more.empty?
       result
     else

--- a/src/main/ruby/truffleruby/core/truffle/diggable.rb
+++ b/src/main/ruby/truffleruby/core/truffle/diggable.rb
@@ -29,11 +29,7 @@ module Truffle::Diggable
       when Array
         obj = obj.at(idx)
       when Struct
-        begin
-          obj = obj[idx]
-        rescue IndexError, NameError
-          obj = nil
-        end
+        obj = obj.__send__(:read_or_nil, idx)
       end
 
       return nil if Primitive.nil?(obj)


### PR DESCRIPTION
This attempts to solve https://github.com/oracle/truffleruby/issues/2299.

Not relying on exception flow shows much better perf in interpreter mode.

```ruby
require 'benchmark/ips'

puts RUBY_DESCRIPTION

struct = Struct.new(:foo).new(14)

Benchmark.ips do |x|
  x.report('found') do
      struct[:foo]
  end

  x.report('not-found') do
    struct.dig(:bar)
  end

  x.compare!
end
```

**Before**

```
$ jt ruby demo.rb
Using Interpreted TruffleRuby: mxbuild/truffleruby-jvm
$ /src/github.com/shopify/truffleruby/mxbuild/truffleruby-jvm/languages/ruby/bin/ruby \
  --experimental-options \
  --core-load-path=/src/github.com/shopify/truffleruby/src/main/ruby/truffleruby \
  demo.rb
[ruby] WARNING gem paths: /usr/local/bundle are not marked as installed by TruffleRuby. They might belong to another Ruby implementation and break unexpectedly. Configure your Ruby manager to use TruffleRuby, or `unset GEM_HOME GEM_PATH`. See https://github.com/oracle/truffleruby/blob/master/doc/user/ruby-managers.md
truffleruby 21.1.0-dev-2855d7c9, like ruby 2.7.2, Interpreted JVM [x86_64-linux]
Warming up --------------------------------------
               found    57.241k i/100ms
           not-found     5.873k i/100ms
Calculating -------------------------------------
               found    541.688k (±13.0%) i/s -      2.690M in   5.073909s
           not-found     56.472k (±13.2%) i/s -    281.904k in   5.079920s

Comparison:
               found:   541687.5 i/s
           not-found:    56472.2 i/s - 9.59x  (± 0.00) slower
```

**After**

```
$ jt ruby demo.rb
Using Interpreted TruffleRuby: mxbuild/truffleruby-jvm
$ /src/github.com/shopify/truffleruby/mxbuild/truffleruby-jvm/languages/ruby/bin/ruby \
  --experimental-options \
  --core-load-path=/src/github.com/shopify/truffleruby/src/main/ruby/truffleruby \
  demo.rb
[ruby] WARNING gem paths: /usr/local/bundle are not marked as installed by TruffleRuby. They might belong to another Ruby implementation and break unexpectedly. Configure your Ruby manager to use TruffleRuby, or `unset GEM_HOME GEM_PATH`. See https://github.com/oracle/truffleruby/blob/master/doc/user/ruby-managers.md
truffleruby 21.1.0-dev-2855d7c9, like ruby 2.7.2, Interpreted JVM [x86_64-linux]
Warming up --------------------------------------
               found    57.851k i/100ms
           not-found    52.936k i/100ms
Calculating -------------------------------------
               found    546.247k (± 3.8%) i/s -      2.777M in   5.091750s
           not-found    536.844k (± 2.0%) i/s -      2.700M in   5.030927s

Comparison:
               found:   546247.3 i/s
           not-found:   536844.3 i/s - same-ish: difference falls within error

```

