### PR TITLE
[Ruby 3.0 support] Add support for ENV.except

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Performance:
 * Regexp objects are now interned in a similar way to symbols.
 * Improve performance of regexps using POSIX bracket expressions (e.g., `[[:lower:]]`) matching against ASCII-only strings (#2447).
 * `String#sub`, `sub!`, `gsub`, and `gsub!` have been refactored for better performance.
+* Add `ENV.except` (#2507, @Strech).
 
 Changes:
 

--- a/spec/tags/core/env/except_tags.txt
+++ b/spec/tags/core/env/except_tags.txt
@@ -1,6 +1,0 @@
-fails:ENV.except returns the ENV as a hash
-fails:ENV.except uses the locale encoding for keys
-fails:ENV.except uses the locale encoding for values
-fails:ENV.except duplicates the ENV when converting to a Hash
-fails:ENV.except returns a hash without the requested subset
-fails:ENV.except ignores keys not present in the original hash

--- a/src/main/ruby/truffleruby/core/env.rb
+++ b/src/main/ruby/truffleruby/core/env.rb
@@ -348,6 +348,14 @@ class << ENV
     result
   end
 
+  def except(*keys)
+    # More memory-efficient than delegating to Hash.except
+    result = to_hash
+    keys.each { |k| result.delete(k) }
+
+    result
+  end
+
   def set_encoding(value)
     return unless Primitive.object_kind_of?(value, String)
     if Encoding.default_internal && value.ascii_only?


### PR DESCRIPTION
This PR implements `ENV.except` from the Ruby 3.0 support #2453

>  [easy, pure ruby] ENV.except has been added, which returns a hash excluding the
> given keys and their values. [Feature #15822]

I have a concern regarding how optimal should be the code.
Let's say if the #2463 will be merged, it could be done with a one-liner, like

```ruby
def except(*keys)
  to_hash.except(*keys)
end
```

But in this case, the newly created hash will be duped in the underlying `Hash.except` call, and keys will be unsplattened again. I'm definitely lacking a context to judge is it an issue
