### PR TITLE
Make String#inspect readable with Unicode-coded strings

### DIFF
--- a/spec/ruby/core/string/inspect_spec.rb
+++ b/spec/ruby/core/string/inspect_spec.rb
@@ -502,5 +502,11 @@ describe "String#inspect" do
         "\u{3042}".encode("EUC-JP").inspect.should == '"\\x{A4A2}"'
       end
     end
+
+    describe "and the string has both ASCII-compatible and ASCII-incompatible chars" do
+      it "returns a string with the non-ASCII characters replaced by \\u notation" do
+        "hello привет".encode("utf-16le").inspect.should == '"hello \\u043F\\u0440\\u0438\\u0432\\u0435\\u0442"'
+      end
+    end
   end
 end

--- a/src/main/ruby/truffleruby/core/string.rb
+++ b/src/main/ruby/truffleruby/core/string.rb
@@ -526,6 +526,10 @@ class String
     result.force_encoding(result_encoding)
   end
 
+  # https://github.com/ruby/ruby/blob/12f7ba5ed4a07855d6a9429aa627211db3655ca7/string.c#L6049-L6050
+  MAX_PRINTABLE_UNICODE_CHAR = 0x7F
+  private_constant :MAX_PRINTABLE_UNICODE_CHAR
+
   private def inspect_char(enc, result_encoding, ascii, unicode, index, char, result)
     consumed = char.bytesize
 
@@ -576,7 +580,9 @@ class String
       end
     end
 
-    if Primitive.character_printable_p(char) && (enc == result_encoding || (ascii && char.ascii_only?))
+    if Primitive.character_printable_p(char) && unicode && char.ord < MAX_PRINTABLE_UNICODE_CHAR
+      result << char.encode(result_encoding)
+    elsif Primitive.character_printable_p(char) && (enc == result_encoding || (ascii && char.ascii_only?))
       result << char
     else
       code = char.ord


### PR DESCRIPTION
Closes https://github.com/oracle/truffleruby/issues/2313.

Reverse-engineering `string.c` from MRI I was able to sum its logic:

* if `enc == resenc && rb_enc_isprint(char, enc)` then print char as it is
* if encoding_asciicompat && rb_enc_isascii(char, enc) && rb_isprint(char) then print char as it is
* if encoding is unicode family && char < 0x7F && rb_isprint(char) then print char as it is
* else print encoded

TrufflyRuby already covers the first two points, and the third one is covered by this PR.