### PR TITLE
Remove support for keyword args in Java code

### DIFF
--- a/src/annotations/java/org/truffleruby/builtins/CoreMethod.java
+++ b/src/annotations/java/org/truffleruby/builtins/CoreMethod.java
@@ -47,10 +47,6 @@ public @interface CoreMethod {
 
     int optional() default 0;
 
-    /** Declares that a keyword argument with this name will be passed into the method as if it was an extra trailing
-     * positional optional argument. */
-    String keywordAsOptional() default "";
-
     boolean rest() default false;
 
     boolean needsBlock() default false;

--- a/src/main/ruby/truffleruby/core/kernel.rb
+++ b/src/main/ruby/truffleruby/core/kernel.rb
@@ -749,6 +749,10 @@ module Kernel
   Primitive.method_unimplement method(:fork)
   Primitive.method_unimplement nil.method(:fork)
 
+  def clone(freeze: true)
+    Primitive.clone self, freeze
+  end
+
   Truffle::Boot.delay do
     if Truffle::Boot.get_option('gets-loop')
       def chomp(separator=$/)

--- a/src/processor/java/org/truffleruby/processor/CoreModuleProcessor.java
+++ b/src/processor/java/org/truffleruby/processor/CoreModuleProcessor.java
@@ -285,10 +285,6 @@ public class CoreModuleProcessor extends TruffleRubyProcessor {
                 coreMethod.required() + ", " +
                 coreMethod.optional() + ", " +
                 coreMethod.rest() + ", " +
-                (coreMethod.keywordAsOptional().isEmpty()
-                        ? "null"
-                        : quote(coreMethod.keywordAsOptional())) +
-                ", " +
                 names + ");");
 
         final boolean hasSelfArgument = !coreMethod.onSingleton() && !coreMethod.constructor() &&
@@ -337,10 +333,6 @@ public class CoreModuleProcessor extends TruffleRubyProcessor {
             if (coreMethod.rest()) {
                 args.add("*" + argumentNames.get(index));
                 index++;
-            }
-            if (!coreMethod.keywordAsOptional().isEmpty()) {
-                // TODO (pitr-ch 03-Oct-2019): check interaction with names, or remove it
-                args.add(coreMethod.keywordAsOptional() + ": :unknown_default_value");
             }
             if (coreMethod.needsBlock()) {
                 args.add("&" + argumentNames.get(index));


### PR DESCRIPTION
This is only used in one place. I think it's always going to be better handled in Ruby.