### PR TITLE
Add spec for use of :base in Dir#glob and tag it

### DIFF
--- a/spec/ruby/core/dir/glob_spec.rb
+++ b/spec/ruby/core/dir/glob_spec.rb
@@ -29,6 +29,23 @@ describe "Dir.glob" do
                %w!file_one.ext file_two.ext!
   end
 
+  it 'returns matching file paths when supplied :base keyword argument' do
+    dir = tmp('temp') + '/'
+    file_1 = dir + 'lib/bloop.rb'
+    file_2 = dir + 'lib/soup.rb'
+    file_3 = dir + 'lib/mismatched_file_type.txt'
+    file_4 = dir + 'mismatched_directory.rb'
+
+    touch file_1
+    touch file_2
+    touch file_3
+    touch file_4
+
+    Dir.glob('**/*.rb', base: dir + 'lib').sort.should == ["bloop.rb", "soup.rb"].sort
+
+    rm_r dir[0...-1]
+  end
+
   it "calls #to_path to convert multiple patterns" do
     pat1 = mock('file_one.ext')
     pat1.should_receive(:to_path).and_return('file_one.ext')

--- a/spec/tags/core/dir/glob_tags.txt
+++ b/spec/tags/core/dir/glob_tags.txt
@@ -1,1 +1,2 @@
 fails:Dir.glob recursively matches files and directories in nested dot subdirectory with 'nested/**/*' from the current directory and option File::FNM_DOTMATCH
+fails:Dir.glob returns matching file paths when supplied :base keyword argument


### PR DESCRIPTION
## Issue 

We found this exception because it broke the TruffleRuby CI on SFR.

```
puts RUBY_DESCRIPTION
puts Dir.glob('**/*.rake', base: '.')
```

```
➜  storefront-renderer git:(master) ✗ ruby foo.rb
truffleruby 21.2.0-dev-d2532c21, like ruby 2.7.3, GraalVM CE JVM [x86_64-darwin]
<internal:core> core/dir_glob.rb:305:in `match?': undefined method `end_with?' for nil:NilClass (NoMethodError)
	from <internal:core> core/dir_glob.rb:286:in `process_entry'
	from <internal:core> core/dir_glob.rb:184:in `process_directory'
	from <internal:core> core/dir_glob.rb:413:in `run'
	from <internal:core> core/dir_glob.rb:466:in `glob'
	from <internal:core> core/dir.rb:250:in `block in glob'
	from <internal:core> core/dir.rb:247:in `each'
	from <internal:core> core/dir.rb:247:in `glob'
	from foo.rb:2:in `<main>'
```

TL;DR: If there are [no path entries](https://github.com/oracle/truffleruby/blob/master/src/main/ruby/truffleruby/core/dir_glob.rb#L286) and the entry type is `EndsWithEntryMatch`, a nil class error will occur with the [`#end_with?(suffix)` check](https://github.com/oracle/truffleruby/blob/master/src/main/ruby/truffleruby/core/dir_glob.rb#L305).

I did some digging and it seems like there is no issue if `Dir#glob` is run without a base: `Dir.glob('**/*.rake')`. The code path diverges at [this line](https://github.com/oracle/truffleruby/blob/master/src/main/ruby/truffleruby/core/dir_glob.rb#L184) when there is no `glob_base_dir` specified. In the problematic case, the `@next` is `EndsWithEntryMatch`, and when this Entry type is processed with no entry, there is a NilClass exception on `#end_with?`

## Change

This change is just the test case that covers the issue. It passes on Ruby 2.7.3 and returns the exception (as seen above) on TrufleRuby. 

## Question

I don't have a lot of new context on the new `Dir#glob` changes, but this issue has something to do with the recent changes. 

I have a [branch here at gets rid of the exception](https://github.com/oracle/truffleruby/commit/2ef61330f64369652bba3715e159d5864fd1bd05) but it does not pass the spec I added because the resulting array includes the file path of the mismatched directory.

Any idea to what the issue may be? 