### PR TITLE
Simplify graphs and allow VM options for jt graph

### DIFF
--- a/tool/jt.rb
+++ b/tool/jt.rb
@@ -804,7 +804,7 @@ module Commands
                                        Ruby and cache the result, such as benchmark bench/mri/bm_vm1_not.rb --cache
                                        jt benchmark bench/mri/bm_vm1_not.rb --use-cache
       jt profile                                     profiles an application, including the TruffleRuby runtime, and generates a flamegraph
-      jt graph [--method Object#foo] [--watch] file.rb
+      jt graph [--method Object#foo] [--watch] file.rb [-- vm-args]
                                                      render a graph of Object#foo within file.rb
       jt igv                                         launches IdealGraphVisualizer
       jt next                                        tell you what to work on next (give you a random core library spec)
@@ -2013,6 +2013,7 @@ module Commands
     test_file = nil
     method = 'Object#foo'
     watch = false
+    user_args = []
 
     until args.empty?
       arg = args.shift
@@ -2022,6 +2023,9 @@ module Commands
         method = args.shift
       when '--watch'
         watch = true
+      when '--'
+        user_args.push(*args)
+        args.clear
       else
         raise if arg.start_with?('-')
         raise if test_file
@@ -2051,7 +2055,7 @@ module Commands
 
     loop do # for --watch
       compiled = false
-      IO.popen([ruby_launcher, *options, test_file], :err=>[:child, :out]) do |pipe|
+      IO.popen([ruby_launcher, *options, *user_args, test_file], :err=>[:child, :out]) do |pipe|
         pipe.each_line do |line|
           puts line
           if line =~ /\[engine\] opt done     #{method}/

--- a/tool/jt.rb
+++ b/tool/jt.rb
@@ -804,7 +804,7 @@ module Commands
                                        Ruby and cache the result, such as benchmark bench/mri/bm_vm1_not.rb --cache
                                        jt benchmark bench/mri/bm_vm1_not.rb --use-cache
       jt profile                                     profiles an application, including the TruffleRuby runtime, and generates a flamegraph
-      jt graph [--method Object#foo] [--watch] file.rb [-- vm-args]
+      jt graph [--method Object#foo] [--watch] [--no-simplify] file.rb [-- vm-args]
                                                      render a graph of Object#foo within file.rb
       jt igv                                         launches IdealGraphVisualizer
       jt next                                        tell you what to work on next (give you a random core library spec)
@@ -2014,6 +2014,7 @@ module Commands
     method = 'Object#foo'
     watch = false
     user_args = []
+    simplify = true
 
     until args.empty?
       arg = args.shift
@@ -2023,6 +2024,8 @@ module Commands
         method = args.shift
       when '--watch'
         watch = true
+      when '--no-simplify'
+        simplify = false
       when '--'
         user_args.push(*args)
         args.clear
@@ -2052,6 +2055,17 @@ module Commands
       '--vm.Dgraal.Dump=Truffle:1',
       '--log.file=/dev/stderr', # suppress the Truffle log output help message
     ]
+
+    # As per https://github.com/Shopify/seafoam/blob/master/docs/getting-graphs.md
+    simplify_options = [
+      '--vm.Dgraal.FullUnroll=false',
+      '--vm.Dgraal.PartialUnroll=false',
+      '--vm.Dgraal.LoopPeeling=false',
+      '--vm.Dgraal.LoopUnswitch=false',
+      '--vm.Dgraal.OptScheduleOutOfLoops=false'
+    ]
+
+    options.push(*simplify_options) if simplify
 
     loop do # for --watch
       compiled = false


### PR DESCRIPTION
For example

```ruby
def foo(x)
  x.times do |n|
    if (n % 5 == 0) && (n % 3 == 0)
      out :fizzbuzz
    elsif n % 5 == 0
      out :fizz
    elsif n % 3 == 0
      out :buzz
    else
      out n
    end
  end
end

def out(x)
end

loop do
  foo(rand(10))
end
```

```
% jt graph test.rb --no-simplify -- --engine.InlineOnly=~out
```

Without simplify it's just a bit confusing - you end up with an extra call - an extra copy of part of the logic. For things I use `jt graph` for I want to see what's done with the logic - I don't care if the logic is re-arranged after - I care about what's coming out of PE. If I wanted to know how it's finally compiling down I'd manually examine graphs.

But I've added an option `--no-simplify` so you can turn it off.