### PR TITLE
[Ruby 3.0 support] Add pager support into Launcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Compatibility:
 * Define `Process::{CLOCK_BOOTTIME,CLOCK_BOOTTIME_ALARM,CLOCK_REALTIME_ALARM}` (#1480, @eregon).
 * Improve support of `:chomp` keyword argument in `IO` and `StringIO` methods (#2650, @andrykonchin). 
 * Implement specializations for immutable ruby objects for ObjectSpace methods (@bjfish).
+* Use `$PAGER` for `--help` and `--help*`, similar to CRuby (#2542, @Strech).
 
 Performance:
 

--- a/src/launcher/java/org/truffleruby/launcher/CommandLineParser.java
+++ b/src/launcher/java/org/truffleruby/launcher/CommandLineParser.java
@@ -432,8 +432,10 @@ public class CommandLineParser {
                         disallowedInRubyOpts(argument);
                         warnInternalDebugTool(argument);
                         break FOR;
-                    } else if (rubyOpts && argument.equals("--help")) {
+                    } else if (argument.equals("--help")) {
                         disallowedInRubyOpts(argument);
+                        // --help is handled by org.graalvm.launcher.Launcher#printDefaultHelp
+                        config.getUnknownArguments().add(argument);
                         break FOR;
                     } else if (argument.equals("--version")) {
                         disallowedInRubyOpts(argument);

--- a/src/launcher/java/org/truffleruby/launcher/RubyLauncher.java
+++ b/src/launcher/java/org/truffleruby/launcher/RubyLauncher.java
@@ -57,8 +57,8 @@ public class RubyLauncher extends AbstractLanguageLauncher {
 
     @Override
     protected void printVersion() {
-        System.out.println(TruffleRuby.getVersionString(getImplementationNameFromEngine()));
-        System.out.println();
+        getOutput().println(TruffleRuby.getVersionString(getImplementationNameFromEngine()));
+        getOutput().println();
         printPolyglotVersions();
     }
 
@@ -112,9 +112,9 @@ public class RubyLauncher extends AbstractLanguageLauncher {
             }
 
         } catch (CommandLineException commandLineException) {
-            System.err.println("truffleruby: " + commandLineException.getMessage());
+            getError().println("truffleruby: " + commandLineException.getMessage());
             if (commandLineException.isUsageError()) {
-                printHelp(System.err);
+                printHelp(getError());
             }
             System.exit(1);
         }
@@ -228,7 +228,7 @@ public class RubyLauncher extends AbstractLanguageLauncher {
                 case IRB:
                     config.executionAction = ExecutionAction.PATH;
                     if (System.console() != null) {
-                        System.err.println(
+                        getError().println(
                                 "[ruby] WARNING: truffleruby starts IRB when stdin is a TTY instead of reading from stdin, use '-' to read from stdin");
                         config.executionAction = ExecutionAction.PATH;
                         config.toExecute = "irb";
@@ -247,7 +247,7 @@ public class RubyLauncher extends AbstractLanguageLauncher {
             // Apply options to run gem/bundle more efficiently
             contextBuilder.option("engine.Mode", "latency");
             if (Boolean.getBoolean("truffleruby.launcher.log")) {
-                System.err.println("[ruby] CONFIG: detected gem or bundle command, using --engine.Mode=latency");
+                getError().println("[ruby] CONFIG: detected gem or bundle command, using --engine.Mode=latency");
             }
         }
 
@@ -285,7 +285,7 @@ public class RubyLauncher extends AbstractLanguageLauncher {
                 if (file.isString()) {
                     config.toExecute = file.asString();
                 } else {
-                    System.err
+                    getError()
                             .println("truffleruby: No such file or directory -- " + config.toExecute + " (LoadError)");
                     return 1;
                 }
@@ -314,9 +314,9 @@ public class RubyLauncher extends AbstractLanguageLauncher {
             return exitCode;
         } catch (PolyglotException e) {
             if (e.isHostException()) { // GR-22071
-                System.err.println("truffleruby: a host exception reached the top level:");
+                getError().println("truffleruby: a host exception reached the top level:");
             } else {
-                System.err.println(
+                getError().println(
                         "truffleruby: an exception escaped out of the interpreter - this is an implementation bug");
             }
             e.printStackTrace();
@@ -359,21 +359,21 @@ public class RubyLauncher extends AbstractLanguageLauncher {
 
     private void printPreRunInformation(CommandLineOptions config) {
         if (config.showVersion) {
-            System.out.println(TruffleRuby.getVersionString(getImplementationNameFromEngine()));
+            getOutput().println(TruffleRuby.getVersionString(getImplementationNameFromEngine()));
         }
 
         if (config.showCopyright) {
-            System.out.println(TruffleRuby.RUBY_COPYRIGHT);
+            getOutput().println(TruffleRuby.RUBY_COPYRIGHT);
         }
 
         switch (config.showHelp) {
             case NONE:
                 break;
             case SHORT:
-                printShortHelp(System.out);
+                printShortHelp(getOutput());
                 break;
             case LONG:
-                printHelp(System.out);
+                printHelp(getOutput());
                 break;
         }
     }

--- a/src/launcher/java/org/truffleruby/launcher/RubyLauncher.java
+++ b/src/launcher/java/org/truffleruby/launcher/RubyLauncher.java
@@ -372,9 +372,7 @@ public class RubyLauncher extends AbstractLanguageLauncher {
             case SHORT:
                 printShortHelp(getOutput());
                 break;
-            case LONG:
-                printHelp(getOutput());
-                break;
+            // --help is handled by org.graalvm.launcher.Launcher#printDefaultHelp
         }
     }
 

--- a/src/launcher/java/org/truffleruby/launcher/RubyLauncher.java
+++ b/src/launcher/java/org/truffleruby/launcher/RubyLauncher.java
@@ -191,9 +191,9 @@ public class RubyLauncher extends AbstractLanguageLauncher {
         String pager;
         if (helpOptionUsed && System.console() != null && !(pager = getPagerFromEnv()).isEmpty()) {
             try {
-                Process process = new ProcessBuilder(pager)
-                        .redirectOutput(Redirect.INHERIT)
-                        .redirectErrorStream(true)
+                Process process = new ProcessBuilder(pager.split(" "))
+                        .redirectOutput(Redirect.INHERIT) // set the output of the pager to the terminal and not a pipe
+                        .redirectError(Redirect.INHERIT) // set the error of the pager to the terminal and not a pipe
                         .start();
                 PrintStream out = new PrintStream(process.getOutputStream());
 

--- a/src/launcher/java/org/truffleruby/launcher/RubyLauncher.java
+++ b/src/launcher/java/org/truffleruby/launcher/RubyLauncher.java
@@ -35,7 +35,7 @@ public class RubyLauncher extends AbstractLanguageLauncher {
 
     private CommandLineOptions config;
     private String implementationName = null;
-    private boolean helpOptionUsed;
+    private boolean helpOptionUsed = false; // Any --help* option
 
     public static void main(String[] args) {
         new RubyLauncher().launch(args);
@@ -193,7 +193,7 @@ public class RubyLauncher extends AbstractLanguageLauncher {
         }
 
         String pager = getPagerFromEnv();
-        if (pager == null || pager.length() == 0) {
+        if (pager.isEmpty()) {
             return super.runLauncherAction();
         }
 
@@ -354,7 +354,7 @@ public class RubyLauncher extends AbstractLanguageLauncher {
             return pager.strip();
         }
 
-        return null;
+        return "";
     }
 
     private void printPreRunInformation(CommandLineOptions config) {

--- a/src/launcher/java/org/truffleruby/launcher/ShowHelp.java
+++ b/src/launcher/java/org/truffleruby/launcher/ShowHelp.java
@@ -11,6 +11,6 @@ package org.truffleruby.launcher;
 
 public enum ShowHelp {
     NONE,
-    SHORT,
-    LONG
+    SHORT // -h
+    // LONG // --help is handled by org.graalvm.launcher.Launcher#printDefaultHelp
 }


### PR DESCRIPTION
⚠️ This is not a code to review, but rather PoC and discussion ⚠️ 

After digging into the [MRI implementation](https://github.com/ruby/ruby/pull/3000) and [Graal Launcher](https://github.com/oracle/graal/blob/master/sdk/src/org.graalvm.launcher/src/org/graalvm/launcher/Launcher.java) I have a set of questions and problems to ask.

## MRI-features question

The MRI pager support comes with variates of sub-features. And it would be cool to understand which one I should port:

1. `COLUMNS` environment variable and word wrapping
2. Section highlighting (via escape codes)
3. `HAVE_WORKING_FORK`-thing which I'm not sure how is used 🤔 

## Implementation question

In Graal SDK for Launcher, all the tiny methods to display help combined inside the `runLauncherAction` method which also should return `true` to terminate the build part. And this method seems the best place to inject new `output`. The problem I face is that I can't determine does the `--help` is actually called or it's a `--version`.

Unfortunately in the Graal launcher `help` variable is declared as `private` and I can't use it. Is there a way to understand it or I'm doing it in the wrong place?

And the main issue I see is that logic is spread across many <printSomething> methods and some of them are responsible for termination decisions 🤔 

P.S Does the `autoFlash` a concern or it's totally fine for such small output as help?