### PR TITLE
Add an option --warn-truffle-regex-fallback

### DIFF
--- a/src/main/java/org/truffleruby/core/regexp/TruffleRegexpNodes.java
+++ b/src/main/java/org/truffleruby/core/regexp/TruffleRegexpNodes.java
@@ -41,6 +41,7 @@ import org.truffleruby.core.Hashing;
 import org.truffleruby.core.array.ArrayBuilderNode;
 import org.truffleruby.core.array.ArrayBuilderNode.BuilderState;
 import org.truffleruby.core.array.RubyArray;
+import org.truffleruby.core.encoding.EncodingNodes;
 import org.truffleruby.core.encoding.RubyEncoding;
 import org.truffleruby.core.kernel.KernelNodes.SameOrEqualNode;
 import org.truffleruby.core.regexp.RegexpNodes.ToSNode;
@@ -245,6 +246,7 @@ public class TruffleRegexpNodes {
 
         @Specialization(guards = "libString.isRubyString(str)")
         protected RubyEncoding selectEncoding(RubyRegexp re, Object str, boolean encodingConversion,
+                @Cached EncodingNodes.GetRubyEncodingNode getRubyEncodingNode,
                 @Cached TruffleRegexpNodes.CheckEncodingNode checkEncodingNode,
                 @CachedLibrary(limit = "2") RubyStringLibrary libString) {
             Encoding encoding;
@@ -258,7 +260,8 @@ public class TruffleRegexpNodes {
             } else {
                 encoding = re.regex.getEncoding();
             }
-            return getContext().getEncodingManager().getRubyEncoding(encoding);
+
+            return getRubyEncodingNode.executeGetRubyEncoding(encoding);
         }
     }
 

--- a/src/main/java/org/truffleruby/core/regexp/TruffleRegexpNodes.java
+++ b/src/main/java/org/truffleruby/core/regexp/TruffleRegexpNodes.java
@@ -127,16 +127,17 @@ public class TruffleRegexpNodes {
         }
 
         protected boolean isFixedEncoding(RubyRegexp regexp, Object string) {
-            return regexp.options.isFixed() && stringLibrary.getRope(string).getEncoding().isAsciiCompatible();
+            return regexp.options.isFixed() && stringEncoding(string).isAsciiCompatible();
         }
 
         protected boolean isSameEncoding(RubyRegexp regexp, Object string) {
-            return regexp.regex.getEncoding() == stringLibrary.getRope(string).getEncoding();
+            return regexp.regex.getEncoding() == stringEncoding(string);
         }
 
         protected Encoding stringEncoding(Object string) {
             return stringLibrary.getRope(string).getEncoding();
         }
+
     }
 
     @TruffleBoundary

--- a/src/main/java/org/truffleruby/core/regexp/TruffleRegexpNodes.java
+++ b/src/main/java/org/truffleruby/core/regexp/TruffleRegexpNodes.java
@@ -75,7 +75,6 @@ import org.truffleruby.parser.RubyDeferredWarnings;
 @CoreModule("Truffle::RegexpOperations")
 public class TruffleRegexpNodes {
 
-    @TruffleBoundary
     public static Matcher createMatcher(RubyContext context, RubyRegexp regexp, Rope stringRope, byte[] stringBytes,
             boolean encodingConversion, int start, Node currentNode) {
         final Encoding enc = checkEncoding(regexp, stringRope.getEncoding(), stringRope.getCodeRange());
@@ -86,10 +85,9 @@ public class TruffleRegexpNodes {
             regex = encodingCache.getOrCreate(enc, e -> makeRegexpForEncoding(context, regexp, e, currentNode));
         }
 
-        return regex.matcher(stringBytes, start, stringBytes.length);
+        return getMatcher(regex, stringBytes, start);
     }
 
-    @TruffleBoundary
     public static Encoding checkEncoding(RubyRegexp regexp, Encoding strEnc, CodeRange codeRange) {
         final Encoding regexEnc = regexp.regex.getEncoding();
 
@@ -103,6 +101,12 @@ public class TruffleRegexpNodes {
         return strEnc;
     }
 
+    @TruffleBoundary
+    private static Matcher getMatcher(Regex regex, byte[] stringBytes, int start) {
+        return regex.matcher(stringBytes, start, stringBytes.length);
+    }
+
+    @TruffleBoundary
     private static Regex makeRegexpForEncoding(RubyContext context, RubyRegexp regexp, Encoding enc, Node currentNode) {
         final Encoding[] fixedEnc = new Encoding[]{ null };
         final Rope sourceRope = regexp.source;

--- a/src/main/java/org/truffleruby/core/regexp/TruffleRegexpNodes.java
+++ b/src/main/java/org/truffleruby/core/regexp/TruffleRegexpNodes.java
@@ -350,7 +350,7 @@ public class TruffleRegexpNodes {
         }
     }
 
-    @Primitive(name = "regexp_match_in_region", lowerFixnum = { 2, 3, 6 })
+    @Primitive(name = "regexp_match_in_region", lowerFixnum = { 2, 3, 5 })
     public abstract static class MatchInRegionNode extends PrimitiveArrayArgumentsNode {
 
         /** Matches a regular expression against a string over the specified range of characters.
@@ -366,20 +366,12 @@ public class TruffleRegexpNodes {
          * @param atStart Whether to only match at the beginning of the string, if false then the regexp can have any
          *            amount of prematch.
          *
-         * @param encodingConversion Whether to attempt encoding conversion of the regexp to match the string
-         *
          * @param startPos The position within the string which the matcher should consider the start. Setting this to
          *            the from position allows scanners to match starting partway through a string while still setting
          *            atStart and thus forcing the match to be at the specific starting position. */
         @Specialization(guards = "libString.isRubyString(string)")
         protected Object matchInRegion(
-                RubyRegexp regexp,
-                Object string,
-                int fromPos,
-                int toPos,
-                boolean atStart,
-                boolean encodingConversion,
-                int startPos,
+                RubyRegexp regexp, Object string, int fromPos, int toPos, boolean atStart, int startPos,
                 @Cached RopeNodes.BytesNode bytesNode,
                 @Cached TruffleRegexpNodes.MatchNode matchNode,
                 @CachedLibrary(limit = "2") RubyStringLibrary libString) {

--- a/src/main/java/org/truffleruby/core/regexp/TruffleRegexpNodes.java
+++ b/src/main/java/org/truffleruby/core/regexp/TruffleRegexpNodes.java
@@ -423,6 +423,7 @@ public class TruffleRegexpNodes {
         @Specialization(guards = "libString.isRubyString(string)")
         protected Object matchInRegion(
                 RubyRegexp regexp, Object string, int fromPos, int toPos, boolean atStart, int startPos,
+                @Cached ConditionProfile encodingMismatchProfile,
                 @Cached RopeNodes.BytesNode bytesNode,
                 @Cached TruffleRegexpNodes.MatchNode matchNode,
                 @Cached TruffleRegexpNodes.CheckEncodingNode checkEncodingNode,
@@ -431,7 +432,7 @@ public class TruffleRegexpNodes {
             final Encoding enc = checkEncodingNode.executeCheckEncoding(regexp, string);
             Regex regex = regexp.regex;
 
-            if (regex.getEncoding() != enc) {
+            if (encodingMismatchProfile.profile(regex.getEncoding() != enc)) {
                 final EncodingCache encodingCache = regexp.cachedEncodings;
                 regex = encodingCache.getOrCreate(enc, e -> makeRegexpForEncoding(getContext(), regexp, e, this));
             }

--- a/src/main/java/org/truffleruby/options/Options.java
+++ b/src/main/java/org/truffleruby/options/Options.java
@@ -129,8 +129,8 @@ public class Options {
     public final boolean WARN_EXPERIMENTAL;
     /** --use-truffle-regex=false */
     public final boolean USE_TRUFFLE_REGEX;
-    /** --use-truffle-regex-with-warn=false */
-    public final boolean USE_TRUFFLE_REGEX_WITH_WARN;
+    /** --warn-truffle-regex-fallback=false */
+    public final boolean WARN_TRUFFLE_REGEX_FALLBACK;
     /** --argv-globals=false */
     public final boolean ARGV_GLOBALS;
     /** --chomp-loop=false */
@@ -248,7 +248,7 @@ public class Options {
         WARN_DEPRECATED = options.get(OptionsCatalog.WARN_DEPRECATED_KEY);
         WARN_EXPERIMENTAL = options.get(OptionsCatalog.WARN_EXPERIMENTAL_KEY);
         USE_TRUFFLE_REGEX = options.get(OptionsCatalog.USE_TRUFFLE_REGEX_KEY);
-        USE_TRUFFLE_REGEX_WITH_WARN = options.get(OptionsCatalog.USE_TRUFFLE_REGEX_WITH_WARN_KEY);
+        WARN_TRUFFLE_REGEX_FALLBACK = options.get(OptionsCatalog.WARN_TRUFFLE_REGEX_FALLBACK_KEY);
         ARGV_GLOBALS = options.get(OptionsCatalog.ARGV_GLOBALS_KEY);
         CHOMP_LOOP = options.get(OptionsCatalog.CHOMP_LOOP_KEY);
         GETS_LOOP = options.get(OptionsCatalog.GETS_LOOP_KEY);
@@ -390,8 +390,8 @@ public class Options {
                 return WARN_EXPERIMENTAL;
             case "ruby.use-truffle-regex":
                 return USE_TRUFFLE_REGEX;
-            case "ruby.use-truffle-regex-with-warn":
-                return USE_TRUFFLE_REGEX_WITH_WARN;
+            case "ruby.warn-truffle-regex-fallback":
+                return WARN_TRUFFLE_REGEX_FALLBACK;
             case "ruby.argv-globals":
                 return ARGV_GLOBALS;
             case "ruby.chomp-loop":

--- a/src/main/java/org/truffleruby/options/Options.java
+++ b/src/main/java/org/truffleruby/options/Options.java
@@ -129,6 +129,8 @@ public class Options {
     public final boolean WARN_EXPERIMENTAL;
     /** --use-truffle-regex=false */
     public final boolean USE_TRUFFLE_REGEX;
+    /** --use-truffle-regex-with-warn=false */
+    public final boolean USE_TRUFFLE_REGEX_WITH_WARN;
     /** --argv-globals=false */
     public final boolean ARGV_GLOBALS;
     /** --chomp-loop=false */
@@ -246,6 +248,7 @@ public class Options {
         WARN_DEPRECATED = options.get(OptionsCatalog.WARN_DEPRECATED_KEY);
         WARN_EXPERIMENTAL = options.get(OptionsCatalog.WARN_EXPERIMENTAL_KEY);
         USE_TRUFFLE_REGEX = options.get(OptionsCatalog.USE_TRUFFLE_REGEX_KEY);
+        USE_TRUFFLE_REGEX_WITH_WARN = options.get(OptionsCatalog.USE_TRUFFLE_REGEX_WITH_WARN_KEY);
         ARGV_GLOBALS = options.get(OptionsCatalog.ARGV_GLOBALS_KEY);
         CHOMP_LOOP = options.get(OptionsCatalog.CHOMP_LOOP_KEY);
         GETS_LOOP = options.get(OptionsCatalog.GETS_LOOP_KEY);
@@ -387,6 +390,8 @@ public class Options {
                 return WARN_EXPERIMENTAL;
             case "ruby.use-truffle-regex":
                 return USE_TRUFFLE_REGEX;
+            case "ruby.use-truffle-regex-with-warn":
+                return USE_TRUFFLE_REGEX_WITH_WARN;
             case "ruby.argv-globals":
                 return ARGV_GLOBALS;
             case "ruby.chomp-loop":

--- a/src/main/ruby/truffleruby/core/truffle/regexp_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/regexp_operations.rb
@@ -64,7 +64,7 @@ module Truffle
     Truffle::Boot.delay do
       COMPARE_ENGINES = Truffle::Boot.get_option('compare-regex-engines')
       USE_TRUFFLE_REGEX = Truffle::Boot.get_option('use-truffle-regex')
-      USE_TRUFFLE_REGEX_WITH_WARN = Truffle::Boot.get_option('use-truffle-regex-with-warn')
+      WARN_TRUFFLE_REGEX_FALLBACK = Truffle::Boot.get_option('warn-truffle-regex-fallback')
 
       if Truffle::Boot.get_option('regexp-instrument-creation') or Truffle::Boot.get_option('regexp-instrument-match')
         at_exit do
@@ -76,7 +76,7 @@ module Truffle
     def self.match_in_region(re, str, from, to, at_start, start)
       if COMPARE_ENGINES
         match_in_region_compare_engines(re, str, from, to, at_start, start)
-      elsif USE_TRUFFLE_REGEX || USE_TRUFFLE_REGEX_WITH_WARN
+      elsif USE_TRUFFLE_REGEX
         match_in_region_tregex(re, str, from, to, at_start, start)
       else
         Primitive.regexp_match_in_region(re, str, from, to, at_start, start)
@@ -116,8 +116,8 @@ module Truffle
         regex_result = compiled_regex.execBytes(str_bytes, from)
       end
       if bail_out
-        if USE_TRUFFLE_REGEX_WITH_WARN
-          warn "match_in_region_tregex(/#{re}/, \"#{str}\"@#{str.encoding}, #{from}, #{to}, #{at_start}, #{encoding_conversion}, #{start}) can’t be run as a Truffle regexp and fell back to Joni"
+        if WARN_TRUFFLE_REGEX_FALLBACK
+          warn "match_in_region_tregex(#{re.inspect}, #{str.inspect}@#{str.encoding}, #{from}, #{to}, #{at_start}, #{encoding_conversion}, #{start}) can't be run as a Truffle regexp and fell back to Joni"
         end
         return Primitive.regexp_match_in_region(re, str, from, to, at_start, start)
       elsif regex_result.isMatch

--- a/src/main/ruby/truffleruby/core/truffle/regexp_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/regexp_operations.rb
@@ -78,7 +78,7 @@ module Truffle
       elsif USE_TRUFFLE_REGEX
         match_in_region_tregex(re, str, from, to, at_start, encoding_conversion, start)
       else
-        Primitive.regexp_match_in_region(re, str, from, to, at_start, encoding_conversion, start)
+        Primitive.regexp_match_in_region(re, str, from, to, at_start, start)
       end
     end
 
@@ -89,7 +89,7 @@ module Truffle
         md1 = e
       end
       begin
-        md2 = Primitive.regexp_match_in_region(re, str, from, to, at_start, encoding_conversion, start)
+        md2 = Primitive.regexp_match_in_region(re, str, from, to, at_start, start)
       rescue => e
         md2 = e
       end
@@ -115,7 +115,7 @@ module Truffle
         regex_result = compiled_regex.execBytes(str_bytes, from)
       end
       if bail_out
-        return Primitive.regexp_match_in_region(re, str, from, to, at_start, encoding_conversion, start)
+        return Primitive.regexp_match_in_region(re, str, from, to, at_start, start)
       elsif regex_result.isMatch
         starts = []
         ends = []

--- a/src/main/ruby/truffleruby/core/truffle/regexp_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/regexp_operations.rb
@@ -64,6 +64,7 @@ module Truffle
     Truffle::Boot.delay do
       COMPARE_ENGINES = Truffle::Boot.get_option('compare-regex-engines')
       USE_TRUFFLE_REGEX = Truffle::Boot.get_option('use-truffle-regex')
+      USE_TRUFFLE_REGEX_WITH_WARN = Truffle::Boot.get_option('use-truffle-regex-with-warn')
 
       if Truffle::Boot.get_option('regexp-instrument-creation') or Truffle::Boot.get_option('regexp-instrument-match')
         at_exit do
@@ -75,7 +76,7 @@ module Truffle
     def self.match_in_region(re, str, from, to, at_start, start)
       if COMPARE_ENGINES
         match_in_region_compare_engines(re, str, from, to, at_start, start)
-      elsif USE_TRUFFLE_REGEX
+      elsif USE_TRUFFLE_REGEX || USE_TRUFFLE_REGEX_WITH_WARN
         match_in_region_tregex(re, str, from, to, at_start, start)
       else
         Primitive.regexp_match_in_region(re, str, from, to, at_start, start)
@@ -115,6 +116,9 @@ module Truffle
         regex_result = compiled_regex.execBytes(str_bytes, from)
       end
       if bail_out
+        if USE_TRUFFLE_REGEX_WITH_WARN
+          warn "match_in_region_tregex(/#{re}/, \"#{str}\"@#{str.encoding}, #{from}, #{to}, #{at_start}, #{encoding_conversion}, #{start}) can’t be run as a Truffle regexp and fell back to Joni"
+        end
         return Primitive.regexp_match_in_region(re, str, from, to, at_start, start)
       elsif regex_result.isMatch
         starts = []

--- a/src/main/ruby/truffleruby/core/truffle/regexp_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/regexp_operations.rb
@@ -97,10 +97,10 @@ module Truffle
       if self.results_match?(md1, md2)
         return self.return_match_data(md1)
       else
-        $stderr.puts "match_in_region(/#{re}/, \"#{str}\"@#{str.encoding}, #{from}, #{to}, #{at_start}, #{start}) gate"
-        self.print_match_data(md1)
+        $stderr.puts "match_in_region(#{re.inspect}, #{str.inspect}@#{str.encoding}, #{from}, #{to}, #{at_start}, #{start}) gave"
+        print_match_data(md1)
         $stderr.puts 'but we expected'
-        self.print_match_data(md2)
+        print_match_data(md2)
         return self.return_match_data(md2)
       end
     end

--- a/src/main/ruby/truffleruby/core/truffle/regexp_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/regexp_operations.rb
@@ -31,7 +31,7 @@ module Truffle
         from = end_index
         to = start_index
       end
-      match_in_region(re, str, from, to, false, true, 0)
+      match_in_region(re, str, from, to, false, 0)
     end
 
     # This path is used by some string and scanner methods and allows
@@ -39,7 +39,7 @@ module Truffle
     # possible to refactor search region to offer the ability to
     # specify at start, we should investigate this at some point.
     def self.match_onwards(re, str, from, at_start)
-      md = match_in_region(re, str, from, str.bytesize, at_start, true, from)
+      md = match_in_region(re, str, from, str.bytesize, at_start, from)
       Primitive.matchdata_fixup_positions(md, from) if md
       md
     end
@@ -72,19 +72,19 @@ module Truffle
       end
     end
 
-    def self.match_in_region(re, str, from, to, at_start, encoding_conversion, start)
+    def self.match_in_region(re, str, from, to, at_start, start)
       if COMPARE_ENGINES
-        match_in_region_compare_engines(re, str, from, to, at_start, encoding_conversion, start)
+        match_in_region_compare_engines(re, str, from, to, at_start, start)
       elsif USE_TRUFFLE_REGEX
-        match_in_region_tregex(re, str, from, to, at_start, encoding_conversion, start)
+        match_in_region_tregex(re, str, from, to, at_start, start)
       else
         Primitive.regexp_match_in_region(re, str, from, to, at_start, start)
       end
     end
 
-    def self.match_in_region_compare_engines(re, str, from, to, at_start, encoding_conversion, start)
+    def self.match_in_region_compare_engines(re, str, from, to, at_start, start)
       begin
-        md1 = match_in_region_tregex(re, str, from, to, at_start, encoding_conversion, start)
+        md1 = match_in_region_tregex(re, str, from, to, at_start, start)
       rescue => e
         md1 = e
       end
@@ -96,7 +96,7 @@ module Truffle
       if self.results_match?(md1, md2)
         return self.return_match_data(md1)
       else
-        $stderr.puts "match_in_region(/#{re}/, \"#{str}\"@#{str.encoding}, #{from}, #{to}, #{at_start}, #{encoding_conversion}, #{start}) gate"
+        $stderr.puts "match_in_region(/#{re}/, \"#{str}\"@#{str.encoding}, #{from}, #{to}, #{at_start}, #{start}) gate"
         self.print_match_data(md1)
         $stderr.puts 'but we expected'
         self.print_match_data(md2)
@@ -104,10 +104,10 @@ module Truffle
       end
     end
 
-    def self.match_in_region_tregex(re, str, from, to, at_start, encoding_conversion, start)
+    def self.match_in_region_tregex(re, str, from, to, at_start, start)
       bail_out = to < from || to != str.bytesize || start != 0 || from < 0
       if !bail_out
-        compiled_regex = tregex_compile(re, at_start, select_encoding(re, str, encoding_conversion))
+        compiled_regex = tregex_compile(re, at_start, select_encoding(re, str))
         bail_out = compiled_regex.nil?
       end
       if !bail_out

--- a/src/main/ruby/truffleruby/core/truffle/regexp_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/regexp_operations.rb
@@ -117,7 +117,7 @@ module Truffle
       end
       if bail_out
         if WARN_TRUFFLE_REGEX_FALLBACK
-          warn "match_in_region_tregex(#{re.inspect}, #{str.inspect}@#{str.encoding}, #{from}, #{to}, #{at_start}, #{encoding_conversion}, #{start}) can't be run as a Truffle regexp and fell back to Joni"
+          warn "match_in_region_tregex(#{re.inspect}, #{str.inspect}@#{str.encoding}, #{from}, #{to}, #{at_start}, #{encoding_conversion}, #{start}) can't be run as a Truffle regexp and fell back to Joni", uplevel: 1
         end
         return Primitive.regexp_match_in_region(re, str, from, to, at_start, start)
       elsif regex_result.isMatch

--- a/src/options.yml
+++ b/src/options.yml
@@ -144,7 +144,7 @@ EXPERT:
 
     # Controlling the regular expression engines
     USE_TRUFFLE_REGEX: [use-truffle-regex, boolean, false, 'Use the Truffle regular expression engine for Regexp objects']
-    USE_TRUFFLE_REGEX_WITH_WARN: [use-truffle-regex-with-warn, boolean, false, 'Use the Truffle regular expression engine for Regexp objects and warn when falling back to Joni']
+    WARN_TRUFFLE_REGEX_FALLBACK: [warn-truffle-regex-fallback, boolean, false, 'Warn when Truffle Regex could not be used for a Regexp and instead Joni is used']
 
 INTERNAL: # Options for debugging the TruffleRuby implementation
   EXPERIMENTAL:

--- a/src/options.yml
+++ b/src/options.yml
@@ -144,6 +144,7 @@ EXPERT:
 
     # Controlling the regular expression engines
     USE_TRUFFLE_REGEX: [use-truffle-regex, boolean, false, 'Use the Truffle regular expression engine for Regexp objects']
+    USE_TRUFFLE_REGEX_WITH_WARN: [use-truffle-regex-with-warn, boolean, false, 'Use the Truffle regular expression engine for Regexp objects and warn when falling back to Joni']
 
 INTERNAL: # Options for debugging the TruffleRuby implementation
   EXPERIMENTAL:

--- a/src/shared/java/org/truffleruby/shared/options/OptionsCatalog.java
+++ b/src/shared/java/org/truffleruby/shared/options/OptionsCatalog.java
@@ -83,7 +83,7 @@ public class OptionsCatalog {
     public static final OptionKey<Boolean> WARN_DEPRECATED_KEY = new OptionKey<>(false);
     public static final OptionKey<Boolean> WARN_EXPERIMENTAL_KEY = new OptionKey<>(true);
     public static final OptionKey<Boolean> USE_TRUFFLE_REGEX_KEY = new OptionKey<>(false);
-    public static final OptionKey<Boolean> USE_TRUFFLE_REGEX_WITH_WARN_KEY = new OptionKey<>(false);
+    public static final OptionKey<Boolean> WARN_TRUFFLE_REGEX_FALLBACK_KEY = new OptionKey<>(false);
     public static final OptionKey<Boolean> ARGV_GLOBALS_KEY = new OptionKey<>(false);
     public static final OptionKey<Boolean> CHOMP_LOOP_KEY = new OptionKey<>(false);
     public static final OptionKey<Boolean> GETS_LOOP_KEY = new OptionKey<>(false);
@@ -597,9 +597,9 @@ public class OptionsCatalog {
             .stability(OptionStability.EXPERIMENTAL)
             .build();
 
-    public static final OptionDescriptor USE_TRUFFLE_REGEX_WITH_WARN = OptionDescriptor
-            .newBuilder(USE_TRUFFLE_REGEX_WITH_WARN_KEY, "ruby.use-truffle-regex-with-warn")
-            .help("Use the Truffle regular expression engine for Regexp objects and warn when falling back to Joni")
+    public static final OptionDescriptor WARN_TRUFFLE_REGEX_FALLBACK = OptionDescriptor
+            .newBuilder(WARN_TRUFFLE_REGEX_FALLBACK_KEY, "ruby.warn-truffle-regex-fallback")
+            .help("Warn when Truffle Regex could not be used for a Regexp and instead Joni is used")
             .category(OptionCategory.EXPERT)
             .stability(OptionStability.EXPERIMENTAL)
             .build();
@@ -1229,8 +1229,8 @@ public class OptionsCatalog {
                 return WARN_EXPERIMENTAL;
             case "ruby.use-truffle-regex":
                 return USE_TRUFFLE_REGEX;
-            case "ruby.use-truffle-regex-with-warn":
-                return USE_TRUFFLE_REGEX_WITH_WARN;
+            case "ruby.warn-truffle-regex-fallback":
+                return WARN_TRUFFLE_REGEX_FALLBACK;
             case "ruby.argv-globals":
                 return ARGV_GLOBALS;
             case "ruby.chomp-loop":
@@ -1443,7 +1443,7 @@ public class OptionsCatalog {
             WARN_DEPRECATED,
             WARN_EXPERIMENTAL,
             USE_TRUFFLE_REGEX,
-            USE_TRUFFLE_REGEX_WITH_WARN,
+            WARN_TRUFFLE_REGEX_FALLBACK,
             ARGV_GLOBALS,
             CHOMP_LOOP,
             GETS_LOOP,

--- a/src/shared/java/org/truffleruby/shared/options/OptionsCatalog.java
+++ b/src/shared/java/org/truffleruby/shared/options/OptionsCatalog.java
@@ -83,6 +83,7 @@ public class OptionsCatalog {
     public static final OptionKey<Boolean> WARN_DEPRECATED_KEY = new OptionKey<>(false);
     public static final OptionKey<Boolean> WARN_EXPERIMENTAL_KEY = new OptionKey<>(true);
     public static final OptionKey<Boolean> USE_TRUFFLE_REGEX_KEY = new OptionKey<>(false);
+    public static final OptionKey<Boolean> USE_TRUFFLE_REGEX_WITH_WARN_KEY = new OptionKey<>(false);
     public static final OptionKey<Boolean> ARGV_GLOBALS_KEY = new OptionKey<>(false);
     public static final OptionKey<Boolean> CHOMP_LOOP_KEY = new OptionKey<>(false);
     public static final OptionKey<Boolean> GETS_LOOP_KEY = new OptionKey<>(false);
@@ -592,6 +593,13 @@ public class OptionsCatalog {
     public static final OptionDescriptor USE_TRUFFLE_REGEX = OptionDescriptor
             .newBuilder(USE_TRUFFLE_REGEX_KEY, "ruby.use-truffle-regex")
             .help("Use the Truffle regular expression engine for Regexp objects")
+            .category(OptionCategory.EXPERT)
+            .stability(OptionStability.EXPERIMENTAL)
+            .build();
+
+    public static final OptionDescriptor USE_TRUFFLE_REGEX_WITH_WARN = OptionDescriptor
+            .newBuilder(USE_TRUFFLE_REGEX_WITH_WARN_KEY, "ruby.use-truffle-regex-with-warn")
+            .help("Use the Truffle regular expression engine for Regexp objects and warn when falling back to Joni")
             .category(OptionCategory.EXPERT)
             .stability(OptionStability.EXPERIMENTAL)
             .build();
@@ -1221,6 +1229,8 @@ public class OptionsCatalog {
                 return WARN_EXPERIMENTAL;
             case "ruby.use-truffle-regex":
                 return USE_TRUFFLE_REGEX;
+            case "ruby.use-truffle-regex-with-warn":
+                return USE_TRUFFLE_REGEX_WITH_WARN;
             case "ruby.argv-globals":
                 return ARGV_GLOBALS;
             case "ruby.chomp-loop":
@@ -1433,6 +1443,7 @@ public class OptionsCatalog {
             WARN_DEPRECATED,
             WARN_EXPERIMENTAL,
             USE_TRUFFLE_REGEX,
+            USE_TRUFFLE_REGEX_WITH_WARN,
             ARGV_GLOBALS,
             CHOMP_LOOP,
             GETS_LOOP,


### PR DESCRIPTION
To print a warning when falling back to Joni because a regular expression can’t be run as a Truffle regex, so we can explicitly see when this occurs.