### PR TITLE
String#squeeze fastpath single char case

### DIFF
--- a/src/main/java/org/truffleruby/core/string/StringNodes.java
+++ b/src/main/java/org/truffleruby/core/string/StringNodes.java
@@ -2527,7 +2527,7 @@ public abstract class StringNodes {
 
             boolean singlebyte = rope.isSingleByteOptimizable() && otherRope.isSingleByteOptimizable();
 
-            if (otherStrings.length == 1 && otherRope.characterLength() == 1 && singlebyte) {
+            if (singlebyte && otherRope.byteLength() == 1 && otherStrings.length == 1) {
                 squeeze[otherRope.getRawBytes()[0]] = true;
                 if (!StringSupport.singleByteSqueeze(buffer, squeeze)) {
                     return nil;

--- a/src/main/java/org/truffleruby/core/string/StringNodes.java
+++ b/src/main/java/org/truffleruby/core/string/StringNodes.java
@@ -2524,9 +2524,20 @@ public abstract class StringNodes {
             Rope otherRope = RubyStringLibrary.getUncached().getRope(otherStr);
             Encoding enc = checkEncodingNode.executeCheckEncoding(string, otherStr);
             final boolean squeeze[] = new boolean[StringSupport.TRANS_SIZE + 1];
-            StringSupport.TrTables tables = StringSupport.trSetupTable(otherRope, squeeze, null, true, enc);
 
             boolean singlebyte = rope.isSingleByteOptimizable() && otherRope.isSingleByteOptimizable();
+
+            if (otherStrings.length == 1 && otherRope.characterLength() == 1 && singlebyte) {
+                squeeze[otherRope.getRawBytes()[0]] = true;
+                if (!StringSupport.singleByteSqueeze(buffer, squeeze)) {
+                    return nil;
+                } else {
+                    string.setRope(RopeOperations.ropeFromRopeBuilder(buffer));
+                    return string;
+                }
+            }
+
+            StringSupport.TrTables tables = StringSupport.trSetupTable(otherRope, squeeze, null, true, enc);
 
             for (int i = 1; i < otherStrings.length; i++) {
                 otherStr = otherStrings[i];


### PR DESCRIPTION
The single character case of String#squeeze is fairly common, i.e. getting rid of '/' in filepaths or extra ' ' whitespace, adding a fastpath allows 4x IPS without significantly affecting other cases.

``` ruby
require 'benchmark/ips'

puts RUBY_DESCRIPTION

Benchmark.ips do |x|
  x.report('h') do
    "hhhhddddjkkjhjhjsdfkjshdkjfjhsdkdfeeeererer".squeeze('h')
  end
  x.report('hk') do
    "hhhhddddjkkjhjhjsdfkjshdkjfjhsdkdfeeeererer".squeeze('hk')
  end
end
```

```
ruby 2.7.2p137 (2020-10-01 revision 5445e04352) [x86_64-darwin19]
Warming up --------------------------------------
                   h   182.925k i/100ms
                  hk   166.829k i/100ms
Calculating -------------------------------------
                   h      1.842M (± 9.1%) i/s -      9.146M in   5.009349s
                  hk      2.053M (± 3.0%) i/s -     10.343M in   5.042977s

BEFORE: truffleruby 21.2.0-dev-482320f3, like ruby 2.7.2, GraalVM CE JVM [x86_64-darwin]
Warming up --------------------------------------
                   h   190.193k i/100ms
                  hk   229.448k i/100ms
Calculating -------------------------------------
                   h      2.276M (± 7.2%) i/s -     11.412M in   5.054696s
                  hk      2.281M (± 2.8%) i/s -     11.472M in   5.032964s

AFTER: truffleruby 21.2.0-dev-482320f3, like ruby 2.7.2, GraalVM CE JVM [x86_64-darwin]
Warming up --------------------------------------
                   h   771.098k i/100ms
                  hk   224.888k i/100ms
Calculating -------------------------------------
                   h      8.698M (± 9.7%) i/s -     43.181M in   5.029779s
                  hk      2.207M (± 3.8%) i/s -     11.244M in   5.103107s
```


