### PR TITLE
TRegex splitting

### DIFF
--- a/src/main/java/org/truffleruby/core/string/TruffleStringNodes.java
+++ b/src/main/java/org/truffleruby/core/string/TruffleStringNodes.java
@@ -15,12 +15,10 @@ import org.truffleruby.builtins.CoreModule;
 import org.truffleruby.core.rope.Rope;
 import org.truffleruby.core.rope.RopeNodes;
 import org.truffleruby.language.control.RaiseException;
-import org.truffleruby.language.library.RubyStringLibrary;
 
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.library.CachedLibrary;
 
 @CoreModule("Truffle::StringOperations")
 public class TruffleStringNodes {
@@ -70,16 +68,5 @@ public class TruffleStringNodes {
                     .format("Invalid byte count: %d exceeds string size of %d bytes", count, rope.byteLength());
         }
 
-    }
-
-    @CoreMethod(names = "raw_bytes", onSingleton = true, required = 1)
-    public abstract static class RawBytesNode extends CoreMethodArrayArgumentsNode {
-        @Specialization(guards = "libString.isRubyString(string)")
-        protected Object rawBytes(Object string,
-                @CachedLibrary(limit = "2") RubyStringLibrary libString,
-                @Cached RopeNodes.BytesNode bytesNode) {
-            byte[] bytes = bytesNode.execute(libString.getRope(string));
-            return getContext().getEnv().asGuestValue(bytes);
-        }
     }
 }

--- a/src/main/ruby/truffleruby/core/truffle/regexp_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/regexp_operations.rb
@@ -77,7 +77,7 @@ module Truffle
       if COMPARE_ENGINES
         match_in_region_compare_engines(re, str, from, to, at_start, start)
       elsif USE_TRUFFLE_REGEX
-        match_in_region_tregex(re, str, from, to, at_start, start)
+        Primitive.regexp_match_in_region_tregex(re, str, from, to, at_start, start)
       else
         Primitive.regexp_match_in_region(re, str, from, to, at_start, start)
       end
@@ -85,7 +85,7 @@ module Truffle
 
     def self.match_in_region_compare_engines(re, str, from, to, at_start, start)
       begin
-        md1 = match_in_region_tregex(re, str, from, to, at_start, start)
+        md1 = Primitive.regexp_match_in_region_tregex(re, str, from, to, at_start, start)
       rescue => e
         md1 = e
       end
@@ -102,29 +102,6 @@ module Truffle
         $stderr.puts 'but we expected'
         print_match_data(md2)
         return self.return_match_data(md2)
-      end
-    end
-
-    def self.match_in_region_tregex(re, str, from, to, at_start, start)
-      if to < from || to != str.bytesize || start != 0 || from < 0 ||
-          Primitive.nil?((compiled_regex = tregex_compile(re, at_start, select_encoding(re, str))))
-        warn_fallback(re, str, from, to, at_start, start) if WARN_TRUFFLE_REGEX_FALLBACK
-        return Primitive.regexp_match_in_region(re, str, from, to, at_start, start)
-      end
-
-      str_bytes = StringOperations.raw_bytes(str)
-      regex_result = compiled_regex.execBytes(str_bytes, from)
-
-      if regex_result.isMatch
-        starts = []
-        ends = []
-        compiled_regex.groupCount.times do |pos|
-          starts << regex_result.getStart(pos)
-          ends << regex_result.getEnd(pos)
-        end
-        Primitive.matchdata_create(re, str.dup, starts, ends)
-      else
-        nil
       end
     end
 


### PR DESCRIPTION
This is a port of `Truffle::RegexOperations.match_in_region_tregex` from Ruby to Java in order to reduce the number of AST nodes needed, which in turn allows for splitting. Being able to split leads to substantial performance improvements. Using the microbenchmarks from #2381, I have:

Joni for all regexs:
```
Warming up --------------------------------------
literal characters - no match
                       146.557k i/100ms
literal characters - match
                       268.784k i/100ms
   universal - match   418.954k i/100ms
character class - match
                       416.244k i/100ms
character class - no match
                       454.312k i/100ms
   unique - no match   335.215k i/100ms
      unique - match   370.972k i/100ms
Calculating -------------------------------------
literal characters - no match
                          6.058M (±12.4%) i/s -     29.751M in   5.009168s
literal characters - match
                          4.819M (±10.1%) i/s -     23.922M in   5.032138s
   universal - match      5.047M (± 8.7%) i/s -     25.137M in   5.029133s
character class - match
                          4.790M (± 8.4%) i/s -     24.142M in   5.081252s
character class - no match
                          5.727M (± 8.0%) i/s -     28.622M in   5.036076s
   unique - no match      3.353M (± 6.6%) i/s -     16.761M in   5.021652s
      unique - match      4.631M (±10.6%) i/s -     23.000M in   5.038905s

Comparison:
literal characters - no match:  6058081.9 i/s
character class - no match:  5726703.3 i/s - same-ish: difference falls within error
   universal - match:  5047020.0 i/s - same-ish: difference falls within error
literal characters - match:  4819255.1 i/s - 1.26x  (± 0.00) slower
character class - match:  4789748.9 i/s - 1.26x  (± 0.00) slower
      unique - match:  4631319.4 i/s - 1.31x  (± 0.00) slower
   unique - no match:  3353318.8 i/s - 1.81x  (± 0.00) slower
```

Truffle Regex with Joni fallback:
```
Warming up --------------------------------------
literal characters - no match
                       227.018k i/100ms
literal characters - match
                       307.603k i/100ms
   universal - match   262.539k i/100ms
character class - match
                       517.341k i/100ms
character class - no match
                         1.233M i/100ms
   unique - no match     3.771M i/100ms
      unique - match   569.974k i/100ms
Calculating -------------------------------------
literal characters - no match
                         83.620M (± 6.9%) i/s -    414.081M in   4.980405s
literal characters - match
                         55.248M (±14.1%) i/s -    261.770M in   4.993725s
   universal - match      9.618M (±14.5%) i/s -     46.994M in   5.018544s
character class - match
                          8.689M (±17.9%) i/s -     41.905M in   5.033010s
character class - no match
                         74.890M (±20.0%) i/s -    355.090M in   5.017734s
   unique - no match     88.609M (±24.7%) i/s -    414.766M in   4.999963s
      unique - match      5.252M (±22.5%) i/s -     25.079M in   5.000489s

Comparison:
   unique - no match: 88608780.1 i/s
literal characters - no match: 83620213.8 i/s - same-ish: difference falls within error
character class - no match: 74890461.6 i/s - same-ish: difference falls within error
literal characters - match: 55248302.6 i/s - 1.60x  (± 0.00) slower
   universal - match:  9618264.2 i/s - 9.21x  (± 0.00) slower
character class - match:  8689317.1 i/s - 10.20x  (± 0.00) slower
      unique - match:  5251575.9 i/s - 16.87x  (± 0.00) slower
```

This was run on a MacBook Pro i7 2.6 GHz with macOS 11.3.1.