### PR TITLE
Shift boundaries for String#chr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Performance:
 * Make `Struct#dig` faster in interpreter by avoiding exceptions (#2306, @kirs).
 * Reduce the number of AST nodes created for methods and blocks (#2261).
 * Fiber-local variables are much faster now by using less synchronization.
+* Improved the performance of the exceptional case of `String#chr` (#2318, #chrisseaton).
 
 Changes:
 

--- a/src/main/java/org/truffleruby/core/exception/CoreExceptions.java
+++ b/src/main/java/org/truffleruby/core/exception/CoreExceptions.java
@@ -1031,11 +1031,15 @@ public class CoreExceptions {
 
     // RangeError
 
-    @TruffleBoundary
     public RubyException rangeError(long code, RubyEncoding encoding, Node currentNode) {
         return rangeError(
-                StringUtils.format("invalid codepoint %x in %s", code, encoding.encoding),
+                rangeErrorMessage(code, encoding.encoding),
                 currentNode);
+    }
+
+    @TruffleBoundary
+    private String rangeErrorMessage(long code, Encoding encoding) {
+        return StringUtils.format("invalid codepoint %x in %s", code, encoding);
     }
 
     @TruffleBoundary
@@ -1062,7 +1066,6 @@ public class CoreExceptions {
         return rangeError(StringUtils.format("integer %d too %s to convert to `int'", value, direction), currentNode);
     }
 
-    @TruffleBoundary
     public RubyException rangeError(String message, Node currentNode) {
         RubyClass exceptionClass = context.getCoreLibrary().rangeErrorClass;
         RubyString errorMessage = StringOperations


### PR DESCRIPTION
Partial fix to #2316. A better fix would remove more boundaries in classes like `CoreExceptions` - should rarely be creating an object like an exception behind a boundary. Possibly do it via a new node.