### PR TITLE
Replace boundary on StringCharacterIndexPrimitiveNode

### DIFF
--- a/spec/ruby/core/string/index_spec.rb
+++ b/spec/ruby/core/string/index_spec.rb
@@ -146,6 +146,7 @@ describe "String#index with String" do
 
   it "returns the character index after offset" do
     "われわれ".index("わ", 1).should == 2
+    "ありがとうありがとう".index("が",3).should == 7
   end
 
   it "returns the character index after a partial first match" do

--- a/src/main/java/org/truffleruby/core/string/StringNodes.java
+++ b/src/main/java/org/truffleruby/core/string/StringNodes.java
@@ -4472,7 +4472,7 @@ public abstract class StringNodes {
                 @Cached RopeNodes.BytesNode stringBytesNode,
                 @Cached RopeNodes.BytesNode patternBytesNode) {
 
-            int p = offset;
+            int p = 0;
             final int e = stringRope.byteLength();
             final int pe = patternRope.byteLength();
             final int l = e - pe + 1;

--- a/src/main/java/org/truffleruby/core/string/StringNodes.java
+++ b/src/main/java/org/truffleruby/core/string/StringNodes.java
@@ -4500,7 +4500,7 @@ public abstract class StringNodes {
                         "offset >= 0",
                         "singleByteOptimizableNode.execute(stringRope)",
                         "patternRope.byteLength() <= stringRope.byteLength()" })
-        protected Object stringCharacterIndexSingleByteOptimizable(Rope stringRope, Rope patternRope, int offset,
+        protected Object stringByteIndexSingleByteOptimizable(Rope stringRope, Rope patternRope, int offset,
                 @Cached RopeNodes.BytesNode stringBytesNode,
                 @Cached RopeNodes.BytesNode patternBytesNode,
                 @Cached LoopConditionProfile loopProfile,
@@ -4533,7 +4533,7 @@ public abstract class StringNodes {
                         "offset >= 0",
                         "!singleByteOptimizableNode.execute(stringRope)",
                         "patternRope.byteLength() <= stringRope.byteLength()" })
-        protected Object stringCharacterIndex(Rope stringRope, Rope patternRope, int offset,
+        protected Object stringByteIndex(Rope stringRope, Rope patternRope, int offset,
                 @Cached RopeNodes.CalculateCharacterLengthNode calculateCharacterLengthNode,
                 @Cached RopeNodes.BytesNode stringBytesNode,
                 @Cached RopeNodes.BytesNode patternBytesNode) {

--- a/src/main/java/org/truffleruby/core/string/StringNodes.java
+++ b/src/main/java/org/truffleruby/core/string/StringNodes.java
@@ -4416,16 +4416,11 @@ public abstract class StringNodes {
             return ToRopeNodeGen.create(pattern);
         }
 
-        @Specialization(guards = "offset < 0")
-        protected Object stringCharacterIndexNegativeOffset(Rope stringRope, Rope patternRope, int offset) {
-            return nil;
-        }
-
         @Specialization(
                 guards = {
                         "offset >= 0",
                         "singleByteOptimizableNode.execute(stringRope)",
-                        "patternRope.byteLength() > stringRope.byteLength()" })
+                        "!patternFits(stringRope, patternRope, offset)" })
         protected Object stringCharacterIndexPatternTooLarge(Rope stringRope, Rope patternRope, int offset) {
             return nil;
         }
@@ -4434,7 +4429,7 @@ public abstract class StringNodes {
                 guards = {
                         "offset >= 0",
                         "singleByteOptimizableNode.execute(stringRope)",
-                        "patternRope.byteLength() <= stringRope.byteLength()" })
+                        "patternFits(stringRope, patternRope, offset)" })
         protected Object stringCharacterIndexSingleByteOptimizable(Rope stringRope, Rope patternRope, int offset,
                 @Cached RopeNodes.BytesNode stringBytesNode,
                 @Cached RopeNodes.BytesNode patternBytesNode,
@@ -4506,6 +4501,10 @@ public abstract class StringNodes {
             }
 
             return nil;
+        }
+
+        protected boolean patternFits(Rope stringRope, Rope patternRope, int offset) {
+            return patternRope.byteLength() + offset <= stringRope.byteLength();
         }
     }
 


### PR DESCRIPTION
with faster specializations for boundary checks and single-byte-optimizable strings by copying StringByteIndexPrimitiveNode after https://github.com/oracle/truffleruby/pull/2380 . (When singleByteOptimizable, the character case is the same as the byte case, so only minor differences in the last case). 

Similarly, the change creates similar or better performance, with 5x occurring for a long pattern relative to string case, and 2x occurring for variable-width character case.

BEFORE:
```
Calculating -------------------------------------
                          2.961B (±29.5%) i/s -      6.145B in   5.079150s
                   a     29.806M (±12.5%) i/s -    144.054M in   5.015924s
             ablabla     26.532M (±12.7%) i/s -    128.575M in   5.039081s
                   z     24.248M (±12.2%) i/s -    117.892M in   5.050822s
                   z      2.949B (±29.0%) i/s -      6.096B in   5.032540s
                          2.785B (±35.9%) i/s -      4.309B in   5.090509s
                   a     17.337M (±10.9%) i/s -     86.103M in   5.102710s
             ablabla      5.132M (± 9.5%) i/s -     25.630M in   5.085396s
                   z      5.417M (± 8.8%) i/s -     26.908M in   5.061476s
                   が     18.421M (±12.7%) i/s -     90.434M in   5.079164s
                 reg      6.193M (± 3.1%) i/s -     31.271M in   5.054981s
                 reg      6.192M (± 6.1%) i/s -     31.027M in   5.033315s
                 reg    853.298k (± 5.0%) i/s -      4.261M in   5.007935s 
```

AFTER:
```
                          3.214B (± 7.1%) i/s -     14.587B in   4.986813s
                   a    140.627M (±15.5%) i/s -    666.584M in   5.071025s
             ablabla    128.231M (±16.3%) i/s -    593.787M in   5.016626s
                   z     95.290M (±16.4%) i/s -    448.075M in   5.027422s
                   z      2.931B (±29.1%) i/s -      6.142B in   5.076050s
                          2.930B (±30.2%) i/s -      5.718B in   5.057414s
                   a     63.495M (±13.0%) i/s -    308.726M in   5.086479s
             ablabla     13.743M (±10.2%) i/s -     67.054M in   5.018824s
                   z     15.479M (±10.5%) i/s -     75.350M in   5.017034s
                   が     45.899M (±12.3%) i/s -    222.415M in   5.026720s
                 reg      5.920M (± 2.0%) i/s -     29.649M in   5.010390s
                 reg      5.959M (± 2.7%) i/s -     29.784M in   5.002301s
                 reg    932.086k (± 5.5%) i/s -      4.694M in   5.054531s
```

benchmark:
``` ruby
require 'benchmark/ips'

puts RUBY_DESCRIPTION

Benchmark.ips do |x|
  x.report('') do
    "blablabla".index("")
  end
  x.report('a') do
    "blablabla".index("a")
  end
  x.report('ablabla') do
    "blablabla".index("ablabla")
  end
  x.report('z') do
    "blablabla".index("z")
  end
  x.report('z') do
    "blablabla".index("z", 20)
  end
  x.report('') do
    "sdfkglwejhrewlrhkjeawdfnasdfad45f4ad5sf4a65sdf46sadgfadgfjklhasdfjasdkjfnklxcnsDfadfsdfgsfgblablabla".index("")
  end
  x.report('a') do
    "sdfkglwejhrewlrhkjeawdfnasdfad45f4ad5sf4a65sdf46sadgfadgfjklhasdfjasdkjfnklxcnsDfadfsdfgsfgblablabla".index("a")
  end
  x.report('ablabla') do
    "sdfkglwejhrewlrhkjeawdfnasdfad45f4ad5sf4a65sdf46sadgfadgfjklhasdfjasdkjfnklxcnsDfadfsdfgsfgblablabla".index("ablabla")
  end
  x.report('z') do
    "sdfkglwejhrewlrhkjeawdfnasdfad45f4ad5sf4a65sdf46sadgfadgfjklhasdfjasdkjfnklxcnsDfadfsdfgsfgblablabla".index("z")
  end
  x.report('が') do
    "ありがとう".index("が")
  end
  x.report('reg') do
    "bl\nablabla".index(/$/)
  end
  x.report('reg') do
    "blablabla".index(/.{5}/, 3)
  end
  x.report('reg') do
    re = /\G.+YOU/
    # The # marks where \G will match.
    [
      ["#hi!YOUall.", 0],
      ["h#i!YOUall.", 1],
      ["hi#!YOUall.", 2],
      ["hi!#YOUall.", nil]
    ].each do |spec|

      start = spec[0].index("#")
      str = spec[0].delete("#")

      str.index(re, start)
    end
  end
end
```