### PR TITLE
Inline AddNode specialization that are not yet inlined into InlinedAddNode

### DIFF
--- a/spec/ruby/core/integer/plus_spec.rb
+++ b/spec/ruby/core/integer/plus_spec.rb
@@ -40,4 +40,19 @@ describe "Integer#+" do
       -> { @bignum + :symbol}.should raise_error(TypeError)
     end
   end
+
+  it "can be redefined" do
+    code = <<~RUBY
+      class Integer
+        alias_method :old_plus, :+
+        def +(other)
+          self - other
+        end
+      end
+      result = 1 + 2
+      Integer.alias_method :+, :old_plus
+      print result
+    RUBY
+    ruby_exe(code).should == "-1"
+  end
 end

--- a/spec/tags/core/integer/plus_tags.txt
+++ b/spec/tags/core/integer/plus_tags.txt
@@ -1,0 +1,1 @@
+slow:Integer#+ can be redefined

--- a/src/main/java/org/truffleruby/core/inlined/InlinedAddNode.java
+++ b/src/main/java/org/truffleruby/core/inlined/InlinedAddNode.java
@@ -48,7 +48,8 @@ public abstract class InlinedAddNode extends BinaryInlinedOperationNode {
     }
 
     @Specialization
-    protected Object addWithOverflow(long a, long b, @Cached("create()") FixnumOrBignumNode fixnumOrBignum) {
+    protected Object addWithOverflow(long a, long b,
+            @Cached FixnumOrBignumNode fixnumOrBignum) {
         return fixnumOrBignum.fixnumOrBignum(BigIntegerOps.add(a, b));
     }
 

--- a/src/main/java/org/truffleruby/core/inlined/InlinedAddNode.java
+++ b/src/main/java/org/truffleruby/core/inlined/InlinedAddNode.java
@@ -30,22 +30,22 @@ public abstract class InlinedAddNode extends BinaryInlinedOperationNode {
                 language.coreMethodAssumptions.floatAddAssumption);
     }
 
-    @Specialization(rewriteOn = ArithmeticException.class)
+    @Specialization(rewriteOn = ArithmeticException.class, assumptions = "assumptions")
     protected int intAdd(int a, int b) {
         return Math.addExact(a, b);
     }
 
-    @Specialization
+    @Specialization(assumptions = "assumptions")
     protected long intAddWithOverflow(int a, int b) {
         return (long) a + (long) b;
     }
 
-    @Specialization(rewriteOn = ArithmeticException.class)
+    @Specialization(rewriteOn = ArithmeticException.class, assumptions = "assumptions")
     protected long longAdd(long a, long b) {
         return Math.addExact(a, b);
     }
 
-    @Specialization
+    @Specialization(assumptions = "assumptions")
     protected Object longAddWithOverflow(long a, long b,
             @Cached FixnumOrBignumNode fixnumOrBignum) {
         return fixnumOrBignum.fixnumOrBignum(BigIntegerOps.add(a, b));

--- a/src/main/java/org/truffleruby/core/inlined/InlinedAddNode.java
+++ b/src/main/java/org/truffleruby/core/inlined/InlinedAddNode.java
@@ -43,10 +43,6 @@ public abstract class InlinedAddNode extends BinaryInlinedOperationNode {
         return Math.addExact(a, b);
     }
 
-    protected static FixnumOrBignumNode create() {
-        return new FixnumOrBignumNode();
-    }
-
     @Specialization
     protected Object addWithOverflow(long a, long b,
             @Cached FixnumOrBignumNode fixnumOrBignum) {

--- a/src/main/java/org/truffleruby/core/inlined/InlinedAddNode.java
+++ b/src/main/java/org/truffleruby/core/inlined/InlinedAddNode.java
@@ -18,6 +18,8 @@ import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
 
+/** See {@link org.truffleruby.core.numeric.IntegerNodes.AddNode} and
+ * {@link org.truffleruby.core.numeric.FloatNodes.AddNode} */
 public abstract class InlinedAddNode extends BinaryInlinedOperationNode {
 
     public InlinedAddNode(RubyLanguage language, RubyCallNodeParameters callNodeParameters) {

--- a/src/main/java/org/truffleruby/core/inlined/InlinedAddNode.java
+++ b/src/main/java/org/truffleruby/core/inlined/InlinedAddNode.java
@@ -31,22 +31,22 @@ public abstract class InlinedAddNode extends BinaryInlinedOperationNode {
     }
 
     @Specialization(rewriteOn = ArithmeticException.class)
-    protected int add(int a, int b) {
+    protected int intAdd(int a, int b) {
         return Math.addExact(a, b);
     }
 
     @Specialization
-    protected long addWithOverflow(int a, int b) {
+    protected long intAddWithOverflow(int a, int b) {
         return (long) a + (long) b;
     }
 
     @Specialization(rewriteOn = ArithmeticException.class)
-    protected long add(long a, long b) {
+    protected long longAdd(long a, long b) {
         return Math.addExact(a, b);
     }
 
     @Specialization
-    protected Object addWithOverflow(long a, long b,
+    protected Object longAddWithOverflow(long a, long b,
             @Cached FixnumOrBignumNode fixnumOrBignum) {
         return fixnumOrBignum.fixnumOrBignum(BigIntegerOps.add(a, b));
     }

--- a/src/main/java/org/truffleruby/core/inlined/InlinedSubNode.java
+++ b/src/main/java/org/truffleruby/core/inlined/InlinedSubNode.java
@@ -30,22 +30,22 @@ public abstract class InlinedSubNode extends BinaryInlinedOperationNode {
                 language.coreMethodAssumptions.floatSubAssumption);
     }
 
-    @Specialization(rewriteOn = ArithmeticException.class)
+    @Specialization(rewriteOn = ArithmeticException.class, assumptions = "assumptions")
     protected int intSub(int a, int b) {
         return Math.subtractExact(a, b);
     }
 
-    @Specialization
+    @Specialization(assumptions = "assumptions")
     protected long intSubWithOverflow(int a, int b) {
         return (long) a - (long) b;
     }
 
-    @Specialization(rewriteOn = ArithmeticException.class)
+    @Specialization(rewriteOn = ArithmeticException.class, assumptions = "assumptions")
     protected long longSub(long a, long b) {
         return Math.subtractExact(a, b);
     }
 
-    @Specialization
+    @Specialization(assumptions = "assumptions")
     protected Object longSubWithOverflow(long a, long b,
             @Cached FixnumOrBignumNode fixnumOrBignumNode) {
         return fixnumOrBignumNode.fixnumOrBignum(BigIntegerOps.subtract(a, b));

--- a/src/main/java/org/truffleruby/core/inlined/InlinedSubNode.java
+++ b/src/main/java/org/truffleruby/core/inlined/InlinedSubNode.java
@@ -31,22 +31,22 @@ public abstract class InlinedSubNode extends BinaryInlinedOperationNode {
     }
 
     @Specialization(rewriteOn = ArithmeticException.class)
-    protected int sub(int a, int b) {
+    protected int intSub(int a, int b) {
         return Math.subtractExact(a, b);
     }
 
     @Specialization
-    protected long subWithOverflow(int a, int b) {
+    protected long intSubWithOverflow(int a, int b) {
         return (long) a - (long) b;
     }
 
     @Specialization(rewriteOn = ArithmeticException.class)
-    protected long sub(long a, long b) {
+    protected long longSub(long a, long b) {
         return Math.subtractExact(a, b);
     }
 
     @Specialization
-    protected Object subWithOverflow(long a, long b,
+    protected Object longSubWithOverflow(long a, long b,
             @Cached FixnumOrBignumNode fixnumOrBignumNode) {
         return fixnumOrBignumNode.fixnumOrBignum(BigIntegerOps.subtract(a, b));
     }

--- a/src/main/java/org/truffleruby/core/numeric/FixnumOrBignumNode.java
+++ b/src/main/java/org/truffleruby/core/numeric/FixnumOrBignumNode.java
@@ -23,6 +23,10 @@ public class FixnumOrBignumNode extends RubyBaseNode {
     private static final BigInteger LONG_MIN_BIGINT = BigInteger.valueOf(Long.MIN_VALUE);
     private static final BigInteger LONG_MAX_BIGINT = BigInteger.valueOf(Long.MAX_VALUE);
 
+    public static FixnumOrBignumNode create() {
+        return new FixnumOrBignumNode();
+    }
+
     public FixnumOrBignumNode() {
     }
 

--- a/src/main/java/org/truffleruby/core/numeric/FloatNodes.java
+++ b/src/main/java/org/truffleruby/core/numeric/FloatNodes.java
@@ -639,7 +639,7 @@ public abstract class FloatNodes {
 
         @Specialization(guards = "isPositive(n)", replaces = "roundFittingLongPositive")
         protected Object roundPositive(double n,
-                @Cached("new()") FixnumOrBignumNode fixnumOrBignum) {
+                @Cached FixnumOrBignumNode fixnumOrBignum) {
             double f = Math.floor(n);
             if (n - f >= 0.5) {
                 f += 1.0;
@@ -649,7 +649,7 @@ public abstract class FloatNodes {
 
         @Specialization(guards = "!isPositive(n)", replaces = "roundFittingLongNegative")
         protected Object roundNegative(double n,
-                @Cached("new()") FixnumOrBignumNode fixnumOrBignum) {
+                @Cached FixnumOrBignumNode fixnumOrBignum) {
             double f = Math.ceil(n);
             if (f - n >= 0.5) {
                 f -= 1.0;
@@ -702,7 +702,7 @@ public abstract class FloatNodes {
 
         @Specialization(guards = "isPositive(n)", replaces = "roundFittingLongPositive")
         protected Object roundPositive(double n,
-                @Cached("new()") FixnumOrBignumNode fixnumOrBignum) {
+                @Cached FixnumOrBignumNode fixnumOrBignum) {
             double f = Math.floor(n);
             if (n - f == 0.5) {
                 f += f % 2;
@@ -712,7 +712,7 @@ public abstract class FloatNodes {
 
         @Specialization(guards = "!isPositive(n)", replaces = "roundFittingLongNegative")
         protected Object roundNegative(double n,
-                @Cached("new()") FixnumOrBignumNode fixnumOrBignum) {
+                @Cached FixnumOrBignumNode fixnumOrBignum) {
             double f = Math.ceil(n);
             if (n - f == 0.5) {
                 f -= f % 2;
@@ -764,7 +764,7 @@ public abstract class FloatNodes {
 
         @Specialization(guards = "isPositive(n)", replaces = "roundFittingLongPositive")
         protected Object roundPositive(double n,
-                @Cached("new()") FixnumOrBignumNode fixnumOrBignum) {
+                @Cached FixnumOrBignumNode fixnumOrBignum) {
             double f = Math.floor(n);
             if (n - f > 0.5) {
                 f += 1.0;
@@ -774,7 +774,7 @@ public abstract class FloatNodes {
 
         @Specialization(guards = "!isPositive(n)", replaces = "roundFittingLongNegative")
         protected Object roundNegative(double n,
-                @Cached("new()") FixnumOrBignumNode fixnumOrBignum) {
+                @Cached FixnumOrBignumNode fixnumOrBignum) {
             double f = Math.ceil(n);
             if (f - n > 0.5) {
                 f -= 1.0;

--- a/src/main/java/org/truffleruby/core/numeric/FloatNodes.java
+++ b/src/main/java/org/truffleruby/core/numeric/FloatNodes.java
@@ -52,6 +52,7 @@ public abstract class FloatNodes {
 
     }
 
+    /** See {@link org.truffleruby.core.inlined.InlinedAddNode} */
     @CoreMethod(names = "+", required = 1)
     public abstract static class AddNode extends CoreMethodArrayArgumentsNode {
 
@@ -77,6 +78,7 @@ public abstract class FloatNodes {
         }
     }
 
+    /** See {@link org.truffleruby.core.inlined.InlinedSubNode} */
     @CoreMethod(names = "-", required = 1)
     public abstract static class SubNode extends CoreMethodArrayArgumentsNode {
 

--- a/src/main/java/org/truffleruby/core/numeric/IntegerNodes.java
+++ b/src/main/java/org/truffleruby/core/numeric/IntegerNodes.java
@@ -111,10 +111,9 @@ public abstract class IntegerNodes {
 
     }
 
+    /** See {@link org.truffleruby.core.inlined.InlinedAddNode} */
     @CoreMethod(names = "+", required = 1)
     public abstract static class AddNode extends BignumCoreMethodNode {
-
-        public abstract Object executeAdd(Object a, Object b);
 
         @Specialization(rewriteOn = ArithmeticException.class)
         protected int add(int a, int b) {
@@ -168,10 +167,9 @@ public abstract class IntegerNodes {
         }
     }
 
+    /** See {@link org.truffleruby.core.inlined.InlinedSubNode} */
     @CoreMethod(names = "-", required = 1)
     public abstract static class SubNode extends BignumCoreMethodNode {
-
-        public abstract Object executeSub(Object a, Object b);
 
         @Specialization(rewriteOn = ArithmeticException.class)
         protected int sub(int a, int b) {

--- a/src/main/java/org/truffleruby/core/string/StringNodes.java
+++ b/src/main/java/org/truffleruby/core/string/StringNodes.java
@@ -4180,7 +4180,7 @@ public abstract class StringNodes {
         @Specialization
         protected Object stringToF(Object string,
                 @CachedLibrary(limit = "2") RubyStringLibrary strings,
-                @Cached("new()") FixnumOrBignumNode fixnumOrBignumNode,
+                @Cached FixnumOrBignumNode fixnumOrBignumNode,
                 @Cached BytesNode bytesNode) {
             final Rope rope = strings.getRope(string);
             if (rope.isEmpty()) {
@@ -5288,7 +5288,7 @@ public abstract class StringNodes {
 
         @Specialization(guards = "!isLazyIntRopeOptimizable(rope, fixBase)")
         protected Object stringToInum(Rope rope, int fixBase, boolean strict, boolean raiseOnError,
-                @Cached("new()") FixnumOrBignumNode fixnumOrBignumNode,
+                @Cached FixnumOrBignumNode fixnumOrBignumNode,
                 @Cached BytesNode bytesNode,
                 @Cached BranchProfile exceptionProfile) {
             try {

--- a/src/main/java/org/truffleruby/core/support/RandomizerNodes.java
+++ b/src/main/java/org/truffleruby/core/support/RandomizerNodes.java
@@ -82,7 +82,7 @@ public abstract class RandomizerNodes {
 
         @Specialization
         protected Object randomizerRandInt(RubyRandomizer randomizer, RubyBignum limit,
-                @Cached("new()") FixnumOrBignumNode fixnumOrBignum) {
+                @Cached FixnumOrBignumNode fixnumOrBignum) {
             return fixnumOrBignum.fixnumOrBignum(randLimitedBignum(randomizer, limit.value));
         }
 


### PR DESCRIPTION
This change improves interpreter speed on microbenchmarks like Mandelbrot, Sieve, Storage,  reducing run time by 7%.
More interesting benchmarks, don't really show any change.

Performance report here: https://rebench.stefan-marr.de/compare/TruffleRuby/069b9e68efef1a09f6fa2a2c722059af43e300ae/60c3282176185aa99c0f1ab8c727c6e6822c8513#ruby-startup-TruffleRuby-native-interp

The drawback is that this duplicates logic from the `AddNode`. Though, the logic duplicated seems trivial, and the `double` logic was already duplicated to start with.