### PR TITLE
[Ruby 3.0 support] Add support for Array subclass methods to return Array

### DIFF
--- a/spec/tags/core/array/drop_tags.txt
+++ b/spec/tags/core/array/drop_tags.txt
@@ -1,1 +1,0 @@
-fails:Array#drop returns a Array instance for Array subclasses

--- a/spec/tags/core/array/element_reference_tags.txt
+++ b/spec/tags/core/array/element_reference_tags.txt
@@ -1,9 +1,3 @@
-fails:Array#[] with a subclass of Array returns a Array instance with [n, m]
-fails:Array#[] with a subclass of Array returns a Array instance with [-n, m]
-fails:Array#[] with a subclass of Array returns a Array instance with [n..m]
-fails:Array#[] with a subclass of Array returns a Array instance with [n...m]
-fails:Array#[] with a subclass of Array returns a Array instance with [-n..-m]
-fails:Array#[] with a subclass of Array returns a Array instance with [-n...-m]
 fails:Array#[] can be sliced with Enumerator::ArithmeticSequence has endless range and positive steps
 fails:Array#[] can be sliced with Enumerator::ArithmeticSequence has beginless range and positive steps
 fails:Array#[] can be sliced with Enumerator::ArithmeticSequence has endless range and negative steps

--- a/spec/tags/core/array/flatten_tags.txt
+++ b/spec/tags/core/array/flatten_tags.txt
@@ -1,1 +1,0 @@
-fails:Array#flatten returns Array instance for Array subclasses

--- a/spec/tags/core/array/multiply_tags.txt
+++ b/spec/tags/core/array/multiply_tags.txt
@@ -1,1 +1,0 @@
-fails:Array#* with an integer with a subclass of Array returns an Array instance

--- a/spec/tags/core/array/slice_tags.txt
+++ b/spec/tags/core/array/slice_tags.txt
@@ -1,15 +1,3 @@
-fails:Array#slice! with a subclass of Array returns a Array instance with [n, m]
-fails:Array#slice! with a subclass of Array returns a Array instance with [-n, m]
-fails:Array#slice! with a subclass of Array returns a Array instance with [n..m]
-fails:Array#slice! with a subclass of Array returns a Array instance with [n...m]
-fails:Array#slice! with a subclass of Array returns a Array instance with [-n..-m]
-fails:Array#slice! with a subclass of Array returns a Array instance with [-n...-m]
-fails:Array#slice with a subclass of Array returns a Array instance with [n, m]
-fails:Array#slice with a subclass of Array returns a Array instance with [-n, m]
-fails:Array#slice with a subclass of Array returns a Array instance with [n..m]
-fails:Array#slice with a subclass of Array returns a Array instance with [n...m]
-fails:Array#slice with a subclass of Array returns a Array instance with [-n..-m]
-fails:Array#slice with a subclass of Array returns a Array instance with [-n...-m]
 fails:Array#slice can be sliced with Enumerator::ArithmeticSequence has endless range and positive steps
 fails:Array#slice can be sliced with Enumerator::ArithmeticSequence has beginless range and positive steps
 fails:Array#slice can be sliced with Enumerator::ArithmeticSequence has endless range and negative steps

--- a/spec/tags/core/array/uniq_tags.txt
+++ b/spec/tags/core/array/uniq_tags.txt
@@ -1,1 +1,0 @@
-fails:Array#uniq returns Array instance on Array subclasses

--- a/src/main/java/org/truffleruby/core/array/ArrayIndexNodes.java
+++ b/src/main/java/org/truffleruby/core/array/ArrayIndexNodes.java
@@ -13,7 +13,6 @@ import org.truffleruby.builtins.CoreModule;
 import org.truffleruby.builtins.Primitive;
 import org.truffleruby.builtins.PrimitiveArrayArgumentsNode;
 import org.truffleruby.core.array.library.ArrayStoreLibrary;
-import org.truffleruby.core.klass.RubyClass;
 import org.truffleruby.language.RubyContextSourceNode;
 import org.truffleruby.language.RubyNode;
 
@@ -25,7 +24,6 @@ import com.oracle.truffle.api.dsl.ReportPolymorphism;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.library.CachedLibrary;
 import com.oracle.truffle.api.profiles.ConditionProfile;
-import org.truffleruby.language.objects.AllocationTracing;
 
 @CoreModule(value = "Truffle::ArrayIndex", isClass = false)
 public abstract class ArrayIndexNodes {
@@ -123,22 +121,11 @@ public abstract class ArrayIndexNodes {
                     ? length
                     : size - index;
             final Object slice = cowNode.execute(array, index, end);
-            return createArrayOfSameClass(array, slice, end);
+            return createArray(slice, end);
         }
 
         protected static boolean indexInBounds(RubyArray array, int index) {
             return index >= 0 && index <= array.size;
-        }
-
-        protected RubyArray createArrayOfSameClass(RubyArray array, Object store, int size) {
-            final RubyClass logicalClass = array.getLogicalClass();
-            RubyArray newArray = new RubyArray(
-                    logicalClass,
-                    getLanguage().arrayShape,
-                    store,
-                    size);
-            AllocationTracing.trace(newArray, this);
-            return newArray;
         }
     }
 }

--- a/src/main/java/org/truffleruby/core/array/ArrayNodes.java
+++ b/src/main/java/org/truffleruby/core/array/ArrayNodes.java
@@ -163,12 +163,7 @@ public abstract class ArrayNodes {
 
         @Specialization(guards = "count == 0")
         protected RubyArray mulZero(RubyArray array, int count) {
-            final RubyClass logicalClass = array.getLogicalClass();
-            return new RubyArray(
-                    logicalClass,
-                    getLanguage().arrayShape,
-                    ArrayStoreLibrary.INITIAL_STORE,
-                    0);
+            return createEmptyArray();
         }
 
         @Specialization(
@@ -197,12 +192,7 @@ public abstract class ArrayNodes {
                 profileAndReportLoopCount(loopProfile, n);
             }
 
-            final RubyClass logicalClass = array.getLogicalClass();
-            return new RubyArray(
-                    logicalClass,
-                    getLanguage().arrayShape,
-                    newStore,
-                    newSize);
+            return createArray(newStore, newSize);
         }
 
         @Specialization(guards = "count < 0")
@@ -217,12 +207,7 @@ public abstract class ArrayNodes {
 
         @Specialization(guards = { "isEmptyArray(array)" })
         protected RubyArray mulEmpty(RubyArray array, long count) {
-            final RubyClass logicalClass = array.getLogicalClass();
-            return new RubyArray(
-                    logicalClass,
-                    getLanguage().arrayShape,
-                    ArrayStoreLibrary.INITIAL_STORE,
-                    0);
+            return createEmptyArray();
         }
 
         @Specialization(guards = { "!isImplicitLong(count)" })

--- a/src/main/ruby/truffleruby/core/array.rb
+++ b/src/main/ruby/truffleruby/core/array.rb
@@ -109,6 +109,7 @@ class Array
 
   def *(count)
     result = Primitive.array_mul(self, count)
+
     if !Primitive.undefined?(result)
       result
     elsif str = Truffle::Type.rb_check_convert_type(count, String, :to_str)
@@ -443,9 +444,9 @@ class Array
 
   def flatten(level=-1)
     level = Primitive.rb_num2int level
-    return self.dup if level == 0
+    return Array.new(self) if level == 0
 
-    out = self.class.allocate # new_reserved size
+    out = [] # new_reserved size
     Primitive.array_flatten_helper(self, out, level)
     out
   end
@@ -1590,13 +1591,6 @@ class Array
     end
   end
   private :delete_range
-
-  def uniq(&block)
-    copy_of_same_class = dup
-    result = super(&block)
-    Primitive.steal_array_storage(copy_of_same_class, result)
-    copy_of_same_class
-  end
 
   def uniq!(&block)
     Primitive.check_frozen self

--- a/src/main/ruby/truffleruby/core/enumerable.rb
+++ b/src/main/ruby/truffleruby/core/enumerable.rb
@@ -1051,6 +1051,7 @@ class Array
   alias_method :take, :take
   alias_method :drop_while, :drop_while
   alias_method :take_while, :take_while
+  alias_method :uniq, :uniq
   alias_method :sum, :sum
   alias_method :all?, :all?
   alias_method :none?, :none?


### PR DESCRIPTION
This PR will add adjust Array that its subclasses on below methods return Array (from the Ruby 3.0 support #2453)

- [x] Array#drop
- [x] Array#drop_while
- [x] Array#flatten
- [x] Array#slice!
- [x] Array#slice / Array#[]
- [x] Array#take
- [x] Array#take_while
- [x] Array#uniq
- [x] Array#*

I find out that for `Array.slice` I would need to adjust Java code. I will dig a bit to get the context around, but I probably would need some help (or an example)