### PR TITLE
[Ruby 3.0 support] Add category kwarg to Kernel.warn and Warning.warn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Compatibility:
 * Implement `rb_str_locktmp` and `rb_str_unlocktmp` (#2524, @bjfish).
 * Update `Kernel#instance_variables` to return insertion order (@bjfish).
 * Fixed `rb_path2class()` to not error for a module (#2511, @eregon).
+* Add category kwarg to Kernel.warn and Warning.warn (#2533, @Strech).
 
 Performance:
 

--- a/spec/mspec/lib/mspec/utils/warnings.rb
+++ b/spec/mspec/lib/mspec/utils/warnings.rb
@@ -10,7 +10,7 @@ if Object.const_defined?(:Warning) and Warning.respond_to?(:[]=)
 end
 
 if Object.const_defined?(:Warning) and Warning.respond_to?(:warn)
-  def Warning.warn(message)
+  def Warning.warn(message, category: nil)
     # Suppress any warning inside the method to prevent recursion
     verbose = $VERBOSE
     $VERBOSE = nil

--- a/spec/ruby/core/warning/warn_spec.rb
+++ b/spec/ruby/core/warning/warn_spec.rb
@@ -50,42 +50,4 @@ describe "Warning.warn" do
       $VERBOSE = verbose
     end
   end
-
-
-  ruby_version_is '3.0' do
-    it "is called by Kernel.warn with nil category keyword" do
-      Warning.should_receive(:warn).with("Chunky bacon!\n", category: nil)
-      verbose = $VERBOSE
-      $VERBOSE = false
-      begin
-        Kernel.warn("Chunky bacon!")
-      ensure
-        $VERBOSE = verbose
-      end
-    end
-
-    it "is called by Kernel.warn with given category keyword converted to a symbol" do
-      Warning.should_receive(:warn).with("Chunky bacon!\n", category: :deprecated)
-      verbose = $VERBOSE
-      $VERBOSE = false
-      begin
-        Kernel.warn("Chunky bacon!", category: 'deprecated')
-      ensure
-        $VERBOSE = verbose
-      end
-    end
-  end
-
-  ruby_version_is ''...'3.0' do
-    it "is called by Kernel.warn" do
-      Warning.should_receive(:warn).with("Chunky bacon!\n")
-      verbose = $VERBOSE
-      $VERBOSE = false
-      begin
-        Kernel.warn("Chunky bacon!")
-      ensure
-        $VERBOSE = verbose
-      end
-    end
-  end
 end

--- a/src/main/ruby/truffleruby/core/kernel.rb
+++ b/src/main/ruby/truffleruby/core/kernel.rb
@@ -615,7 +615,7 @@ module Kernel
   end
   module_function :untrace_var
 
-  def warn(*messages, uplevel: undefined)
+  def warn(*messages, uplevel: undefined, category: nil)
     if !Primitive.nil?($VERBOSE) && !messages.empty?
       prefix = if Primitive.undefined?(uplevel)
                  ''
@@ -650,11 +650,19 @@ module Kernel
         unless message.encoding.ascii_compatible?
           raise Encoding::CompatibilityError, "ASCII incompatible encoding: #{message.encoding}"
         end
+        Truffle::WarningOperations.check_category(category) unless Primitive.nil?(category)
+
         $stderr.write message
       else
-        Warning.warn(message)
+        if Primitive.nil?(category)
+          Warning.warn(message)
+        else
+          category = Truffle::Type.rb_convert_type(category, Symbol, :to_sym)
+          Warning.warn(message, category: category)
+        end
       end
     end
+
     nil
   end
   module_function :warn

--- a/src/main/ruby/truffleruby/core/kernel.rb
+++ b/src/main/ruby/truffleruby/core/kernel.rb
@@ -654,11 +654,12 @@ module Kernel
 
         $stderr.write message
       else
-        if Primitive.nil?(category)
-          Warning.warn(message)
+        warning_warn = Warning.method(:warn)
+        if warning_warn.arity == 1
+          warning_warn.call(message)
         else
-          category = Truffle::Type.rb_convert_type(category, Symbol, :to_sym)
-          Warning.warn(message, category: category)
+          category = Truffle::Type.rb_convert_type(category, Symbol, :to_sym) unless Primitive.nil?(category)
+          warning_warn.call(message, category: category)
         end
       end
     end

--- a/src/main/ruby/truffleruby/core/truffle/warning_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/warning_operations.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved. This
+# code is released under a tri EPL/GPL/LGPL license. You can use it,
+# redistribute it and/or modify it under the terms of the:
+#
+# Eclipse Public License version 2.0, or
+# GNU General Public License version 2, or
+# GNU Lesser General Public License version 2.1.
+
+module Truffle
+  module WarningOperations
+    def self.check_category(category)
+      return if category == :deprecated || category == :experimental
+
+      raise ArgumentError, "unknown category: #{category}"
+    end
+  end
+end

--- a/src/main/ruby/truffleruby/core/warning.rb
+++ b/src/main/ruby/truffleruby/core/warning.rb
@@ -11,18 +11,23 @@
 module Warning
   extend self
 
-  def warn(message)
-    unless Primitive.object_kind_of?(message, String)
-      raise TypeError, "wrong argument type #{message.class} (expected String)"
-    end
+  def warn(message, category: nil)
+    Truffle::Type.rb_check_type(message, String)
     unless message.encoding.ascii_compatible?
       raise Encoding::CompatibilityError, "ASCII incompatible encoding: #{message.encoding}"
     end
+    unless Primitive.nil?(category)
+      Truffle::Type.rb_check_type(category, Symbol)
+      Truffle::WarningOperations.check_category(category)
+    end
+
     $stderr.write message
     nil
   end
 
   def self.[](category)
+    Truffle::Type.rb_check_type(category, Symbol)
+
     case category
     when :deprecated
       Primitive.warning_get_category(:deprecated)
@@ -34,6 +39,8 @@ module Warning
   end
 
   def self.[]=(category, value)
+    Truffle::Type.rb_check_type(category, Symbol)
+
     case category
     when :deprecated
       Primitive.warning_set_category(:deprecated, Primitive.as_boolean(value))


### PR DESCRIPTION
Also, some existing behaviour were ported to other `Warning` methods, like type check in `Warning#[]` and `Warnign#[]=`

In addition, some ruby specs were added https://github.com/ruby/spec/pull/897

### Implementation concerns

1. I'm a bit concerned about [that line](https://github.com/oracle/truffleruby/pull/2533/files#diff-33ede40d852b46aaee908894016af8a4f4f85c4b5716749c3e44975a87cb08eeR22). In MRI implementation C-code shares that functionality between `warn` and `[]`, both call the same function which returns internal category value, but not sure that I can reuse it as I did
2. Not sure that I fully understand [that line](https://github.com/oracle/truffleruby/pull/2533/files#diff-969237b8b62a64ee081b533c88e005515aa98af8051cd5cd5273d4cee60d0d34R649) does it mean that I have to copy some checks like inclusion in a pre-defined list of values?