### PR TITLE
Make Process.clock_gettime(Process::CLOCK_MONOTONIC) simpler

### DIFF
--- a/src/main/java/org/truffleruby/core/ProcessNodes.java
+++ b/src/main/java/org/truffleruby/core/ProcessNodes.java
@@ -27,7 +27,6 @@ public abstract class ProcessNodes {
     @Primitive(name = "process_time_nanotime")
     public abstract static class ProcessTimeNanoTimeNode extends PrimitiveArrayArgumentsNode {
 
-        @TruffleBoundary
         @Specialization
         protected long nanoTime() {
             return System.nanoTime();

--- a/src/main/ruby/truffleruby/core/process.rb
+++ b/src/main/ruby/truffleruby/core/process.rb
@@ -156,10 +156,10 @@ module Process
     end
 
     case id
-    when CLOCK_REALTIME
-      time = Primitive.process_time_instant
     when CLOCK_MONOTONIC
       time = Primitive.process_time_nanotime
+    when CLOCK_REALTIME
+      time = Primitive.process_time_instant
     else
       time = Truffle::POSIX.truffleposix_clock_gettime(id)
       Errno.handle if time == 0
@@ -170,20 +170,20 @@ module Process
 
   def self.nanoseconds_to_unit(nanoseconds, unit)
     case unit
-    when :nanosecond
-      nanoseconds
-    when :microsecond
-      nanoseconds / 1_000
-    when :millisecond
-      nanoseconds / 1_000_000
-    when :second
-      nanoseconds / 1_000_000_000
+    when :float_second, nil
+      nanoseconds / 1e9
     when :float_microsecond
       nanoseconds / 1e3
     when :float_millisecond
       nanoseconds / 1e6
-    when :float_second, nil
-      nanoseconds / 1e9
+    when :second
+      nanoseconds / 1_000_000_000
+    when :millisecond
+      nanoseconds / 1_000_000
+    when :microsecond
+      nanoseconds / 1_000
+    when :nanosecond
+      nanoseconds
     else
       raise ArgumentError, "unexpected unit: #{unit}"
     end

--- a/src/main/ruby/truffleruby/core/process.rb
+++ b/src/main/ruby/truffleruby/core/process.rb
@@ -169,9 +169,13 @@ module Process
   end
 
   def self.nanoseconds_to_unit(nanoseconds, unit)
-    case unit
+    case unit # ordered by expected frequency
     when :float_second, nil
       nanoseconds / 1e9
+    when :nanosecond
+      nanoseconds
+    when :microsecond
+      nanoseconds / 1_000
     when :float_microsecond
       nanoseconds / 1e3
     when :float_millisecond
@@ -180,10 +184,6 @@ module Process
       nanoseconds / 1_000_000_000
     when :millisecond
       nanoseconds / 1_000_000
-    when :microsecond
-      nanoseconds / 1_000
-    when :nanosecond
-      nanoseconds
     else
       raise ArgumentError, "unexpected unit: #{unit}"
     end

--- a/src/main/ruby/truffleruby/core/process.rb
+++ b/src/main/ruby/truffleruby/core/process.rb
@@ -156,7 +156,7 @@ module Process
     end
 
     case id
-    when CLOCK_MONOTONIC
+    when CLOCK_MONOTONIC # most common clock id
       time = Primitive.process_time_nanotime
     when CLOCK_REALTIME
       time = Primitive.process_time_instant


### PR DESCRIPTION
We use `Process.clock_gettime(Process::CLOCK_MONOTONIC)` a lot - this simplifies it, at both the level of Truffle and Graal optimisation.

```ruby
def foo
  Process.clock_gettime(Process::CLOCK_MONOTONIC)
end

loop do
  foo
end
```

First of all we re-order switches on options for `clock_gettime` so that the ones we, and probably a lot of people, use most often. TruffleRuby currently isn't able to re-order switches on symbols.

Goes from:

```
[engine] Inline start Object#foo                                                  |call diff     0.00|Recursion Depth      0|Explore/inline ratio     1.00|IR Nodes   1192|Frequency     1.00|Truffle Callees      1|Forced false|Depth      0
[engine] Inlined        Process.clock_gettime                                     |call diff   -10.00|Recursion Depth      0|Explore/inline ratio      NaN|IR Nodes    114|Frequency     1.00|Truffle Callees      1|Forced false|Depth      1
[engine] Inlined          Process.nanoseconds_to_unit                             |call diff    -9.00|Recursion Depth      0|Explore/inline ratio      NaN|IR Nodes    325|Frequency     1.00|Truffle Callees      8|Forced false|Depth      2
[engine] Inlined            BasicObject#equal?                                    |call diff    -1.00|Recursion Depth      0|Explore/inline ratio      NaN|IR Nodes    123|Frequency     1.00|Truffle Callees      0|Forced false|Depth      3
[engine] Inlined            BasicObject#equal?                                    |call diff    -1.00|Recursion Depth      0|Explore/inline ratio      NaN|IR Nodes    123|Frequency     1.00|Truffle Callees      0|Forced false|Depth      3
[engine] Inlined            BasicObject#equal?                                    |call diff    -1.00|Recursion Depth      0|Explore/inline ratio      NaN|IR Nodes    123|Frequency     1.00|Truffle Callees      0|Forced false|Depth      3
[engine] Inlined            BasicObject#equal?                                    |call diff    -1.00|Recursion Depth      0|Explore/inline ratio      NaN|IR Nodes    123|Frequency     1.00|Truffle Callees      0|Forced false|Depth      3
[engine] Inlined            BasicObject#equal?                                    |call diff    -1.00|Recursion Depth      0|Explore/inline ratio      NaN|IR Nodes    123|Frequency     1.00|Truffle Callees      0|Forced false|Depth      3
[engine] Inlined            BasicObject#equal?                                    |call diff    -1.00|Recursion Depth      0|Explore/inline ratio      NaN|IR Nodes    123|Frequency     1.00|Truffle Callees      0|Forced false|Depth      3
[engine] Inlined            BasicObject#equal?                                    |call diff    -1.00|Recursion Depth      0|Explore/inline ratio      NaN|IR Nodes    123|Frequency     1.00|Truffle Callees      0|Forced false|Depth      3
[engine] Inlined            Integer#/                                             |call diff    -1.00|Recursion Depth      0|Explore/inline ratio      NaN|IR Nodes     35|Frequency     1.00|Truffle Callees      0|Forced false|Depth      3
[engine] Inline done  Object#foo                                                  |call diff     0.00|Recursion Depth      0|Explore/inline ratio     1.00|IR Nodes   1192|Frequency     1.00|Truffle Callees      1|Forced false|Depth      0
[engine] opt done     Object#foo                                                  |AST   21|Tier 2|Time  339( 320+19  )ms|Inlined  10Y   0N|IR    93/  157|CodeSize    499|Addr 0x12961ed10|Src loop.rb:1

```

To:

```
[engine] Inline start Object#foo                                                  |call diff     0.00|Recursion Depth      0|Explore/inline ratio     1.00|IR Nodes    361|Frequency     1.00|Truffle Callees      1|Forced false|Depth      0
[engine] Inlined        Process.clock_gettime                                     |call diff    -4.00|Recursion Depth      0|Explore/inline ratio      NaN|IR Nodes     99|Frequency     1.00|Truffle Callees      1|Forced false|Depth      1
[engine] Inlined          Process.nanoseconds_to_unit                             |call diff    -3.00|Recursion Depth      0|Explore/inline ratio      NaN|IR Nodes    121|Frequency     1.00|Truffle Callees      2|Forced false|Depth      2
[engine] Inlined            BasicObject#equal?                                    |call diff    -1.00|Recursion Depth      0|Explore/inline ratio      NaN|IR Nodes    123|Frequency     1.00|Truffle Callees      0|Forced false|Depth      3
[engine] Inlined            Integer#/                                             |call diff    -1.00|Recursion Depth      0|Explore/inline ratio      NaN|IR Nodes     35|Frequency     1.00|Truffle Callees      0|Forced false|Depth      3
[engine] Inline done  Object#foo                                                  |call diff     0.00|Recursion Depth      0|Explore/inline ratio     1.00|IR Nodes    361|Frequency     1.00|Truffle Callees      1|Forced false|Depth      0
[engine] opt done     Object#foo                                                  |AST   21|Tier 2|Time  232( 222+10  )ms|Inlined   4Y   0N|IR    27/   62|CodeSize    306|Addr 0x11e4d5e90|Src loop.rb:1
```

This reduces the impact on the inlining budget, allowing other inlining to be more effective.

Then we removed a barrier around `System.nanoTime` that isn't needed on either JVM or SVM. This also removes a useless exception edge coming out of `ProcessTimeNanoTimeNode.nanoTime`.

![graph](https://user-images.githubusercontent.com/341094/124684217-8a4b1780-dec6-11eb-8c3d-e480e25ed6bd.png)

There's not a huge different to the resulting machine code, but the process to get there relies on fewer optimisations.

```
	0x1297f86c0:	mov	r10d, dword ptr [rsi + 8]
	0x1297f86c4:	shl	r10, 3
	0x1297f86c8:	movabs	r12, 0x800000000
	0x1297f86d2:	add	r10, r12
	0x1297f86d5:	xor	r12, r12
	0x1297f86d8:	nop	dword ptr [rax + rax]
	0x1297f86e0:	cmp	rax, r10
	0x1297f86e3:	jne	0x11e681080
	0x1297f86e9:	nop	
	0x1297f86ea:	nop	word ptr [rax + rax]
	0x1297f86f5:	nop	
	0x1297f86f9:	nop	dword ptr [rax]
	0x1297f8700:	mov	dword ptr [rsp - 0x14000], eax
	0x1297f8707:	sub	rsp, 0x18
	0x1297f870b:	mov	qword ptr [rsp + 0x10], rbp
	0x1297f8710:	mov	qword ptr [rsp], rdx
	0x1297f8714:	call	0x114e5b29a
	0x1297f8719:	nop	
	0x1297f871a:	mov	r10, rax
	0x1297f871d:	mov	rax, qword ptr [r15 + 0x118]
	0x1297f8724:	lea	rsi, [rax + 0x18]
	0x1297f8728:	movabs	rdx, 0x800343218
	0x1297f8732:	cmp	rsi, qword ptr [r15 + 0x128]
	0x1297f8739:	ja	0x1297f87a4
	0x1297f873f:	mov	qword ptr [r15 + 0x118], rsi
	0x1297f8746:	prefetchw	byte ptr [rax + 0xd8]
	0x1297f874d:	mov	rsi, qword ptr [rdx + 0xb8]
	0x1297f8754:	mov	qword ptr [rax], rsi
	0x1297f8757:	mov	dword ptr [rax + 8], 0x68643
	0x1297f875e:	mov	dword ptr [rax + 0xc], 0
	0x1297f8765:	mov	qword ptr [rax + 0x10], 0
	0x1297f876d:	vcvtsi2sd	xmm0, xmm0, r10
	0x1297f8772:	vdivsd	xmm0, xmm0, qword ptr [rip - 0xda]
	0x1297f877a:	vmovsd	qword ptr [rax + 0x10], xmm0
	0x1297f877f:	nop	
	0x1297f8780:	cmp	dword ptr [r15 + 0x410], 0
	0x1297f8788:	jne	0x1297f87b1
	0x1297f878e:	mov	rbp, qword ptr [rsp + 0x10]
	0x1297f8793:	add	rsp, 0x18
	0x1297f8797:	mov	rcx, qword ptr [r15 + 0x108]
	0x1297f879e:	test	dword ptr [rcx], eax
	0x1297f87a0:	vzeroupper	
	0x1297f87a3:	ret	
```

I don't know if we need to think-bigger on allowing these `case` statements to re-order, so that we only test for cases we've seen and deoptimise when they don't match? Graal can turn a sequence of `if` nodes into an integer-switch, but that's too late for this kind of inlining problem, and I don't know if that even works with pointers.