### PR TITLE
Simplify fromOnStackMarker access to basic object read/write

### DIFF
--- a/src/main/java/org/truffleruby/language/control/FrameOnStackNode.java
+++ b/src/main/java/org/truffleruby/language/control/FrameOnStackNode.java
@@ -11,8 +11,6 @@ package org.truffleruby.language.control;
 
 import org.truffleruby.language.RubyContextSourceNode;
 import org.truffleruby.language.RubyNode;
-import org.truffleruby.language.locals.WriteFrameSlotNode;
-import org.truffleruby.language.locals.WriteFrameSlotNodeGen;
 
 import com.oracle.truffle.api.frame.FrameSlot;
 import com.oracle.truffle.api.frame.VirtualFrame;
@@ -20,18 +18,18 @@ import com.oracle.truffle.api.frame.VirtualFrame;
 public class FrameOnStackNode extends RubyContextSourceNode {
 
     @Child private RubyNode child;
-    @Child private WriteFrameSlotNode writeMarker;
+    private final FrameSlot markerSlot;
 
     public FrameOnStackNode(RubyNode child, FrameSlot markerSlot) {
         this.child = child;
-        writeMarker = WriteFrameSlotNodeGen.create(markerSlot);
+        this.markerSlot = markerSlot;
     }
 
     @Override
     public Object execute(VirtualFrame frame) {
         final FrameOnStackMarker marker = new FrameOnStackMarker();
 
-        writeMarker.executeWrite(frame, marker);
+        frame.setObject(markerSlot, marker);
 
         try {
             return child.execute(frame);

--- a/src/main/java/org/truffleruby/parser/BodyTranslator.java
+++ b/src/main/java/org/truffleruby/parser/BodyTranslator.java
@@ -266,6 +266,7 @@ import org.truffleruby.parser.scope.StaticScope;
 
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.frame.FrameSlot;
+import com.oracle.truffle.api.frame.FrameSlotKind;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.NodeUtil;
 import com.oracle.truffle.api.source.Source;
@@ -713,6 +714,7 @@ public class BodyTranslator extends Translator {
             frameOnStackMarkerSlot = null;
         } else if (iterNode != null) {
             frameOnStackMarkerSlot = environment.declareVar(environment.allocateLocalTemp("frame_on_stack_marker"));
+            environment.getFrameDescriptor().setFrameSlotKind(frameOnStackMarkerSlot, FrameSlotKind.Object);
 
             frameOnStackMarkerSlotStack.push(frameOnStackMarkerSlot);
             try {


### PR DESCRIPTION
Since the marker is an object, we don't need specializing nodes.

Performance impact is practically minimal.
Results are too noisy to say either way. It looks minimally worse. Possibly inlining heuristics that trigger differently.
The node is likely rare to start with, and memory savings are likely negligible.

Overall, it seems to be a small worthwhile simplification to me.

https://rebench.stefan-marr.de/compare/TruffleRuby/7e4ad0862b3002c20022547386b63ab00271fa19/71c8dfe8e7f205c8f843dd0aa8657a69f20ca295