### PR TITLE
Rope fixes

### DIFF
--- a/src/main/java/org/truffleruby/core/regexp/MatchDataNodes.java
+++ b/src/main/java/org/truffleruby/core/regexp/MatchDataNodes.java
@@ -34,6 +34,7 @@ import org.truffleruby.core.range.RubyIntRange;
 import org.truffleruby.core.regexp.MatchDataNodesFactory.ValuesNodeFactory;
 import org.truffleruby.core.rope.Rope;
 import org.truffleruby.core.rope.RopeNodes;
+import org.truffleruby.core.rope.RopeOperations;
 import org.truffleruby.core.string.RubyString;
 import org.truffleruby.core.string.StringSupport;
 import org.truffleruby.core.string.StringUtils;
@@ -309,7 +310,7 @@ public abstract class MatchDataNodes {
                 @CachedLibrary(limit = "2") RubyStringLibrary libIndex) {
             return executeGetIndex(
                     matchData,
-                    getBackRefFromRope(matchData, index, libIndex.getRope(index)),
+                    getBackRefFromRope(matchData, libIndex.getRope(index)),
                     NotProvided.INSTANCE);
         }
 
@@ -368,12 +369,11 @@ public abstract class MatchDataNodes {
 
         @TruffleBoundary
         private int getBackRefFromSymbol(RubyMatchData matchData, RubySymbol index) {
-            final Rope value = index.getRope();
-            return getBackRefFromRope(matchData, index, value);
+            return getBackRefFromRope(matchData, index.getRope());
         }
 
         @TruffleBoundary
-        private int getBackRefFromRope(RubyMatchData matchData, Object index, Rope value) {
+        private int getBackRefFromRope(RubyMatchData matchData, Rope value) {
             try {
                 return getRegexp(matchData).regex.nameToBackrefNumber(
                         value.getBytes(),
@@ -384,7 +384,8 @@ public abstract class MatchDataNodes {
                 throw new RaiseException(
                         getContext(),
                         coreExceptions().indexError(
-                                StringUtils.format("undefined group name reference: %s", index),
+                                StringUtils
+                                        .format("undefined group name reference: %s", RopeOperations.decodeRope(value)),
                                 this));
             }
         }

--- a/src/main/java/org/truffleruby/core/rope/ConcatRope.java
+++ b/src/main/java/org/truffleruby/core/rope/ConcatRope.java
@@ -65,6 +65,8 @@ public class ConcatRope extends ManagedRope {
             int characterLength,
             byte[] bytes) {
         super(encoding, codeRange, byteLength, characterLength, bytes);
+        assert left != null;
+        assert right != null;
         this.left = left;
         this.right = right;
     }
@@ -81,10 +83,14 @@ public class ConcatRope extends ManagedRope {
         return withEncoding(ASCIIEncoding.INSTANCE, CodeRange.CR_VALID, byteLength(), bytesNotNull);
     }
 
-    private ConcatRope withEncoding(Encoding encoding, CodeRange codeRange, int characterLength,
+    private Rope withEncoding(Encoding encoding, CodeRange codeRange, int characterLength,
             ConditionProfile bytesNotNull) {
         final ConcatState state = getState(bytesNotNull);
-        return new ConcatRope(state.left, state.right, encoding, codeRange, byteLength(), characterLength, state.bytes);
+        if (state.isFlattened()) {
+            return RopeOperations.create(state.bytes, encoding, codeRange);
+        } else {
+            return new ConcatRope(state.left, state.right, encoding, codeRange, byteLength(), characterLength, null);
+        }
     }
 
     @Override

--- a/src/main/java/org/truffleruby/core/rope/ConcatRope.java
+++ b/src/main/java/org/truffleruby/core/rope/ConcatRope.java
@@ -33,12 +33,8 @@ public class ConcatRope extends ManagedRope {
             this.bytes = bytes;
         }
 
-        public boolean isBytes() {
+        public boolean isFlattened() {
             return bytes != null;
-        }
-
-        public boolean isChildren() {
-            return bytes == null;
         }
     }
 

--- a/src/main/java/org/truffleruby/core/rope/ConcatRope.java
+++ b/src/main/java/org/truffleruby/core/rope/ConcatRope.java
@@ -89,11 +89,15 @@ public class ConcatRope extends ManagedRope {
 
     @Override
     protected byte[] getBytesSlow() {
+        flatten();
+        return bytes;
+    }
+
+    private void flatten() {
         bytes = RopeOperations.flattenBytes(this);
         MemoryFence.storeStore();
         left = null;
         right = null;
-        return bytes;
     }
 
     /** Access the state in a way that prevents race conditions.

--- a/src/main/java/org/truffleruby/core/rope/ManagedRope.java
+++ b/src/main/java/org/truffleruby/core/rope/ManagedRope.java
@@ -54,16 +54,4 @@ public abstract class ManagedRope extends Rope {
         return bytes;
     }
 
-    @Override
-    public final String toString() {
-        if (DEBUG_ROPE_BYTES) {
-            final byte[] bytesBefore = bytes;
-            final String string = RopeOperations.decodeOrEscapeBinaryRope(this, RopeOperations.flattenBytes(this));
-            assert bytes == bytesBefore : "bytes should not be modified by Rope#toString() as otherwise inspecting a Rope would have a side effect";
-            return string;
-        } else {
-            return RopeOperations.decodeRope(this);
-        }
-    }
-
 }

--- a/src/main/java/org/truffleruby/core/rope/NativeRope.java
+++ b/src/main/java/org/truffleruby/core/rope/NativeRope.java
@@ -184,11 +184,6 @@ public class NativeRope extends Rope {
     }
 
     @Override
-    public String toString() {
-        return toLeafRope().toString();
-    }
-
-    @Override
     Rope withEncoding7bit(Encoding newEncoding, ConditionProfile bytesNotNull) {
         return withEncoding(newEncoding);
     }

--- a/src/main/java/org/truffleruby/core/rope/Rope.java
+++ b/src/main/java/org/truffleruby/core/rope/Rope.java
@@ -21,9 +21,6 @@ public abstract class Rope implements Comparable<Rope> {
     // NativeRope, RepeatingRope, 3 LeafRope, ConcatRope, SubstringRope, 1 LazyRope
     public static final int NUMBER_OF_CONCRETE_CLASSES = 8;
 
-    // Useful for debugging. Setting to true avoids ManagedRope#toString to populate bytes as a side-effect of the debugger calling toString().
-    protected static final boolean DEBUG_ROPE_BYTES = false;
-
     public final Encoding encoding;
     private final int byteLength;
     private int hashCode = 0;
@@ -161,8 +158,15 @@ public abstract class Rope implements Comparable<Rope> {
         return getByteSlow(index);
     }
 
+    @Override
+    public String toString() {
+        // This is designed to not have any side effects - compare to getString
+        return RopeOperations.decode(encoding, RopeOperations.flattenBytes(this));
+    }
+
     /** Should only be used by the parser */
-    public final String getString() {
+    public final String normaliseAndGetJavaString() {
+        // This will have side effects such as flattening a ConcatString
         return RopeOperations.decodeRope(this);
     }
 

--- a/src/main/java/org/truffleruby/core/rope/Rope.java
+++ b/src/main/java/org/truffleruby/core/rope/Rope.java
@@ -158,15 +158,15 @@ public abstract class Rope implements Comparable<Rope> {
         return getByteSlow(index);
     }
 
+    /** This is designed to not have any side effects - compare to {@link #getJavaString} - but this makes it
+     * inefficient - for debugging only */
     @Override
     public String toString() {
-        // This is designed to not have any side effects - compare to getString
         return RopeOperations.decode(encoding, RopeOperations.flattenBytes(this));
     }
 
-    /** Should only be used by the parser */
-    public final String normaliseAndGetJavaString() {
-        // This will have side effects such as flattening a ConcatString
+    /** Should only be used by the parser - it has side effects */
+    public final String getJavaString() {
         return RopeOperations.decodeRope(this);
     }
 

--- a/src/main/java/org/truffleruby/core/rope/RopeCache.java
+++ b/src/main/java/org/truffleruby/core/rope/RopeCache.java
@@ -54,7 +54,7 @@ public class RopeCache {
         final BytesKey key = new BytesKey(rope.getBytes(), rope.getEncoding());
         final Rope existing = bytesToRope.put(key, rope);
         if (existing != null && existing != rope) {
-            throw new AssertionError("Duplicate Rope in RopeCache: " + existing.getString());
+            throw new AssertionError("Duplicate Rope in RopeCache: " + existing);
         }
     }
 

--- a/src/main/java/org/truffleruby/core/rope/RopeConstants.java
+++ b/src/main/java/org/truffleruby/core/rope/RopeConstants.java
@@ -112,7 +112,7 @@ public class RopeConstants {
             final LeafRope rope = new AsciiOnlyLeafRope(bytes, USASCIIEncoding.INSTANCE).computeHashCode();
             final Rope existing = ROPE_CONSTANTS.putIfAbsent(string, rope);
             if (existing != null) {
-                throw new AssertionError("Duplicate Rope in RopeConstants: " + existing.getString());
+                throw new AssertionError("Duplicate Rope in RopeConstants: " + existing);
             }
             return rope;
         }

--- a/src/main/java/org/truffleruby/core/rope/RopeNodes.java
+++ b/src/main/java/org/truffleruby/core/rope/RopeNodes.java
@@ -747,7 +747,7 @@ public abstract class RopeNodes {
 
             System.err.println(StringUtils.format(
                     "%s (%s; BN: %b; BL: %d; CL: %d; CR: %s; E: %s)",
-                    printString ? rope.toString() : "<skipped>",
+                    printString ? RopeOperations.escape(rope) : "<skipped>",
                     rope.getClass().getSimpleName(),
                     bytesAreNull,
                     rope.byteLength(),
@@ -768,7 +768,7 @@ public abstract class RopeNodes {
 
             System.err.println(StringUtils.format(
                     "%s (%s; BN: %b; BL: %d; CL: %d; CR: %s; O: %d; E: %s)",
-                    printString ? rope.toString() : "<skipped>",
+                    printString ? RopeOperations.escape(rope) : "<skipped>",
                     rope.getClass().getSimpleName(),
                     bytesAreNull,
                     rope.byteLength(),
@@ -795,7 +795,7 @@ public abstract class RopeNodes {
             if (state.isFlattened()) {
                 System.err.println(StringUtils.format(
                         "%s (%s; BN: %b; BL: %d; CL: %d; CR: %s; E: %s)",
-                        printString ? rope.toString() : "<skipped>",
+                        printString ? RopeOperations.escape(rope) : "<skipped>",
                         rope.getClass().getSimpleName(),
                         bytesAreNull,
                         rope.byteLength(),
@@ -805,7 +805,7 @@ public abstract class RopeNodes {
             } else {
                 System.err.println(StringUtils.format(
                         "%s (%s; BN: %b; BL: %d; CL: %d; CR: %s; E: %s)",
-                        printString ? rope.toString() : "<skipped>",
+                        printString ? RopeOperations.escape(rope) : "<skipped>",
                         rope.getClass().getSimpleName(),
                         bytesAreNull,
                         rope.byteLength(),
@@ -830,7 +830,7 @@ public abstract class RopeNodes {
 
             System.err.println(StringUtils.format(
                     "%s (%s; BN: %b; BL: %d; CL: %d; CR: %s; T: %d; D: %d; E: %s)",
-                    printString ? rope.toString() : "<skipped>",
+                    printString ? RopeOperations.escape(rope) : "<skipped>",
                     rope.getClass().getSimpleName(),
                     bytesAreNull,
                     rope.byteLength(),
@@ -854,7 +854,7 @@ public abstract class RopeNodes {
 
             System.err.println(StringUtils.format(
                     "%s (%s; BN: %b; BL: %d; CL: %d; CR: %s; V: %d, D: %d; E: %s)",
-                    printString ? rope.toString() : "<skipped>",
+                    printString ? RopeOperations.escape(rope) : "<skipped>",
                     rope.getClass().getSimpleName(),
                     bytesAreNull,
                     rope.byteLength(),

--- a/src/main/java/org/truffleruby/core/rope/RopeNodes.java
+++ b/src/main/java/org/truffleruby/core/rope/RopeNodes.java
@@ -791,7 +791,7 @@ public abstract class RopeNodes {
             // Before the print, as `toString()` may cause the bytes to become populated.
             final boolean bytesAreNull = rope.getRawBytes() == null;
 
-            if (state.isBytes()) {
+            if (state.isFlattened()) {
                 System.err.println(StringUtils.format(
                         "%s (%s; BN: %b; BL: %d; CL: %d; CR: %s; E: %s)",
                         printString ? rope.toString() : "<skipped>",
@@ -994,7 +994,7 @@ public abstract class RopeNodes {
         //   Therefore it's important to test isChildren first, as it's possible to transition from children to bytes
         //   but not the other way around.
 
-        @Specialization(guards = "state.isChildren()")
+        @Specialization(guards = "!state.isFlattened()")
         protected int getByteConcatRope(ConcatRope rope, int index,
                 @Cached ConditionProfile stateBytesNotNull,
                 @Bind("rope.getState(stateBytesNotNull)") ConcatState state,
@@ -1020,7 +1020,7 @@ public abstract class RopeNodes {
 
         // Necessary because getRawBytes() might return null, but then be populated and the children nulled
         // before we get to run the other getByteConcatRope.
-        @Specialization(guards = "state.isBytes()")
+        @Specialization(guards = "state.isFlattened()")
         protected int getByteConcatRope(ConcatRope rope, int index,
                 @Cached ConditionProfile stateBytesNotNull,
                 @Bind("rope.getState(stateBytesNotNull)") ConcatState state) {

--- a/src/main/java/org/truffleruby/core/rope/RopeNodes.java
+++ b/src/main/java/org/truffleruby/core/rope/RopeNodes.java
@@ -783,6 +783,7 @@ public abstract class RopeNodes {
         }
 
         @TruffleBoundary
+        @Specialization
         protected Object debugPrintConcatRopeBytes(ConcatRope rope, int currentLevel, boolean printString) {
             printPreamble(currentLevel);
 

--- a/src/main/java/org/truffleruby/core/rope/RopeOperations.java
+++ b/src/main/java/org/truffleruby/core/rope/RopeOperations.java
@@ -379,7 +379,7 @@ public class RopeOperations {
                 final ConcatRope concatRope = (ConcatRope) current;
 
                 final ConcatState state = concatRope.getState();
-                if (state.isBytes()) {
+                if (state.isFlattened()) {
                     // The rope got concurrently flattened between entering the iteration and reaching here,
                     // restart the iteration from the top.
                     workStack.push(concatRope);
@@ -508,7 +508,7 @@ public class RopeOperations {
             } else if (rope instanceof ConcatRope) {
                 final ConcatRope concatRope = (ConcatRope) rope;
                 final ConcatState state = concatRope.getState();
-                if (state.isBytes()) {
+                if (state.isFlattened()) {
                     // Rope got concurrently flattened.
                     return state.bytes[index];
                 }
@@ -580,7 +580,7 @@ public class RopeOperations {
             } else if (rope instanceof ConcatRope) {
                 final ConcatRope concatRope = (ConcatRope) rope;
                 final ConcatState state = concatRope.getState();
-                if (state.isBytes()) {
+                if (state.isFlattened()) {
                     // Rope got concurrently flattened.
                     resultHash = Hashing.stringHash(state.bytes, startingHashCode, offset, length);
                 } else {

--- a/src/main/java/org/truffleruby/core/rope/RopeOperations.java
+++ b/src/main/java/org/truffleruby/core/rope/RopeOperations.java
@@ -687,4 +687,32 @@ public class RopeOperations {
         //   to worry about the risk of retaining a substring rope whose child contains the value.
         return rope.byteLength() >= value.length() && RopeOperations.decodeRope(rope).contains(value);
     }
+
+    public static String escape(Rope rope) {
+        final StringBuilder builder = new StringBuilder();
+        builder.append('"');
+
+        for (int i = 0; i < rope.byteLength(); i++) {
+            final byte character = rope.get(i);
+            switch (character) {
+                case '\\':
+                    builder.append("\\");
+                    break;
+                case '"':
+                    builder.append("\\\"");
+                    break;
+                default:
+                    if (character >= 32 && character <= 126) {
+                        builder.append((char) character);
+                    } else {
+                        builder.append(StringUtils.format("\\x%02x", character));
+                    }
+                    break;
+            }
+        }
+
+        builder.append('"');
+        return builder.toString();
+    }
+
 }

--- a/src/main/java/org/truffleruby/core/rope/TruffleRopesNodes.java
+++ b/src/main/java/org/truffleruby/core/rope/TruffleRopesNodes.java
@@ -116,13 +116,13 @@ public abstract class TruffleRopesNodes {
         }
 
         private static String getStructure(LeafRope rope) {
-            return "\"" + rope.toString() + "\"";
+            return escape(rope);
         }
 
         private static String getStructure(ConcatRope rope) {
             final ConcatState state = rope.getState();
             return state.isFlattened()
-                    ? "(\"flat concat rope\"; " + rope.toString() + ")"
+                    ? "(\"flat concat rope\"; " + escape(rope) + ")"
                     : "(" + getStructure(state.left) + " + " + getStructure(state.right) + ")";
         }
 
@@ -135,6 +135,33 @@ public abstract class TruffleRopesNodes {
 
         private static String getStructure(RepeatingRope rope) {
             return "(" + getStructure(rope.getChild()) + "*" + rope.getTimes() + ")";
+        }
+
+        private static String escape(Rope rope) {
+            final StringBuilder builder = new StringBuilder();
+            builder.append('"');
+
+            for (int i = 0; i < rope.byteLength(); i++) {
+                final byte character = rope.get(i);
+                switch (character) {
+                    case '\\':
+                        builder.append("\\");
+                        break;
+                    case '"':
+                        builder.append("\\\"");
+                        break;
+                    default:
+                        if (character >= 32 && character <= 126) {
+                            builder.append((char) character);
+                        } else {
+                            builder.append(StringUtils.format("\\x%02x", character));
+                        }
+                        break;
+                }
+            }
+
+            builder.append('"');
+            return builder.toString();
         }
 
     }

--- a/src/main/java/org/truffleruby/core/rope/TruffleRopesNodes.java
+++ b/src/main/java/org/truffleruby/core/rope/TruffleRopesNodes.java
@@ -116,13 +116,13 @@ public abstract class TruffleRopesNodes {
         }
 
         private static String getStructure(LeafRope rope) {
-            return escape(rope);
+            return RopeOperations.escape(rope);
         }
 
         private static String getStructure(ConcatRope rope) {
             final ConcatState state = rope.getState();
             return state.isFlattened()
-                    ? "(\"flat concat rope\"; " + escape(rope) + ")"
+                    ? "(\"flat concat rope\"; " + RopeOperations.escape(rope) + ")"
                     : "(" + getStructure(state.left) + " + " + getStructure(state.right) + ")";
         }
 
@@ -135,33 +135,6 @@ public abstract class TruffleRopesNodes {
 
         private static String getStructure(RepeatingRope rope) {
             return "(" + getStructure(rope.getChild()) + "*" + rope.getTimes() + ")";
-        }
-
-        private static String escape(Rope rope) {
-            final StringBuilder builder = new StringBuilder();
-            builder.append('"');
-
-            for (int i = 0; i < rope.byteLength(); i++) {
-                final byte character = rope.get(i);
-                switch (character) {
-                    case '\\':
-                        builder.append("\\");
-                        break;
-                    case '"':
-                        builder.append("\\\"");
-                        break;
-                    default:
-                        if (character >= 32 && character <= 126) {
-                            builder.append((char) character);
-                        } else {
-                            builder.append(StringUtils.format("\\x%02x", character));
-                        }
-                        break;
-                }
-            }
-
-            builder.append('"');
-            return builder.toString();
         }
 
     }

--- a/src/main/java/org/truffleruby/core/rope/TruffleRopesNodes.java
+++ b/src/main/java/org/truffleruby/core/rope/TruffleRopesNodes.java
@@ -121,9 +121,9 @@ public abstract class TruffleRopesNodes {
 
         private static String getStructure(ConcatRope rope) {
             final ConcatState state = rope.getState();
-            return state.isChildren()
-                    ? "(" + getStructure(state.left) + " + " + getStructure(state.right) + ")"
-                    : "(\"flat concat rope\"; " + rope.toString() + ")";
+            return state.isFlattened()
+                    ? "(\"flat concat rope\"; " + rope.toString() + ")"
+                    : "(" + getStructure(state.left) + " + " + getStructure(state.right) + ")";
         }
 
         private static String getStructure(SubstringRope rope) {

--- a/src/main/java/org/truffleruby/core/string/StringNodes.java
+++ b/src/main/java/org/truffleruby/core/string/StringNodes.java
@@ -5200,7 +5200,9 @@ public abstract class StringNodes {
                 final ConcatRope concatRope = (ConcatRope) base;
 
                 final ConcatState state = concatRope.getState();
-                if (state.isChildren()) {
+                if (state.isFlattened()) {
+                    return new SearchResult(index, base);
+                } else {
                     final Rope left = state.left;
                     final Rope right = state.right;
                     if (index + characterLength <= left.characterLength()) {
@@ -5213,8 +5215,6 @@ public abstract class StringNodes {
                     } else {
                         return new SearchResult(index, concatRope);
                     }
-                } else {
-                    return new SearchResult(index, base);
                 }
             } else if (base instanceof RepeatingRope) {
                 final RepeatingRope repeatingRope = (RepeatingRope) base;

--- a/src/main/java/org/truffleruby/interop/PolyglotNodes.java
+++ b/src/main/java/org/truffleruby/interop/PolyglotNodes.java
@@ -111,7 +111,7 @@ public abstract class PolyglotNodes {
                     throw new RaiseException(
                             getContext(),
                             coreExceptions().argumentError(
-                                    "Could not find language of file " + strings.getJavaString(fileName),
+                                    "Could not find language of file " + path,
                                     this));
                 }
                 source = Source.newBuilder(language, file).build();

--- a/src/main/java/org/truffleruby/interop/PolyglotNodes.java
+++ b/src/main/java/org/truffleruby/interop/PolyglotNodes.java
@@ -110,7 +110,9 @@ public abstract class PolyglotNodes {
                 if (language == null) {
                     throw new RaiseException(
                             getContext(),
-                            coreExceptions().argumentError("Could not find language of file " + fileName, this));
+                            coreExceptions().argumentError(
+                                    "Could not find language of file " + strings.getJavaString(fileName),
+                                    this));
                 }
                 source = Source.newBuilder(language, file).build();
             } catch (IOException e) {

--- a/src/main/java/org/truffleruby/parser/ast/ClassVarAsgnParseNode.java
+++ b/src/main/java/org/truffleruby/parser/ast/ClassVarAsgnParseNode.java
@@ -47,7 +47,7 @@ public class ClassVarAsgnParseNode extends AssignableParseNode implements INameN
     public ClassVarAsgnParseNode(SourceIndexLength position, Rope name, ParseNode valueNode) {
         super(position, valueNode);
 
-        this.name = name.normaliseAndGetJavaString();
+        this.name = name.getJavaString();
     }
 
     @Override

--- a/src/main/java/org/truffleruby/parser/ast/ClassVarAsgnParseNode.java
+++ b/src/main/java/org/truffleruby/parser/ast/ClassVarAsgnParseNode.java
@@ -47,7 +47,7 @@ public class ClassVarAsgnParseNode extends AssignableParseNode implements INameN
     public ClassVarAsgnParseNode(SourceIndexLength position, Rope name, ParseNode valueNode) {
         super(position, valueNode);
 
-        this.name = name.getString();
+        this.name = name.normaliseAndGetJavaString();
     }
 
     @Override

--- a/src/main/java/org/truffleruby/parser/ast/ClassVarParseNode.java
+++ b/src/main/java/org/truffleruby/parser/ast/ClassVarParseNode.java
@@ -43,7 +43,7 @@ public class ClassVarParseNode extends ParseNode implements INameNode, SideEffec
     private String name;
 
     public ClassVarParseNode(SourceIndexLength position, Rope name) {
-        this(position, name.normaliseAndGetJavaString());
+        this(position, name.getJavaString());
     }
 
     public ClassVarParseNode(SourceIndexLength position, String name) {

--- a/src/main/java/org/truffleruby/parser/ast/ClassVarParseNode.java
+++ b/src/main/java/org/truffleruby/parser/ast/ClassVarParseNode.java
@@ -43,7 +43,7 @@ public class ClassVarParseNode extends ParseNode implements INameNode, SideEffec
     private String name;
 
     public ClassVarParseNode(SourceIndexLength position, Rope name) {
-        this(position, name.getString());
+        this(position, name.normaliseAndGetJavaString());
     }
 
     public ClassVarParseNode(SourceIndexLength position, String name) {

--- a/src/main/java/org/truffleruby/parser/ast/Colon3ParseNode.java
+++ b/src/main/java/org/truffleruby/parser/ast/Colon3ParseNode.java
@@ -45,7 +45,7 @@ public class Colon3ParseNode extends ParseNode implements INameNode {
 
     public Colon3ParseNode(SourceIndexLength position, Rope name) {
         super(position);
-        this.name = name.getString();
+        this.name = name.normaliseAndGetJavaString();
     }
 
     @Override

--- a/src/main/java/org/truffleruby/parser/ast/Colon3ParseNode.java
+++ b/src/main/java/org/truffleruby/parser/ast/Colon3ParseNode.java
@@ -45,7 +45,7 @@ public class Colon3ParseNode extends ParseNode implements INameNode {
 
     public Colon3ParseNode(SourceIndexLength position, Rope name) {
         super(position);
-        this.name = name.normaliseAndGetJavaString();
+        this.name = name.getJavaString();
     }
 
     @Override

--- a/src/main/java/org/truffleruby/parser/ast/ConstDeclParseNode.java
+++ b/src/main/java/org/truffleruby/parser/ast/ConstDeclParseNode.java
@@ -48,7 +48,7 @@ public class ConstDeclParseNode extends AssignableParseNode implements INameNode
         super(position, valueNode);
 
         assert constNode != null || (name != null && !name.isEmpty());
-        this.name = name == null ? null : name.normaliseAndGetJavaString();
+        this.name = name == null ? null : name.getJavaString();
         this.constNode = constNode;
     }
 

--- a/src/main/java/org/truffleruby/parser/ast/ConstDeclParseNode.java
+++ b/src/main/java/org/truffleruby/parser/ast/ConstDeclParseNode.java
@@ -48,7 +48,7 @@ public class ConstDeclParseNode extends AssignableParseNode implements INameNode
         super(position, valueNode);
 
         assert constNode != null || (name != null && !name.isEmpty());
-        this.name = name == null ? null : name.getString();
+        this.name = name == null ? null : name.normaliseAndGetJavaString();
         this.constNode = constNode;
     }
 

--- a/src/main/java/org/truffleruby/parser/ast/ConstParseNode.java
+++ b/src/main/java/org/truffleruby/parser/ast/ConstParseNode.java
@@ -43,7 +43,7 @@ public class ConstParseNode extends ParseNode implements INameNode {
     private String name;
 
     public ConstParseNode(SourceIndexLength position, Rope name) {
-        this(position, name.getString());
+        this(position, name.normaliseAndGetJavaString());
     }
 
     public ConstParseNode(SourceIndexLength position, String name) {

--- a/src/main/java/org/truffleruby/parser/ast/ConstParseNode.java
+++ b/src/main/java/org/truffleruby/parser/ast/ConstParseNode.java
@@ -43,7 +43,7 @@ public class ConstParseNode extends ParseNode implements INameNode {
     private String name;
 
     public ConstParseNode(SourceIndexLength position, Rope name) {
-        this(position, name.normaliseAndGetJavaString());
+        this(position, name.getJavaString());
     }
 
     public ConstParseNode(SourceIndexLength position, String name) {

--- a/src/main/java/org/truffleruby/parser/ast/GlobalAsgnParseNode.java
+++ b/src/main/java/org/truffleruby/parser/ast/GlobalAsgnParseNode.java
@@ -47,7 +47,7 @@ public class GlobalAsgnParseNode extends AssignableParseNode implements INameNod
     public GlobalAsgnParseNode(SourceIndexLength position, Rope name, ParseNode valueNode) {
         super(position, valueNode);
 
-        this.name = name.getString();
+        this.name = name.normaliseAndGetJavaString();
     }
 
     @Override

--- a/src/main/java/org/truffleruby/parser/ast/GlobalAsgnParseNode.java
+++ b/src/main/java/org/truffleruby/parser/ast/GlobalAsgnParseNode.java
@@ -47,7 +47,7 @@ public class GlobalAsgnParseNode extends AssignableParseNode implements INameNod
     public GlobalAsgnParseNode(SourceIndexLength position, Rope name, ParseNode valueNode) {
         super(position, valueNode);
 
-        this.name = name.normaliseAndGetJavaString();
+        this.name = name.getJavaString();
     }
 
     @Override

--- a/src/main/java/org/truffleruby/parser/ast/GlobalVarParseNode.java
+++ b/src/main/java/org/truffleruby/parser/ast/GlobalVarParseNode.java
@@ -43,7 +43,7 @@ public class GlobalVarParseNode extends ParseNode implements INameNode {
     private String name;
 
     public GlobalVarParseNode(SourceIndexLength position, Rope name) {
-        this(position, name.getString());
+        this(position, name.normaliseAndGetJavaString());
     }
 
     public GlobalVarParseNode(SourceIndexLength position, String name) {

--- a/src/main/java/org/truffleruby/parser/ast/GlobalVarParseNode.java
+++ b/src/main/java/org/truffleruby/parser/ast/GlobalVarParseNode.java
@@ -43,7 +43,7 @@ public class GlobalVarParseNode extends ParseNode implements INameNode {
     private String name;
 
     public GlobalVarParseNode(SourceIndexLength position, Rope name) {
-        this(position, name.normaliseAndGetJavaString());
+        this(position, name.getJavaString());
     }
 
     public GlobalVarParseNode(SourceIndexLength position, String name) {

--- a/src/main/java/org/truffleruby/parser/ast/InstAsgnParseNode.java
+++ b/src/main/java/org/truffleruby/parser/ast/InstAsgnParseNode.java
@@ -48,7 +48,7 @@ public class InstAsgnParseNode extends AssignableParseNode implements INameNode 
     public InstAsgnParseNode(SourceIndexLength position, Rope name, ParseNode valueNode) {
         super(position, valueNode);
 
-        this.name = name.getString();
+        this.name = name.normaliseAndGetJavaString();
     }
 
     @Override

--- a/src/main/java/org/truffleruby/parser/ast/InstAsgnParseNode.java
+++ b/src/main/java/org/truffleruby/parser/ast/InstAsgnParseNode.java
@@ -48,7 +48,7 @@ public class InstAsgnParseNode extends AssignableParseNode implements INameNode 
     public InstAsgnParseNode(SourceIndexLength position, Rope name, ParseNode valueNode) {
         super(position, valueNode);
 
-        this.name = name.normaliseAndGetJavaString();
+        this.name = name.getJavaString();
     }
 
     @Override

--- a/src/main/java/org/truffleruby/parser/ast/InstVarParseNode.java
+++ b/src/main/java/org/truffleruby/parser/ast/InstVarParseNode.java
@@ -44,7 +44,7 @@ public class InstVarParseNode extends ParseNode implements INameNode, SideEffect
     private String name;
 
     public InstVarParseNode(SourceIndexLength position, Rope name) {
-        this(position, name.normaliseAndGetJavaString());
+        this(position, name.getJavaString());
     }
 
     public InstVarParseNode(SourceIndexLength position, String name) {

--- a/src/main/java/org/truffleruby/parser/ast/InstVarParseNode.java
+++ b/src/main/java/org/truffleruby/parser/ast/InstVarParseNode.java
@@ -44,7 +44,7 @@ public class InstVarParseNode extends ParseNode implements INameNode, SideEffect
     private String name;
 
     public InstVarParseNode(SourceIndexLength position, Rope name) {
-        this(position, name.getString());
+        this(position, name.normaliseAndGetJavaString());
     }
 
     public InstVarParseNode(SourceIndexLength position, String name) {

--- a/src/main/java/org/truffleruby/parser/ast/LiteralParseNode.java
+++ b/src/main/java/org/truffleruby/parser/ast/LiteralParseNode.java
@@ -42,7 +42,7 @@ public class LiteralParseNode extends ParseNode implements InvisibleNode {
     public LiteralParseNode(SourceIndexLength position, Rope name) {
         super(position);
 
-        this.name = name.getString();
+        this.name = name.normaliseAndGetJavaString();
     }
 
     public String getName() {

--- a/src/main/java/org/truffleruby/parser/ast/LiteralParseNode.java
+++ b/src/main/java/org/truffleruby/parser/ast/LiteralParseNode.java
@@ -42,7 +42,7 @@ public class LiteralParseNode extends ParseNode implements InvisibleNode {
     public LiteralParseNode(SourceIndexLength position, Rope name) {
         super(position);
 
-        this.name = name.normaliseAndGetJavaString();
+        this.name = name.getJavaString();
     }
 
     public String getName() {

--- a/src/main/java/org/truffleruby/parser/ast/MethodDefParseNode.java
+++ b/src/main/java/org/truffleruby/parser/ast/MethodDefParseNode.java
@@ -53,7 +53,7 @@ public abstract class MethodDefParseNode extends ParseNode implements INameNode,
 
         assert bodyNode != null : "bodyNode must not be null";
 
-        this.name = name.normaliseAndGetJavaString();
+        this.name = name.getJavaString();
         this.argsNode = argsNode;
         this.scope = scope;
         this.bodyNode = bodyNode;

--- a/src/main/java/org/truffleruby/parser/ast/MethodDefParseNode.java
+++ b/src/main/java/org/truffleruby/parser/ast/MethodDefParseNode.java
@@ -53,7 +53,7 @@ public abstract class MethodDefParseNode extends ParseNode implements INameNode,
 
         assert bodyNode != null : "bodyNode must not be null";
 
-        this.name = name.getString();
+        this.name = name.normaliseAndGetJavaString();
         this.argsNode = argsNode;
         this.scope = scope;
         this.bodyNode = bodyNode;

--- a/src/main/java/org/truffleruby/parser/ast/OpAsgnConstDeclParseNode.java
+++ b/src/main/java/org/truffleruby/parser/ast/OpAsgnConstDeclParseNode.java
@@ -57,7 +57,7 @@ public class OpAsgnConstDeclParseNode extends ParseNode implements BinaryOperato
     }
 
     public String getOperator() {
-        return operator.getString();
+        return operator.normaliseAndGetJavaString();
     }
 
     @Override

--- a/src/main/java/org/truffleruby/parser/ast/OpAsgnConstDeclParseNode.java
+++ b/src/main/java/org/truffleruby/parser/ast/OpAsgnConstDeclParseNode.java
@@ -57,7 +57,7 @@ public class OpAsgnConstDeclParseNode extends ParseNode implements BinaryOperato
     }
 
     public String getOperator() {
-        return operator.normaliseAndGetJavaString();
+        return operator.getJavaString();
     }
 
     @Override

--- a/src/main/java/org/truffleruby/parser/ast/VAliasParseNode.java
+++ b/src/main/java/org/truffleruby/parser/ast/VAliasParseNode.java
@@ -44,8 +44,8 @@ public class VAliasParseNode extends ParseNode {
 
     public VAliasParseNode(SourceIndexLength position, Rope newName, Rope oldName) {
         super(position);
-        this.oldName = oldName.normaliseAndGetJavaString();
-        this.newName = newName.normaliseAndGetJavaString();
+        this.oldName = oldName.getJavaString();
+        this.newName = newName.getJavaString();
     }
 
     @Override

--- a/src/main/java/org/truffleruby/parser/ast/VAliasParseNode.java
+++ b/src/main/java/org/truffleruby/parser/ast/VAliasParseNode.java
@@ -44,8 +44,8 @@ public class VAliasParseNode extends ParseNode {
 
     public VAliasParseNode(SourceIndexLength position, Rope newName, Rope oldName) {
         super(position);
-        this.oldName = oldName.getString();
-        this.newName = newName.getString();
+        this.oldName = oldName.normaliseAndGetJavaString();
+        this.newName = newName.normaliseAndGetJavaString();
     }
 
     @Override

--- a/src/main/java/org/truffleruby/parser/lexer/RubyLexer.java
+++ b/src/main/java/org/truffleruby/parser/lexer/RubyLexer.java
@@ -232,7 +232,7 @@ public class RubyLexer implements MagicCommentHandler {
         Rope value = createTokenRope();
 
         if (isLexState(last_state, EXPR_DOT | EXPR_FNAME) &&
-                parserSupport.getCurrentScope().isDefined(value.getString().intern()) >= 0) {
+                parserSupport.getCurrentScope().isDefined(value.normaliseAndGetJavaString().intern()) >= 0) {
             setState(EXPR_END);
         }
 
@@ -1076,7 +1076,7 @@ public class RubyLexer implements MagicCommentHandler {
 
     private int identifierToken(int result, Rope value) {
         if (result == RubyParser.tIDENTIFIER && !isLexState(last_state, EXPR_DOT | EXPR_FNAME) &&
-                parserSupport.getCurrentScope().isDefined(value.getString().intern()) >= 0) {
+                parserSupport.getCurrentScope().isDefined(value.normaliseAndGetJavaString().intern()) >= 0) {
             setState(EXPR_END | EXPR_LABEL);
         }
 
@@ -1663,7 +1663,7 @@ public class RubyLexer implements MagicCommentHandler {
                 }
 
                 int ref;
-                String refAsString = createTokenRope().getString();
+                String refAsString = createTokenRope().normaliseAndGetJavaString();
 
                 try {
                     ref = Integer.parseInt(refAsString.substring(1).intern());

--- a/src/main/java/org/truffleruby/parser/lexer/RubyLexer.java
+++ b/src/main/java/org/truffleruby/parser/lexer/RubyLexer.java
@@ -232,7 +232,7 @@ public class RubyLexer implements MagicCommentHandler {
         Rope value = createTokenRope();
 
         if (isLexState(last_state, EXPR_DOT | EXPR_FNAME) &&
-                parserSupport.getCurrentScope().isDefined(value.normaliseAndGetJavaString().intern()) >= 0) {
+                parserSupport.getCurrentScope().isDefined(value.getJavaString().intern()) >= 0) {
             setState(EXPR_END);
         }
 
@@ -1076,7 +1076,7 @@ public class RubyLexer implements MagicCommentHandler {
 
     private int identifierToken(int result, Rope value) {
         if (result == RubyParser.tIDENTIFIER && !isLexState(last_state, EXPR_DOT | EXPR_FNAME) &&
-                parserSupport.getCurrentScope().isDefined(value.normaliseAndGetJavaString().intern()) >= 0) {
+                parserSupport.getCurrentScope().isDefined(value.getJavaString().intern()) >= 0) {
             setState(EXPR_END | EXPR_LABEL);
         }
 
@@ -1663,7 +1663,7 @@ public class RubyLexer implements MagicCommentHandler {
                 }
 
                 int ref;
-                String refAsString = createTokenRope().normaliseAndGetJavaString();
+                String refAsString = createTokenRope().getJavaString();
 
                 try {
                     ref = Integer.parseInt(refAsString.substring(1).intern());

--- a/src/main/java/org/truffleruby/parser/parser/ParserSupport.java
+++ b/src/main/java/org/truffleruby/parser/parser/ParserSupport.java
@@ -238,7 +238,7 @@ public class ParserSupport {
             case LOCALASGNNODE:
                 String name = ((INameNode) node).getName();
                 final Rope currentArg = lexer.getCurrentArg();
-                if (currentArg != null && name.equals(currentArg.getString())) {
+                if (currentArg != null && name.equals(currentArg.normaliseAndGetJavaString())) {
                     warn(node.getPosition(), "circular argument reference - " + name);
                 }
                 checkDeclarationForNumberedParameterMisuse(name, node);
@@ -283,21 +283,21 @@ public class ParserSupport {
     }
 
     public void checkMethodName(Rope rope) {
-        String name = rope.getString();
+        String name = rope.normaliseAndGetJavaString();
         if (isNumberedParameter(name)) {
             warnNumberedParameterLikeDeclaration(lexer.getPosition(), name);
         }
     }
 
     public ParseNode declareIdentifier(Rope rope) {
-        return declareIdentifier(rope.getString());
+        return declareIdentifier(rope.normaliseAndGetJavaString());
     }
 
     // Despite the confusing name, called for every identifier use in expressions.
     public ParseNode declareIdentifier(String string) {
         String name = string.intern();
         final Rope currentArg = lexer.getCurrentArg();
-        if (currentArg != null && name.equals(currentArg.getString())) {
+        if (currentArg != null && name.equals(currentArg.normaliseAndGetJavaString())) {
             warn(lexer.getPosition(), "circular argument reference - " + name);
         }
 
@@ -334,7 +334,7 @@ public class ParserSupport {
 
     // We know it has to be tLABEL or tIDENTIFIER so none of the other assignable logic is needed
     public AssignableParseNode assignableLabelOrIdentifier(Rope name, ParseNode value) {
-        return assignableLabelOrIdentifier(name.getString().intern(), value);
+        return assignableLabelOrIdentifier(name.normaliseAndGetJavaString().intern(), value);
     }
 
     public AssignableParseNode assignableLabelOrIdentifier(String name, ParseNode value) {
@@ -417,7 +417,7 @@ public class ParserSupport {
 
     // We know it has to be tLABEL or tIDENTIFIER so none of the other assignable logic is needed
     public AssignableParseNode assignableInCurr(Rope name, ParseNode value) {
-        String nameString = name.getString().intern();
+        String nameString = name.normaliseAndGetJavaString().intern();
         checkDeclarationForNumberedParameterMisuse(nameString, value);
         currentScope.addVariableThisScope(nameString);
         return currentScope.assign(lexer.getPosition(), nameString, makeNullNil(value));
@@ -426,7 +426,7 @@ public class ParserSupport {
     public ParseNode getOperatorCallNode(ParseNode firstNode, Rope operator) {
         value_expr(lexer, firstNode);
 
-        return new CallParseNode(firstNode.getPosition(), firstNode, operator.getString(), null, null);
+        return new CallParseNode(firstNode.getPosition(), firstNode, operator.normaliseAndGetJavaString(), null, null);
     }
 
     public ParseNode getOperatorCallNode(ParseNode firstNode, Rope operator, ParseNode secondNode) {
@@ -446,7 +446,7 @@ public class ParserSupport {
         return new CallParseNode(
                 firstNode.getPosition(),
                 firstNode,
-                operator.getString(),
+                operator.normaliseAndGetJavaString(),
                 new ArrayParseNode(secondNode.getPosition(), secondNode),
                 null);
     }
@@ -487,7 +487,12 @@ public class ParserSupport {
     public ParseNode attrset(ParseNode receiver, Rope callType, Rope name) {
         value_expr(lexer, receiver);
 
-        return new_attrassign(receiver.getPosition(), receiver, name.getString() + "=", null, isLazy(callType));
+        return new_attrassign(
+                receiver.getPosition(),
+                receiver,
+                name.normaliseAndGetJavaString() + "=",
+                null,
+                isLazy(callType));
     }
 
     public void backrefAssignError(ParseNode node) {
@@ -1022,7 +1027,7 @@ public class ParserSupport {
         ParseNode newNode = new OpElementAsgnParseNode(
                 position,
                 receiverNode,
-                operatorName.getString(),
+                operatorName.normaliseAndGetJavaString(),
                 argsNode,
                 valueNode);
 
@@ -1042,8 +1047,8 @@ public class ParserSupport {
                 position,
                 receiverNode,
                 valueNode,
-                variableName.getString(),
-                operatorName.getString(),
+                variableName.normaliseAndGetJavaString(),
+                operatorName.normaliseAndGetJavaString(),
                 isLazy(callType));
     }
 
@@ -1075,7 +1080,7 @@ public class ParserSupport {
             return new CallParseNode(
                     position(receiver, argsNode),
                     receiver,
-                    name.getString(),
+                    name.normaliseAndGetJavaString(),
                     blockPass.getArgsNode(),
                     blockPass,
                     isLazy(callType));
@@ -1084,7 +1089,7 @@ public class ParserSupport {
         return new CallParseNode(
                 position(receiver, argsNode),
                 receiver,
-                name.getString(),
+                name.normaliseAndGetJavaString(),
                 argsNode,
                 iter,
                 isLazy(callType));
@@ -1131,7 +1136,7 @@ public class ParserSupport {
     }
 
     public ParseNode new_fcall(Rope operation) {
-        return new FCallParseNode(lexer.tokline, operation.getString());
+        return new FCallParseNode(lexer.tokline, operation.normaliseAndGetJavaString());
     }
 
     public ParseNode new_super(SourceIndexLength position, ParseNode args) {
@@ -1440,7 +1445,7 @@ public class ParserSupport {
         if (keywordRestArgNameRope.isEmpty()) {
             restKwargsName = TEMP_PREFIX + "_kwrest";
         } else {
-            restKwargsName = keywordRestArgNameRope.getString().intern();
+            restKwargsName = keywordRestArgNameRope.normaliseAndGetJavaString().intern();
         }
 
         int slot = currentScope.exists(restKwargsName);
@@ -1558,7 +1563,7 @@ public class ParserSupport {
     // 1.9
     public ParseNode new_bv(Rope identifier) {
         if (!is_local_id(identifier)) {
-            getterIdentifierError(lexer.getPosition(), identifier.getString());
+            getterIdentifierError(lexer.getPosition(), identifier.normaliseAndGetJavaString());
         }
         shadowing_lvar(identifier);
 
@@ -1568,7 +1573,7 @@ public class ParserSupport {
     // 1.9
     @SuppressFBWarnings("ES")
     public ArgumentParseNode arg_var(Rope rope) {
-        return arg_var(rope.getString());
+        return arg_var(rope.normaliseAndGetJavaString());
     }
 
     // Called with parameter names
@@ -1604,7 +1609,7 @@ public class ParserSupport {
     // 1.9
     @SuppressFBWarnings("ES")
     public Rope shadowing_lvar(Rope rope) {
-        String name = rope.getString().intern();
+        String name = rope.normaliseAndGetJavaString().intern();
         if (name == "_") {
             return rope;
         }

--- a/src/main/java/org/truffleruby/parser/parser/ParserSupport.java
+++ b/src/main/java/org/truffleruby/parser/parser/ParserSupport.java
@@ -238,7 +238,7 @@ public class ParserSupport {
             case LOCALASGNNODE:
                 String name = ((INameNode) node).getName();
                 final Rope currentArg = lexer.getCurrentArg();
-                if (currentArg != null && name.equals(currentArg.normaliseAndGetJavaString())) {
+                if (currentArg != null && name.equals(currentArg.getJavaString())) {
                     warn(node.getPosition(), "circular argument reference - " + name);
                 }
                 checkDeclarationForNumberedParameterMisuse(name, node);
@@ -283,21 +283,21 @@ public class ParserSupport {
     }
 
     public void checkMethodName(Rope rope) {
-        String name = rope.normaliseAndGetJavaString();
+        String name = rope.getJavaString();
         if (isNumberedParameter(name)) {
             warnNumberedParameterLikeDeclaration(lexer.getPosition(), name);
         }
     }
 
     public ParseNode declareIdentifier(Rope rope) {
-        return declareIdentifier(rope.normaliseAndGetJavaString());
+        return declareIdentifier(rope.getJavaString());
     }
 
     // Despite the confusing name, called for every identifier use in expressions.
     public ParseNode declareIdentifier(String string) {
         String name = string.intern();
         final Rope currentArg = lexer.getCurrentArg();
-        if (currentArg != null && name.equals(currentArg.normaliseAndGetJavaString())) {
+        if (currentArg != null && name.equals(currentArg.getJavaString())) {
             warn(lexer.getPosition(), "circular argument reference - " + name);
         }
 
@@ -334,7 +334,7 @@ public class ParserSupport {
 
     // We know it has to be tLABEL or tIDENTIFIER so none of the other assignable logic is needed
     public AssignableParseNode assignableLabelOrIdentifier(Rope name, ParseNode value) {
-        return assignableLabelOrIdentifier(name.normaliseAndGetJavaString().intern(), value);
+        return assignableLabelOrIdentifier(name.getJavaString().intern(), value);
     }
 
     public AssignableParseNode assignableLabelOrIdentifier(String name, ParseNode value) {
@@ -417,7 +417,7 @@ public class ParserSupport {
 
     // We know it has to be tLABEL or tIDENTIFIER so none of the other assignable logic is needed
     public AssignableParseNode assignableInCurr(Rope name, ParseNode value) {
-        String nameString = name.normaliseAndGetJavaString().intern();
+        String nameString = name.getJavaString().intern();
         checkDeclarationForNumberedParameterMisuse(nameString, value);
         currentScope.addVariableThisScope(nameString);
         return currentScope.assign(lexer.getPosition(), nameString, makeNullNil(value));
@@ -426,7 +426,7 @@ public class ParserSupport {
     public ParseNode getOperatorCallNode(ParseNode firstNode, Rope operator) {
         value_expr(lexer, firstNode);
 
-        return new CallParseNode(firstNode.getPosition(), firstNode, operator.normaliseAndGetJavaString(), null, null);
+        return new CallParseNode(firstNode.getPosition(), firstNode, operator.getJavaString(), null, null);
     }
 
     public ParseNode getOperatorCallNode(ParseNode firstNode, Rope operator, ParseNode secondNode) {
@@ -446,7 +446,7 @@ public class ParserSupport {
         return new CallParseNode(
                 firstNode.getPosition(),
                 firstNode,
-                operator.normaliseAndGetJavaString(),
+                operator.getJavaString(),
                 new ArrayParseNode(secondNode.getPosition(), secondNode),
                 null);
     }
@@ -490,7 +490,7 @@ public class ParserSupport {
         return new_attrassign(
                 receiver.getPosition(),
                 receiver,
-                name.normaliseAndGetJavaString() + "=",
+                name.getJavaString() + "=",
                 null,
                 isLazy(callType));
     }
@@ -1027,7 +1027,7 @@ public class ParserSupport {
         ParseNode newNode = new OpElementAsgnParseNode(
                 position,
                 receiverNode,
-                operatorName.normaliseAndGetJavaString(),
+                operatorName.getJavaString(),
                 argsNode,
                 valueNode);
 
@@ -1047,8 +1047,8 @@ public class ParserSupport {
                 position,
                 receiverNode,
                 valueNode,
-                variableName.normaliseAndGetJavaString(),
-                operatorName.normaliseAndGetJavaString(),
+                variableName.getJavaString(),
+                operatorName.getJavaString(),
                 isLazy(callType));
     }
 
@@ -1080,7 +1080,7 @@ public class ParserSupport {
             return new CallParseNode(
                     position(receiver, argsNode),
                     receiver,
-                    name.normaliseAndGetJavaString(),
+                    name.getJavaString(),
                     blockPass.getArgsNode(),
                     blockPass,
                     isLazy(callType));
@@ -1089,7 +1089,7 @@ public class ParserSupport {
         return new CallParseNode(
                 position(receiver, argsNode),
                 receiver,
-                name.normaliseAndGetJavaString(),
+                name.getJavaString(),
                 argsNode,
                 iter,
                 isLazy(callType));
@@ -1136,7 +1136,7 @@ public class ParserSupport {
     }
 
     public ParseNode new_fcall(Rope operation) {
-        return new FCallParseNode(lexer.tokline, operation.normaliseAndGetJavaString());
+        return new FCallParseNode(lexer.tokline, operation.getJavaString());
     }
 
     public ParseNode new_super(SourceIndexLength position, ParseNode args) {
@@ -1445,7 +1445,7 @@ public class ParserSupport {
         if (keywordRestArgNameRope.isEmpty()) {
             restKwargsName = TEMP_PREFIX + "_kwrest";
         } else {
-            restKwargsName = keywordRestArgNameRope.normaliseAndGetJavaString().intern();
+            restKwargsName = keywordRestArgNameRope.getJavaString().intern();
         }
 
         int slot = currentScope.exists(restKwargsName);
@@ -1563,7 +1563,7 @@ public class ParserSupport {
     // 1.9
     public ParseNode new_bv(Rope identifier) {
         if (!is_local_id(identifier)) {
-            getterIdentifierError(lexer.getPosition(), identifier.normaliseAndGetJavaString());
+            getterIdentifierError(lexer.getPosition(), identifier.getJavaString());
         }
         shadowing_lvar(identifier);
 
@@ -1573,7 +1573,7 @@ public class ParserSupport {
     // 1.9
     @SuppressFBWarnings("ES")
     public ArgumentParseNode arg_var(Rope rope) {
-        return arg_var(rope.normaliseAndGetJavaString());
+        return arg_var(rope.getJavaString());
     }
 
     // Called with parameter names
@@ -1609,7 +1609,7 @@ public class ParserSupport {
     // 1.9
     @SuppressFBWarnings("ES")
     public Rope shadowing_lvar(Rope rope) {
-        String name = rope.normaliseAndGetJavaString().intern();
+        String name = rope.getJavaString().intern();
         if (name == "_") {
             return rope;
         }

--- a/src/main/java/org/truffleruby/parser/parser/RubyParser.java
+++ b/src/main/java/org/truffleruby/parser/parser/RubyParser.java
@@ -2234,7 +2234,7 @@ states[266] = (support, lexer, yyVal, yyVals, yyTop) -> {
     return yyVal;
 };
 states[267] = (support, lexer, yyVal, yyVals, yyTop) -> {
-    support.warning(lexer.getPosition(), "comparison '" + ((Rope)yyVals[-1+yyTop]).normaliseAndGetJavaString() + "' after comparison");
+    support.warning(lexer.getPosition(), "comparison '" + ((Rope)yyVals[-1+yyTop]).getJavaString() + "' after comparison");
     yyVal = support.getOperatorCallNode(((ParseNode)yyVals[-2+yyTop]), ((Rope)yyVals[-1+yyTop]), ((ParseNode)yyVals[0+yyTop]), lexer.getPosition());
     return yyVal;
 };

--- a/src/main/java/org/truffleruby/parser/parser/RubyParser.java
+++ b/src/main/java/org/truffleruby/parser/parser/RubyParser.java
@@ -2234,7 +2234,7 @@ states[266] = (support, lexer, yyVal, yyVals, yyTop) -> {
     return yyVal;
 };
 states[267] = (support, lexer, yyVal, yyVals, yyTop) -> {
-    support.warning(lexer.getPosition(), "comparison '" + ((Rope)yyVals[-1+yyTop]).getString() + "' after comparison");
+    support.warning(lexer.getPosition(), "comparison '" + ((Rope)yyVals[-1+yyTop]).normaliseAndGetJavaString() + "' after comparison");
     yyVal = support.getOperatorCallNode(((ParseNode)yyVals[-2+yyTop]), ((Rope)yyVals[-1+yyTop]), ((ParseNode)yyVals[0+yyTop]), lexer.getPosition());
     return yyVal;
 };

--- a/src/main/java/org/truffleruby/parser/parser/RubyParser.y
+++ b/src/main/java/org/truffleruby/parser/parser/RubyParser.y
@@ -1277,7 +1277,7 @@ rel_expr        : arg relop arg   %prec tGT {
                      $$ = support.getOperatorCallNode($1, $2, $3, lexer.getPosition());
                 }
                 | rel_expr relop arg   %prec tGT {
-                     support.warning(lexer.getPosition(), "comparison '" + $2.getString() + "' after comparison");
+                     support.warning(lexer.getPosition(), "comparison '" + $2.normaliseAndGetJavaString() + "' after comparison");
                      $$ = support.getOperatorCallNode($1, $2, $3, lexer.getPosition());
                 }
  

--- a/src/main/java/org/truffleruby/parser/parser/RubyParser.y
+++ b/src/main/java/org/truffleruby/parser/parser/RubyParser.y
@@ -1277,7 +1277,7 @@ rel_expr        : arg relop arg   %prec tGT {
                      $$ = support.getOperatorCallNode($1, $2, $3, lexer.getPosition());
                 }
                 | rel_expr relop arg   %prec tGT {
-                     support.warning(lexer.getPosition(), "comparison '" + $2.normaliseAndGetJavaString() + "' after comparison");
+                     support.warning(lexer.getPosition(), "comparison '" + $2.getJavaString() + "' after comparison");
                      $$ = support.getOperatorCallNode($1, $2, $3, lexer.getPosition());
                 }
  


### PR DESCRIPTION
`Truffle::Ropes.debug_print_rope` and `Truffle::Ropes.debug_get_structure_creation` were broken, and people were using `Rope#toString()` in non-debug code.