### PR TITLE
Add IO#set_encoding_by_bom method

### DIFF
--- a/spec/ruby/core/io/set_encoding_by_bom_spec.rb
+++ b/spec/ruby/core/io/set_encoding_by_bom_spec.rb
@@ -67,5 +67,11 @@ describe "IO#set_encoding_by_bom" do
 
       -> { @io.set_encoding_by_bom }.should raise_error(ArgumentError, 'encoding is set to UTF-8 already')
     end
+
+    it 'returns exception if encoding conversion is already set' do
+      @io.set_encoding(Encoding::UTF_8, Encoding::UTF_16BE)
+
+      -> { @io.set_encoding_by_bom }.should raise_error(ArgumentError, 'encoding conversion is set')
+    end
   end
 end

--- a/spec/tags/core/io/set_encoding_by_bom_tags.txt
+++ b/spec/tags/core/io/set_encoding_by_bom_tags.txt
@@ -1,8 +1,0 @@
-fails:IO#set_encoding_by_bom returns the result encoding if found BOM UTF-8 sequence
-fails:IO#set_encoding_by_bom returns the result encoding if found BOM UTF_16LE sequence
-fails:IO#set_encoding_by_bom returns the result encoding if found BOM UTF_16BE sequence
-fails:IO#set_encoding_by_bom returns nil if found BOM sequence not provided
-fails:IO#set_encoding_by_bom returns exception if io not in binary mode
-fails:IO#set_encoding_by_bom returns exception if encoding already set
-fails:IO#set_encoding_by_bom returns the result encoding if found BOM UTF_32LE sequence
-fails:IO#set_encoding_by_bom returns the result encoding if found BOM UTF_32BE sequence

--- a/src/main/ruby/truffleruby/core/io.rb
+++ b/src/main/ruby/truffleruby/core/io.rb
@@ -2158,6 +2158,25 @@ class IO
     self
   end
 
+  def set_encoding_by_bom
+    unless binmode?
+      raise ArgumentError, 'ASCII incompatible encoding needs binmode'
+    end
+
+    if internal_encoding
+      raise ArgumentError, 'encoding conversion is set'
+    end
+
+    if external_encoding && external_encoding != Encoding::ASCII_8BIT
+      raise ArgumentError, "encoding is set to #{external_encoding} already"
+    end
+
+    external = strip_bom
+    if external
+      @external = Encoding.find(external)
+    end
+  end
+
   private def strip_bom
     mode = Truffle::POSIX.truffleposix_fstat_mode(Primitive.io_fd(self))
     return unless Truffle::StatOperations.file?(mode)


### PR DESCRIPTION
Part of https://github.com/oracle/truffleruby/issues/2004

Adds the `IO#set_encoding_by_bom` method. Method was introduced in MRI in 2.7.0 in ruby/ruby@e717d6faa.

I've basically reproduced the implementation from the MRI commit linked above.