### PR TITLE
Support precision when formatting string

### DIFF
--- a/spec/ruby/core/kernel/format_spec.rb
+++ b/spec/ruby/core/kernel/format_spec.rb
@@ -11,4 +11,20 @@ describe "Kernel.format" do
   it "is accessible as a module function" do
     Kernel.format("%s", "hello").should == "hello"
   end
+
+  it "formats string with precision" do
+    Kernel.format("%.3s", "hello").should == "hel"
+    Kernel.format("%-3.3s", "hello").should == "hel"
+  end
+
+  describe "on multibyte strings" do
+    it "formats string with precision" do
+      Kernel.format("%.3s", "hello".encode('UTF-16LE')).should == "hel".encode('UTF-16LE')
+    end
+
+    it "preserves encoding" do
+      str = format('%s', 'foobar'.encode('UTF-16LE'))
+      str.encoding.to_s.should == "UTF-16LE"
+    end
+  end
 end

--- a/spec/tags/core/kernel/format_tags.txt
+++ b/spec/tags/core/kernel/format_tags.txt
@@ -1,0 +1,2 @@
+fails:Kernel.format on multibyte strings formats string with precision
+fails:Kernel.format on multibyte strings preserves encoding

--- a/src/main/java/org/truffleruby/core/format/TruncateStringNode.java
+++ b/src/main/java/org/truffleruby/core/format/TruncateStringNode.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2015, 2020 Oracle and/or its affiliates. All rights reserved. This
+ * code is released under a tri EPL/GPL/LGPL license. You can use it,
+ * redistribute it and/or modify it under the terms of the:
+ *
+ * Eclipse Public License version 2.0, or
+ * GNU General Public License version 2, or
+ * GNU Lesser General Public License version 2.1.
+ */
+package org.truffleruby.core.format;
+
+import com.oracle.truffle.api.dsl.NodeChild;
+import com.oracle.truffle.api.dsl.Specialization;
+import org.truffleruby.core.string.RubyString;
+import org.truffleruby.core.string.StringNodes;
+import org.truffleruby.core.string.StringNodesFactory.StringSubstringPrimitiveNodeFactory;
+
+@NodeChild(value = "string", type = FormatNode.class)
+public abstract class TruncateStringNode extends FormatNode {
+    @Child private StringNodes.StringSubstringPrimitiveNode substringNode = StringSubstringPrimitiveNodeFactory
+            .create(null);
+    private final int size;
+
+    public abstract Object execute(Object string);
+
+    public TruncateStringNode(Integer size) {
+        this.size = size;
+    }
+
+    @Specialization
+    protected Object truncate(RubyString string) {
+        return substringNode.execute(string, 0, size);
+    }
+}

--- a/src/main/java/org/truffleruby/core/format/pack/SimplePackTreeBuilder.java
+++ b/src/main/java/org/truffleruby/core/format/pack/SimplePackTreeBuilder.java
@@ -158,6 +158,7 @@ public class SimplePackTreeBuilder implements SimplePackListener {
                         "to_str",
                         false,
                         Nil.INSTANCE,
+                        null,
                         new SourceNode())));
     }
 
@@ -184,6 +185,7 @@ public class SimplePackTreeBuilder implements SimplePackListener {
                         "to_s",
                         true,
                         Nil.INSTANCE,
+                        null,
                         new SourceNode())));
     }
 
@@ -201,6 +203,7 @@ public class SimplePackTreeBuilder implements SimplePackListener {
                         "to_str",
                         false,
                         Nil.INSTANCE,
+                        null,
                         new SourceNode())));
     }
 
@@ -385,6 +388,7 @@ public class SimplePackTreeBuilder implements SimplePackListener {
                         "to_str",
                         false,
                         Nil.INSTANCE,
+                        null,
                         new SourceNode())));
 
     }
@@ -401,6 +405,7 @@ public class SimplePackTreeBuilder implements SimplePackListener {
                         "to_str",
                         false,
                         Nil.INSTANCE,
+                        null,
                         new SourceNode())));
     }
 
@@ -423,6 +428,7 @@ public class SimplePackTreeBuilder implements SimplePackListener {
                         "to_str",
                         false,
                         Nil.INSTANCE,
+                        null,
                         new SourceNode())));
 
     }

--- a/src/main/java/org/truffleruby/core/format/printf/PrintfSimpleTreeBuilder.java
+++ b/src/main/java/org/truffleruby/core/format/printf/PrintfSimpleTreeBuilder.java
@@ -183,7 +183,13 @@ public class PrintfSimpleTreeBuilder {
 
                                 if (config.getAbsoluteArgumentIndex() == null && config.getNamesBytes() == null) {
                                     conversionNode = ReadStringNodeGen
-                                            .create(true, conversionMethodName, false, EMPTY_BYTES, new SourceNode());
+                                            .create(
+                                                    true,
+                                                    conversionMethodName,
+                                                    false,
+                                                    EMPTY_BYTES,
+                                                    config.getPrecision(),
+                                                    new SourceNode());
                                 } else {
                                     conversionNode = ToStringNodeGen
                                             .create(true, conversionMethodName, false, EMPTY_BYTES, valueNode);


### PR DESCRIPTION
Closes https://github.com/oracle/truffleruby/issues/2281

Something like `format("%.3s", "abc. this is supposed to be truncated")` wasn't working as expected on TruffleRuby. This PR fixes that by checking `precision` of formatting config.