### PR TITLE
[Ruby 3.0 support] Remove TRUE, FALSE, and NIL constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Compatibility:
 * `Module#attr_*` methods now return an array of method names (#2498, @gogainda).
 * Fixed `Socket#(local|remote)_address` to retrieve family and type from the file descriptor (#2444, @larskanis).
 * Add `Thread.ignore_deadlock` accessor (#2453).
+* Remove `TRUE`, `FALSE`, and `NIL` constants like CRuby 3.0 (#2505, @andrykonchin).
 
 Performance:
 

--- a/spec/tags/language/predefined_tags.txt
+++ b/spec/tags/language/predefined_tags.txt
@@ -6,6 +6,3 @@ slow:The predefined global constant ARGV contains Strings encoded in locale Enco
 slow:Global variable $0 is the path given as the main script and the same as __FILE__
 slow:Global variable $? is thread-local
 slow:Global variable $0 actually sets the program name
-fails:The predefined global constants TRUE is no longer defined
-fails:The predefined global constants FALSE is no longer defined
-fails:The predefined global constants NIL is no longer defined

--- a/src/main/ruby/truffleruby/core/false.rb
+++ b/src/main/ruby/truffleruby/core/false.rb
@@ -48,6 +48,3 @@ class FalseClass
     raise TypeError, "allocator undefined for #{self}"
   end
 end
-
-FALSE = false
-Object.deprecate_constant :FALSE

--- a/src/main/ruby/truffleruby/core/nil.rb
+++ b/src/main/ruby/truffleruby/core/nil.rb
@@ -87,6 +87,3 @@ class NilClass
     raise TypeError, "allocator undefined for #{self}"
   end
 end
-
-NIL = nil
-Object.deprecate_constant :NIL

--- a/src/main/ruby/truffleruby/core/true.rb
+++ b/src/main/ruby/truffleruby/core/true.rb
@@ -48,6 +48,3 @@ class TrueClass
     raise TypeError, "allocator undefined for #{self}"
   end
 end
-
-TRUE = true
-Object.deprecate_constant :TRUE


### PR DESCRIPTION
The PR fixes the following item:

>[easy, pure ruby] TRUE/FALSE/NIL constants are no longer defined.

Related issue - https://github.com/oracle/truffleruby/issues/2453