### PR TITLE
Remove the boundary on identityHashCode

### DIFF
--- a/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
+++ b/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
@@ -1026,7 +1026,7 @@ public abstract class KernelNodes {
             return System.identityHashCode(self);
         }
 
-        @Specialization(guards = "!isRubyBignum(self)")
+        @Specialization
         protected int hash(RubyDynamicObject self) {
             return System.identityHashCode(self);
         }

--- a/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
+++ b/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
@@ -985,7 +985,6 @@ public abstract class KernelNodes {
     @CoreMethod(names = "hash")
     public abstract static class HashNode extends CoreMethodArrayArgumentsNode {
 
-
         public static HashNode create() {
             return KernelNodesFactory.HashNodeFactory.create(null);
         }
@@ -1013,23 +1012,20 @@ public abstract class KernelNodes {
         }
 
         @Specialization
-        protected long hashBignum(RubyBignum value) {
+        protected long hash(RubyBignum value) {
             return HashOperations.hashBignum(value, getContext(), this);
         }
 
-        @TruffleBoundary
         @Specialization
         protected int hash(Nil self) {
             return System.identityHashCode(self);
         }
 
-        @TruffleBoundary
         @Specialization
-        protected int hashEncoding(RubyEncoding self) {
+        protected int hash(RubyEncoding self) {
             return System.identityHashCode(self);
         }
 
-        @TruffleBoundary
         @Specialization(guards = "!isRubyBignum(self)")
         protected int hash(RubyDynamicObject self) {
             return System.identityHashCode(self);

--- a/src/main/java/org/truffleruby/debug/TruffleDebugNodes.java
+++ b/src/main/java/org/truffleruby/debug/TruffleDebugNodes.java
@@ -555,7 +555,6 @@ public abstract class TruffleDebugNodes {
                 return other instanceof ForeignObject ? TriState.valueOf(this == other) : TriState.UNDEFINED;
             }
 
-            @TruffleBoundary
             @ExportMessage
             protected int identityHashCode() {
                 return System.identityHashCode(this);


### PR DESCRIPTION
Works fine and produces good code on JVM and Native.

Why do we have individual classes' hash implementations in `Kernel`?