### PR TITLE
Add more comprehensive regexp instrumentation

### DIFF
--- a/src/main/java/org/truffleruby/core/regexp/InterpolatedRegexpNode.java
+++ b/src/main/java/org/truffleruby/core/regexp/InterpolatedRegexpNode.java
@@ -110,6 +110,7 @@ public class InterpolatedRegexpNode extends RubyContextSourceNode {
                         null,
                         preprocessed,
                         options,
+                        false,
                         this);
             } catch (DeferredRaiseException dre) {
                 throw dre.getException(getContext());

--- a/src/main/java/org/truffleruby/core/regexp/RegexpCacheKey.java
+++ b/src/main/java/org/truffleruby/core/regexp/RegexpCacheKey.java
@@ -48,6 +48,7 @@ public final class RegexpCacheKey {
     @Override
     public String toString() {
         return '/' + RopeOperations.decodeOrEscapeBinaryRope(rope) + '/' +
-                RegexpOptions.fromJoniOptions(joniOptions).toOptionsString();
+                RegexpOptions.fromJoniOptions(joniOptions).toOptionsString() +
+                " -- " + RopeOperations.decodeOrEscapeBinaryRope(encoding.name.rope);
     }
 }

--- a/src/main/java/org/truffleruby/core/regexp/RegexpCacheKey.java
+++ b/src/main/java/org/truffleruby/core/regexp/RegexpCacheKey.java
@@ -51,7 +51,7 @@ public final class RegexpCacheKey {
     public boolean equals(Object o) {
         if (o instanceof RegexpCacheKey) {
             final RegexpCacheKey other = (RegexpCacheKey) o;
-            return rope.equals(other.rope) && encoding == other.encoding && joniOptions == other.joniOptions;
+            return encoding == other.encoding && joniOptions == other.joniOptions && rope.equals(other.getRope());
         } else {
             return false;
         }

--- a/src/main/java/org/truffleruby/core/regexp/RegexpCacheKey.java
+++ b/src/main/java/org/truffleruby/core/regexp/RegexpCacheKey.java
@@ -30,6 +30,18 @@ public final class RegexpCacheKey {
         this.hashing = hashing;
     }
 
+    public Rope getRope() {
+        return rope;
+    }
+
+    public RubyEncoding getEncoding() {
+        return encoding;
+    }
+
+    public int getJoniOptions() {
+        return joniOptions;
+    }
+
     @Override
     public int hashCode() {
         return hashing.hash(rope.hashCode());

--- a/src/main/java/org/truffleruby/core/regexp/RegexpNodes.java
+++ b/src/main/java/org/truffleruby/core/regexp/RegexpNodes.java
@@ -64,6 +64,7 @@ public abstract class RegexpNodes {
                 null,
                 new RopeWithEncoding(setSource, setSourceEncoding),
                 regexpOptions,
+                false,
                 currentNode);
         return new RubyRegexp(regex, regexpOptions);
     }

--- a/src/main/java/org/truffleruby/core/regexp/TruffleRegexpNodes.java
+++ b/src/main/java/org/truffleruby/core/regexp/TruffleRegexpNodes.java
@@ -363,43 +363,29 @@ public class TruffleRegexpNodes {
         }
     }
 
-    @CoreMethod(names = "literal_regexp_compilation_stats_array", onSingleton = true, required = 0)
-    public abstract static class LiteralRegexpCompilationStatsArrayNode extends RegexpStatsNode {
+    @CoreMethod(names = "regexp_compilation_stats_array", onSingleton = true, required = 1)
+    public abstract static class RegexpCompilationStatsArrayNode extends RegexpStatsNode {
 
         @Specialization
-        protected Object buildStatsArray(
+        protected Object buildStatsArray(boolean literalRegexps,
                 @Cached ArrayBuilderNode arrayBuilderNode) {
-            return fillinInstrumentData(COMPILED_REGEXPS_LITERAL, arrayBuilderNode, getContext());
+            return fillinInstrumentData(
+                    literalRegexps ? COMPILED_REGEXPS_LITERAL : COMPILED_REGEXPS_DYNAMIC,
+                    arrayBuilderNode,
+                    getContext());
         }
     }
 
-    @CoreMethod(names = "dynamic_regexp_compilation_stats_array", onSingleton = true, required = 0)
-    public abstract static class DynamicRegexpCompilationStatsArrayNode extends RegexpStatsNode {
+    @CoreMethod(names = "match_stats_array", onSingleton = true, required = 1)
+    public abstract static class MatchStatsArrayNode extends RegexpStatsNode {
 
         @Specialization
-        protected Object buildStatsArray(
+        protected Object buildStatsArray(boolean joniMatches,
                 @Cached ArrayBuilderNode arrayBuilderNode) {
-            return fillinInstrumentData(COMPILED_REGEXPS_DYNAMIC, arrayBuilderNode, getContext());
-        }
-    }
-
-    @CoreMethod(names = "joni_match_stats_array", onSingleton = true, required = 0)
-    public abstract static class JoniMatchStatsArrayNode extends RegexpStatsNode {
-
-        @Specialization
-        protected Object buildStatsArray(
-                @Cached ArrayBuilderNode arrayBuilderNode) {
-            return fillinInstrumentData(MATCHED_REGEXPS_JONI, arrayBuilderNode, getContext());
-        }
-    }
-
-    @CoreMethod(names = "tregex_match_stats_array", onSingleton = true, required = 0)
-    public abstract static class TRegexMatchStatsArrayNode extends RegexpStatsNode {
-
-        @Specialization
-        protected Object buildStatsArray(
-                @Cached ArrayBuilderNode arrayBuilderNode) {
-            return fillinInstrumentData(MATCHED_REGEXPS_TREGEX, arrayBuilderNode, getContext());
+            return fillinInstrumentData(
+                    joniMatches ? MATCHED_REGEXPS_JONI : MATCHED_REGEXPS_TREGEX,
+                    arrayBuilderNode,
+                    getContext());
         }
     }
 

--- a/src/main/java/org/truffleruby/core/regexp/TruffleRegexpNodes.java
+++ b/src/main/java/org/truffleruby/core/regexp/TruffleRegexpNodes.java
@@ -962,7 +962,7 @@ public class TruffleRegexpNodes {
 
         if (language.options.REGEXP_INSTRUMENT_CREATION) {
             final RegexpCacheKey key = new RegexpCacheKey(
-                    bytes.getRope(),
+                    RopeOperations.withEncoding(bytes.getRope(), enc.jcoding),
                     enc,
                     options,
                     Hashing.NO_SEED);

--- a/src/main/java/org/truffleruby/options/Options.java
+++ b/src/main/java/org/truffleruby/options/Options.java
@@ -193,6 +193,8 @@ public class Options {
     public final boolean METHODMISSING_ALWAYS_INLINE;
     /** --regexp-instrument-match=false */
     public final boolean REGEXP_INSTRUMENT_MATCH;
+    /** --regexp-instrumentation-output-format="text" */
+    public final String REGEXP_INSTRUMENT_OUTPUT_FORMAT;
     /** --metrics-time-parsing-file=false */
     public final boolean METRICS_TIME_PARSING_FILE;
     /** --metrics-time-require=false */
@@ -288,6 +290,7 @@ public class Options {
         METHODMISSING_ALWAYS_CLONE = options.hasBeenSet(OptionsCatalog.METHODMISSING_ALWAYS_CLONE_KEY) ? options.get(OptionsCatalog.METHODMISSING_ALWAYS_CLONE_KEY) : CLONE_DEFAULT;
         METHODMISSING_ALWAYS_INLINE = options.hasBeenSet(OptionsCatalog.METHODMISSING_ALWAYS_INLINE_KEY) ? options.get(OptionsCatalog.METHODMISSING_ALWAYS_INLINE_KEY) : INLINE_DEFAULT;
         REGEXP_INSTRUMENT_MATCH = options.get(OptionsCatalog.REGEXP_INSTRUMENT_MATCH_KEY);
+        REGEXP_INSTRUMENT_OUTPUT_FORMAT = options.get(OptionsCatalog.REGEXP_INSTRUMENT_OUTPUT_FORMAT_KEY);
         METRICS_TIME_PARSING_FILE = options.get(OptionsCatalog.METRICS_TIME_PARSING_FILE_KEY);
         METRICS_TIME_REQUIRE = options.get(OptionsCatalog.METRICS_TIME_REQUIRE_KEY);
         TESTING_RUBYGEMS = options.get(OptionsCatalog.TESTING_RUBYGEMS_KEY);
@@ -466,6 +469,8 @@ public class Options {
                 return METHODMISSING_ALWAYS_INLINE;
             case "ruby.regexp-instrument-match":
                 return REGEXP_INSTRUMENT_MATCH;
+            case "ruby.regexp-instrumentation-output-format":
+                return REGEXP_INSTRUMENT_OUTPUT_FORMAT;
             case "ruby.metrics-time-parsing-file":
                 return METRICS_TIME_PARSING_FILE;
             case "ruby.metrics-time-require":

--- a/src/main/java/org/truffleruby/options/Options.java
+++ b/src/main/java/org/truffleruby/options/Options.java
@@ -193,6 +193,8 @@ public class Options {
     public final boolean METHODMISSING_ALWAYS_INLINE;
     /** --regexp-instrument-match=false */
     public final boolean REGEXP_INSTRUMENT_MATCH;
+    /** --regexp-instrument-match-detailed=false */
+    public final boolean REGEXP_INSTRUMENT_MATCH_DETAILED;
     /** --regexp-instrumentation-output-format="text" */
     public final String REGEXP_INSTRUMENT_OUTPUT_FORMAT;
     /** --metrics-time-parsing-file=false */
@@ -290,6 +292,7 @@ public class Options {
         METHODMISSING_ALWAYS_CLONE = options.hasBeenSet(OptionsCatalog.METHODMISSING_ALWAYS_CLONE_KEY) ? options.get(OptionsCatalog.METHODMISSING_ALWAYS_CLONE_KEY) : CLONE_DEFAULT;
         METHODMISSING_ALWAYS_INLINE = options.hasBeenSet(OptionsCatalog.METHODMISSING_ALWAYS_INLINE_KEY) ? options.get(OptionsCatalog.METHODMISSING_ALWAYS_INLINE_KEY) : INLINE_DEFAULT;
         REGEXP_INSTRUMENT_MATCH = options.get(OptionsCatalog.REGEXP_INSTRUMENT_MATCH_KEY);
+        REGEXP_INSTRUMENT_MATCH_DETAILED = options.get(OptionsCatalog.REGEXP_INSTRUMENT_MATCH_DETAILED_KEY);
         REGEXP_INSTRUMENT_OUTPUT_FORMAT = options.get(OptionsCatalog.REGEXP_INSTRUMENT_OUTPUT_FORMAT_KEY);
         METRICS_TIME_PARSING_FILE = options.get(OptionsCatalog.METRICS_TIME_PARSING_FILE_KEY);
         METRICS_TIME_REQUIRE = options.get(OptionsCatalog.METRICS_TIME_REQUIRE_KEY);
@@ -469,6 +472,8 @@ public class Options {
                 return METHODMISSING_ALWAYS_INLINE;
             case "ruby.regexp-instrument-match":
                 return REGEXP_INSTRUMENT_MATCH;
+            case "ruby.regexp-instrument-match-detailed":
+                return REGEXP_INSTRUMENT_MATCH_DETAILED;
             case "ruby.regexp-instrumentation-output-format":
                 return REGEXP_INSTRUMENT_OUTPUT_FORMAT;
             case "ruby.metrics-time-parsing-file":

--- a/src/main/java/org/truffleruby/parser/BodyTranslator.java
+++ b/src/main/java/org/truffleruby/parser/BodyTranslator.java
@@ -2667,7 +2667,7 @@ public class BodyTranslator extends Translator {
         Regex regex = null;
         try {
             regex = TruffleRegexpNodes
-                    .compile(language, rubyWarnings, new RopeWithEncoding(rope, encoding), options, currentNode);
+                    .compile(language, rubyWarnings, new RopeWithEncoding(rope, encoding), options, true, currentNode);
         } catch (DeferredRaiseException dre) {
             throw dre.getException(RubyLanguage.getCurrentContext());
         }

--- a/src/main/ruby/truffleruby/core/truffle/regexp_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/regexp_operations.rb
@@ -158,20 +158,33 @@ module Truffle
       Hash[*compilation_stats_array]
     end
 
-    def self.match_stats
-      Hash[*match_stats_array]
+    def self.match_stats_joni
+      Hash[*joni_match_stats_array]
+    end
+
+    def self.match_stats_tregex
+      Hash[*tregex_match_stats_array]
     end
 
     def self.print_stats
       puts '--------------------'
       puts 'Regular expression statistics'
       puts '--------------------'
-      puts '  Compilation'
-      print_stats_table compilation_stats
-      puts '  --------------------'
-      puts '  Matches'
-      print_stats_table match_stats
-      puts '--------------------'
+
+      if Truffle::Boot.get_option('regexp-instrument-creation')
+        puts '  Compilation'
+        print_stats_table compilation_stats
+        puts '  --------------------'
+      end
+
+      if Truffle::Boot.get_option('regexp-instrument-match')
+        puts '  Matches (Joni)'
+        print_stats_table match_stats_joni
+        puts '  --------------------'
+        puts '  Matches (TRegex)'
+        print_stats_table match_stats_tregex
+        puts '--------------------'
+      end
     end
 
     def self.print_stats_table(table)

--- a/src/main/ruby/truffleruby/core/truffle/regexp_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/regexp_operations.rb
@@ -154,20 +154,12 @@ module Truffle
       end
     end
 
-    def self.compilation_stats_literal_regexp
-      Hash[*literal_regexp_compilation_stats_array]
+    def self.compilation_stats_regexp(literal_regexps:)
+      Hash[*regexp_compilation_stats_array(literal_regexps)]
     end
 
-    def self.compilation_stats_dynamic_regexp
-      Hash[*dynamic_regexp_compilation_stats_array]
-    end
-
-    def self.match_stats_joni
-      Hash[*joni_match_stats_array]
-    end
-
-    def self.match_stats_tregex
-      Hash[*tregex_match_stats_array]
+    def self.match_stats(joni_matches:)
+      Hash[*match_stats_array(joni_matches)]
     end
 
     def self.print_stats
@@ -180,19 +172,19 @@ module Truffle
 
         if Truffle::Boot.get_option('regexp-instrument-creation')
           puts '  Compilation (Literal)'
-          print_stats_table compilation_stats_literal_regexp
+          print_stats_table compilation_stats_regexp(literal_regexps: true)
           puts '  --------------------'
           puts '  Compilation (Dynamic)'
-          print_stats_table compilation_stats_dynamic_regexp
+          print_stats_table compilation_stats_regexp(literal_regexps: false)
           puts '  --------------------'
         end
 
         if Truffle::Boot.get_option('regexp-instrument-match')
           puts '  Matches (Joni)'
-          print_stats_table match_stats_joni
+          print_stats_table match_stats(joni_matches: true)
           puts '  --------------------'
           puts '  Matches (TRegex)'
-          print_stats_table match_stats_tregex
+          print_stats_table match_stats(joni_matches: false)
 
           if Truffle::Boot.get_option('regexp-instrument-creation')
             puts '  --------------------'

--- a/src/main/ruby/truffleruby/core/truffle/regexp_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/regexp_operations.rb
@@ -154,8 +154,12 @@ module Truffle
       end
     end
 
-    def self.compilation_stats
-      Hash[*compilation_stats_array]
+    def self.compilation_stats_literal_regexp
+      Hash[*literal_regexp_compilation_stats_array]
+    end
+
+    def self.compilation_stats_dynamic_regexp
+      Hash[*dynamic_regexp_compilation_stats_array]
     end
 
     def self.match_stats_joni
@@ -172,8 +176,11 @@ module Truffle
       puts '--------------------'
 
       if Truffle::Boot.get_option('regexp-instrument-creation')
-        puts '  Compilation'
-        print_stats_table compilation_stats
+        puts '  Compilation (Literal)'
+        print_stats_table compilation_stats_literal_regexp
+        puts '  --------------------'
+        puts '  Compilation (Dynamic)'
+        print_stats_table compilation_stats_dynamic_regexp
         puts '  --------------------'
       end
 

--- a/src/main/ruby/truffleruby/core/truffle/regexp_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/regexp_operations.rb
@@ -190,6 +190,13 @@ module Truffle
         puts '  --------------------'
         puts '  Matches (TRegex)'
         print_stats_table match_stats_tregex
+
+        if Truffle::Boot.get_option('regexp-instrument-creation')
+          puts '  --------------------'
+          puts '  Unused Regexps'
+          puts unused_regexps_array.map { |regexp| "  #{regexp}" }
+        end
+
         puts '--------------------'
       end
     end

--- a/src/options.yml
+++ b/src/options.yml
@@ -236,6 +236,7 @@ INTERNAL: # Options for debugging the TruffleRuby implementation
     # Instrumentation to debug performance
     REGEXP_INSTRUMENT_CREATION: [regexp-instrument-creation, boolean, false, Enable instrumentation to gather stats on regexp creation]
     REGEXP_INSTRUMENT_MATCH: [regexp-instrument-match, boolean, false, Enable instrumentation to gather stats on regexp matching]
+    REGEXP_INSTRUMENT_MATCH_DETAILED: [regexp-instrument-match-detailed, boolean, false, Enable instrumentation to gather detailed stats on strings matched against a regexp]
     REGEXP_INSTRUMENT_OUTPUT_FORMAT: [regexp-instrumentation-output-format, string, 'text', 'Output format for regexp instrumentation (\\\"text\\\" or \\\"json\\\")']
 
     # Options for metrics, the output cannot be used directly without processing

--- a/src/options.yml
+++ b/src/options.yml
@@ -236,6 +236,7 @@ INTERNAL: # Options for debugging the TruffleRuby implementation
     # Instrumentation to debug performance
     REGEXP_INSTRUMENT_CREATION: [regexp-instrument-creation, boolean, false, Enable instrumentation to gather stats on regexp creation]
     REGEXP_INSTRUMENT_MATCH: [regexp-instrument-match, boolean, false, Enable instrumentation to gather stats on regexp matching]
+    REGEXP_INSTRUMENT_OUTPUT_FORMAT: [regexp-instrumentation-output-format, string, 'text', 'Output format for regexp instrumentation (\\\"text\\\" or \\\"json\\\")']
 
     # Options for metrics, the output cannot be used directly without processing
     METRICS_TIME_PARSING_FILE: [metrics-time-parsing-file, boolean, false, 'Measure time for parsing, translating and executing files, per file']

--- a/src/shared/java/org/truffleruby/shared/options/OptionsCatalog.java
+++ b/src/shared/java/org/truffleruby/shared/options/OptionsCatalog.java
@@ -151,6 +151,7 @@ public class OptionsCatalog {
     public static final OptionKey<Boolean> METHODMISSING_ALWAYS_INLINE_KEY = new OptionKey<>(INLINE_DEFAULT_KEY.getDefaultValue());
     public static final OptionKey<Boolean> REGEXP_INSTRUMENT_CREATION_KEY = new OptionKey<>(false);
     public static final OptionKey<Boolean> REGEXP_INSTRUMENT_MATCH_KEY = new OptionKey<>(false);
+    public static final OptionKey<String> REGEXP_INSTRUMENT_OUTPUT_FORMAT_KEY = new OptionKey<>("text");
     public static final OptionKey<Boolean> METRICS_TIME_PARSING_FILE_KEY = new OptionKey<>(false);
     public static final OptionKey<Boolean> METRICS_TIME_REQUIRE_KEY = new OptionKey<>(false);
     public static final OptionKey<Boolean> SHARED_OBJECTS_ENABLED_KEY = new OptionKey<>(true);
@@ -1078,6 +1079,13 @@ public class OptionsCatalog {
             .stability(OptionStability.EXPERIMENTAL)
             .build();
 
+    public static final OptionDescriptor REGEXP_INSTRUMENT_OUTPUT_FORMAT = OptionDescriptor
+            .newBuilder(REGEXP_INSTRUMENT_OUTPUT_FORMAT_KEY, "ruby.regexp-instrumentation-output-format")
+            .help("Output format for regexp instrumentation (\\\"text\\\" or \\\"json\\\")")
+            .category(OptionCategory.INTERNAL)
+            .stability(OptionStability.EXPERIMENTAL)
+            .build();
+
     public static final OptionDescriptor METRICS_TIME_PARSING_FILE = OptionDescriptor
             .newBuilder(METRICS_TIME_PARSING_FILE_KEY, "ruby.metrics-time-parsing-file")
             .help("Measure time for parsing, translating and executing files, per file")
@@ -1405,6 +1413,8 @@ public class OptionsCatalog {
                 return REGEXP_INSTRUMENT_CREATION;
             case "ruby.regexp-instrument-match":
                 return REGEXP_INSTRUMENT_MATCH;
+            case "ruby.regexp-instrumentation-output-format":
+                return REGEXP_INSTRUMENT_OUTPUT_FORMAT;
             case "ruby.metrics-time-parsing-file":
                 return METRICS_TIME_PARSING_FILE;
             case "ruby.metrics-time-require":
@@ -1561,6 +1571,7 @@ public class OptionsCatalog {
             METHODMISSING_ALWAYS_INLINE,
             REGEXP_INSTRUMENT_CREATION,
             REGEXP_INSTRUMENT_MATCH,
+            REGEXP_INSTRUMENT_OUTPUT_FORMAT,
             METRICS_TIME_PARSING_FILE,
             METRICS_TIME_REQUIRE,
             SHARED_OBJECTS_ENABLED,

--- a/src/shared/java/org/truffleruby/shared/options/OptionsCatalog.java
+++ b/src/shared/java/org/truffleruby/shared/options/OptionsCatalog.java
@@ -151,6 +151,7 @@ public class OptionsCatalog {
     public static final OptionKey<Boolean> METHODMISSING_ALWAYS_INLINE_KEY = new OptionKey<>(INLINE_DEFAULT_KEY.getDefaultValue());
     public static final OptionKey<Boolean> REGEXP_INSTRUMENT_CREATION_KEY = new OptionKey<>(false);
     public static final OptionKey<Boolean> REGEXP_INSTRUMENT_MATCH_KEY = new OptionKey<>(false);
+    public static final OptionKey<Boolean> REGEXP_INSTRUMENT_MATCH_DETAILED_KEY = new OptionKey<>(false);
     public static final OptionKey<String> REGEXP_INSTRUMENT_OUTPUT_FORMAT_KEY = new OptionKey<>("text");
     public static final OptionKey<Boolean> METRICS_TIME_PARSING_FILE_KEY = new OptionKey<>(false);
     public static final OptionKey<Boolean> METRICS_TIME_REQUIRE_KEY = new OptionKey<>(false);
@@ -1079,6 +1080,13 @@ public class OptionsCatalog {
             .stability(OptionStability.EXPERIMENTAL)
             .build();
 
+    public static final OptionDescriptor REGEXP_INSTRUMENT_MATCH_DETAILED = OptionDescriptor
+            .newBuilder(REGEXP_INSTRUMENT_MATCH_DETAILED_KEY, "ruby.regexp-instrument-match-detailed")
+            .help("Enable instrumentation to gather detailed stats on strings matched against a regexp")
+            .category(OptionCategory.INTERNAL)
+            .stability(OptionStability.EXPERIMENTAL)
+            .build();
+
     public static final OptionDescriptor REGEXP_INSTRUMENT_OUTPUT_FORMAT = OptionDescriptor
             .newBuilder(REGEXP_INSTRUMENT_OUTPUT_FORMAT_KEY, "ruby.regexp-instrumentation-output-format")
             .help("Output format for regexp instrumentation (\\\"text\\\" or \\\"json\\\")")
@@ -1413,6 +1421,8 @@ public class OptionsCatalog {
                 return REGEXP_INSTRUMENT_CREATION;
             case "ruby.regexp-instrument-match":
                 return REGEXP_INSTRUMENT_MATCH;
+            case "ruby.regexp-instrument-match-detailed":
+                return REGEXP_INSTRUMENT_MATCH_DETAILED;
             case "ruby.regexp-instrumentation-output-format":
                 return REGEXP_INSTRUMENT_OUTPUT_FORMAT;
             case "ruby.metrics-time-parsing-file":
@@ -1571,6 +1581,7 @@ public class OptionsCatalog {
             METHODMISSING_ALWAYS_INLINE,
             REGEXP_INSTRUMENT_CREATION,
             REGEXP_INSTRUMENT_MATCH,
+            REGEXP_INSTRUMENT_MATCH_DETAILED,
             REGEXP_INSTRUMENT_OUTPUT_FORMAT,
             METRICS_TIME_PARSING_FILE,
             METRICS_TIME_REQUIRE,


### PR DESCRIPTION
This PR adds detailed instrumentation about `Regexp` construction and the strings used in any match operations. During the development, I ran into two bugs that this PR also fixes. I can pull those out to a separate PR if you'd like. An overview of what's added is:

* Add a new `--regexp-instrument-match-detailed` boolean flag (default: `false`) to collect details about strings used in a match (e.g., code range and rope type).
* Add a new JSON output format for the regexp instrumentation, activated via `--regexp-instrumentation-output-format` flag with a value of `json`. The only other permitted value is `text`, which is also the default to be backwards compatible.
* Collect more info about `Regexp` instances, such as whether they're ever used and if they come from regexp literals.
* Fix a problem with `RegexpCacheKey` using the wrong rope encoding in some cases.
* Fix #2416. Matches made with the TRegex engine are now counted.
* Changes to regexp instrumentation output in the `text` format:
  * Add new output to the `text` format that prints out which regexps go unused.
  * Split the regexp output in the `text` format between regexp literals and those created dynamically.
  * Split the match output in the `text` format between Joni & TRegex.

There was a little churn in this branch as I initially tried to add more data to the `text` format output before adding the `json` one. I can try to rebase that or we could squash the whole branch. Otherwise, the commits are split on logic boundaries and it probably easiest to review the PR commit-by-commit. I can pull the `RegexpCacheKey` rope encoding bug fix out to another PR if you'd like.

I've been running this instrumentation on various workloads at Shopify as part of a larger project of improving regexp performance of TruffleRuby in common cases. I suspect as that work advances, there may be some additional data that would be helpful to collect from the runtime instrumentation, so there may be a follow-up PR for those data. The current JSON output has already proven to be quite helpful.