### PR TITLE
Clarify needed specializations in StringCharacterIndexNode

### DIFF
--- a/src/main/java/org/truffleruby/core/string/StringNodes.java
+++ b/src/main/java/org/truffleruby/core/string/StringNodes.java
@@ -4420,22 +4420,14 @@ public abstract class StringNodes {
         @Specialization(
                 guards = {
                         "offset >= 0",
-                        "singleByteOptimizableNode.execute(stringRope)",
-                        "!patternFits(stringRope, patternRope, offset)" })
-        protected Object patternTooLarge(Rope stringRope, Rope patternRope, int offset) {
-            return nil;
-        }
-
-        @Specialization(
-                guards = {
-                        "offset >= 0",
-                        "singleByteOptimizableNode.execute(stringRope)",
-                        "patternFits(stringRope, patternRope, offset)" })
+                        "singleByteOptimizableNode.execute(stringRope)" })
         protected Object singleByteOptimizable(Rope stringRope, Rope patternRope, int offset,
                 @Cached RopeNodes.BytesNode stringBytesNode,
                 @Cached RopeNodes.BytesNode patternBytesNode,
                 @Cached LoopConditionProfile loopProfile,
                 @Cached("createCountingProfile()") ConditionProfile matchProfile) {
+
+            assert offset + patternRope.byteLength() <= stringRope.byteLength(); // otherwise returns in ruby fastpath
 
             int p = offset;
             final int e = stringRope.byteLength();
@@ -4467,6 +4459,8 @@ public abstract class StringNodes {
                 @Cached RopeNodes.CalculateCharacterLengthNode calculateCharacterLengthNode,
                 @Cached RopeNodes.BytesNode stringBytesNode,
                 @Cached RopeNodes.BytesNode patternBytesNode) {
+
+            assert offset + patternRope.byteLength() <= stringRope.byteLength(); // otherwise returns in ruby fastpath
 
             int p = 0;
             final int e = stringRope.byteLength();
@@ -4502,10 +4496,6 @@ public abstract class StringNodes {
             }
 
             return nil;
-        }
-
-        protected boolean patternFits(Rope stringRope, Rope patternRope, int offset) {
-            return offset + patternRope.byteLength() <= stringRope.byteLength();
         }
     }
 

--- a/src/main/java/org/truffleruby/core/string/StringNodes.java
+++ b/src/main/java/org/truffleruby/core/string/StringNodes.java
@@ -4516,14 +4516,14 @@ public abstract class StringNodes {
             return ToRopeNodeGen.create(pattern);
         }
 
-        @Specialization(guards = { "offset >= 0", "!patternFits(stringRope, patternRope, offset)" })
+        @Specialization(guards = { "!patternFits(stringRope, patternRope, offset)" })
         protected Object patternTooLarge(Rope stringRope, Rope patternRope, int offset) {
+            assert offset >= 0;
             return nil;
         }
 
         @Specialization(
                 guards = {
-                        "offset >= 0",
                         "singleByteOptimizableNode.execute(stringRope)",
                         "patternFits(stringRope, patternRope, offset)" })
         protected Object singleByteOptimizable(Rope stringRope, Rope patternRope, int offset,
@@ -4532,6 +4532,7 @@ public abstract class StringNodes {
                 @Cached LoopConditionProfile loopProfile,
                 @Cached("createCountingProfile()") ConditionProfile matchProfile) {
 
+            assert offset >= 0;
             int p = offset;
             final int e = stringRope.byteLength();
             final int pe = patternRope.byteLength();
@@ -4556,7 +4557,6 @@ public abstract class StringNodes {
         @TruffleBoundary
         @Specialization(
                 guards = {
-                        "offset >= 0",
                         "!singleByteOptimizableNode.execute(stringRope)",
                         "patternFits(stringRope, patternRope, offset)" })
         protected Object multiByte(Rope stringRope, Rope patternRope, int offset,
@@ -4564,6 +4564,7 @@ public abstract class StringNodes {
                 @Cached RopeNodes.BytesNode stringBytesNode,
                 @Cached RopeNodes.BytesNode patternBytesNode) {
 
+            assert offset >= 0;
             int p = offset;
             final int e = stringRope.byteLength();
             final int pe = patternRope.byteLength();

--- a/src/main/java/org/truffleruby/core/string/StringNodes.java
+++ b/src/main/java/org/truffleruby/core/string/StringNodes.java
@@ -4418,15 +4418,14 @@ public abstract class StringNodes {
         }
 
         @Specialization(
-                guards = {
-                        "offset >= 0",
-                        "singleByteOptimizableNode.execute(stringRope)" })
+                guards = { "singleByteOptimizableNode.execute(stringRope)" })
         protected Object singleByteOptimizable(Rope stringRope, Rope patternRope, int offset,
                 @Cached RopeNodes.BytesNode stringBytesNode,
                 @Cached RopeNodes.BytesNode patternBytesNode,
                 @Cached LoopConditionProfile loopProfile,
                 @Cached("createCountingProfile()") ConditionProfile matchProfile) {
 
+            assert offset >= 0;
             assert offset + patternRope.byteLength() <= stringRope.byteLength(); // otherwise returns in ruby fastpath
 
             int p = offset;
@@ -4452,14 +4451,13 @@ public abstract class StringNodes {
 
         @TruffleBoundary
         @Specialization(
-                guards = {
-                        "offset >= 0",
-                        "!singleByteOptimizableNode.execute(stringRope)" })
+                guards = { "!singleByteOptimizableNode.execute(stringRope)" })
         protected Object multiByte(Rope stringRope, Rope patternRope, int offset,
                 @Cached RopeNodes.CalculateCharacterLengthNode calculateCharacterLengthNode,
                 @Cached RopeNodes.BytesNode stringBytesNode,
                 @Cached RopeNodes.BytesNode patternBytesNode) {
 
+            assert offset >= 0;
             assert offset + patternRope.byteLength() <= stringRope.byteLength(); // otherwise returns in ruby fastpath
 
             int p = 0;

--- a/src/main/java/org/truffleruby/core/string/StringNodes.java
+++ b/src/main/java/org/truffleruby/core/string/StringNodes.java
@@ -594,7 +594,7 @@ public abstract class StringNodes {
 
         @Specialization
         protected Object getIndex(Object string, long index, NotProvided length) {
-            assert (int) index != index; // verified via lowerFixnum
+            assert (int) index != index : "verified via lowerFixnum";
             return outOfBoundsNil();
         }
 
@@ -4418,7 +4418,7 @@ public abstract class StringNodes {
         }
 
         @Specialization(
-                guards = { "singleByteOptimizableNode.execute(stringRope)" })
+                guards = "singleByteOptimizableNode.execute(stringRope)")
         protected Object singleByteOptimizable(Rope stringRope, Rope patternRope, int offset,
                 @Cached RopeNodes.BytesNode stringBytesNode,
                 @Cached RopeNodes.BytesNode patternBytesNode,
@@ -4426,7 +4426,8 @@ public abstract class StringNodes {
                 @Cached("createCountingProfile()") ConditionProfile matchProfile) {
 
             assert offset >= 0;
-            assert offset + patternRope.byteLength() <= stringRope.byteLength(); // otherwise returns in ruby fastpath
+            assert offset + patternRope.byteLength() <= stringRope
+                    .byteLength() : "already checked in the caller, String#index";
 
             int p = offset;
             final int e = stringRope.byteLength();
@@ -4451,14 +4452,15 @@ public abstract class StringNodes {
 
         @TruffleBoundary
         @Specialization(
-                guards = { "!singleByteOptimizableNode.execute(stringRope)" })
+                guards = "!singleByteOptimizableNode.execute(stringRope)")
         protected Object multiByte(Rope stringRope, Rope patternRope, int offset,
                 @Cached RopeNodes.CalculateCharacterLengthNode calculateCharacterLengthNode,
                 @Cached RopeNodes.BytesNode stringBytesNode,
                 @Cached RopeNodes.BytesNode patternBytesNode) {
 
             assert offset >= 0;
-            assert offset + patternRope.byteLength() <= stringRope.byteLength(); // otherwise returns in ruby fastpath
+            assert offset + patternRope.byteLength() <= stringRope
+                    .byteLength() : "already checked in the caller, String#index";
 
             int p = 0;
             final int e = stringRope.byteLength();
@@ -4516,7 +4518,7 @@ public abstract class StringNodes {
             return ToRopeNodeGen.create(pattern);
         }
 
-        @Specialization(guards = { "!patternFits(stringRope, patternRope, offset)" })
+        @Specialization(guards = "!patternFits(stringRope, patternRope, offset)")
         protected Object patternTooLarge(Rope stringRope, Rope patternRope, int offset) {
             assert offset >= 0;
             return nil;

--- a/src/main/ruby/truffleruby/core/string.rb
+++ b/src/main/ruby/truffleruby/core/string.rb
@@ -1312,7 +1312,7 @@ class String
 
     Primitive.encoding_ensure_compatible self, str
 
-    return if str.size > size
+    return if str.size + start > size
 
     Primitive.string_character_index(self, str, start)
   end

--- a/src/main/ruby/truffleruby/core/string.rb
+++ b/src/main/ruby/truffleruby/core/string.rb
@@ -1312,7 +1312,7 @@ class String
 
     Primitive.encoding_ensure_compatible self, str
 
-    return if str.size + start > size
+    return if start + str.size > size
 
     Primitive.string_character_index(self, str, start)
   end


### PR DESCRIPTION
The better version of the last commit in https://github.com/oracle/truffleruby/pull/2383# that handle negatives offset and overlong pattern (+offset) in StringCharacterIndexNode.

Also turns non-negative offset guard in StringByteIndexNode to an assertion, since the only caller does not give negative offsets.

