### PR TITLE
Disable compiler when running tests with JVM CE to speed up execution.

### DIFF
--- a/.spin/bin/env
+++ b/.spin/bin/env
@@ -3,6 +3,7 @@ SCRIPT_PATH=$(dirname "${BASH_SOURCE[0]:-${(%):-%x}}")
 SCRIPT_PATH=$(cd "$SCRIPT_PATH" && pwd)
 TRUFFLERUBY_DIR=$SCRIPT_PATH/../..
 export JT_ENV=jvm-ce
+export JT_SPECS_COMPILATION=false
 
 unset JAVA_HOME
 


### PR DESCRIPTION
Tests are short-lived and don't benefit much from compilation. The '--with-compiler' flag is added if the optimizations need to be disabled.

I'm open to other ways of doing this. Initially, I had added a `--dev` flag like JRuby has which could be applied anywhere `ruby_options` are handled (e.g., `jt test fast -- --dev`). But, the most compelling use case at the moment is running the TruffleRuby test suites with JVM CE and having that fast by default. The optimization flags can be skipped with the new `--with-compiler` argument to `jt test` (e.g., `jt test --with-compiler`).

If someone feels strongly about the option names or where to apply this, feel free to make changes without me. I'd like the functionality to be there in some way, but I don't have a strong opinion on how it should be done.