### PR TITLE
`LazyIntRope` specialization for `string_to_inum` primitive

### DIFF
--- a/src/main/java/org/truffleruby/core/exception/CoreExceptions.java
+++ b/src/main/java/org/truffleruby/core/exception/CoreExceptions.java
@@ -30,13 +30,13 @@ import org.truffleruby.core.module.RubyModule;
 import org.truffleruby.core.proc.RubyProc;
 import org.truffleruby.core.range.RubyIntRange;
 import org.truffleruby.core.rope.Rope;
+import org.truffleruby.core.rope.RopeOperations;
 import org.truffleruby.core.string.CoreStrings;
 import org.truffleruby.core.string.RubyString;
 import org.truffleruby.core.string.StringOperations;
 import org.truffleruby.core.string.StringUtils;
 import org.truffleruby.core.symbol.RubySymbol;
 import org.truffleruby.core.thread.ThreadNodes.ThreadGetExceptionNode;
-import org.truffleruby.core.string.ImmutableRubyString;
 import org.truffleruby.language.Nil;
 import org.truffleruby.language.backtrace.Backtrace;
 import org.truffleruby.language.backtrace.BacktraceFormatter;
@@ -233,12 +233,8 @@ public class CoreExceptions {
     }
 
     @TruffleBoundary
-    public RubyException argumentErrorInvalidStringToInteger(Object object, Node currentNode) {
-        assert object instanceof RubyString || object instanceof ImmutableRubyString;
-        // TODO (nirvdrum 19-Apr-18): Guard against String#inspect being redefined to return something other than a String.
-        final String formattedObject = RubyStringLibrary
-                .getUncached()
-                .getJavaString(RubyContext.send(object, "inspect"));
+    public RubyException argumentErrorInvalidStringToInteger(Rope rope, Node currentNode) {
+        final String formattedObject = RopeOperations.decodeRope(rope);
         return argumentError(StringUtils.format("invalid value for Integer(): %s", formattedObject), currentNode);
     }
 

--- a/src/main/java/org/truffleruby/core/string/ConvertBytes.java
+++ b/src/main/java/org/truffleruby/core/string/ConvertBytes.java
@@ -70,11 +70,10 @@ public class ConvertBytes {
     }
 
     /** rb_cstr_to_inum */
-
-    public static Object byteListToInum19(RubyContext context, Node node, FixnumOrBignumNode fixnumOrBignumNode,
+    public static Object bytesToInum(RubyContext context, Node node, FixnumOrBignumNode fixnumOrBignumNode,
             RopeNodes.BytesNode bytesNode, Object str, Rope strRope, int base, boolean badcheck) {
         return new ConvertBytes(context, node, fixnumOrBignumNode, bytesNode, str, strRope, base, badcheck)
-                .byteListToInum();
+                .bytesToInum();
     }
 
     /** conv_digit */
@@ -307,7 +306,7 @@ public class ConvertBytes {
     }
 
     @TruffleBoundary
-    public Object byteListToInum() {
+    public Object bytesToInum() {
         if (_str == null) {
             if (badcheck) {
                 invalidString();
@@ -550,16 +549,16 @@ public class ConvertBytes {
     }
 
     public static final byte[] intToBinaryBytes(int i) {
-        return intToUnsignedByteList(i, 1, LOWER_DIGITS).getBytes();
+        return intToUnsignedBytes(i, 1, LOWER_DIGITS).getBytes();
     }
 
     public static final byte[] intToOctalBytes(int i) {
-        return intToUnsignedByteList(i, 3, LOWER_DIGITS).getBytes();
+        return intToUnsignedBytes(i, 3, LOWER_DIGITS).getBytes();
     }
 
     public static final byte[] intToHexBytes(int i, boolean upper) {
-        RopeBuilder byteList = intToUnsignedByteList(i, 4, upper ? UPPER_DIGITS : LOWER_DIGITS);
-        return byteList.getBytes();
+        RopeBuilder ropeBuilder = intToUnsignedBytes(i, 4, upper ? UPPER_DIGITS : LOWER_DIGITS);
+        return ropeBuilder.getBytes();
     }
 
     public static final byte[] intToByteArray(int i, int radix, boolean upper) {
@@ -567,32 +566,32 @@ public class ConvertBytes {
     }
 
     public static final byte[] intToCharBytes(int i) {
-        return longToByteList(i, 10, LOWER_DIGITS).getBytes();
+        return longToBytes(i, 10, LOWER_DIGITS).getBytes();
     }
 
     public static final byte[] longToBinaryBytes(long i) {
-        return longToUnsignedByteList(i, 1, LOWER_DIGITS).getBytes();
+        return longToUnsignedBytes(i, 1, LOWER_DIGITS).getBytes();
     }
 
     public static final byte[] longToOctalBytes(long i) {
-        return longToUnsignedByteList(i, 3, LOWER_DIGITS).getBytes();
+        return longToUnsignedBytes(i, 3, LOWER_DIGITS).getBytes();
     }
 
     public static final byte[] longToHexBytes(long i, boolean upper) {
-        RopeBuilder byteList = longToUnsignedByteList(i, 4, upper ? UPPER_DIGITS : LOWER_DIGITS);
-        return byteList.getBytes();
+        RopeBuilder ropeBuilder = longToUnsignedBytes(i, 4, upper ? UPPER_DIGITS : LOWER_DIGITS);
+        return ropeBuilder.getBytes();
     }
 
     public static final byte[] longToByteArray(long i, int radix, boolean upper) {
-        RopeBuilder byteList = longToByteList(i, radix, upper ? UPPER_DIGITS : LOWER_DIGITS);
-        return byteList.getBytes();
+        RopeBuilder ropeBuilder = longToBytes(i, radix, upper ? UPPER_DIGITS : LOWER_DIGITS);
+        return ropeBuilder.getBytes();
     }
 
     public static final byte[] longToCharBytes(long i) {
-        return longToByteList(i, 10, LOWER_DIGITS).getBytes();
+        return longToBytes(i, 10, LOWER_DIGITS).getBytes();
     }
 
-    public static final RopeBuilder longToByteList(long i, int radix, byte[] digitmap) {
+    public static final RopeBuilder longToBytes(long i, int radix, byte[] digitmap) {
         if (i == 0) {
             return RopeBuilder.createRopeBuilder(ZERO_BYTES);
         }
@@ -622,7 +621,7 @@ public class ConvertBytes {
         return RopeBuilder.createRopeBuilder(buf, pos, len - pos);
     }
 
-    private static final RopeBuilder intToUnsignedByteList(int i, int shift, byte[] digitmap) {
+    private static final RopeBuilder intToUnsignedBytes(int i, int shift, byte[] digitmap) {
         byte[] buf = new byte[32];
         int charPos = 32;
         int radix = 1 << shift;
@@ -634,7 +633,7 @@ public class ConvertBytes {
         return RopeBuilder.createRopeBuilder(buf, charPos, (32 - charPos));
     }
 
-    private static final RopeBuilder longToUnsignedByteList(long i, int shift, byte[] digitmap) {
+    private static final RopeBuilder longToUnsignedBytes(long i, int shift, byte[] digitmap) {
         byte[] buf = new byte[64];
         int charPos = 64;
         int radix = 1 << shift;

--- a/src/main/java/org/truffleruby/core/string/ConvertBytes.java
+++ b/src/main/java/org/truffleruby/core/string/ConvertBytes.java
@@ -47,6 +47,8 @@ public class ConvertBytes {
             Rope rope,
             int base,
             boolean badcheck) {
+        assert rope != null;
+
         this.context = context;
         this.caller = caller;
         this.fixnumOrBignumNode = fixnumOrBignumNode;
@@ -304,13 +306,6 @@ public class ConvertBytes {
 
     @TruffleBoundary
     public Object bytesToInum() {
-        if (rope == null) {
-            if (badcheck) {
-                invalidString();
-            }
-            return 0;
-        }
-
         ignoreLeadingWhitespace();
 
         boolean sign = getSign();

--- a/src/main/java/org/truffleruby/core/string/StringNodes.java
+++ b/src/main/java/org/truffleruby/core/string/StringNodes.java
@@ -4064,6 +4064,7 @@ public abstract class StringNodes {
             if (rope.isEmpty()) {
                 return nil;
             }
+
             final String javaString = strings.getJavaString(string);
             if (javaString.startsWith("0x")) {
                 try {
@@ -4076,8 +4077,7 @@ public abstract class StringNodes {
                                     this,
                                     fixnumOrBignumNode,
                                     bytesNode,
-                                    string,
-                                    strings.getRope(string),
+                                    rope,
                                     16,
                                     true);
                     if (result instanceof Integer) {
@@ -5114,14 +5114,15 @@ public abstract class StringNodes {
                 @Cached RopeNodes.BytesNode bytesNode,
                 @Cached BranchProfile exceptionProfile,
                 @CachedLibrary(limit = "2") RubyStringLibrary libString) {
+            final Rope rope = libString.getRope(string);
+
             try {
                 return ConvertBytes.bytesToInum(
                         getContext(),
                         this,
                         fixnumOrBignumNode,
                         bytesNode,
-                        string,
-                        libString.getRope(string),
+                        rope,
                         fixBase,
                         strict);
             } catch (RaiseException e) {

--- a/src/main/java/org/truffleruby/core/string/StringNodes.java
+++ b/src/main/java/org/truffleruby/core/string/StringNodes.java
@@ -4071,7 +4071,7 @@ public abstract class StringNodes {
                 } catch (NumberFormatException e) {
                     // Try falling back to this implementation if the first fails, neither 100% complete
                     final Object result = ConvertBytes
-                            .byteListToInum19(
+                            .bytesToInum(
                                     getContext(),
                                     this,
                                     fixnumOrBignumNode,
@@ -5115,7 +5115,7 @@ public abstract class StringNodes {
                 @Cached BranchProfile exceptionProfile,
                 @CachedLibrary(limit = "2") RubyStringLibrary libString) {
             try {
-                return ConvertBytes.byteListToInum19(
+                return ConvertBytes.bytesToInum(
                         getContext(),
                         this,
                         fixnumOrBignumNode,

--- a/src/main/ruby/truffleruby/core/kernel.rb
+++ b/src/main/ruby/truffleruby/core/kernel.rb
@@ -107,7 +107,7 @@ module Kernel
     raise_exception = !exception.equal?(false)
 
     if String === obj
-      Primitive.string_to_inum(obj, base, true, !exception.equal?(false))
+      Primitive.string_to_inum(obj, base, true, raise_exception)
     else
       bad_base_check = Proc.new do
         if base != 0


### PR DESCRIPTION
This PR takes care of two related issues. Most of the work went into a clean-up pass on `ConvertBytes`. That process simplified Ruby exceptions thrown from within `ConvertBytes`, which used to require having a reference to both a Ruby string and its underlying rope. With that clean-up in place, the `string_to_inum` primitive was updated to work with ropes directly, which makes specializing on rope metadata easier.

The PR also adds a new specialization from the `string_to_inum` primitive around `LazyIntRope`. If the base is either `0` (signifying base auto-discovery; `Kernel#Integer` default) or `10` (`String#to_i` default), then we can simply read the integer value out of the `LazyIntRope` without having to look at its string bytes at all. While that process admittedly sounds a bit contrived, it is a real case that [occurs in Rack](https://github.com/rack/rack/blob/1741c580d71cfca8e541e96cc372305c8892ee74/lib/rack/request.rb#L233-L254). Here, the port may be specified as an integer, which is turned into a String  to function as a server header, which is then converted to an integer (with `Kernel#integer`) -- presumably for data validation, and then turned back into a string via the `"#{host}:#{port}"` string interpolation.

I believe there are opportunities for other specializations that may be able to return results efficiently. E.g., as far as I can tell, any string with a `CR_VALID` coderange cannot be converted into an integer, and so would either turn into `0` or an exception, without ever having to actually look at its contents. I'm leaving that for future work because I think if we add a `ConvertBytesNodes` class, we can optimize common cases nicely.

Currently, all of the machinery for converting a string to an integer is behind a boundary. That code needs to handle base conversions `2..36` and has a logic switch if the base is `0` or negative. Looking through a real world application at Shopify, only two bases were ever used: `0` (the `Kernel#Integer` default) and `10` (the `String#to_i` default). It may makes sense to also optimize bases 2, 8, and 16 since there are special prefixes for those, although with some supporting method (`String#hex` and `String#oct`). `ConvertBytes` is also used for methods other than `string_to_inum`, but I haven't investigated those beyond working out exceptional paths.