### PR TITLE
Apply Rubocop Style/AndOr

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -385,3 +385,6 @@ Layout/SpaceInsideBlockBraces:
   Enabled: true
   EnforcedStyle: space
   EnforcedStyleForEmptyBraces: space
+
+Style/AndOr:
+  Enabled: true

--- a/lib/truffle/rubygems/defaults/truffleruby.rb
+++ b/lib/truffle/rubygems/defaults/truffleruby.rb
@@ -14,7 +14,7 @@
 module Gem
   # The path to the gems shipped with TruffleRuby
   def self.default_dir
-    @default_dir ||= "#{Truffle::Boot.ruby_home or raise 'TruffleRuby home not found'}/lib/gems"
+    @default_dir ||= "#{Truffle::Boot.ruby_home || raise('TruffleRuby home not found')}/lib/gems"
   end
 
   # Only report the RUBY platform as supported to make sure gems precompiled for MRI are not used.

--- a/lib/truffle/socket/addrinfo.rb
+++ b/lib/truffle/socket/addrinfo.rb
@@ -42,7 +42,7 @@ class Addrinfo
       sockaddr = Socket.pack_sockaddr_in(lport, laddress)
       addr     = Addrinfo.new(sockaddr, lfamily, lsocktype, lprotocol)
 
-      if flags and flags | Socket::AI_CANONNAME
+      if flags && flags |(Socket::AI_CANONNAME)
         addr.instance_variable_set(:@canonname, lhost)
       end
 
@@ -103,7 +103,7 @@ class Addrinfo
       @ip_address = sockaddr[3]
 
       # When using AF_INET6 the protocol family can only be PF_INET6
-      if @afamily == Socket::AF_INET6 and !pfamily
+      if (@afamily == Socket::AF_INET6) && !pfamily
         pfamily = Socket::PF_INET6
       end
     else
@@ -126,9 +126,9 @@ class Addrinfo
     # Per MRI behaviour setting the protocol family should also set the address
     # family, but only if the address and protocol families are compatible.
     if @pfamily && @pfamily != 0
-      if @afamily == Socket::AF_INET6 and
-      @pfamily != Socket::PF_INET and
-      @pfamily != Socket::PF_INET6
+      if (@afamily == Socket::AF_INET6) &&
+      (@pfamily != Socket::PF_INET) &&
+      (@pfamily != Socket::PF_INET6)
         raise SocketError, 'The given protocol and address families are incompatible'
       end
 
@@ -145,10 +145,10 @@ class Addrinfo
     end
 
     # Based on MRI's (re-)implementation of getaddrinfo()
-    if @afamily != Socket::AF_UNIX and
-    @afamily != Socket::AF_UNSPEC and
-    @afamily != Socket::AF_INET and
-    @afamily != Socket::AF_INET6
+    if (@afamily != Socket::AF_UNIX) &&
+    (@afamily != Socket::AF_UNSPEC) &&
+    (@afamily != Socket::AF_INET) &&
+    (@afamily != Socket::AF_INET6)
       raise(
         SocketError,
         'Address family must be AF_UNIX, AF_INET, AF_INET6, PF_INET or PF_INET6'
@@ -159,17 +159,17 @@ class Addrinfo
     if sockaddr.is_a?(Array)
       case @socktype
       when 0, nil
-        if @protocol != 0 and @protocol != nil and @protocol != Socket::IPPROTO_UDP
+        if (@protocol != 0) && (@protocol != nil) && (@protocol != Socket::IPPROTO_UDP)
           raise SocketError, 'Socket protocol must be IPPROTO_UDP or left unset'
         end
       when Socket::SOCK_RAW
         # nothing to do
       when Socket::SOCK_DGRAM
-        if @protocol != Socket::IPPROTO_UDP and @protocol != 0
+        if (@protocol != Socket::IPPROTO_UDP) && (@protocol != 0)
           raise SocketError, 'Socket protocol must be IPPROTO_UDP or left unset'
         end
       when Socket::SOCK_STREAM
-        if @protocol != Socket::IPPROTO_TCP and @protocol != 0
+        if (@protocol != Socket::IPPROTO_TCP) && (@protocol != 0)
           raise SocketError, 'Socket protocol must be IPPROTO_TCP or left unset'
         end
       # Based on MRI behaviour, though MRI itself doesn't seem to explicitly
@@ -236,7 +236,7 @@ class Addrinfo
 
   def inspect_sockaddr
     if ipv4?
-      if ip_port and ip_port != 0
+      if ip_port && (ip_port != 0)
         "#{ip_address}:#{ip_port}"
       elsif ip_address
         ip_address.dup
@@ -244,7 +244,7 @@ class Addrinfo
         'UNKNOWN'
       end
     elsif ipv6?
-      if ip_port and ip_port != 0
+      if ip_port && (ip_port != 0)
         "[#{ip_address}]:#{ip_port}"
       else
         ip_address.dup
@@ -261,7 +261,7 @@ class Addrinfo
   end
 
   def inspect
-    if socktype and socktype != 0
+    if socktype && (socktype != 0)
       if ip?
         case socktype
         when Socket::SOCK_STREAM
@@ -424,7 +424,7 @@ class Addrinfo
     @pfamily  = Truffle::Socket.protocol_family(pfamily)
     @socktype = Truffle::Socket.socket_type(socktype)
 
-    if protocol and protocol != 0
+    if protocol && (protocol != 0)
       @protocol = ::Socket.const_get(protocol)
     else
       @protocol = protocol

--- a/lib/truffle/socket/ancillary_data.rb
+++ b/lib/truffle/socket/ancillary_data.rb
@@ -100,7 +100,7 @@ class Socket < BasicSocket
     end
 
     def unix_rights
-      if @level != Socket::SOL_SOCKET or @type != Socket::SCM_RIGHTS
+      if (@level != Socket::SOL_SOCKET) || (@type != Socket::SCM_RIGHTS)
         raise TypeError, 'SCM_RIGHTS ancillary data expected'
       end
 
@@ -108,7 +108,7 @@ class Socket < BasicSocket
     end
 
     def data
-      if @ip_pktinfo or @ipv6_pktinfo
+      if @ip_pktinfo || @ipv6_pktinfo
         raise NotImplementedError,
           'AncillaryData#data is not supported as its output depends on ' \
           'MRI specific internals, use #ip_pktinfo or #ipv6_pktinfo instead'

--- a/lib/truffle/socket/basic_socket.rb
+++ b/lib/truffle/socket/basic_socket.rb
@@ -215,7 +215,7 @@ class BasicSocket < IO
           end
         end
 
-        if grow_msg and header.message_truncated?
+        if grow_msg && header.message_truncated?
           need_more = true
           msg_len *= 2
         end

--- a/lib/truffle/socket/socket.rb
+++ b/lib/truffle/socket/socket.rb
@@ -156,7 +156,7 @@ class Socket < BasicSocket
   end
 
   def self.gethostbyaddr(addr, family = nil)
-    if !family and addr.bytesize == 16
+    if !family && (addr.bytesize == 16)
       family = Socket::AF_INET6
     elsif !family
       family = Socket::AF_INET

--- a/lib/truffle/socket/tcp_socket.rb
+++ b/lib/truffle/socket/tcp_socket.rb
@@ -58,7 +58,7 @@ class TCPSocket < IPSocket
 
     # When a local address and/or service/port are given we should bind the
     # socket to said address (besides also connecting to the remote address).
-    if local_host or local_service
+    if local_host || local_service
       if local_host
         local_host = Truffle::Socket.coerce_to_string(local_host)
       end

--- a/lib/truffle/socket/truffle.rb
+++ b/lib/truffle/socket/truffle.rb
@@ -78,8 +78,8 @@ module Truffle
       end
 
       # Socket created using for example Socket.unix('foo')
-      if socket.is_a?(::Socket) and
-        socket.instance_variable_get(:@family) == ::Socket::AF_UNIX
+      if socket.is_a?(::Socket) &&
+        (socket.instance_variable_get(:@family) == ::Socket::AF_UNIX)
         return Foreign::SockaddrUn
       end
 
@@ -169,7 +169,7 @@ module Truffle
     end
 
     def self.coerce_to_string(object)
-      if object.is_a?(String) or object.is_a?(Symbol)
+      if object.is_a?(String) || object.is_a?(Symbol)
         object.to_s
       elsif object.respond_to?(:to_str)
         Truffle::Type.coerce_to(object, String, :to_str)
@@ -343,7 +343,7 @@ module Truffle
       elsif reverse_lookup == :numeric
         reverse_lookup = false
 
-      elsif reverse_lookup != true and reverse_lookup != false
+      elsif (reverse_lookup != true) && (reverse_lookup != false)
         raise ArgumentError,
           "invalid reverse_lookup flag: #{reverse_lookup.inspect}"
       end
@@ -372,9 +372,9 @@ module Truffle
           "unknown shutdown argument: #{how}"
         end
       when Integer
-        if how == ::Socket::SHUT_RD or
-          how == ::Socket::SHUT_WR or
-          how == ::Socket::SHUT_RDWR
+        if (how == ::Socket::SHUT_RD) ||
+          (how == ::Socket::SHUT_WR) ||
+          (how == ::Socket::SHUT_RDWR)
           how
         else
           raise ArgumentError,

--- a/lib/truffle/socket/truffle/ancillary_data.rb
+++ b/lib/truffle/socket/truffle/ancillary_data.rb
@@ -41,7 +41,7 @@ module Truffle
         else
           level = Socket.coerce_to_string(raw_level)
 
-          if level == 'SOL_SOCKET' or level == 'SOCKET'
+          if (level == 'SOL_SOCKET') || (level == 'SOCKET')
             ::Socket::SOL_SOCKET
 
           # Translates "TCP" into "IPPROTO_TCP", "UDP" into "IPPROTO_UDP", etc.
@@ -59,7 +59,7 @@ module Truffle
         else
           type = Socket.coerce_to_string(raw_type)
 
-          if family == ::Socket::AF_INET or family == ::Socket::AF_INET6
+          if (family == ::Socket::AF_INET) || (family == ::Socket::AF_INET6)
             prefix, label = LEVEL_PREFIXES[level]
           else
             prefix, label = LEVEL_PREFIXES[::Socket::SOL_SOCKET]
@@ -67,7 +67,7 @@ module Truffle
 
           # Translates "RIGHTS" into "SCM_RIGHTS", "CORK" into "TCP_CORK" (when
           # the level is IPPROTO_TCP), etc.
-          if prefix and label
+          if prefix && label
             Socket.prefixed_socket_constant(type, prefix) do
               "Unknown #{label} control message: #{type}"
             end

--- a/lib/truffle/socket/truffle/foreign.rb
+++ b/lib/truffle/socket/truffle/foreign.rb
@@ -280,7 +280,7 @@ module Truffle
         hints[:ai_socktype] = type
         hints[:ai_flags]    = flags
 
-        if host and host.empty?
+        if host && host.empty?
           host = '0.0.0.0'
         end
 

--- a/lib/truffle/socket/truffle/socket_options.rb
+++ b/lib/truffle/socket/truffle/socket_options.rb
@@ -30,11 +30,11 @@ module Truffle
   module Socket
     module SocketOptions
       def self.socket_level(level, family = nil)
-        if level.is_a?(Symbol) or level.is_a?(String)
+        if level.is_a?(Symbol) || level.is_a?(String)
           if ::Socket.const_defined?(level, false) # Truffle: added inherit false
             ::Socket.const_get(level, false) # Truffle: added inherit false
           else
-            if family and is_ip_family?(family)
+            if family && is_ip_family?(family)
               ip_level_to_int(level)
             elsif level.to_s == 'SOCKET'
               ::Socket::SOL_SOCKET

--- a/lib/truffle/socket/udp_socket.rb
+++ b/lib/truffle/socket/udp_socket.rb
@@ -62,7 +62,7 @@ class UDPSocket < IPSocket
   end
 
   def send(message, flags, host = nil, port = nil)
-    if host and port
+    if host && port
       addr = Socket.sockaddr_in(port.to_i, host)
     elsif host
       addr = host

--- a/lib/truffle/stringio.rb
+++ b/lib/truffle/stringio.rb
@@ -62,7 +62,7 @@ Truffle::CExt.rb_define_module_under(IO, 'generic_readable').module_eval do
   def read_nonblock(length, buffer = nil, exception: true)
     str = read(length, buffer)
 
-    if exception and str.nil?
+    if exception && str.nil?
       raise EOFError, 'end of file reached'
     end
 
@@ -486,7 +486,7 @@ class StringIO
   end
 
   def reopen(string=nil, mode=Undefined)
-    if string and not string.kind_of? String and mode.equal? Undefined
+    if string && (not string.kind_of? String) && mode.equal?(Undefined)
       stringio = Truffle::Type.coerce_to(string, StringIO, :to_strio)
 
       initialize_copy stringio
@@ -667,7 +667,7 @@ class StringIO
     @readable = @writable = @append = false
     d = @__data__
 
-    if mode == 0 or mode & IO::RDWR != 0
+    if (mode == 0) || (mode & IO::RDWR != 0)
       @readable = true
     end
 
@@ -687,14 +687,14 @@ class StringIO
     else
       limit = nil
 
-      unless sep == $/ or sep.nil?
+      unless (sep == $/) || sep.nil?
         osep = sep
         sep = Truffle::Type.rb_check_convert_type sep, String, :to_str
         limit = Primitive.rb_to_int osep unless sep
       end
     end
 
-    raise ArgumentError if arg_error and limit == 0
+    raise ArgumentError if arg_error && (limit == 0)
 
     return nil if eof?
 

--- a/lib/truffle/strscan.rb
+++ b/lib/truffle/strscan.rb
@@ -64,7 +64,7 @@ class StringScanner
 
     n += @string.bytesize if n < 0
 
-    if n < 0 or n > @string.bytesize
+    if (n < 0) || (n > @string.bytesize)
       raise RangeError, "index out of range (#{n})"
     end
 
@@ -83,7 +83,7 @@ class StringScanner
   end
 
   def bol?
-    @pos == 0 or @string.getbyte(pos-1) == 10
+    (@pos == 0) || (@string.getbyte(pos-1) == 10)
   end
 
   alias_method :beginning_of_line?, :bol?

--- a/lib/truffle/timeout.rb
+++ b/lib/truffle/timeout.rb
@@ -66,7 +66,7 @@ module Timeout
 
     # Raise @exception if @thread.
     def cancel
-      if @thread and @thread.alive?
+      if @thread && @thread.alive?
         @thread.raise @exception, @message
       end
 
@@ -155,7 +155,7 @@ module Timeout
     # module method, so you can call it directly as Timeout.timeout().
 
     def timeout(sec, exception = Error, message = nil)
-      return yield if sec == nil or sec.zero?
+      return yield if (sec == nil) || sec.zero?
 
       message ||= 'execution expired'
       req = Timeout.add_timeout sec, exception, message

--- a/lib/truffle/truffle/cext.rb
+++ b/lib/truffle/truffle/cext.rb
@@ -1265,7 +1265,7 @@ module Truffle::CExt
   end
 
   def rb_undef(mod, name)
-    if mod.frozen? or mod.method_defined?(name) or mod.private_method_defined?(name)
+    if mod.frozen? || mod.method_defined?(name) || mod.private_method_defined?(name)
       mod.send(:undef_method, name)
     end
   end

--- a/lib/truffle/truffle/cext_structs.rb
+++ b/lib/truffle/truffle/cext_structs.rb
@@ -93,7 +93,7 @@ class Truffle::CExt::RData
   end
 
   def polyglot_member_readable?(name)
-    name == 'basic' or name == 'data' or name == 'type' or name == 'typed_flag'
+    (name == 'basic') || (name == 'data') || (name == 'type') || (name == 'typed_flag')
   end
 
   def polyglot_member_modifiable?(name)

--- a/lib/truffle/truffle/ffi_backend/function.rb
+++ b/lib/truffle/truffle/ffi_backend/function.rb
@@ -40,7 +40,7 @@ module FFI
     def initialize(return_type, param_types, function = nil, options = {}, &block)
       function ||= block
 
-      if FunctionType === return_type and nil == param_types
+      if (FunctionType === return_type) && (nil == param_types)
         @function_info = return_type
       else
         @function_info = FunctionType.new(return_type, param_types, options)
@@ -84,7 +84,7 @@ module FFI
       if blocking
         begin
           result = Primitive.thread_run_blocking_nfi_system_call(@function, args)
-        end while Integer === result and result == -1 and Errno.errno == Errno::EINTR::Errno
+        end while (Integer === result) && (result == -1) && (Errno.errno == Errno::EINTR::Errno)
       else
         result = @function.call(*args)
       end
@@ -140,9 +140,9 @@ module FFI
     private def convert_ruby_to_native(type, value, enums)
       if FFI::Type::Mapped === type
         type.to_native(value, nil)
-      elsif enums and Symbol === value
+      elsif enums && (Symbol === value)
         enums.__map_symbol(value)
-      elsif FFI::Type::UINT64 == type or FFI::Type::ULONG == type
+      elsif (FFI::Type::UINT64 == type) || (FFI::Type::ULONG == type)
         Truffle::Type.rb_num2ulong(value)
       elsif FFI::Type::FLOAT32 == type
         Primitive.double_to_float(Truffle::Type.rb_num2dbl(value))
@@ -151,7 +151,7 @@ module FFI
       elsif FFI::Type::STRING == type
         Truffle::Type.check_null_safe(value) unless nil.equal?(value)
         get_pointer_value(value)
-      elsif FFI::FunctionType === type and Proc === value
+      elsif (FFI::FunctionType === type) && (Proc === value)
         callback(value, type)
       else
         value
@@ -175,7 +175,7 @@ module FFI
         else
           FFI::Pointer.new(Truffle::Interop.as_pointer(value)).read_string_to_null
         end
-      elsif FFI::Type::Builtin === type and type.unsigned?
+      elsif (FFI::Type::Builtin === type) && type.unsigned?
         # TODO: NFI workaround
         type.signed2unsigned(value)
       elsif FFI::FunctionType === type

--- a/lib/truffle/truffle/ffi_backend/struct.rb
+++ b/lib/truffle/truffle/ffi_backend/struct.rb
@@ -118,7 +118,7 @@ module FFI
         unless FFI::StructLayout === layout
           raise RuntimeError, "invalid Struct layout for #{self.class}"
         end
-        unless defined?(@pointer) and @pointer
+        unless defined?(@pointer) && @pointer
           @pointer = MemoryPointer.new(layout.size, 1, true)
         end
         @layout = layout
@@ -164,7 +164,7 @@ module FFI
       end
 
       def [](index)
-        if @length > 0 and (index < 0 or index >= @length)
+        if (@length > 0) && ((index < 0) || (index >= @length))
           raise IndexError, "index #{index} out of bounds"
         end
 
@@ -172,7 +172,7 @@ module FFI
       end
 
       def []=(index, value)
-        if @length > 0 and (index < 0 or index >= @length)
+        if (@length > 0) && ((index < 0) || (index >= @length))
           raise IndexError, "index #{index} out of bounds"
         end
 

--- a/lib/truffle/truffle/ffi_backend/struct_layout.rb
+++ b/lib/truffle/truffle/ffi_backend/struct_layout.rb
@@ -47,7 +47,7 @@ module FFI
         unless type
           raise RuntimeError, "type of field #{i} not supported"
         end
-        if type.size == 0 and i < fields.size-1
+        if (type.size == 0) && (i < fields.size-1)
           raise TypeError, "type of field #{i} has zero size"
         end
         @field_map[field.name] = field
@@ -139,7 +139,7 @@ module FFI
       end
 
       def put(struct_pointer, value)
-        if nil == value or FFI::Function === value
+        if (nil == value) || (FFI::Function === value)
           function = value
         elsif ::Proc === value || value.respond_to?(:call)
           function = FFI::Function.new(@type, nil, value)

--- a/lib/truffle/truffle/ffi_backend/type.rb
+++ b/lib/truffle/truffle/ffi_backend/type.rb
@@ -43,7 +43,7 @@ module FFI
     end
 
     def nfi_type
-      @nfi_type or raise "Unknown nfi_type for #{inspect}"
+      @nfi_type || raise("Unknown nfi_type for #{inspect}")
     end
 
     def get_at(pointer, offset)
@@ -162,7 +162,7 @@ module FFI
       end
 
       def char_array?
-        FFI::Type::INT8 == @elem_type or FFI::Type::UINT8 == @elem_type
+        (FFI::Type::INT8 == @elem_type) || (FFI::Type::UINT8 == @elem_type)
       end
 
       def get_element_at(pointer, offset, index)

--- a/lib/truffle/truffle/openssl-prefix.rb
+++ b/lib/truffle/truffle/openssl-prefix.rb
@@ -9,9 +9,9 @@
 # Set OPENSSL_PREFIX in ENV to find the OpenSSL headers
 
 search_homebrew = -> homebrew {
-  if prefix = "#{homebrew}/opt/openssl@1.1" and Dir.exist?(prefix)
+  if (prefix = "#{homebrew}/opt/openssl@1.1") && Dir.exist?(prefix)
     prefix
-  elsif prefix = "#{homebrew}/opt/openssl" and Dir.exist?(prefix)
+  elsif (prefix = "#{homebrew}/opt/openssl") && Dir.exist?(prefix)
     prefix
   end
 }
@@ -23,9 +23,9 @@ if macOS && !ENV['OPENSSL_PREFIX']
     # found
   else
     homebrew = `brew --prefix 2>/dev/null`.strip
-    homebrew = nil unless $?.success? and !homebrew.empty? and Dir.exist?(homebrew)
+    homebrew = nil unless $?.success? && !homebrew.empty? && Dir.exist?(homebrew)
 
-    if homebrew and prefix = search_homebrew.call(homebrew)
+    if homebrew && (prefix = search_homebrew.call(homebrew))
       # found
     elsif Dir.exist?('/opt/local/include/openssl') # MacPorts
       prefix = '/opt/local'

--- a/spec/truffle/gc/time_spec.rb
+++ b/spec/truffle/gc/time_spec.rb
@@ -17,7 +17,7 @@ describe "GC.time" do
   it "increases as collections are run" do
     time_before = GC.time
     i = 0
-    while GC.time <= time_before and i < 10
+    while (GC.time <= time_before) && (i < 10)
       GC.start
       i += 1
     end

--- a/spec/truffle/interop/fixtures/classes.rb
+++ b/spec/truffle/interop/fixtures/classes.rb
@@ -90,7 +90,7 @@ module TruffleInteropSpecs
     end
 
     def polyglot_as_pointer
-      @address or raise Truffle::Interop::UnsupportedMessageException
+      @address || raise(Truffle::Interop::UnsupportedMessageException)
     end
 
     def polyglot_to_native
@@ -125,7 +125,7 @@ module TruffleInteropSpecs
 
     def polyglot_write_array_element(index, value)
       @log << [__callee__, index, value]
-      @value_validator.call(value) or raise Truffle::Interop::UnsupportedTypeException
+      @value_validator.call(value) || raise(Truffle::Interop::UnsupportedTypeException)
       @storage[index] = value
       nil
     end

--- a/spec/truffle/interop/methods_spec.rb
+++ b/spec/truffle/interop/methods_spec.rb
@@ -12,7 +12,7 @@ require_relative '../../ruby/spec_helper'
 
 describe "Truffle::Interop" do
   # Run locally and in TruffleRuby's CI but not in GraalVM's CI to not prevent adding new interop messages
-  guard -> { !ENV.key?('BUILD_URL') or ENV.key?('TRUFFLERUBY_CI') } do
+  guard -> { !ENV.key?('BUILD_URL') || ENV.key?('TRUFFLERUBY_CI') } do
     it "has a method for each InteropLibrary message" do
       all_methods = Primitive.interop_library_all_methods
       expected = all_methods.map do |name|

--- a/spec/truffle/io/read_spec.rb
+++ b/spec/truffle/io/read_spec.rb
@@ -53,6 +53,6 @@ describe "IO#read(n)" do
       [], [],
       [], [],
       timeout_us, timeout_us)
-    result and result[0]
+    result && result[0]
   end
 end

--- a/spec/truffle/launcher_spec.rb
+++ b/spec/truffle/launcher_spec.rb
@@ -429,7 +429,7 @@ describe "The launcher" do
 
   guard -> {
     # GraalVM with both --jvm and --native
-    TruffleRuby.graalvm_home and TruffleRuby.native?
+    TruffleRuby.graalvm_home && TruffleRuby.native?
   } do
     describe "runtime configuration flags" do
       before :each do

--- a/src/main/ruby/truffleruby/core/argf.rb
+++ b/src/main/ruby/truffleruby/core/argf.rb
@@ -201,7 +201,7 @@ module Truffle
     # status.
     #
     def eof?
-      @stream and @stream.eof?
+      @stream && @stream.eof?
     end
     alias_method :eof, :eof?
 

--- a/src/main/ruby/truffleruby/core/array.rb
+++ b/src/main/ruby/truffleruby/core/array.rb
@@ -147,7 +147,7 @@ class Array
 
   def assoc(obj)
     each do |x|
-      if x.kind_of? Array and x.first == obj
+      if x.kind_of?(Array) && (x.first == obj)
         return x
       end
     end
@@ -174,7 +174,7 @@ class Array
     last_true = nil
     i = size / 2
 
-    while max >= min and i >= 0 and i < total
+    while (max >= min) && (i >= 0) && (i < total)
       x = yield at(i)
 
       return i if x == 0
@@ -349,7 +349,7 @@ class Array
 
     idx += size if idx < 0
 
-    if idx < 0 or idx >= size
+    if (idx < 0) || (idx >= size)
       if block_given?
         warn 'block supersedes default value argument', uplevel: 1 unless Primitive.undefined?(default)
 
@@ -398,7 +398,7 @@ class Array
       left += size if left < 0
       left = 0 if left < 0
 
-      if !Primitive.undefined?(length) and length
+      if !Primitive.undefined?(length) && length
         begin
           right = Primitive.rb_num2int length
         rescue TypeError
@@ -797,7 +797,7 @@ class Array
 
   def rassoc(obj)
     each do |elem|
-      if elem.kind_of? Array and elem.at(1) == obj
+      if elem.kind_of?(Array) && (elem.at(1) == obj)
         return elem
       end
     end
@@ -983,12 +983,12 @@ class Array
       options = Truffle::Type.coerce_to options, Hash, :to_hash
     end
 
-    if count and count < 0
+    if count && (count < 0)
       raise ArgumentError, 'count must be >= 0'
     end
 
     rng = options[:random] if options
-    if rng and rng.respond_to? :rand
+    if rng && rng.respond_to?(:rand)
       rng = SampleRandom.new rng
     else
       rng = Kernel
@@ -1258,7 +1258,7 @@ class Array
   end
 
   def zip(*others)
-    if !block_given? and others.size == 1 and Array === others[0]
+    if !block_given? && (others.size == 1) && (Array === others[0])
       return Primitive.array_zip self, others[0]
     end
 
@@ -1545,7 +1545,7 @@ class Array
         # This is to match the MRI behaviour of not extending the array
         # with nil when specifying an index greater than the length
         # of the array.
-        return out unless start >= 0 and start < size
+        return out unless (start >= 0) && (start < size)
 
         out = at start
 

--- a/src/main/ruby/truffleruby/core/comparable.rb
+++ b/src/main/ruby/truffleruby/core/comparable.rb
@@ -88,7 +88,7 @@ module Comparable
     end
 
     comp = min <=> max
-    raise ArgumentError, 'min argument must be smaller than max argument' if Primitive.nil?(comp) or comp > 0
+    raise ArgumentError, 'min argument must be smaller than max argument' if Primitive.nil?(comp) || (comp > 0)
     return min if self < min
     return max if self > max
     self

--- a/src/main/ruby/truffleruby/core/complex.rb
+++ b/src/main/ruby/truffleruby/core/complex.rb
@@ -93,9 +93,9 @@ class Complex < Numeric
   private_class_method :convert
 
   def Complex.generic?(other) # :nodoc:
-    other.kind_of?(Integer) or
-    other.kind_of?(Float) or
-    (defined?(Rational) and other.kind_of?(Rational))
+    other.kind_of?(Integer) ||
+    other.kind_of?(Float) ||
+    (defined?(Rational) && other.kind_of?(Rational))
   end
 
   def Complex.rect(real, imag=0)
@@ -246,10 +246,10 @@ class Complex < Numeric
   end
 
   def eql?(other)
-    other.kind_of?(Complex) and
-    imag.class == other.imag.class and
-    real.class == other.real.class and
-    self == other
+    other.kind_of?(Complex) &&
+    (imag.class == other.imag.class) &&
+    (real.class == other.real.class) &&
+    (self == other)
   end
 
   def coerce(other)
@@ -277,7 +277,7 @@ class Complex < Numeric
   end
 
   def finite?
-    @real.finite? and @imag.finite?
+    @real.finite? && @imag.finite?
   end
 
   def infinite?

--- a/src/main/ruby/truffleruby/core/dir.rb
+++ b/src/main/ruby/truffleruby/core/dir.rb
@@ -138,7 +138,7 @@ class Dir
   def children
     ret = []
     while s = read
-      ret << s if s != '.' and s != '..'
+      ret << s if (s != '.') && (s != '..')
     end
     ret
   end
@@ -147,7 +147,7 @@ class Dir
     return to_enum(:each_child) unless block_given?
 
     while s = read
-      yield s unless s == '.' or s == '..'
+      yield s unless (s == '.') || (s == '..')
     end
     self
   end
@@ -184,7 +184,7 @@ class Dir
 
       open(path, options) do |dir|
         while s = dir.read
-          yield s unless s == '.' or s == '..'
+          yield s unless (s == '.') || (s == '..')
         end
       end
     end
@@ -203,13 +203,13 @@ class Dir
 
     def empty?(path)
       path = Truffle::Type.coerce_to_path(path)
-      if Truffle::FileOperations.exist?(path) and !PrivateFile.directory?(path)
+      if Truffle::FileOperations.exist?(path) && !PrivateFile.directory?(path)
         return false
       end
 
       open(path) do |dir|
         while s = dir.read
-          return false if s != '.' and s != '..'
+          return false if (s != '.') && (s != '..')
         end
       end
       true

--- a/src/main/ruby/truffleruby/core/dir_glob.rb
+++ b/src/main/ruby/truffleruby/core/dir_glob.rb
@@ -117,7 +117,7 @@ class Dir
             full = path_join(path, ent)
             mode = Truffle::POSIX.truffleposix_lstat_mode(path_join(glob_base_dir, full))
 
-            if Truffle::StatOperations.directory?(mode) and (allow_dots or ent.getbyte(0) != 46) # ?.
+            if Truffle::StatOperations.directory?(mode) && (allow_dots || (ent.getbyte(0) != 46)) # ?.
               stack << full
               @next.call matches, full, glob_base_dir
             end
@@ -151,7 +151,7 @@ class Dir
           next if ent == '.' || ent == '..'
           mode = Truffle::POSIX.truffleposix_lstat_mode(path_join(glob_base_dir, ent))
 
-          if Truffle::StatOperations.directory?(mode) and (allow_dots or ent.getbyte(0) != 46) # ?.
+          if Truffle::StatOperations.directory?(mode) && (allow_dots || (ent.getbyte(0) != 46)) # ?.
             stack << ent
             @next.call matches, ent, glob_base_dir
           end
@@ -166,7 +166,7 @@ class Dir
             full = path_join(path, ent)
             mode = Truffle::POSIX.truffleposix_lstat_mode(path_join(glob_base_dir, full))
 
-            if Truffle::StatOperations.directory?(mode) and (allow_dots or ent.getbyte(0) != 46) # ?.
+            if Truffle::StatOperations.directory?(mode) && (allow_dots || (ent.getbyte(0) != 46)) # ?.
               stack << full
               @next.call matches, full, glob_base_dir
             end
@@ -195,7 +195,7 @@ class Dir
       end
 
       def call(matches, path, glob_base_dir)
-        return if path and !Truffle::FileOperations.exist?(path_join(glob_base_dir, "#{path}/."))
+        return if path && !Truffle::FileOperations.exist?(path_join(glob_base_dir, "#{path}/."))
 
         dir = Dir.new(path_join(glob_base_dir, path ? path : '.'))
         while ent = dir.read
@@ -213,7 +213,7 @@ class Dir
 
     class EntryMatch < Match
       def call(matches, path, glob_base_dir)
-        return if path and !Truffle::FileOperations.exist?("#{path_join(glob_base_dir, path)}/.")
+        return if path && !Truffle::FileOperations.exist?("#{path_join(glob_base_dir, path)}/.")
 
         dir_path = path_join(glob_base_dir, path ? path : '.')
         dir = Dir.allocate.send(:initialize_internal, dir_path)
@@ -233,7 +233,7 @@ class Dir
 
     class DirectoriesOnly < Node
       def call(matches, path, glob_base_dir)
-        if path and Truffle::FileOperations.exist?("#{path_join(glob_base_dir, path)}/.")
+        if path && Truffle::FileOperations.exist?("#{path_join(glob_base_dir, path)}/.")
           matches << "#{path}/"
         end
       end
@@ -264,7 +264,7 @@ class Dir
 
       # Trim from end
       if !ret.empty?
-        while s = ret.last and s.empty?
+        while (s = ret.last) && s.empty?
           ret.pop
         end
       end
@@ -348,7 +348,7 @@ class Dir
       # Rubygems uses Dir[] as a glorified File.exist? to check for multiple
       # extensions. So we went ahead and sped up that specific case.
 
-      if flags == 0 and m = TRAILING_BRACES.match(pattern)
+      if (flags == 0) && (m = TRAILING_BRACES.match(pattern))
         # no meta characters, so this is a glorified
         # File.exist? check. We allow for a brace expansion
         # only as a suffix.
@@ -412,7 +412,7 @@ class Dir
               rbrace = i
               break
             end
-          elsif char == '\\' and escape
+          elsif (char == '\\') && escape
             i += 1
           end
 
@@ -422,7 +422,7 @@ class Dir
 
       # There was a full {} expression detected, expand each part of it
       # recursively.
-      if lbrace and rbrace
+      if lbrace && rbrace
         pos = lbrace
         front = pattern[0...lbrace]
         back = pattern[(rbrace + 1)..-1]
@@ -432,14 +432,14 @@ class Dir
           pos += 1
           last = pos
 
-          while pos < rbrace and not (pattern[pos] == ',' and nest == 0)
+          while (pos < rbrace) && (not ((pattern[pos] == ',') && (nest == 0)))
             char = pattern[pos]
 
             if char == '{'
               nest += 1
             elsif char == '}'
               nest -= 1
-            elsif char == '\\' and escape
+            elsif (char == '\\') && escape
               pos += 1
               break if pos == rbrace
             end

--- a/src/main/ruby/truffleruby/core/encoding.rb
+++ b/src/main/ruby/truffleruby/core/encoding.rb
@@ -167,7 +167,7 @@ class Encoding
   def self.name_list
     EncodingMap.map do |_n, r|
       index = r.last
-      r.first or (index and Primitive.encoding_get_encoding_by_index(index).name)
+      r.first || (index && Primitive.encoding_get_encoding_by_index(index).name)
     end
   end
 
@@ -184,7 +184,7 @@ class Encoding
     names = [name]
     EncodingMap.each do |_k, r|
       aname = r.first
-      names << aname if aname and r.last == entry.last
+      names << aname if aname && (r.last == entry.last)
     end
     names
   end

--- a/src/main/ruby/truffleruby/core/enumerable.rb
+++ b/src/main/ruby/truffleruby/core/enumerable.rb
@@ -463,7 +463,7 @@ module Enumerable
       return Primitive.array_inject(self, initial, sym, block)
     end
 
-    if !block_given? or !Primitive.undefined?(sym)
+    if !block_given? || !Primitive.undefined?(sym)
       if Primitive.undefined?(sym)
         sym = initial
         initial = undefined
@@ -757,8 +757,8 @@ module Enumerable
       object = Primitive.single_block_arg
       result = yield object
 
-      if Primitive.undefined?(max_result) or \
-           Truffle::Type.coerce_to_comparison(max_result, result) < 0
+      if Primitive.undefined?(max_result) || \
+           (Truffle::Type.coerce_to_comparison(max_result, result) < 0)
         max_object = object
         max_result = result
       end
@@ -785,8 +785,8 @@ module Enumerable
       object = Primitive.single_block_arg
       result = yield object
 
-      if Primitive.undefined?(min_result) or \
-           Truffle::Type.coerce_to_comparison(min_result, result) > 0
+      if Primitive.undefined?(min_result) || \
+           (Truffle::Type.coerce_to_comparison(min_result, result) > 0)
         min_object = object
         min_result = result
       end
@@ -843,14 +843,14 @@ module Enumerable
       object = Primitive.single_block_arg
       result = yield object
 
-      if Primitive.undefined?(min_result) or \
-           Truffle::Type.coerce_to_comparison(min_result, result) > 0
+      if Primitive.undefined?(min_result) || \
+           (Truffle::Type.coerce_to_comparison(min_result, result) > 0)
         min_object = object
         min_result = result
       end
 
-      if Primitive.undefined?(max_result) or \
-           Truffle::Type.coerce_to_comparison(max_result, result) < 0
+      if Primitive.undefined?(max_result) || \
+           (Truffle::Type.coerce_to_comparison(max_result, result) < 0)
         max_object = object
         max_result = result
       end

--- a/src/main/ruby/truffleruby/core/env.rb
+++ b/src/main/ruby/truffleruby/core/env.rb
@@ -142,7 +142,7 @@ class << ENV
   alias_method :member?, :include?
 
   def fetch(key, absent=undefined)
-    if block_given? and !Primitive.undefined?(absent)
+    if block_given? && !Primitive.undefined?(absent)
       warn 'block supersedes default value argument', uplevel: 1
     end
 

--- a/src/main/ruby/truffleruby/core/file.rb
+++ b/src/main/ruby/truffleruby/core/file.rb
@@ -187,7 +187,7 @@ class File < IO
 
         # Now that we've trimmed the /'s at the end, search again
         pos = Primitive.find_string_reverse(path, slash, path.bytesize)
-        if ext_not_present and !pos
+        if ext_not_present && !pos
           # No /'s found and ext not present, return path.
           return path
         end
@@ -563,7 +563,7 @@ class File < IO
           break
         end
 
-        if char == '\\' and escape
+        if (char == '\\') && escape
           i += 1
         end
 
@@ -573,7 +573,7 @@ class File < IO
 
     # There was a full {} expression detected, expand each part of it
     # recursively.
-    if lbrace and rbrace
+    if lbrace && rbrace
       pos = lbrace
       front = pattern[0...lbrace]
       back = pattern[(rbrace + 1)..-1]
@@ -583,11 +583,11 @@ class File < IO
         pos += 1
         last = pos
 
-        while pos < rbrace and not (pattern[pos] == ',' and nest == 0)
+        while (pos < rbrace) && (not ((pattern[pos] == ',') && (nest == 0)))
           nest += 1 if pattern[pos] == '{'
           nest -= 1 if pattern[pos] == '}'
 
-          if pattern[pos] == '\\' and escape
+          if (pattern[pos] == '\\') && escape
             pos += 1
             break if pos == rbrace
           end
@@ -885,7 +885,7 @@ class File < IO
 
     buffer = Primitive.io_thread_buffer_allocate(Truffle::Platform::PATH_MAX)
     begin
-      if ptr = Truffle::POSIX.realpath(path, buffer) and !ptr.null?
+      if (ptr = Truffle::POSIX.realpath(path, buffer)) && !ptr.null?
         real = ptr.read_string
       else
         Errno.handle(path)
@@ -1208,7 +1208,7 @@ class File < IO
         mode = nil
       end
 
-      if Primitive.undefined?(options) and !Primitive.undefined?(perm)
+      if Primitive.undefined?(options) && !Primitive.undefined?(perm)
         options = Truffle::Type.try_convert(perm, Hash, :to_hash)
         perm = undefined if options
       end

--- a/src/main/ruby/truffleruby/core/float.rb
+++ b/src/main/ruby/truffleruby/core/float.rb
@@ -223,7 +223,7 @@ class Float < Numeric
         round(half: half)
       elsif ndigits < 0
         to_i.round(ndigits, :half => half)
-      elsif infinite? or nan?
+      elsif infinite? || nan?
         self
       else
         _, exp = Math.frexp(self)
@@ -258,7 +258,7 @@ class Float < Numeric
   alias_method :modulo, :%
 
   def finite?
-    not (nan? or infinite?)
+    not (nan? || infinite?)
   end
 
   class << self

--- a/src/main/ruby/truffleruby/core/hash.rb
+++ b/src/main/ruby/truffleruby/core/hash.rb
@@ -150,7 +150,7 @@ class Hash
 
         # Order of the comparison matters! We must compare our value with
         # the other Hash's value and not the other way around.
-        unless Primitive.object_equal(value, other_value) or value.send(op, other_value)
+        unless Primitive.object_equal(value, other_value) || value.send(op, other_value)
           return false
         end
       end
@@ -185,7 +185,7 @@ class Hash
   end
 
   def default(key=undefined)
-    if default_proc and !Primitive.undefined?(key)
+    if default_proc && !Primitive.undefined?(key)
       default_proc.call(self, key)
     else
       Primitive.hash_default_value self
@@ -197,7 +197,7 @@ class Hash
     unless Primitive.nil? proc
       proc = Truffle::Type.coerce_to proc, Proc, :to_proc
 
-      if proc.lambda? and proc.arity != 2
+      if proc.lambda? && (proc.arity != 2)
         raise TypeError, 'default proc must have arity 2'
       end
     end

--- a/src/main/ruby/truffleruby/core/integer.rb
+++ b/src/main/ruby/truffleruby/core/integer.rb
@@ -208,7 +208,7 @@ class Integer < Numeric
 
       f = 10 ** ndigits
 
-      if kind_of? Integer and f.kind_of? Integer
+      if kind_of?(Integer) && f.kind_of?(Integer)
         x = self < 0 ? -self : self
         case half
         when :up, nil
@@ -270,7 +270,7 @@ class Integer < Numeric
 
   def lcm(other)
     raise TypeError, "Expected Integer but got #{other.class}" unless other.kind_of?(Integer)
-    if self.zero? or other.zero?
+    if self.zero? || other.zero?
       0
     else
       (self.div(self.gcd(other)) * other).abs
@@ -279,7 +279,7 @@ class Integer < Numeric
 
   def gcdlcm(other)
     gcd = self.gcd(other)
-    if self.zero? or other.zero?
+    if self.zero? || other.zero?
       [gcd, 0]
     else
       [gcd, (self.div(gcd) * other).abs]

--- a/src/main/ruby/truffleruby/core/kernel.rb
+++ b/src/main/ruby/truffleruby/core/kernel.rb
@@ -121,7 +121,7 @@ module Kernel
         obj
       when Float
         bad_base_check.call
-        if obj.nan? or obj.infinite?
+        if obj.nan? || obj.infinite?
           return nil unless raise_exception
         end
         # TODO BJF 14-Jan-2020 Add fixable conversion logic
@@ -349,7 +349,7 @@ module Kernel
     raise ArgumentError, 'wrong number of arguments (0 for 1+)' if modules.empty?
 
     modules.reverse_each do |mod|
-      if !mod.kind_of?(Module) or mod.kind_of?(Class)
+      if !mod.kind_of?(Module) || mod.kind_of?(Class)
         raise TypeError, "wrong argument type #{mod.class} (expected Module)"
       end
 
@@ -455,7 +455,7 @@ module Kernel
 
     path = Truffle::Type.coerce_to_path obj
 
-    if path.kind_of? String and path.start_with? '|'
+    if path.kind_of?(String) && path.start_with?('|')
       return IO.popen(path[1..-1], *rest, &block)
     end
 
@@ -658,7 +658,7 @@ module Kernel
                  caller = initial
                  # MRI would reuse the file:line of the user code caller for methods defined in C.
                  # Similarly, we skip <internal:* calls, notably to skip Kernel#require calls.
-                 while caller and caller.path.start_with?('<internal:')
+                 while caller && caller.path.start_with?('<internal:')
                    uplevel += 1
                    caller, = Kernel.caller_locations(uplevel, 1)
                  end
@@ -693,7 +693,7 @@ module Kernel
     cause_given = !Primitive.undefined?(cause)
     cause = cause_given ? cause : $!
 
-    if Primitive.undefined?(exc) and cause
+    if Primitive.undefined?(exc) && cause
       raise ArgumentError, 'only cause is given with no arguments' if cause_given
       exc = cause
     else
@@ -738,7 +738,7 @@ module Kernel
 
   def caller(start = 1, limit = nil)
     args =  if start.is_a? Range
-              if Primitive.nil?(start.begin) and Primitive.nil?(start.end)
+              if Primitive.nil?(start.begin) && Primitive.nil?(start.end)
                 [1]
               elsif Primitive.nil? start.begin
                 size = start.end + 1

--- a/src/main/ruby/truffleruby/core/marshal.rb
+++ b/src/main/ruby/truffleruby/core/marshal.rb
@@ -75,7 +75,7 @@ class Float
     else
       s, decimal, sign, digits = dtoa
 
-      if decimal < -3 or decimal > digits
+      if (decimal < -3) || (decimal > digits)
         str = s.insert(1, '.') << "e#{decimal - 1}"
       elsif decimal > 0
         str = s[0, decimal]
@@ -411,7 +411,7 @@ class Time
     obj = _load(data)
     ms.store_unique_object obj
 
-    if ivar_index and has_ivar[ivar_index]
+    if ivar_index && has_ivar[ivar_index]
       ms.set_instance_variables obj
       has_ivar[ivar_index] = false
     end
@@ -534,7 +534,7 @@ module Marshal
               end
       end
 
-      if type and not mod.instance_of? type
+      if type && (not mod.instance_of? type)
         raise ArgumentError, "#{name} does not refer to a #{type}"
       end
 
@@ -648,7 +648,7 @@ module Marshal
               raise ArgumentError, "load error, unknown type #{type}"
             end
 
-      @proc.call(obj) if call_proc and @proc and @call
+      @proc.call(obj) if call_proc && @proc && @call
 
       obj
     end
@@ -795,10 +795,10 @@ module Marshal
       # We've read c as unsigned char in a way, but we need to honor
       # the sign bit. We do that by simply comparing with the +128 values
       return 0 if c == 0
-      return c - 5 if 4 < c and c < 128
+      return c - 5 if (4 < c) && (c < 128)
 
       # negative, but checked known it's instead in 2's complement
-      return c - 251 if 252 > c and c > 127
+      return c - 251 if (252 > c) && (c > 127)
 
       # otherwise c (now in the 1 to 4 range) indicates how many
       # bytes to read to construct the value.
@@ -874,7 +874,7 @@ module Marshal
 
       # A Symbol has no instance variables (it's frozen),
       # but we need to know the encoding before building the Symbol
-      if ivar_index and @has_ivar[ivar_index]
+      if ivar_index && @has_ivar[ivar_index]
         # This sets the encoding of the String
         set_instance_variables data
         @has_ivar[ivar_index] = false
@@ -896,7 +896,7 @@ module Marshal
         return klass.__construct__(self, data, ivar_index, @has_ivar)
       end
 
-      if ivar_index and @has_ivar[ivar_index]
+      if ivar_index && @has_ivar[ivar_index]
         set_instance_variables data
         @has_ivar[ivar_index] = false
       end
@@ -1014,7 +1014,7 @@ module Marshal
     def serialize_instance_variables_suffix(obj, force = false)
       ivars = Primitive.object_ivars(obj)
 
-      unless force or !ivars.empty? or serialize_encoding?(obj)
+      unless force || !ivars.empty? || serialize_encoding?(obj)
         return ''.b
       end
 
@@ -1055,9 +1055,9 @@ module Marshal
     def serialize_fixnum(n)
       if n == 0
         s = n.chr
-      elsif n > 0 and n < 123
+      elsif (n > 0) && (n < 123)
         s = (n + 5).chr
-      elsif n < 0 and n > -124
+      elsif (n < 0) && (n > -124)
         s = (256 + (n - 5)).chr
       else
         s = +"\0"
@@ -1066,7 +1066,7 @@ module Marshal
           s << (n & 0xff).chr
           n >>= 8
           cnt += 1
-          break if n == 0 or n == -1
+          break if (n == 0) || (n == -1)
         end
         s[0] = (n < 0 ? 256 - cnt : cnt).chr
       end
@@ -1094,7 +1094,7 @@ module Marshal
 
     def serialize_symbol(obj)
       str = obj.to_s
-      mf = 'I' unless str.ascii_only? or str.encoding == Encoding::BINARY
+      mf = 'I' unless str.ascii_only? || (str.encoding == Encoding::BINARY)
       if mf
         me = serialize_integer(1) + serialize_encoding(obj.encoding)
       end
@@ -1308,8 +1308,8 @@ module Marshal
 
       ms = StringState.new data, nil, prc
 
-    elsif Primitive.object_respond_to? obj, :read, false and
-          Primitive.object_respond_to? obj, :getc, false
+    elsif Primitive.object_respond_to?(obj, :read, false) &&
+          Primitive.object_respond_to?(obj, :getc, false)
       ms = IOState.new obj, nil, prc
 
       major = ms.consume_byte
@@ -1318,7 +1318,7 @@ module Marshal
       raise TypeError, 'instance of IO needed'
     end
 
-    if major != MAJOR_VERSION or minor > MINOR_VERSION
+    if (major != MAJOR_VERSION) || (minor > MINOR_VERSION)
       raise TypeError, "incompatible marshal file format (can't be read)\n\tformat version #{MAJOR_VERSION}.#{MINOR_VERSION} required; #{major.inspect}.#{minor.inspect} given"
     end
 

--- a/src/main/ruby/truffleruby/core/math.rb
+++ b/src/main/ruby/truffleruby/core/math.rb
@@ -18,7 +18,7 @@ module Math
   module_function
 
   def hypot(a, b)
-    if Truffle::Type.fits_into_long?(a) and Truffle::Type.fits_into_long?(b)
+    if Truffle::Type.fits_into_long?(a) && Truffle::Type.fits_into_long?(b)
       # Much faster (~10x) than calling the Math.hypot() / hypot(3)
       Math.sqrt(a*a + b*b)
     else
@@ -39,7 +39,7 @@ module Math
     result = Primitive.math_ldexp(fraction, exponent)
     if !Primitive.undefined?(result)
       result
-    elsif Float === exponent and exponent.nan?
+    elsif (Float === exponent) && exponent.nan?
       raise RangeError, 'float NaN out of range of integer'
     else
       ldexp(

--- a/src/main/ruby/truffleruby/core/module.rb
+++ b/src/main/ruby/truffleruby/core/module.rb
@@ -53,7 +53,7 @@ class Module
   alias_method :freeze, :freeze
 
   def include?(mod)
-    if !mod.kind_of?(Module) or mod.kind_of?(Class)
+    if !mod.kind_of?(Module) || mod.kind_of?(Class)
       raise TypeError, "wrong argument type #{mod.class} (expected Module)"
     end
 
@@ -76,7 +76,7 @@ class Module
   def include(*modules)
     raise ArgumentError, 'wrong number of arguments (given 0, expected 1+)' if modules.empty?
     modules.reverse_each do |mod|
-      if !mod.kind_of?(Module) or mod.kind_of?(Class)
+      if !mod.kind_of?(Module) || mod.kind_of?(Class)
         raise TypeError, "wrong argument type #{mod.class} (expected Module)"
       end
 
@@ -89,7 +89,7 @@ class Module
   def prepend(*modules)
     raise ArgumentError, 'wrong number of arguments (given 0, expected 1+)' if modules.empty?
     modules.reverse_each do |mod|
-      if !mod.kind_of?(Module) or mod.kind_of?(Class)
+      if !mod.kind_of?(Module) || mod.kind_of?(Class)
         raise TypeError, "wrong argument type #{mod.class} (expected Module)"
       end
 

--- a/src/main/ruby/truffleruby/core/numeric.rb
+++ b/src/main/ruby/truffleruby/core/numeric.rb
@@ -151,7 +151,7 @@ class Numeric
   def remainder(other)
     mod = self % other
 
-    if mod != 0 and ((self < 0 and other > 0) or (self > 0 and other < 0))
+    if (mod != 0) && (((self < 0) && (other > 0)) || ((self > 0) && (other < 0)))
       mod - other
     else
       mod

--- a/src/main/ruby/truffleruby/core/posix.rb
+++ b/src/main/ruby/truffleruby/core/posix.rb
@@ -141,7 +141,7 @@ module Truffle::POSIX
         if blocking
           begin
             result = Primitive.thread_run_blocking_nfi_system_call(bound_func, args)
-          end while Integer === result and result == -1 and Errno.errno == EINTR
+          end while (Integer === result) && (result == -1) && (Errno.errno == EINTR)
         else
           result = bound_func.call(*args)
         end

--- a/src/main/ruby/truffleruby/core/pre.rb
+++ b/src/main/ruby/truffleruby/core/pre.rb
@@ -50,7 +50,7 @@ class Module
       kinds = method.parameters.map(&:first)
       if !kinds.include?(:rest)
         warn "Skipping set of ruby2_keywords flag for #{name} (method does not accept argument splat)", uplevel: 1
-      elsif kinds.include?(:key) or kinds.include?(:keyreq) or kinds.include?(:keyrest)
+      elsif kinds.include?(:key) || kinds.include?(:keyreq) || kinds.include?(:keyrest)
         warn "Skipping set of ruby2_keywords flag for #{name} (method accepts keywords)", uplevel: 1
       end
     end
@@ -64,7 +64,7 @@ class Proc
     kinds = parameters.map(&:first)
     if !kinds.include?(:rest)
       warn 'Skipping set of ruby2_keywords flag for proc (proc does not accept argument splat)', uplevel: 1
-    elsif kinds.include?(:key) or kinds.include?(:keyreq) or kinds.include?(:keyrest)
+    elsif kinds.include?(:key) || kinds.include?(:keyreq) || kinds.include?(:keyrest)
       warn 'Skipping set of ruby2_keywords flag for proc (proc accepts keywords)', uplevel: 1
     end
     warn 'Proc#ruby2_keywords was ignored', uplevel: 1 if $DEBUG

--- a/src/main/ruby/truffleruby/core/proc.rb
+++ b/src/main/ruby/truffleruby/core/proc.rb
@@ -89,7 +89,7 @@ class Proc
     suffix = ''.b
     if sym = Primitive.proc_symbol_to_proc_symbol(self)
       suffix << "(&#{sym.inspect})"
-    elsif file and line
+    elsif file && line
       suffix << " #{file}:#{line}"
     end
     suffix << ' (lambda)' if lambda?

--- a/src/main/ruby/truffleruby/core/process.rb
+++ b/src/main/ruby/truffleruby/core/process.rb
@@ -289,7 +289,7 @@ module Process
     end
 
     rlim_t = Truffle::Config['platform.typedef.rlim_t']
-    raise rlim_t unless rlim_t == 'ulong' or rlim_t == 'ulong_long'
+    raise rlim_t unless (rlim_t == 'ulong') || (rlim_t == 'ulong_long')
 
     Truffle::FFI::MemoryPointer.new(:rlim_t, 2) do |ptr|
       ptr[0].write_ulong cur_limit
@@ -304,7 +304,7 @@ module Process
     resource = coerce_rlimit_resource(resource)
 
     rlim_t = Truffle::Config['platform.typedef.rlim_t']
-    raise rlim_t unless rlim_t == 'ulong' or rlim_t == 'ulong_long'
+    raise rlim_t unless (rlim_t == 'ulong') || (rlim_t == 'ulong_long')
 
     Truffle::FFI::MemoryPointer.new(:rlim_t, 2) do |ptr|
       ret = Truffle::POSIX.getrlimit(resource, ptr)

--- a/src/main/ruby/truffleruby/core/random.rb
+++ b/src/main/ruby/truffleruby/core/random.rb
@@ -123,7 +123,7 @@ module Random::Formatter
                  end
 
     # Weird case, spec'd for SecureRandom.random_number
-    if Primitive.object_kind_of?(limit, Numeric) and limit <= 0
+    if Primitive.object_kind_of?(limit, Numeric) && (limit <= 0)
       return randomizer.random_float
     end
 

--- a/src/main/ruby/truffleruby/core/range.rb
+++ b/src/main/ruby/truffleruby/core/range.rb
@@ -50,19 +50,19 @@ class Range
   def ==(other)
     return true if equal? other
 
-    other.kind_of?(Range) and
-      self.begin == other.begin and
-      self.end == other.end and
-      self.exclude_end? == other.exclude_end?
+    other.kind_of?(Range) &&
+      (self.begin == other.begin) &&
+      (self.end == other.end) &&
+      (self.exclude_end? == other.exclude_end?)
   end
 
   def eql?(other)
     return true if equal? other
 
-    other.kind_of?(Range) and
-        self.begin.eql?(other.begin) and
-        self.end.eql?(other.end) and
-        self.exclude_end? == other.exclude_end?
+    other.kind_of?(Range) &&
+        self.begin.eql?(other.begin) &&
+        self.end.eql?(other.end) &&
+        (self.exclude_end? == other.exclude_end?)
   end
 
   def bsearch(&block)
@@ -229,7 +229,7 @@ class Range
   private def bsearch_integer(&block)
     min = self.begin
     max = self.end
-    max -= 1 if max.kind_of? Integer and exclude_end?
+    max -= 1 if max.kind_of?(Integer) && exclude_end?
     return nil if max < min
     last_admissible = nil
     stop = false
@@ -548,7 +548,7 @@ class Range
   alias_method :collect, :map
 
   private def to_a_internal # MODIFIED called from java to_a
-    return to_a_from_enumerable unless self.begin.kind_of? Integer and self.end.kind_of? Integer
+    return to_a_from_enumerable unless self.begin.kind_of?(Integer) && self.end.kind_of?(Integer)
 
     fin = self.end
     fin += 1 unless exclude_end?

--- a/src/main/ruby/truffleruby/core/regexp.rb
+++ b/src/main/ruby/truffleruby/core/regexp.rb
@@ -138,7 +138,7 @@ class Regexp
     if pattern.kind_of?(Regexp)
       opts = pattern.options
       pattern = pattern.source
-    elsif pattern.kind_of?(Integer) or pattern.kind_of?(Float)
+    elsif pattern.kind_of?(Integer) || pattern.kind_of?(Float)
       raise TypeError, "can't convert #{pattern.class} into String"
     elsif opts.kind_of?(Integer)
       opts = opts & (OPTION_MASK | KCODE_MASK) if opts > 0
@@ -149,7 +149,7 @@ class Regexp
     end
 
     code = lang[0] if lang
-    opts |= NOENCODING if code == ?n or code == ?N
+    opts |= NOENCODING if (code == ?n) || (code == ?N)
 
     compile pattern, opts # may be overridden by subclasses
   end

--- a/src/main/ruby/truffleruby/core/string.rb
+++ b/src/main/ruby/truffleruby/core/string.rb
@@ -49,7 +49,7 @@ class String
     # Convert to (int index, int length) form.
     if Range === index_or_range && Primitive.undefined?(length)
       index, length = Primitive.range_normalized_start_length(index_or_range, bytesize)
-      return if index < 0 or index > bytesize
+      return if (index < 0) || (index > bytesize)
       return byteslice 0, 0 if length < 0
     else
       index = Primitive.rb_num2long(index_or_range)
@@ -64,7 +64,7 @@ class String
       end
 
       length = bytesize unless Primitive.integer_fits_into_int(index)
-      return if index < 0 or index > bytesize
+      return if (index < 0) || (index > bytesize)
     end
 
     byteslice index, length
@@ -424,7 +424,7 @@ class String
       end
     end
 
-    if ascii_only? and from_enc.ascii_compatible? and to_enc and to_enc.ascii_compatible?
+    if ascii_only? && from_enc.ascii_compatible? && to_enc && to_enc.ascii_compatible?
       force_encoding to_enc
     elsif to_enc
       if from_enc != to_enc
@@ -474,7 +474,7 @@ class String
   end
 
   def end_with?(*suffixes)
-    if suffixes.size == 1 and suffix = suffixes[0] and String === suffix
+    if (suffixes.size == 1) && (suffix = suffixes[0]) && (String === suffix)
       enc = Primitive.encoding_ensure_compatible self, suffix
       return Primitive.string_end_with?(self, suffix, enc)
     end
@@ -529,11 +529,11 @@ class String
   private def inspect_char(enc, result_encoding, ascii, unicode, index, char, result)
     consumed = char.bytesize
 
-    if (ascii or unicode) and consumed == 1
+    if (ascii || unicode) || consumed == 1
       escaped = nil
 
       byte = getbyte(index)
-      if byte >= 7 and byte <= 92
+      if byte >= 7 || byte <= 92
         case byte
         when 7  # \a
           escaped = '\a'
@@ -872,7 +872,7 @@ class String
         nxt = Primitive.find_string(self, sep, pos)
         break unless nxt
 
-        while data[nxt] == 10 and nxt < bytesize
+        while (data[nxt] == 10) && (nxt < bytesize)
           nxt += 1
         end
 
@@ -894,7 +894,7 @@ class String
 
       # No more separates, but we need to grab the last part still.
       fin = byteslice pos, bytesize - pos
-      yield maybe_chomp.call(fin) if fin and !fin.empty?
+      yield maybe_chomp.call(fin) if fin && !fin.empty?
     else
 
       # This is the normal case.
@@ -985,7 +985,7 @@ class String
   def scrub(replace = nil, &block)
     return dup if valid_encoding?
 
-    if !replace and !block
+    if !replace && !block
       # The unicode replacement character or '?''
       begin
         replace = "\xEF\xBF\xBD".encode(self.encoding, :undef => :replace, :replace => '?')
@@ -1059,7 +1059,7 @@ class String
   def assign_index(index, count, replacement)
     index += size if index < 0
 
-    if index < 0 or index > size
+    if (index < 0) || (index > size)
       raise IndexError, "index #{index} out of string"
     end
 
@@ -1105,7 +1105,7 @@ class String
     start, length = Primitive.range_normalized_start_length(index, size)
     stop = start + length - 1
 
-    raise RangeError, "#{index.first} is out of range" if start < 0 or start > size
+    raise RangeError, "#{index.first} is out of range" if (start < 0) || (start > size)
 
     bi = Primitive.string_byte_index_from_char_index(self, start)
     raise IndexError, "unable to find character at: #{start}" unless bi
@@ -1137,8 +1137,8 @@ class String
       raise IndexError, 'regexp does not match'
     end
 
-    count += ms if count < 0 and -count < ms
-    unless count < ms and count >= 0
+    count += ms if (count < 0) && (-count < ms)
+    unless (count < ms) && (count >= 0)
       raise IndexError, "index #{count} out of match bounds"
     end
 
@@ -1282,7 +1282,7 @@ class String
       start = Primitive.rb_to_int start
 
       start += size if start < 0
-      if start < 0 or start > size
+      if (start < 0) || (start > size)
         Primitive.regexp_last_match_set(Primitive.caller_special_variables, nil) if str.kind_of? Regexp
         return
       end
@@ -1375,7 +1375,7 @@ class String
   end
 
   def start_with?(*prefixes)
-    if prefixes.size == 1 and prefix = prefixes[0] and String === prefix
+    if (prefixes.size == 1) && (prefix = prefixes[0]) && (String === prefix)
       return self[0, prefix.length] == prefix
     end
 
@@ -1406,7 +1406,7 @@ class String
     index = Primitive.rb_to_int index
     index = length + 1 + index if index < 0
 
-    if index > length or index < 0 then
+    if (index > length) || (index < 0) then
       raise IndexError, "index #{index} out of string"
     end
 

--- a/src/main/ruby/truffleruby/core/struct.rb
+++ b/src/main/ruby/truffleruby/core/struct.rb
@@ -212,7 +212,7 @@ class Struct
     else
       var = Integer(var)
       a_len = _attrs.length
-      return nil if var >= a_len or var < -a_len
+      return nil if (var >= a_len) || (var < -a_len)
       var = _attrs[var]
     end
 

--- a/src/main/ruby/truffleruby/core/time.rb
+++ b/src/main/ruby/truffleruby/core/time.rb
@@ -137,7 +137,7 @@ class Time
   end
 
   def eql?(other)
-    other.kind_of?(Time) and tv_sec == other.tv_sec and tv_nsec == other.tv_nsec
+    other.kind_of?(Time) && (tv_sec == other.tv_sec) && (tv_nsec == other.tv_nsec)
   end
 
   def <=>(other)
@@ -311,7 +311,7 @@ class Time
                    copy
                  elsif Primitive.object_kind_of?(sec, Integer)
                    Primitive.time_at self, sec, 0
-                 elsif Primitive.object_kind_of?(sec, Float) and sec >= 0.0
+                 elsif Primitive.object_kind_of?(sec, Float) && (sec >= 0.0)
                    ns = (sec % 1.0 * 1e9).round
                    Primitive.time_at self, sec.to_i, ns
                  end
@@ -406,7 +406,7 @@ class Time
         is_dst = is_dst ? 1 : 0
       end
 
-      if m.kind_of?(String) or m.respond_to?(:to_str)
+      if m.kind_of?(String) || m.respond_to?(:to_str)
         m = StringValue(m)
         m = MonthValue[m.upcase] || m.to_i
 

--- a/src/main/ruby/truffleruby/core/transcoding.rb
+++ b/src/main/ruby/truffleruby/core/transcoding.rb
@@ -97,7 +97,7 @@ class Encoding
       name = encoding.name.upcase.to_sym
       transcoders = Primitive.encoding_transcoders_from_encoding name
 
-      return unless transcoders and transcoders.size == 1
+      return unless transcoders && (transcoders.size == 1)
 
       enc = Encoding.find transcoders[0].to_s
       enc if enc.ascii_compatible?
@@ -121,15 +121,15 @@ class Encoding
           @options |= INVALID_REPLACE if options[:invalid] == :replace
           @options |= UNDEF_REPLACE if options[:undef] == :replace
 
-          if options[:newline] == :universal or options[:universal_newline]
+          if (options[:newline] == :universal) || options[:universal_newline]
             @options |= UNIVERSAL_NEWLINE_DECORATOR
           end
 
-          if options[:newline] == :crlf or options[:crlf_newline]
+          if (options[:newline] == :crlf) || options[:crlf_newline]
             @options |= CRLF_NEWLINE_DECORATOR
           end
 
-          if options[:newline] == :cr or options[:cr_newline]
+          if (options[:newline] == :cr) || options[:cr_newline]
             @options |= CR_NEWLINE_DECORATOR
           end
 
@@ -165,9 +165,9 @@ class Encoding
       dest = +''
       status = primitive_convert str.dup, dest, nil, nil, @options | PARTIAL_INPUT
 
-      if status == :invalid_byte_sequence or
-         status == :undefined_conversion or
-         status == :incomplete_input
+      if (status == :invalid_byte_sequence) ||
+         (status == :undefined_conversion) ||
+         (status == :incomplete_input)
         raise last_error
       end
 
@@ -230,9 +230,9 @@ class Encoding
       dest = +''
       status = primitive_convert nil, dest
 
-      if status == :invalid_byte_sequence or
-         status == :undefined_conversion or
-         status == :incomplete_input
+      if (status == :invalid_byte_sequence) ||
+         (status == :undefined_conversion) ||
+         (status == :incomplete_input)
         raise last_error
       end
 
@@ -271,8 +271,8 @@ class Encoding
           error_bytes_msg = 'U+%04X' % codepoint
         end
 
-        if source_encoding_name.to_sym == @source_encoding.name and
-           destination_encoding_name.to_sym == @destination_encoding.name
+        if (source_encoding_name.to_sym == @source_encoding.name) &&
+           (destination_encoding_name.to_sym == @destination_encoding.name)
           msg = "#{error_bytes_msg} from #{source_encoding_name} to #{destination_encoding_name}"
         else
           convpath = @convpath.map { |upcase_name| Encoding.find(upcase_name.to_s).name }
@@ -295,7 +295,7 @@ class Encoding
         exc.__send__ :error_char=, error_char
       end
 
-      if result == :invalid_byte_sequence or result == :incomplete_input
+      if (result == :invalid_byte_sequence) || (result == :incomplete_input)
         exc.__send__ :error_bytes=, error_bytes.force_encoding(Encoding::ASCII_8BIT)
 
         if bytes = read_again_bytes

--- a/src/main/ruby/truffleruby/core/truffle/boot.rb
+++ b/src/main/ruby/truffleruby/core/truffle/boot.rb
@@ -38,9 +38,9 @@ module Truffle::Boot
     # Standard lookups
 
     if ENV['RUBYPATH']
-      path = find_in_environment_paths(name, ENV['RUBYPATH']) and return path
+      (path = find_in_environment_paths(name, ENV['RUBYPATH'])) && (return path)
     end
-    path = find_in_environment_paths(name, ENV['PATH']) and return path
+    (path = find_in_environment_paths(name, ENV['PATH'])) && (return path)
     return name if File.exist?(name)
 
     # Not found, let the RubyLauncher print the error

--- a/src/main/ruby/truffleruby/core/truffle/ctype.rb
+++ b/src/main/ruby/truffleruby/core/truffle/ctype.rb
@@ -41,6 +41,6 @@
 
 module Truffle::CType
   def self.isdigit(num)
-    num >= 48 and num <= 57
+    (num >= 48) && (num <= 57)
   end
 end

--- a/src/main/ruby/truffleruby/core/truffle/file_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/file_operations.rb
@@ -67,7 +67,7 @@ module Truffle
       start = 0
       bytesize = path.bytesize
 
-      while index = Primitive.find_string(path, '/', start) or (start < bytesize and index = bytesize)
+      while (index = Primitive.find_string(path, '/', start)) || ((start < bytesize) && (index = bytesize))
         length = index - start
 
         if length > 0

--- a/src/main/ruby/truffleruby/core/truffle/gem_util.rb
+++ b/src/main/ruby/truffleruby/core/truffle/gem_util.rb
@@ -71,14 +71,14 @@ module Truffle::GemUtil
 
     if DEFAULT_GEMS.include?(first_component)
       # No need to check for 'io/nonblock' and 'io/wait', just for 'io/console'
-      return false if first_component == 'io' and !feature.start_with?('io/console')
+      return false if (first_component == 'io') && !feature.start_with?('io/console')
 
       matcher = "#{first_component}-"
       gem_paths.each do |gem_dir|
         spec_dir = "#{gem_dir}/specifications"
         if File.directory?(spec_dir)
           Dir.each_child(spec_dir) do |spec|
-            if spec.start_with?(matcher) and digit = spec[matcher.size] and '0' <= digit && digit <= '9'
+            if spec.start_with?(matcher) && (digit = spec[matcher.size]) && '0' <= digit && digit <= '9'
               return true
             end
           end

--- a/src/main/ruby/truffleruby/core/truffle/interop.rb
+++ b/src/main/ruby/truffleruby/core/truffle/interop.rb
@@ -302,7 +302,7 @@ module Truffle
           array_or_map = true
           string << " {#{pairs_from_java_map(object).map { |k, v| "#{basic_inspect_for k}=>#{basic_inspect_for v}" }.join(', ')}}"
         end
-        if Truffle::Interop.has_members?(object) and !array_or_map
+        if Truffle::Interop.has_members?(object) && !array_or_map
           pairs = pairs_from_object(object)
           unless pairs.empty?
             string << " #{pairs.map { |k, v| "#{k}=#{basic_inspect_for v}" }.join(', ')}"

--- a/src/main/ruby/truffleruby/core/truffle/numeric_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/numeric_operations.rb
@@ -187,8 +187,8 @@ module Truffle
       desc = step < 0
       default_limit = desc ? -Float::INFINITY : Float::INFINITY
 
-      if Primitive.object_kind_of?(value, Float) or
-          Primitive.object_kind_of?(limit, Float) or
+      if Primitive.object_kind_of?(value, Float) ||
+          Primitive.object_kind_of?(limit, Float) ||
           Primitive.object_kind_of?(step, Float)
         [Truffle::Type.rb_num2dbl(value), Truffle::Type.rb_num2dbl(limit || default_limit),
          Truffle::Type.rb_num2dbl(step), desc, true]

--- a/src/main/ruby/truffleruby/core/truffle/process_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/process_operations.rb
@@ -125,7 +125,7 @@ module Truffle
           command = env_or_cmd
         end
 
-        if args.empty? and cmd = Truffle::Type.try_convert(command, String, :to_str)
+        if args.empty? && (cmd = Truffle::Type.try_convert(command, String, :to_str))
           @command = cmd
           @argv = []
         else
@@ -168,7 +168,7 @@ module Truffle
 
         parse_options(options)
 
-        if env and !env.empty?
+        if env && !env.empty?
           array = (@options[:env] ||= [])
 
           env.each_pair do |key, value|
@@ -303,7 +303,7 @@ module Truffle
       end
 
       def default_mode(target)
-        if target == 1 or target == 2
+        if (target == 1) || (target == 2)
           OFLAGS['w']
         else
           OFLAGS['r']

--- a/src/main/ruby/truffleruby/core/truffle/range_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/range_operations.rb
@@ -47,7 +47,7 @@ module Truffle
     end
 
     def self.validate_step_size(first, last, step_size)
-      if step_size.kind_of? Float or first.kind_of? Float or last.kind_of? Float
+      if step_size.kind_of?(Float) || first.kind_of?(Float) || last.kind_of?(Float)
         # if any are floats they all must be
         begin
           step_size = Float(from = step_size)

--- a/src/main/ruby/truffleruby/core/truffle/regexp_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/regexp_operations.rb
@@ -57,7 +57,7 @@ module Truffle
       COMPARE_ENGINES = Truffle::Boot.get_option('compare-regex-engines')
       USE_TRUFFLE_REGEX = Truffle::Boot.get_option('use-truffle-regex')
 
-      if Truffle::Boot.get_option('regexp-instrument-creation') or Truffle::Boot.get_option('regexp-instrument-match')
+      if Truffle::Boot.get_option('regexp-instrument-creation') || Truffle::Boot.get_option('regexp-instrument-match')
         at_exit do
           Truffle::RegexpOperations.print_stats
         end

--- a/src/main/ruby/truffleruby/core/truffle/string_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/string_operations.rb
@@ -128,7 +128,7 @@ module Truffle
 
       unless other.kind_of? String
         if other.kind_of? Integer
-          if string.encoding == Encoding::US_ASCII and other >= 128 and other < 256
+          if (string.encoding == Encoding::US_ASCII) && (other >= 128) && (other < 256)
             string.force_encoding(Encoding::ASCII_8BIT)
           end
 
@@ -272,7 +272,7 @@ module Truffle
 
     def self.byte_index(src, str, start=0)
       start += src.bytesize if start < 0
-      if start < 0 or start > src.bytesize
+      if (start < 0) || (start > src.bytesize)
         Primitive.regexp_last_match_set(Primitive.caller_special_variables, nil) if str.kind_of? Regexp
         return nil
       end

--- a/src/main/ruby/truffleruby/core/type.rb
+++ b/src/main/ruby/truffleruby/core/type.rb
@@ -328,7 +328,7 @@ module Truffle
     def self.check_funcall_missing(recv, meth, args, respond, priv = false)
       ret = basic_obj_respond_to_missing(recv, meth, priv)
       respond_to_missing = !Primitive.undefined?(ret)
-      if respond_to_missing and !ret
+      if respond_to_missing && !ret
         undefined
       elsif object_respond_to_no_built_in?(recv, :method_missing, true)
         begin

--- a/src/main/ruby/truffleruby/post-boot/post-boot.rb
+++ b/src/main/ruby/truffleruby/post-boot/post-boot.rb
@@ -73,7 +73,7 @@ end
 
 if Truffle::Boot.ruby_home
   Truffle::Boot.delay do
-    if Truffle::Boot.get_option('rubygems') and !Truffle::Boot.get_option('lazy-rubygems')
+    if Truffle::Boot.get_option('rubygems') && !Truffle::Boot.get_option('lazy-rubygems')
       begin
         Truffle::Boot.print_time_metric :'before-rubygems'
         begin

--- a/tool/jt.rb
+++ b/tool/jt.rb
@@ -2213,7 +2213,7 @@ module Commands
       end
 
       link_path = "#{rubies_dir}/#{name}"
-      File.delete link_path if File.symlink? link_path or File.exist? link_path
+      File.delete link_path if File.symlink?(link_path) || File.exist?(link_path)
       File.symlink dest_ruby, link_path
     end
   end
@@ -2262,7 +2262,7 @@ module Commands
   alias :'native-launcher' :native_launcher
 
   def rubocop(*args)
-    if args.empty? or args.all? { |arg| arg.start_with?('-') }
+    if args.empty? || args.all? { |arg| arg.start_with?('-') }
       args += RUBOCOP_INCLUDE_LIST
     end
 
@@ -2369,7 +2369,7 @@ module Commands
   def check_documentation
     status = true
     allowed = -> str {
-      str.ascii_only? or str.chars.all? { |c| c.ascii_only? or %w[± – → ⌥ ⌘ ⇧].include?(c) }
+      str.ascii_only? || str.chars.all? { |c| c.ascii_only? || %w[± – → ⌥ ⌘ ⇧].include?(c) }
     }
 
     `git -C #{TRUFFLERUBY_DIR} ls-files '**/*.md'`.lines.map(&:chomp).each do |file|
@@ -2410,7 +2410,7 @@ module Commands
     hardcoded_urls.each_line do |line|
       abort "Could not parse #{line.inspect}" unless /(.+?):(\d+):.+?(https:.+?)[ "'\n]/ =~ line
       file, line, url = $1, $2, $3
-      if !%w[tool/jt.rb tool/generate-user-doc.rb].include?(file) and !known_hardcoded_urls.include?(url)
+      if !%w[tool/jt.rb tool/generate-user-doc.rb].include?(file) && !known_hardcoded_urls.include?(url)
         puts "Found unknown hardcoded url #{url} in #{file}:#{line}, add it in tool/jt.rb"
         status = false
       end
@@ -2445,7 +2445,7 @@ module Commands
     status = $?
 
     unused_import = /: Unused import -/
-    if !status.success? and output =~ unused_import
+    if !status.success? && output =~(unused_import)
       puts 'Automatically removing unused imports'
       output.lines.reverse.grep(unused_import) do |line|
         path, lineno, _ = line.split(':', 3)
@@ -2473,7 +2473,7 @@ module Commands
 
     def format_specializations_visibility
       iterate do |type, (first, *rest)|
-        if type == :ExportMessage and first !~ /\bstatic\b/
+        if (type == :ExportMessage) && first !~(/\bstatic\b/)
           # Keep non-static @ExportMessage public
           [first, *rest]
         else
@@ -2658,7 +2658,7 @@ module Commands
     fast = args.first == 'fast'
     args.shift if fast
 
-    if fast and compare_to = args.shift
+    if fast && (compare_to = args.shift)
       changed_files = `git diff --cached --name-only #{compare_to}`.lines.map(&:chomp)
       changed = {}
       changed_files.each do |file|
@@ -2677,7 +2677,7 @@ module Commands
     sh 'tool/lint.sh' if changed['.c']
     checkstyle(changed['.java']) if changed['.java']
     command_format(changed['.java']) if changed['.java']
-    shellcheck if changed['.sh'] or changed['.inc']
+    shellcheck if changed['.sh'] || changed['.inc']
 
     mx 'verify-ci' if changed['.py']
 


### PR DESCRIPTION
https://rubystyle.guide/#no-and-or-or has some good reasons why it's a good practice to stick with `||` and `&&` instead of `and` / `or`.

Unless the team feels strongly I think it would be a good to go with the community-recommended style.

@eregon 