### PR TITLE
Shift TruffleBoundary around in Truffle::RegexOperations

### DIFF
--- a/src/main/java/org/truffleruby/core/regexp/TruffleRegexpNodes.java
+++ b/src/main/java/org/truffleruby/core/regexp/TruffleRegexpNodes.java
@@ -41,6 +41,7 @@ import org.truffleruby.core.Hashing;
 import org.truffleruby.core.array.ArrayBuilderNode;
 import org.truffleruby.core.array.ArrayBuilderNode.BuilderState;
 import org.truffleruby.core.array.RubyArray;
+import org.truffleruby.core.encoding.EncodingNodes;
 import org.truffleruby.core.encoding.RubyEncoding;
 import org.truffleruby.core.kernel.KernelNodes.SameOrEqualNode;
 import org.truffleruby.core.regexp.RegexpNodes.ToSNode;
@@ -245,6 +246,7 @@ public class TruffleRegexpNodes {
 
         @Specialization(guards = "libString.isRubyString(str)")
         protected RubyEncoding selectEncoding(RubyRegexp re, Object str, boolean encodingConversion,
+                @Cached EncodingNodes.GetRubyEncodingNode getRubyEncodingNode,
                 @Cached TruffleRegexpNodes.CheckEncodingNode checkEncodingNode,
                 @CachedLibrary(limit = "2") RubyStringLibrary libString) {
             Encoding encoding;
@@ -258,7 +260,8 @@ public class TruffleRegexpNodes {
             } else {
                 encoding = re.regex.getEncoding();
             }
-            return getContext().getEncodingManager().getRubyEncoding(encoding);
+
+            return getRubyEncodingNode.executeGetRubyEncoding(encoding);
         }
     }
 

--- a/src/main/java/org/truffleruby/core/regexp/TruffleRegexpNodes.java
+++ b/src/main/java/org/truffleruby/core/regexp/TruffleRegexpNodes.java
@@ -75,7 +75,6 @@ import org.truffleruby.parser.RubyDeferredWarnings;
 @CoreModule("Truffle::RegexpOperations")
 public class TruffleRegexpNodes {
 
-    @TruffleBoundary
     public static Matcher createMatcher(RubyContext context, RubyRegexp regexp, Rope stringRope, byte[] stringBytes,
             boolean encodingConversion, int start, Node currentNode) {
         final Encoding enc = checkEncoding(regexp, stringRope.getEncoding(), stringRope.getCodeRange());
@@ -86,10 +85,9 @@ public class TruffleRegexpNodes {
             regex = encodingCache.getOrCreate(enc, e -> makeRegexpForEncoding(context, regexp, e, currentNode));
         }
 
-        return regex.matcher(stringBytes, start, stringBytes.length);
+        return getMatcher(regex, stringBytes, start);
     }
 
-    @TruffleBoundary
     public static Encoding checkEncoding(RubyRegexp regexp, Encoding strEnc, CodeRange codeRange) {
         final Encoding regexEnc = regexp.regex.getEncoding();
 
@@ -103,6 +101,12 @@ public class TruffleRegexpNodes {
         return strEnc;
     }
 
+    @TruffleBoundary
+    private static Matcher getMatcher(Regex regex, byte[] stringBytes, int start) {
+        return regex.matcher(stringBytes, start, stringBytes.length);
+    }
+
+    @TruffleBoundary
     private static Regex makeRegexpForEncoding(RubyContext context, RubyRegexp regexp, Encoding enc, Node currentNode) {
         final Encoding[] fixedEnc = new Encoding[]{ null };
         final Rope sourceRope = regexp.source;

--- a/src/main/java/org/truffleruby/core/regexp/TruffleRegexpNodes.java
+++ b/src/main/java/org/truffleruby/core/regexp/TruffleRegexpNodes.java
@@ -350,7 +350,7 @@ public class TruffleRegexpNodes {
         }
     }
 
-    @Primitive(name = "regexp_match_in_region", lowerFixnum = { 2, 3, 6 })
+    @Primitive(name = "regexp_match_in_region", lowerFixnum = { 2, 3, 5 })
     public abstract static class MatchInRegionNode extends PrimitiveArrayArgumentsNode {
 
         /** Matches a regular expression against a string over the specified range of characters.
@@ -366,20 +366,12 @@ public class TruffleRegexpNodes {
          * @param atStart Whether to only match at the beginning of the string, if false then the regexp can have any
          *            amount of prematch.
          *
-         * @param encodingConversion Whether to attempt encoding conversion of the regexp to match the string
-         *
          * @param startPos The position within the string which the matcher should consider the start. Setting this to
          *            the from position allows scanners to match starting partway through a string while still setting
          *            atStart and thus forcing the match to be at the specific starting position. */
         @Specialization(guards = "libString.isRubyString(string)")
         protected Object matchInRegion(
-                RubyRegexp regexp,
-                Object string,
-                int fromPos,
-                int toPos,
-                boolean atStart,
-                boolean encodingConversion,
-                int startPos,
+                RubyRegexp regexp, Object string, int fromPos, int toPos, boolean atStart, int startPos,
                 @Cached RopeNodes.BytesNode bytesNode,
                 @Cached TruffleRegexpNodes.MatchNode matchNode,
                 @CachedLibrary(limit = "2") RubyStringLibrary libString) {

--- a/src/main/java/org/truffleruby/core/regexp/TruffleRegexpNodes.java
+++ b/src/main/java/org/truffleruby/core/regexp/TruffleRegexpNodes.java
@@ -423,6 +423,7 @@ public class TruffleRegexpNodes {
         @Specialization(guards = "libString.isRubyString(string)")
         protected Object matchInRegion(
                 RubyRegexp regexp, Object string, int fromPos, int toPos, boolean atStart, int startPos,
+                @Cached ConditionProfile encodingMismatchProfile,
                 @Cached RopeNodes.BytesNode bytesNode,
                 @Cached TruffleRegexpNodes.MatchNode matchNode,
                 @Cached TruffleRegexpNodes.CheckEncodingNode checkEncodingNode,
@@ -431,7 +432,7 @@ public class TruffleRegexpNodes {
             final Encoding enc = checkEncodingNode.executeCheckEncoding(regexp, string);
             Regex regex = regexp.regex;
 
-            if (regex.getEncoding() != enc) {
+            if (encodingMismatchProfile.profile(regex.getEncoding() != enc)) {
                 final EncodingCache encodingCache = regexp.cachedEncodings;
                 regex = encodingCache.getOrCreate(enc, e -> makeRegexpForEncoding(getContext(), regexp, e, this));
             }

--- a/src/main/ruby/truffleruby/core/truffle/regexp_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/regexp_operations.rb
@@ -78,7 +78,7 @@ module Truffle
       elsif USE_TRUFFLE_REGEX
         match_in_region_tregex(re, str, from, to, at_start, encoding_conversion, start)
       else
-        Primitive.regexp_match_in_region(re, str, from, to, at_start, encoding_conversion, start)
+        Primitive.regexp_match_in_region(re, str, from, to, at_start, start)
       end
     end
 
@@ -89,7 +89,7 @@ module Truffle
         md1 = e
       end
       begin
-        md2 = Primitive.regexp_match_in_region(re, str, from, to, at_start, encoding_conversion, start)
+        md2 = Primitive.regexp_match_in_region(re, str, from, to, at_start, start)
       rescue => e
         md2 = e
       end
@@ -115,7 +115,7 @@ module Truffle
         regex_result = compiled_regex.execBytes(str_bytes, from)
       end
       if bail_out
-        return Primitive.regexp_match_in_region(re, str, from, to, at_start, encoding_conversion, start)
+        return Primitive.regexp_match_in_region(re, str, from, to, at_start, start)
       elsif regex_result.isMatch
         starts = []
         ends = []


### PR DESCRIPTION
Poking around in `Truffle::RegexpOperations` and tweaking the TruffleBoundary. It's slightly faster. 

## Changes

- Moved `regex.matcher` into a private function with Truffle Boundary
- Add boundary to `makeRegexForEncoding`
- Remove TruffleBoundary from `createMatcher`

## Before
```
truffleruby 21.2.0-dev-36afa76d, like ruby 2.7.3, GraalVM CE JVM [x86_64-darwin]
Warming up --------------------------------------
gsub! from .normalize_path
                       239.460k i/100ms
sub! from .normalize_path
                       354.894k i/100ms
          basic gsub    76.491k i/100ms
Calculating -------------------------------------
gsub! from .normalize_path
                          6.385M (± 8.9%) i/s -     31.609M in   5.010893s
sub! from .normalize_path
                          4.107M (± 4.0%) i/s -     20.584M in   5.020501s
          basic gsub      2.742M (± 8.7%) i/s -     13.615M in   5.018347s
```

## After
```
truffleruby 21.2.0-dev-36afa76d, like ruby 2.7.3, GraalVM CE JVM [x86_64-darwin]
Warming up --------------------------------------
gsub! from .normalize_path
                       159.989k i/100ms
sub! from .normalize_path
                       352.139k i/100ms
          basic gsub    74.733k i/100ms
Calculating -------------------------------------
gsub! from .normalize_path
                          6.851M (± 8.5%) i/s -     33.918M in   5.001933s
sub! from .normalize_path
                          4.328M (± 4.0%) i/s -     21.833M in   5.054152s
          basic gsub      2.812M (± 6.6%) i/s -     13.975M in   5.000743s
```

Using this benchmark: 

```ruby
# frozen_string_literal: true
require 'benchmark/ips'
puts RUBY_DESCRIPTION
path = +"foo/bar/baz"

Benchmark.ips do |x|
  x.report('gsub! from .normalize_path') do
    path.gsub!(/(%[a-f0-9]{2})/, &:upcase)
  end

  x.report('sub! from .normalize_path') do
    path.sub!(%r{/+\z}, "")
  end

  x.report('basic gsub') do
    'haystack'.gsub(/y/, 'X')
  end
end

```