### PR TITLE
Replace boundary on `StringByteIndexPrimitiveNode` with faster specializations for boundary checks and single-byte-optimizable strings.

### DIFF
--- a/src/main/java/org/truffleruby/core/cast/ToRopeNode.java
+++ b/src/main/java/org/truffleruby/core/cast/ToRopeNode.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved. This
+ * code is released under a tri EPL/GPL/LGPL license. You can use it,
+ * redistribute it and/or modify it under the terms of the:
+ *
+ * Eclipse Public License version 2.0, or
+ * GNU General Public License version 2, or
+ * GNU Lesser General Public License version 2.1.
+ */
+
+package org.truffleruby.core.cast;
+
+import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.dsl.Fallback;
+import com.oracle.truffle.api.dsl.NodeChild;
+import com.oracle.truffle.api.dsl.Specialization;
+import org.jcodings.Encoding;
+import org.truffleruby.core.rope.Rope;
+import org.truffleruby.core.string.ImmutableRubyString;
+import org.truffleruby.core.string.RubyString;
+import org.truffleruby.language.RubyContextSourceNode;
+import org.truffleruby.language.RubyNode;
+
+@NodeChild(value = "child", type = RubyNode.class)
+public abstract class ToRopeNode extends RubyContextSourceNode {
+
+    public abstract Rope executeToRope(Object object);
+
+    public static ToRopeNode create() {
+        return ToRopeNodeGen.create(null);
+    }
+
+    @Specialization
+    protected Rope coerceRubyString(RubyString string) {
+        return string.rope;
+    }
+
+    @Specialization
+    protected Rope coerceImmutableRubyString(ImmutableRubyString string) {
+        return string.rope;
+    }
+
+    @Fallback
+    protected Encoding failure(Object value) {
+        throw CompilerDirectives.shouldNotReachHere();
+    }
+}

--- a/src/main/java/org/truffleruby/core/string/StringNodes.java
+++ b/src/main/java/org/truffleruby/core/string/StringNodes.java
@@ -76,6 +76,8 @@ import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 
 import com.oracle.truffle.api.dsl.Bind;
+import com.oracle.truffle.api.nodes.LoopNode;
+import com.oracle.truffle.api.profiles.LoopConditionProfile;
 import org.jcodings.Config;
 import org.jcodings.Encoding;
 import org.jcodings.specific.ASCIIEncoding;
@@ -100,6 +102,7 @@ import org.truffleruby.core.array.RubyArray;
 import org.truffleruby.core.cast.BooleanCastNode;
 import org.truffleruby.core.cast.ToIntNode;
 import org.truffleruby.core.cast.ToLongNode;
+import org.truffleruby.core.cast.ToRopeNodeGen;
 import org.truffleruby.core.cast.ToStrNode;
 import org.truffleruby.core.cast.ToStrNodeGen;
 import org.truffleruby.core.encoding.EncodingLeftCharHeadNode;
@@ -4461,41 +4464,92 @@ public abstract class StringNodes {
     }
 
     @Primitive(name = "string_byte_index", lowerFixnum = 2)
-    public abstract static class StringByteIndexPrimitiveNode extends PrimitiveArrayArgumentsNode {
+    @NodeChild(value = "string", type = RubyNode.class)
+    @NodeChild(value = "pattern", type = RubyNode.class)
+    @NodeChild(value = "offset", type = RubyNode.class)
+    public abstract static class StringByteIndexPrimitiveNode extends PrimitiveNode {
 
-        @TruffleBoundary
-        @Specialization
-        protected Object stringCharacterIndex(Object string, Object pattern, int offset,
-                @Cached RopeNodes.CalculateCharacterLengthNode calculateCharacterLengthNode,
-                @CachedLibrary(limit = "2") RubyStringLibrary libString,
-                @CachedLibrary(limit = "2") RubyStringLibrary libPattern) {
-            if (offset < 0) {
-                return nil;
-            }
+        @Child SingleByteOptimizableNode singleByteOptimizableNode = SingleByteOptimizableNode.create();
 
-            final Rope stringRope = libString.getRope(string);
-            final Rope patternRope = libPattern.getRope(pattern);
+        @CreateCast("string")
+        protected RubyNode coerceStringToRope(RubyNode string) {
+            return ToRopeNodeGen.create(string);
+        }
 
-            final int total = stringRope.byteLength();
-            int p = 0;
-            final int e = p + total;
+        @CreateCast("pattern")
+        protected RubyNode coercePatternToRope(RubyNode pattern) {
+            return ToRopeNodeGen.create(pattern);
+        }
+
+        @Specialization(guards = "offset < 0")
+        protected Object stringByteIndexNegativeOffset(Rope stringRope, Rope patternRope, int offset) {
+            return nil;
+        }
+
+        @Specialization(
+                guards = {
+                        "offset >= 0",
+                        "singleByteOptimizableNode.execute(stringRope)",
+                        "patternRope.byteLength() > stringRope.byteLength()" })
+        protected Object stringByteIndexPatternTooLarge(Rope stringRope, Rope patternRope, int offset) {
+            return nil;
+        }
+
+        @Specialization(
+                guards = {
+                        "offset >= 0",
+                        "singleByteOptimizableNode.execute(stringRope)",
+                        "patternRope.byteLength() <= stringRope.byteLength()" })
+        protected Object stringCharacterIndexSingleByteOptimizable(Rope stringRope, Rope patternRope, int offset,
+                @Cached BranchProfile matchProfile,
+                @Cached BranchProfile noMatchProfile,
+                @Cached RopeNodes.BytesNode stringBytesNode,
+                @Cached RopeNodes.BytesNode patternBytesNode,
+                @Cached LoopConditionProfile loopProfile) {
+
+            int p = offset;
+            final int e = stringRope.byteLength();
             final int pe = patternRope.byteLength();
             final int l = e - pe + 1;
 
-            final byte[] stringBytes = stringRope.getBytes();
-            final byte[] patternBytes = patternRope.getBytes();
+            final byte[] stringBytes = stringBytesNode.execute(stringRope);
+            final byte[] patternBytes = patternBytesNode.execute(patternRope);
 
-            p += offset;
+            try {
+                loopProfile.profileCounted(l - p);
 
-            if (stringRope.isSingleByteOptimizable()) {
                 for (; p < l; p++) {
                     if (ArrayUtils.memcmp(stringBytes, p, patternBytes, 0, pe) == 0) {
+                        matchProfile.enter();
                         return p;
                     }
                 }
-
-                return nil;
+            } finally {
+                LoopNode.reportLoopCount(this, p - offset);
             }
+
+            noMatchProfile.enter();
+            return nil;
+        }
+
+        @TruffleBoundary
+        @Specialization(
+                guards = {
+                        "offset >= 0",
+                        "!singleByteOptimizableNode.execute(stringRope)",
+                        "patternRope.byteLength() <= stringRope.byteLength()" })
+        protected Object stringCharacterIndex(Rope stringRope, Rope patternRope, int offset,
+                @Cached RopeNodes.CalculateCharacterLengthNode calculateCharacterLengthNode,
+                @Cached RopeNodes.BytesNode stringBytesNode,
+                @Cached RopeNodes.BytesNode patternBytesNode) {
+
+            int p = offset;
+            final int e = stringRope.byteLength();
+            final int pe = patternRope.byteLength();
+            final int l = e - pe + 1;
+
+            final byte[] stringBytes = stringBytesNode.execute(stringRope);
+            final byte[] patternBytes = patternBytesNode.execute(patternRope);
 
             final Encoding enc = stringRope.getEncoding();
             final CodeRange cr = stringRope.getCodeRange();


### PR DESCRIPTION
With this set of changes, I'm seeing double the performance for `String.gsub(String, String)` when the pattern fits inside the string (for single byte optimizable strings) and 4x - 5x when the pattern is too large. That last case might seem strange, but if `gsub` is being used to sanitize some text that may vary in size, it's quite possible for the sanitize pattern to be larger than the body it's applied against.

It's a bit hard to nail down an absolute speed improvement due to the `gsub` process varying both on the receiver and the pattern sizes. For the out-of-bounds cases, we can avoid fetching either rope's byte array. The rest of the improvements are due to removing the large boundary.

If you don't like the `ToRopeNode`, I can take another pass at that. I'm not entirely happy that it overlaps with `RubyStringLibrary`, but I did want to `@CreateCast` and just work with the ropes in the various specializations. Likewise, I can adjust the branch profiles as needed. They may not be needed at all.