### PR TITLE
Add barebone Ruby interface for ConcurrentHashMap

### DIFF
--- a/spec/truffle/truffleruby/concurrent_hash_map_spec.rb
+++ b/spec/truffle/truffleruby/concurrent_hash_map_spec.rb
@@ -1,0 +1,153 @@
+require_relative '../../ruby/spec_helper'
+
+describe "TruffleRuby::ConcurrentHashMap" do
+  before do
+    @h = TruffleRuby::ConcurrentHashMap.new
+  end
+
+  it "#[] of a new instance is empty" do
+    @h[:empty].should equal nil
+  end
+
+  it "#[]= creates a new key value pair" do
+    new_value = "bar"
+    @h[:foo] = new_value
+    @h[:foo].should equal new_value
+  end
+
+  it "#compute_if_absent computes and stores new value for key if key is absent" do
+    expected_value = "value for foobar"
+    @h.compute_if_absent(:foobar) { expected_value }.should equal expected_value
+
+    @h[:foobar].should equal expected_value
+  end
+
+  it "#compute_if_present computes and stores new value for key if key is present" do
+    expected_value = "new value"
+    @h[:foobar] = "old value"
+    @h.compute_if_present(:foobar) { expected_value }.should equal expected_value
+
+    @h[:foobar].should equal expected_value
+  end
+
+  it "#compute computes and stores new value" do
+    expected_value = "new value"
+    @h[:foobar] = "old value"
+    @h.compute(:foobar) { expected_value }.should equal expected_value
+
+    @h[:foobar].should equal expected_value
+  end
+
+  it "#merge_pair stores value if key is absent" do
+    new_value = "bloop"
+    @h.merge_pair(:foobar, new_value).should equal new_value
+    @h[:foobar].should equal new_value
+  end
+
+  it "#merge_pair stores computed value if key is present" do
+    old_value, new_value = "bleep", "bloop"
+    expected_value = old_value + new_value
+    @h[:foobar] = old_value
+
+    @h.merge_pair(:foobar, new_value) do |value|
+      value + new_value
+    end.should == expected_value
+    @h[:foobar].should == expected_value
+  end
+
+  it "#replace_pair replaces old value with new value if key exists and current value matches old value" do
+    old_value, new_value = "bleep", "bloop"
+    @h[:foobar] = old_value
+
+    @h.replace_pair(:foobar, old_value, new_value).should be_true
+    @h[:foobar].should equal new_value
+  end
+
+  it "#replace_pair doesn't replace old value if current value doesn't match old value" do
+    expected_old_value = "BLOOP"
+    @h[:foobar] = expected_old_value
+
+    @h.replace_pair(:foobar, "bleep", "bloop").should be_false
+    @h[:foobar].should equal expected_old_value
+  end
+
+  it "#replace_if_exists replaces value if key exists" do
+    @h[:foobar] = "bloop"
+    expected_value = "bleep"
+
+    @h.replace_if_exists(:foobar, expected_value).should == "bloop"
+    @h[:foobar].should equal expected_value
+  end
+
+  it "#get_and_set gets current value and set new value" do
+    @h[:foobar] = "bloop"
+    expected_value = "bleep"
+
+    @h.get_and_set(:foobar, expected_value).should == "bloop"
+    @h[:foobar].should equal expected_value
+  end
+
+  it "#key? returns true if key is present" do
+    @h[:foobar] = "bloop"
+    @h.key?(:foobar).should be_true
+  end
+
+  it "#key? returns false if key is absent" do
+    @h.key?(:foobar).should be_false
+  end
+
+  it "#delete deletes key and value pair" do
+    value = "bloop"
+    @h[:foobar] = value
+    @h.delete(:foobar).should equal value
+    @h[:foobar].should be_nil
+  end
+
+  it "#delete_pair deletes pair if value equals provided value" do
+    value = "bloop"
+    @h[:foobar] = value
+    @h.delete_pair(:foobar, value).should be_true
+    @h[:foobar].should be_nil
+  end
+
+  it "#delete_pair doesn't delete pair if value equals provided value" do
+    value = "bloop"
+    @h[:foobar] = value
+    @h.delete_pair(:foobar, "BLOOP").should be_false
+    @h[:foobar].should equal value
+  end
+
+  it "#clear returns an empty hash" do
+    @h[:foobar] = "bleep"
+    @h.clear
+    @h.key?(:foobar).should be_false
+    @h.size.should == 0
+  end
+
+  it "#size returns the size of hash" do
+    @h[:foobar], @h[:barfoo] = "bleep", "bloop"
+    @h.size.should == 2
+  end
+
+  it "#get_or_default returns value of key if key mapped" do
+    @h[:foobar] = "bleep"
+    @h.get_or_default(:foobar, "BLEEP").should == "bleep"
+    @h.key?(:foobar).should be_true
+  end
+
+  it "#get_or_default returns default if key isn't mapped" do
+    @h.get_or_default(:foobar, "BLEEP").should == "BLEEP"
+    @h.key?(:foobar).should be_false
+  end
+
+  it "#each_pair passes each key value pair to given block" do
+    @h[:foobar], @h[:barfoo] = "bleep", "bloop"
+    @h.each_pair do |key, value|
+      value.should == @h[key]
+    end
+  end
+
+  it "#each_pair returns self" do
+    @h.each_pair { }.should equal(@h)
+  end
+end

--- a/spec/truffle/truffleruby/concurrent_hash_map_spec.rb
+++ b/spec/truffle/truffleruby/concurrent_hash_map_spec.rb
@@ -150,4 +150,8 @@ describe "TruffleRuby::ConcurrentHashMap" do
   it "#each_pair returns self" do
     @h.each_pair { }.should equal(@h)
   end
+
+  it "#initialize_copy creates a new instance" do
+    @h.should_not equal @h.dup
+  end
 end

--- a/src/main/java/org/truffleruby/core/CoreLibrary.java
+++ b/src/main/java/org/truffleruby/core/CoreLibrary.java
@@ -974,6 +974,7 @@ public class CoreLibrary {
             "/core/kernel.rb",
             "/core/lazy_rubygems.rb",
             "/core/truffle/boot.rb",
+            "/core/truffle/concurrent_hash_map.rb",
             "/core/truffle/debug.rb",
             "/core/truffle/diggable.rb",
             "/core/truffle/encoding_operations.rb",

--- a/src/main/ruby/truffleruby/core/truffle/concurrent_hash_map.rb
+++ b/src/main/ruby/truffleruby/core/truffle/concurrent_hash_map.rb
@@ -6,6 +6,11 @@ module TruffleRuby
       @hash = {}
     end
 
+    def initialize_copy(other)
+      @hash = @hash.dup
+      self
+    end
+
     def [](key)
       TruffleRuby.synchronized(self) do
         @hash[key]

--- a/src/main/ruby/truffleruby/core/truffle/concurrent_hash_map.rb
+++ b/src/main/ruby/truffleruby/core/truffle/concurrent_hash_map.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+module TruffleRuby
+  class ConcurrentHashMap
+    def initialize(options = nil)
+      @hash = {}
+    end
+
+    def [](key)
+      TruffleRuby.synchronized(self) do
+        @hash[key]
+      end
+    end
+
+    def []=(key, value)
+      TruffleRuby.synchronized(self) do
+        @hash[key] = value
+      end
+    end
+
+    def compute_if_absent(key)
+      TruffleRuby.synchronized(self) do
+        if @hash.key?(key)
+          @hash[key]
+        else
+          @hash[key] = yield
+        end
+      end
+    end
+
+    def compute_if_present(key)
+      TruffleRuby.synchronized(self) do
+        if @hash.key?(key)
+          store_computed_value(key, yield(@hash[key]))
+        end
+      end
+    end
+
+    def compute(key)
+      TruffleRuby.synchronized(self) do
+        store_computed_value(key, yield(@hash[key]))
+      end
+    end
+
+    def merge_pair(key, value)
+      TruffleRuby.synchronized(self) do
+        if @hash.key?(key)
+          store_computed_value(key, yield(@hash[key]))
+        else
+          @hash[key] = value
+        end
+      end
+    end
+
+    def replace_pair(key, old_value, new_value)
+      TruffleRuby.synchronized(self) do
+        if @hash.key?(key) && @hash[key] == old_value
+          @hash[key] = new_value
+          return true
+        end
+        false
+      end
+    end
+
+    def replace_if_exists(key, new_value)
+      TruffleRuby.synchronized(self) do
+        if @hash.key?(key)
+          old_value = @hash[key]
+          @hash[key] = new_value
+          old_value
+        end
+      end
+    end
+
+    def get_and_set(key, value)
+      TruffleRuby.synchronized(self) do
+        old_value = @hash[key]
+        @hash[key] = value
+        old_value
+      end
+    end
+
+    def key?(key)
+      TruffleRuby.synchronized(self) do
+        @hash.key?(key)
+      end
+    end
+
+    def delete(key)
+      TruffleRuby.synchronized(self) do
+        @hash.delete(key)
+      end
+    end
+
+    def delete_pair(key, value)
+      TruffleRuby.synchronized(self) do
+        if @hash.key?(key) && @hash[key] == value
+          @hash.delete(key)
+          return true
+        end
+        false
+      end
+    end
+
+    def clear
+      TruffleRuby.synchronized(self) do
+        @hash.clear
+        self
+      end
+    end
+
+    def size
+      TruffleRuby.synchronized(self) do
+        @hash.size
+      end
+    end
+
+    def get_or_default(key, default_value)
+      TruffleRuby.synchronized(self) do
+        @hash.fetch(key, default_value)
+      end
+    end
+
+    def each_pair
+      TruffleRuby.synchronized(self) do
+        @hash.each_pair do |key, value|
+          yield(key, value)
+        end
+        self
+      end
+    end
+
+    private
+
+    def store_computed_value(key, new_value)
+      if new_value.nil?
+        @hash.delete(key)
+        nil
+      else
+        @hash[key] = new_value
+      end
+    end
+  end
+end

--- a/src/main/ruby/truffleruby/core/truffle/concurrent_hash_map.rb
+++ b/src/main/ruby/truffleruby/core/truffle/concurrent_hash_map.rb
@@ -12,9 +12,7 @@ module TruffleRuby
     end
 
     def [](key)
-      TruffleRuby.synchronized(self) do
-        @hash[key]
-      end
+      @hash[key]
     end
 
     def []=(key, value)
@@ -86,9 +84,7 @@ module TruffleRuby
     end
 
     def key?(key)
-      TruffleRuby.synchronized(self) do
-        @hash.key?(key)
-      end
+      @hash.key?(key)
     end
 
     def delete(key)
@@ -115,24 +111,18 @@ module TruffleRuby
     end
 
     def size
-      TruffleRuby.synchronized(self) do
-        @hash.size
-      end
+      @hash.size
     end
 
     def get_or_default(key, default_value)
-      TruffleRuby.synchronized(self) do
-        @hash.fetch(key, default_value)
-      end
+      @hash.fetch(key, default_value)
     end
 
     def each_pair
-      TruffleRuby.synchronized(self) do
-        @hash.each_pair do |key, value|
-          yield(key, value)
-        end
-        self
+      @hash.each_pair do |key, value|
+        yield(key, value)
       end
+      self
     end
 
     private


### PR DESCRIPTION
## Change

First step to improve performance of `concurrent-ruby`'s `Concurrent::Map` https://github.com/Shopify/oracle-truffleruby-collab/issues/17

These methods are implemented following the interface in concurrent-ruby's [synchronized_map_backend file](https://github.com/ruby-concurrency/concurrent-ruby/blob/master/lib/concurrent-ruby/concurrent/collection/map/synchronized_map_backend.rb) and following `Concurrent::Map` [API documentation](http://ruby-concurrency.github.io/concurrent-ruby/master/Concurrent/Map.html). 

## Background 

Currently TruffleRuby uses the ConcurrentHashMap-written-in-Ruby backend for Concurrent::Map on `concurrent-ruby` which utilizes a Ruby hash. We are creating a backend on the TruffleRuby side so we are able to optimize the mapping ourselves.

In another change, we'll write the change to patch `concurrent-ruby` with this class, and then implement some parts of this class in Java to make it concurrent. 

As Chris mentions in [this comment](https://github.com/Shopify/oracle-truffleruby-collab/issues/17#issuecomment-814933071), `TruffleRuby::ConcurrentHashMap` is named after the [Java class](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ConcurrentHashMap.html) and not `Concurrent::Hash` from the `concurrent-ruby` gem.  

## Testing

* I've added specs for all of the new methods in `ConcurrentHashMap`.
* I've tested this change on `concurrent-ruby` gem by swapping the `AtomicReferenceMapBackend` with the new `TruffleRuby::ConcurrentHashMap` in [`map.rb`](https://github.com/ruby-concurrency/concurrent-ruby/blob/7b7900a9133a5c31e60fc55133559ae07c934d69/lib/concurrent-ruby/concurrent/map.rb#L20). 

  * See this branch on `concurrent-ruby` with my changes - https://github.com/ruby-concurrency/concurrent-ruby/compare/master...wildmaples:testing-truffleruby-map-backend?expand=1
  * You can run the above changes with this branch's commit (on Truffleruby) to top hat. 

## Note 

As mentioned in my commit message: This current change passes the specs for `concurrent-ruby`'s `Concurrent::Map` specs except for 3: #dup/#clone, updates don't block reads, and atomicity. Atomicity spec is commented out when I tested this change because it stops the entire test process. 

```
Finished in 1 minute 53.88 seconds (files took 5.95 seconds to load)
60 examples, 2 failures

Failed examples:

rspec ./spec/concurrent/map_spec.rb:747 # Concurrent::Map #dup,#clone
rspec ./spec/concurrent/map_spec.rb:256 # Concurrent::Map updates dont block reads
```

Because this PR covers most of the spec cases, I'm hoping to get it merged first. We can continue investigating the remaining failing specs next. 