### PR TITLE
Fix tracing of allocations from C

### DIFF
--- a/spec/ruby/library/objectspace/memsize_of_all_spec.rb
+++ b/spec/ruby/library/objectspace/memsize_of_all_spec.rb
@@ -1,0 +1,21 @@
+require_relative '../../spec_helper'
+require 'objspace'
+
+describe "ObjectSpace.memsize_of_all" do
+  it "returns a non-zero Integer for all objects" do
+    ObjectSpace.memsize_of_all.should be_kind_of(Integer)
+    ObjectSpace.memsize_of_all.zero?.should be_false
+  end
+
+  it "returns a non-zero Integer for Class" do
+    ObjectSpace.memsize_of_all(Class).should be_kind_of(Integer)
+    ObjectSpace.memsize_of_all(Class).zero?.should be_false
+  end
+
+  it "increases when a new object is allocated" do
+    before = ObjectSpace.memsize_of_all(Class)
+    o = Class.new
+    after = ObjectSpace.memsize_of_all(Class)
+    after.should > before
+  end
+end

--- a/spec/ruby/library/objectspace/memsize_of_spec.rb
+++ b/spec/ruby/library/objectspace/memsize_of_spec.rb
@@ -16,10 +16,10 @@ describe "ObjectSpace.memsize_of" do
     ObjectSpace.memsize_of(:abc).should == 0
   end
 
-  it "returns an Integer for an Object" do
+  it "returns a non-zero Integer for an Object" do
     obj = Object.new
     ObjectSpace.memsize_of(obj).should be_kind_of(Integer)
-    ObjectSpace.memsize_of(obj).should > 0
+    ObjectSpace.memsize_of(obj).zero?.should be_false
   end
 
   it "is larger if the Object has more instance variables" do

--- a/spec/ruby/library/objectspace/trace_object_allocations_spec.rb
+++ b/spec/ruby/library/objectspace/trace_object_allocations_spec.rb
@@ -1,0 +1,117 @@
+require_relative '../../spec_helper'
+require 'objspace'
+
+describe "ObjectSpace.trace_object_allocations" do
+  it "runs a block" do
+    ObjectSpace.trace_object_allocations do
+      ScratchPad.record :a
+    end
+    ScratchPad.recorded.should == :a
+  end
+
+  it "records info for allocation_class_path" do
+    ObjectSpace.trace_object_allocations do
+      o = Object.new
+      ObjectSpace.allocation_class_path(o).should == "Class"
+      a = [1, 2, 3]
+      ObjectSpace.allocation_class_path(a).should == nil
+    end
+  end
+
+  it "records info for allocation_generation" do
+    ObjectSpace.trace_object_allocations do
+      o = Object.new
+      ObjectSpace.allocation_generation(o).kind_of?(Integer).should == true
+      a = [1, 2, 3]
+      ObjectSpace.allocation_generation(a).kind_of?(Integer).should == true
+    end
+  end
+
+  it "records info for allocation_method_id" do
+    ObjectSpace.trace_object_allocations do
+      o = Object.new
+      ObjectSpace.allocation_method_id(o).should == :new
+      a = [1, 2, 3]
+      ObjectSpace.allocation_method_id(a).should == nil
+    end
+  end
+
+  it "records info for allocation_sourcefile" do
+
+    ObjectSpace.trace_object_allocations do
+      filename = File.basename(__FILE__)
+      o = Object.new
+      ObjectSpace.allocation_sourcefile(o).end_with?(filename).should == true
+      a = [1, 2, 3]
+      ObjectSpace.allocation_sourcefile(a).end_with?(filename).should == true
+    end
+  end
+
+  it "records info for allocation_sourceline" do
+    ObjectSpace.trace_object_allocations do
+      o = Object.new
+      ObjectSpace.allocation_sourceline(o).should == __LINE__ - 1
+      a = [1, 2, 3]
+      ObjectSpace.allocation_sourceline(a).should == __LINE__ - 1
+    end
+  end
+
+  it "can be cleared using trace_object_allocations_clear" do
+    ObjectSpace.trace_object_allocations do
+      o = Object.new
+      ObjectSpace.allocation_class_path(o).should == "Class"
+      ObjectSpace.trace_object_allocations_clear
+      ObjectSpace.allocation_class_path(o).should be_nil
+    end
+  end
+
+  it "does not clears allocation data after returning" do
+    o = nil
+    ObjectSpace.trace_object_allocations do
+      o = Object.new
+    end
+    ObjectSpace.allocation_class_path(o).should == "Class"
+  end
+
+  it "can be used without a block using trace_object_allocations_start and _stop" do
+    ObjectSpace.trace_object_allocations_start
+    o = Object.new
+    ObjectSpace.allocation_class_path(o).should == "Class"
+    a = [1, 2, 3]
+    ObjectSpace.allocation_class_path(a).should == nil
+    ObjectSpace.trace_object_allocations_stop
+  end
+
+  it "does not clears allocation data after trace_object_allocations_stop" do
+    ObjectSpace.trace_object_allocations_start
+    o = Object.new
+    ObjectSpace.trace_object_allocations_stop
+    ObjectSpace.allocation_class_path(o).should == "Class"
+  end
+
+  it "can be nested" do
+    ObjectSpace.trace_object_allocations do
+      ObjectSpace.trace_object_allocations do
+        o = Object.new
+        ObjectSpace.allocation_class_path(o).should == "Class"
+      end
+    end
+  end
+
+  it "can be nested without a block using trace_object_allocations_start and _stop" do
+    ObjectSpace.trace_object_allocations_start
+    ObjectSpace.trace_object_allocations_start
+    o = Object.new
+    ObjectSpace.allocation_class_path(o).should == "Class"
+    ObjectSpace.trace_object_allocations_stop
+    ObjectSpace.trace_object_allocations_stop
+  end
+
+  it "can be nested with more _stop than _start" do
+    ObjectSpace.trace_object_allocations_start
+    o = Object.new
+    ObjectSpace.allocation_class_path(o).should == "Class"
+    ObjectSpace.trace_object_allocations_stop
+    ObjectSpace.trace_object_allocations_stop
+  end
+end

--- a/spec/tags/library/objectspace/trace_object_allocations_tags.txt
+++ b/spec/tags/library/objectspace/trace_object_allocations_tags.txt
@@ -1,0 +1,3 @@
+fails:ObjectSpace.trace_object_allocations records info for allocation_class_path
+fails:ObjectSpace.trace_object_allocations records info for allocation_method_id
+fails:ObjectSpace.trace_object_allocations can be used without a block using trace_object_allocations_start and _stop

--- a/src/main/java/org/truffleruby/language/CallStackManager.java
+++ b/src/main/java/org/truffleruby/language/CallStackManager.java
@@ -55,6 +55,11 @@ public class CallStackManager {
     }
 
     @TruffleBoundary
+    public Frame getCurrentRubyFrame(FrameAccess frameAccess) {
+        return iterateFrames(0, f -> isRubyFrame(f.getFrame(FrameAccess.READ_ONLY)), f -> f.getFrame(frameAccess));
+    }
+
+    @TruffleBoundary
     public Frame getCallerFrame(FrameAccess frameAccess) {
         // System.err.printf("Getting a caller frame...\n");
         // new Error().printStackTrace();

--- a/src/main/java/org/truffleruby/language/objects/AllocationTracing.java
+++ b/src/main/java/org/truffleruby/language/objects/AllocationTracing.java
@@ -117,7 +117,7 @@ public abstract class AllocationTracing {
                 .getCallStack()
                 .getTopMostUserSourceSection(currentNode.getEncapsulatingSourceSection());
 
-        final Frame allocatingFrame = context.getCallStack().getCurrentFrame(FrameAccess.READ_ONLY);
+        final Frame allocatingFrame = context.getCallStack().getCurrentRubyFrame(FrameAccess.READ_ONLY);
 
         final Object allocatingSelf = RubyArguments.getSelf(allocatingFrame);
         final String allocatingMethod = RubyArguments.getMethod(allocatingFrame).getName();


### PR DESCRIPTION
We get failures while tracing allocations from C extensions. I think this fixes it, but I'm not keen to try to architect a test case, to be honest.