### PR TITLE
Support sourcing the Spin environment file from a Bash script

### DIFF
--- a/.spin/bin/env
+++ b/.spin/bin/env
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 SCRIPT_PATH=$(dirname "${BASH_SOURCE[0]:-${(%):-%x}}")
 SCRIPT_PATH=$(cd "$SCRIPT_PATH" && pwd)
 TRUFFLERUBY_DIR=$SCRIPT_PATH/../..

--- a/.spin/bin/env
+++ b/.spin/bin/env
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-SCRIPT_PATH=$(dirname "$BASH_SOURCE[0]")
+SCRIPT_PATH=$(dirname "${BASH_SOURCE[0]:-${(%):-%x}}")
 SCRIPT_PATH=$(cd "$SCRIPT_PATH" && pwd)
 TRUFFLERUBY_DIR=$SCRIPT_PATH/../..
 export JT_ENV=jvm-ce

--- a/.spin/bin/env
+++ b/.spin/bin/env
@@ -1,3 +1,4 @@
+# $BASH_SOURCE[0] is for Bash, ${(%):-%x} is for Zsh
 SCRIPT_PATH=$(dirname "${BASH_SOURCE[0]:-${(%):-%x}}")
 SCRIPT_PATH=$(cd "$SCRIPT_PATH" && pwd)
 TRUFFLERUBY_DIR=$SCRIPT_PATH/../..

--- a/.spin/bin/env
+++ b/.spin/bin/env
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-SCRIPT_PATH=$(dirname "$0")
+SCRIPT_PATH=$(dirname "$BASH_SOURCE[0]")
 SCRIPT_PATH=$(cd "$SCRIPT_PATH" && pwd)
 TRUFFLERUBY_DIR=$SCRIPT_PATH/../..
 export JT_ENV=jvm-ce


### PR DESCRIPTION
At Shopify we want to use TruffleRuby inside other Spin projects, so it’s important that `source /path/to/truffleruby/.spin/bin/env` works from those projects’ Bash scripts as well as directly from the command line.

When the environment file is sourced by another script, `$0` is the name of the main script being executed rather than the environment file itself, so `dirname "$0"` will return the (probably incorrect) directory containing the main script rather than `/path/to/truffleruby/.spin/bin` as expected.

In Bash, [`$BASH_SOURCE`](https://www.gnu.org/software/bash/manual/html_node/Bash-Variables.html#index-BASH_005fSOURCE) is an array containing the source filenames of all currently-executing shell functions, of which the first is [always the most recent](https://www.gnu.org/software/bash/manual/html_node/Bash-Variables.html#index-FUNCNAME), so we can use `$BASH_SOURCE[0]` to directly ask for the filename of the environment file instead of assuming that `$0` will contain it.

We also need to be able to source the environment file directly from a Zsh command line, but `$BASH_SOURCE` isn’t supported by Zsh so doesn’t work for the latter purpose. We therefore use shell [parameter expansion](https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html) syntax to supply a Zsh-compatible equivalent if `$BASH_SOURCE` isn’t set.

The expression `${(%):-%x}` in Zsh does the same job as `$BASH_SOURCE` in Bash: `(%)` is a [parameter expansion flag](https://zsh.sourceforge.io/Doc/Release/Expansion.html#index-parameter-expansion-flags) which enables [prompt sequence expansion](https://zsh.sourceforge.io/Doc/Release/Prompt-Expansion.html) in what follows, and [`%x`](https://zsh.sourceforge.io/Doc/Release/Prompt-Expansion.html#Shell-state) is the prompt sequence for “the name of the file containing the source code currently being executed”.