### PR TITLE
Avoid BooleanCastNode for InlinedOperationNodes

### DIFF
--- a/src/main/java/org/truffleruby/core/cast/BooleanCastNode.java
+++ b/src/main/java/org/truffleruby/core/cast/BooleanCastNode.java
@@ -29,10 +29,20 @@ import com.oracle.truffle.api.profiles.ConditionProfile;
 /** Casts a value into a boolean. */
 @GenerateUncached
 @NodeChild(value = "value", type = RubyNode.class)
-public abstract class BooleanCastNode extends RubyBaseNode {
+public abstract class BooleanCastNode extends RubyBaseNode implements BooleanExecute {
 
     public static BooleanCastNode create() {
         return BooleanCastNodeGen.create(null);
+    }
+
+    public static BooleanExecute createIfNeeded(RubyNode possibleBoolean) {
+        if (possibleBoolean.needsBooleanCastNode()) {
+            return BooleanCastNodeGen.create(possibleBoolean);
+        }
+
+        BooleanExecute node = (BooleanExecute) possibleBoolean;
+        node.markAvoidedCast();
+        return node;
     }
 
     /** Execute with child node */
@@ -102,5 +112,14 @@ public abstract class BooleanCastNode extends RubyBaseNode {
 
     protected int getCacheLimit() {
         return getLanguage().options.METHOD_LOOKUP_CACHE;
+    }
+
+    @Override
+    public void markAvoidedCast() {
+    }
+
+    @Override
+    public boolean didAvoidCast() {
+        return false;
     }
 }

--- a/src/main/java/org/truffleruby/core/cast/BooleanCastNode.java
+++ b/src/main/java/org/truffleruby/core/cast/BooleanCastNode.java
@@ -45,6 +45,8 @@ public abstract class BooleanCastNode extends RubyBaseNode implements BooleanExe
         return node;
     }
 
+    public abstract RubyNode getValue();
+
     /** Execute with child node */
     public abstract boolean executeBoolean(VirtualFrame frame);
 

--- a/src/main/java/org/truffleruby/core/cast/BooleanExecute.java
+++ b/src/main/java/org/truffleruby/core/cast/BooleanExecute.java
@@ -1,0 +1,12 @@
+package org.truffleruby.core.cast;
+
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.nodes.NodeInterface;
+
+public interface BooleanExecute extends NodeInterface {
+    boolean executeBoolean(VirtualFrame frame);
+
+    void markAvoidedCast();
+
+    boolean didAvoidCast();
+}

--- a/src/main/java/org/truffleruby/core/inlined/BinaryInlinedBooleanNode.java
+++ b/src/main/java/org/truffleruby/core/inlined/BinaryInlinedBooleanNode.java
@@ -1,0 +1,32 @@
+package org.truffleruby.core.inlined;
+
+import org.truffleruby.RubyLanguage;
+import org.truffleruby.core.cast.BooleanExecute;
+import org.truffleruby.language.dispatch.RubyCallNodeParameters;
+
+import com.oracle.truffle.api.Assumption;
+
+public abstract class BinaryInlinedBooleanNode extends BinaryInlinedOperationNode implements BooleanExecute {
+
+    private boolean avoidedCast;
+
+    public BinaryInlinedBooleanNode(
+            RubyLanguage language,
+            RubyCallNodeParameters callNodeParameters,
+            Assumption... assumptions) {
+        super(language, callNodeParameters, assumptions);
+    }
+
+    @Override
+    public boolean needsBooleanCastNode() {
+        return false;
+    }
+
+    public void markAvoidedCast() {
+        avoidedCast = true;
+    }
+
+    public boolean didAvoidCast() {
+        return avoidedCast;
+    }
+}

--- a/src/main/java/org/truffleruby/core/inlined/BinaryInlinedBooleanNode.java
+++ b/src/main/java/org/truffleruby/core/inlined/BinaryInlinedBooleanNode.java
@@ -2,9 +2,11 @@ package org.truffleruby.core.inlined;
 
 import org.truffleruby.RubyLanguage;
 import org.truffleruby.core.cast.BooleanExecute;
+import org.truffleruby.language.BooleanExecuteWrapper;
 import org.truffleruby.language.dispatch.RubyCallNodeParameters;
 
 import com.oracle.truffle.api.Assumption;
+import com.oracle.truffle.api.instrumentation.ProbeNode;
 
 public abstract class BinaryInlinedBooleanNode extends BinaryInlinedOperationNode implements BooleanExecute {
 
@@ -15,6 +17,11 @@ public abstract class BinaryInlinedBooleanNode extends BinaryInlinedOperationNod
             RubyCallNodeParameters callNodeParameters,
             Assumption... assumptions) {
         super(language, callNodeParameters, assumptions);
+    }
+
+    @Override
+    public WrapperNode createWrapper(ProbeNode probe) {
+        return new BooleanExecuteWrapper(this, probe);
     }
 
     @Override

--- a/src/main/java/org/truffleruby/core/inlined/InlinedCaseEqualNode.java
+++ b/src/main/java/org/truffleruby/core/inlined/InlinedCaseEqualNode.java
@@ -20,7 +20,7 @@ import com.oracle.truffle.api.frame.VirtualFrame;
 import org.truffleruby.language.methods.LookupMethodOnSelfNode;
 import org.truffleruby.language.objects.IsANode;
 
-public abstract class InlinedCaseEqualNode extends BinaryInlinedOperationNode {
+public abstract class InlinedCaseEqualNode extends BinaryInlinedBooleanNode {
 
     protected static final String METHOD = "===";
 

--- a/src/main/java/org/truffleruby/core/inlined/InlinedEqualNode.java
+++ b/src/main/java/org/truffleruby/core/inlined/InlinedEqualNode.java
@@ -21,7 +21,7 @@ import com.oracle.truffle.api.frame.VirtualFrame;
 import org.truffleruby.language.library.RubyStringLibrary;
 import org.truffleruby.language.methods.LookupMethodOnSelfNode;
 
-public abstract class InlinedEqualNode extends BinaryInlinedOperationNode {
+public abstract class InlinedEqualNode extends BinaryInlinedBooleanNode {
 
     protected static final String METHOD = "==";
 

--- a/src/main/java/org/truffleruby/core/inlined/InlinedGreaterOrEqualNode.java
+++ b/src/main/java/org/truffleruby/core/inlined/InlinedGreaterOrEqualNode.java
@@ -15,7 +15,7 @@ import org.truffleruby.language.dispatch.RubyCallNodeParameters;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
 
-public abstract class InlinedGreaterOrEqualNode extends BinaryInlinedOperationNode {
+public abstract class InlinedGreaterOrEqualNode extends BinaryInlinedBooleanNode {
 
     public InlinedGreaterOrEqualNode(RubyLanguage language, RubyCallNodeParameters callNodeParameters) {
         super(

--- a/src/main/java/org/truffleruby/core/inlined/InlinedGreaterThanNode.java
+++ b/src/main/java/org/truffleruby/core/inlined/InlinedGreaterThanNode.java
@@ -15,7 +15,7 @@ import org.truffleruby.language.dispatch.RubyCallNodeParameters;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
 
-public abstract class InlinedGreaterThanNode extends BinaryInlinedOperationNode {
+public abstract class InlinedGreaterThanNode extends BinaryInlinedBooleanNode {
 
     public InlinedGreaterThanNode(RubyLanguage language, RubyCallNodeParameters callNodeParameters) {
         super(

--- a/src/main/java/org/truffleruby/core/inlined/InlinedIsANode.java
+++ b/src/main/java/org/truffleruby/core/inlined/InlinedIsANode.java
@@ -19,7 +19,7 @@ import com.oracle.truffle.api.frame.VirtualFrame;
 import org.truffleruby.language.methods.LookupMethodOnSelfNode;
 import org.truffleruby.language.objects.IsANode;
 
-public abstract class InlinedIsANode extends BinaryInlinedOperationNode {
+public abstract class InlinedIsANode extends BinaryInlinedBooleanNode {
 
     protected static final String METHOD = "is_a?";
 

--- a/src/main/java/org/truffleruby/core/inlined/InlinedIsNilNode.java
+++ b/src/main/java/org/truffleruby/core/inlined/InlinedIsNilNode.java
@@ -18,7 +18,7 @@ import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import org.truffleruby.language.methods.LookupMethodOnSelfNode;
 
-public abstract class InlinedIsNilNode extends UnaryInlinedOperationNode {
+public abstract class InlinedIsNilNode extends UnaryInlinedBooleanNode {
 
     protected static final String METHOD = "nil?";
 

--- a/src/main/java/org/truffleruby/core/inlined/InlinedKindOfNode.java
+++ b/src/main/java/org/truffleruby/core/inlined/InlinedKindOfNode.java
@@ -19,7 +19,7 @@ import com.oracle.truffle.api.frame.VirtualFrame;
 import org.truffleruby.language.methods.LookupMethodOnSelfNode;
 import org.truffleruby.language.objects.IsANode;
 
-public abstract class InlinedKindOfNode extends BinaryInlinedOperationNode {
+public abstract class InlinedKindOfNode extends BinaryInlinedBooleanNode {
 
     protected static final String METHOD = "kind_of?";
 

--- a/src/main/java/org/truffleruby/core/inlined/InlinedLessOrEqualNode.java
+++ b/src/main/java/org/truffleruby/core/inlined/InlinedLessOrEqualNode.java
@@ -15,7 +15,7 @@ import org.truffleruby.language.dispatch.RubyCallNodeParameters;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
 
-public abstract class InlinedLessOrEqualNode extends BinaryInlinedOperationNode {
+public abstract class InlinedLessOrEqualNode extends BinaryInlinedBooleanNode {
 
     public InlinedLessOrEqualNode(RubyLanguage language, RubyCallNodeParameters callNodeParameters) {
         super(

--- a/src/main/java/org/truffleruby/core/inlined/InlinedLessThanNode.java
+++ b/src/main/java/org/truffleruby/core/inlined/InlinedLessThanNode.java
@@ -15,7 +15,7 @@ import org.truffleruby.language.dispatch.RubyCallNodeParameters;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
 
-public abstract class InlinedLessThanNode extends BinaryInlinedOperationNode {
+public abstract class InlinedLessThanNode extends BinaryInlinedBooleanNode {
 
     public InlinedLessThanNode(RubyLanguage language, RubyCallNodeParameters callNodeParameters) {
         super(

--- a/src/main/java/org/truffleruby/core/inlined/InlinedNotNode.java
+++ b/src/main/java/org/truffleruby/core/inlined/InlinedNotNode.java
@@ -18,7 +18,7 @@ import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import org.truffleruby.language.methods.LookupMethodOnSelfNode;
 
-public abstract class InlinedNotNode extends UnaryInlinedOperationNode {
+public abstract class InlinedNotNode extends UnaryInlinedBooleanNode {
 
     protected static final String METHOD = "!";
 

--- a/src/main/java/org/truffleruby/core/inlined/InlinedReplaceableNode.java
+++ b/src/main/java/org/truffleruby/core/inlined/InlinedReplaceableNode.java
@@ -18,6 +18,9 @@ import com.oracle.truffle.api.nodes.NodeUtil;
 import org.truffleruby.RubyContext;
 import org.truffleruby.RubyLanguage;
 import org.truffleruby.core.array.ArrayUtils;
+import org.truffleruby.core.cast.BooleanCastNode;
+import org.truffleruby.core.cast.BooleanCastNodeGen;
+import org.truffleruby.core.cast.BooleanExecute;
 import org.truffleruby.language.RubyContextSourceNode;
 import org.truffleruby.language.RubyNode;
 import org.truffleruby.language.dispatch.RubyCallNode;
@@ -57,6 +60,15 @@ public abstract class InlinedReplaceableNode extends RubyContextSourceNode {
                         getBlockNode()));
                 callNode.unsafeSetSourceSection(getSourceIndexLength());
                 replacedBy = callNode;
+
+                if (!needsBooleanCastNode() && ((BooleanExecute) this).didAvoidCast()) {
+                    BooleanCastNode cast = BooleanCastNodeGen.create(callNode);
+                    replace(cast, this + " could not be executed inline");
+                    // TODO: this isn't good enough, because we don't cast the result of the
+                    // first invocation to a bool...
+                    return callNode;
+                }
+
                 return replace(callNode, this + " could not be executed inline");
             } else {
                 return replacedBy;

--- a/src/main/java/org/truffleruby/core/inlined/UnaryInlinedBooleanNode.java
+++ b/src/main/java/org/truffleruby/core/inlined/UnaryInlinedBooleanNode.java
@@ -2,9 +2,11 @@ package org.truffleruby.core.inlined;
 
 import org.truffleruby.RubyLanguage;
 import org.truffleruby.core.cast.BooleanExecute;
+import org.truffleruby.language.BooleanExecuteWrapper;
 import org.truffleruby.language.dispatch.RubyCallNodeParameters;
 
 import com.oracle.truffle.api.Assumption;
+import com.oracle.truffle.api.instrumentation.ProbeNode;
 
 public abstract class UnaryInlinedBooleanNode extends UnaryInlinedOperationNode implements BooleanExecute {
 
@@ -28,5 +30,10 @@ public abstract class UnaryInlinedBooleanNode extends UnaryInlinedOperationNode 
 
     public boolean didAvoidCast() {
         return avoidedCast;
+    }
+
+    @Override
+    public WrapperNode createWrapper(ProbeNode probe) {
+        return new BooleanExecuteWrapper(this, probe);
     }
 }

--- a/src/main/java/org/truffleruby/core/inlined/UnaryInlinedBooleanNode.java
+++ b/src/main/java/org/truffleruby/core/inlined/UnaryInlinedBooleanNode.java
@@ -1,0 +1,32 @@
+package org.truffleruby.core.inlined;
+
+import org.truffleruby.RubyLanguage;
+import org.truffleruby.core.cast.BooleanExecute;
+import org.truffleruby.language.dispatch.RubyCallNodeParameters;
+
+import com.oracle.truffle.api.Assumption;
+
+public abstract class UnaryInlinedBooleanNode extends UnaryInlinedOperationNode implements BooleanExecute {
+
+    private boolean avoidedCast;
+
+    public UnaryInlinedBooleanNode(
+            RubyLanguage language,
+            RubyCallNodeParameters callNodeParameters,
+            Assumption... assumptions) {
+        super(language, callNodeParameters, assumptions);
+    }
+
+    @Override
+    public boolean needsBooleanCastNode() {
+        return false;
+    }
+
+    public void markAvoidedCast() {
+        avoidedCast = true;
+    }
+
+    public boolean didAvoidCast() {
+        return avoidedCast;
+    }
+}

--- a/src/main/java/org/truffleruby/language/BooleanExecuteWrapper.java
+++ b/src/main/java/org/truffleruby/language/BooleanExecuteWrapper.java
@@ -3,6 +3,7 @@ package org.truffleruby.language;
 
 import org.truffleruby.RubyContext;
 import org.truffleruby.RubyLanguage;
+import org.truffleruby.core.cast.BooleanCastNode;
 import org.truffleruby.core.cast.BooleanExecute;
 
 import com.oracle.truffle.api.frame.VirtualFrame;
@@ -58,39 +59,46 @@ public final class BooleanExecuteWrapper extends RubyNode implements BooleanExec
         return returnValue;
     }
 
+    private RubyNode skipCastNode() {
+        if (delegateNode instanceof BooleanCastNode) {
+            return ((BooleanCastNode) delegateNode).getValue();
+        }
+        return (RubyNode) delegateNode;
+    }
+
     @Override
     public Object isDefined(VirtualFrame frame, RubyLanguage language, RubyContext context) {
-        return ((RubyNode) delegateNode).isDefined(frame, language, context);
+        return skipCastNode().isDefined(frame, language, context);
     }
 
     @Override
     protected int getSourceCharIndex() {
-        return ((RubyNode) delegateNode).getSourceCharIndex();
+        return skipCastNode().getSourceCharIndex();
     }
 
     @Override
     protected void setSourceCharIndex(int sourceCharIndex) {
-        ((RubyNode) delegateNode).setSourceCharIndex(sourceCharIndex);
+        skipCastNode().setSourceCharIndex(sourceCharIndex);
     }
 
     @Override
     protected int getSourceLength() {
-        return ((RubyNode) delegateNode).getSourceLength();
+        return skipCastNode().getSourceLength();
     }
 
     @Override
     protected void setSourceLength(int sourceLength) {
-        ((RubyNode) delegateNode).setSourceLength(sourceLength);
+        skipCastNode().setSourceLength(sourceLength);
     }
 
     @Override
     protected byte getFlags() {
-        return ((RubyNode) delegateNode).getFlags();
+        return skipCastNode().getFlags();
     }
 
     @Override
     protected void setFlags(byte flags) {
-        ((RubyNode) delegateNode).setFlags(flags);
+        skipCastNode().setFlags(flags);
     }
 
     @Override

--- a/src/main/java/org/truffleruby/language/BooleanExecuteWrapper.java
+++ b/src/main/java/org/truffleruby/language/BooleanExecuteWrapper.java
@@ -8,7 +8,6 @@ import org.truffleruby.core.cast.BooleanExecute;
 import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.instrumentation.InstrumentableNode.WrapperNode;
 import com.oracle.truffle.api.instrumentation.ProbeNode;
-import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.NodeCost;
 
 public final class BooleanExecuteWrapper extends RubyNode implements BooleanExecute, WrapperNode {

--- a/src/main/java/org/truffleruby/language/BooleanExecuteWrapper.java
+++ b/src/main/java/org/truffleruby/language/BooleanExecuteWrapper.java
@@ -1,0 +1,131 @@
+package org.truffleruby.language;
+
+
+import org.truffleruby.RubyContext;
+import org.truffleruby.RubyLanguage;
+import org.truffleruby.core.cast.BooleanExecute;
+
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.instrumentation.InstrumentableNode.WrapperNode;
+import com.oracle.truffle.api.instrumentation.ProbeNode;
+import com.oracle.truffle.api.nodes.Node;
+import com.oracle.truffle.api.nodes.NodeCost;
+
+public final class BooleanExecuteWrapper extends RubyNode implements BooleanExecute, WrapperNode {
+
+    @Child private RubyNode delegateNode;
+    @Child private ProbeNode probeNode;
+
+    public BooleanExecuteWrapper(RubyNode delegateNode, ProbeNode probeNode) {
+        this.delegateNode = delegateNode;
+        this.probeNode = probeNode;
+    }
+
+    public RubyNode getDelegateNode() {
+        return delegateNode;
+    }
+
+    public ProbeNode getProbeNode() {
+        return probeNode;
+    }
+
+    @Override
+    public NodeCost getCost() {
+        return NodeCost.NONE;
+    }
+
+    @Override
+    public Object execute(VirtualFrame frame) {
+        Object returnValue;
+        for (;;) {
+            boolean wasOnReturnExecuted = false;
+            try {
+                probeNode.onEnter(frame);
+                returnValue = delegateNode.execute(frame);
+                wasOnReturnExecuted = true;
+                probeNode.onReturnValue(frame, returnValue);
+                break;
+            } catch (Throwable t) {
+                Object result = probeNode.onReturnExceptionalOrUnwind(frame, t, wasOnReturnExecuted);
+                if (result == ProbeNode.UNWIND_ACTION_REENTER) {
+                    continue;
+                } else if (result != null) {
+                    returnValue = result;
+                    break;
+                }
+                throw t;
+            }
+        }
+        return returnValue;
+    }
+
+    @Override
+    public Object isDefined(VirtualFrame frame, RubyLanguage language, RubyContext context) {
+        return this.delegateNode.isDefined(frame, language, context);
+    }
+
+    @Override
+    protected int getSourceCharIndex() {
+        return this.delegateNode.getSourceCharIndex();
+    }
+
+    @Override
+    protected void setSourceCharIndex(int sourceCharIndex) {
+        this.delegateNode.setSourceCharIndex(sourceCharIndex);
+    }
+
+    @Override
+    protected int getSourceLength() {
+        return this.delegateNode.getSourceLength();
+    }
+
+    @Override
+    protected void setSourceLength(int sourceLength) {
+        this.delegateNode.setSourceLength(sourceLength);
+    }
+
+    @Override
+    protected byte getFlags() {
+        return this.delegateNode.getFlags();
+    }
+
+    @Override
+    protected void setFlags(byte flags) {
+        this.delegateNode.setFlags(flags);
+    }
+
+    @Override
+    public boolean executeBoolean(VirtualFrame frame) {
+        boolean returnValue;
+        for (;;) {
+            boolean wasOnReturnExecuted = false;
+            try {
+                probeNode.onEnter(frame);
+                returnValue = ((BooleanExecute) delegateNode).executeBoolean(frame);
+                wasOnReturnExecuted = true;
+                probeNode.onReturnValue(frame, returnValue);
+                break;
+            } catch (Throwable t) {
+                Object result = probeNode.onReturnExceptionalOrUnwind(frame, t, wasOnReturnExecuted);
+                if (result == ProbeNode.UNWIND_ACTION_REENTER) {
+                    continue;
+                } else if (result != null) {
+                    returnValue = (boolean) result;
+                    break;
+                }
+                throw t;
+            }
+        }
+        return returnValue;
+    }
+
+    @Override
+    public void markAvoidedCast() {
+        ((BooleanExecute) delegateNode).markAvoidedCast();
+    }
+
+    @Override
+    public boolean didAvoidCast() {
+        return ((BooleanExecute) delegateNode).didAvoidCast();
+    }
+}

--- a/src/main/java/org/truffleruby/language/BooleanExecuteWrapper.java
+++ b/src/main/java/org/truffleruby/language/BooleanExecuteWrapper.java
@@ -12,15 +12,15 @@ import com.oracle.truffle.api.nodes.NodeCost;
 
 public final class BooleanExecuteWrapper extends RubyNode implements BooleanExecute, WrapperNode {
 
-    @Child private RubyNode delegateNode;
+    @Child private RubyBaseNode delegateNode;
     @Child private ProbeNode probeNode;
 
-    public BooleanExecuteWrapper(RubyNode delegateNode, ProbeNode probeNode) {
+    public BooleanExecuteWrapper(RubyBaseNode delegateNode, ProbeNode probeNode) {
         this.delegateNode = delegateNode;
         this.probeNode = probeNode;
     }
 
-    public RubyNode getDelegateNode() {
+    public RubyBaseNode getDelegateNode() {
         return delegateNode;
     }
 
@@ -40,7 +40,7 @@ public final class BooleanExecuteWrapper extends RubyNode implements BooleanExec
             boolean wasOnReturnExecuted = false;
             try {
                 probeNode.onEnter(frame);
-                returnValue = delegateNode.execute(frame);
+                returnValue = ((RubyNode) delegateNode).execute(frame);
                 wasOnReturnExecuted = true;
                 probeNode.onReturnValue(frame, returnValue);
                 break;
@@ -60,37 +60,37 @@ public final class BooleanExecuteWrapper extends RubyNode implements BooleanExec
 
     @Override
     public Object isDefined(VirtualFrame frame, RubyLanguage language, RubyContext context) {
-        return this.delegateNode.isDefined(frame, language, context);
+        return ((RubyNode) delegateNode).isDefined(frame, language, context);
     }
 
     @Override
     protected int getSourceCharIndex() {
-        return this.delegateNode.getSourceCharIndex();
+        return ((RubyNode) delegateNode).getSourceCharIndex();
     }
 
     @Override
     protected void setSourceCharIndex(int sourceCharIndex) {
-        this.delegateNode.setSourceCharIndex(sourceCharIndex);
+        ((RubyNode) delegateNode).setSourceCharIndex(sourceCharIndex);
     }
 
     @Override
     protected int getSourceLength() {
-        return this.delegateNode.getSourceLength();
+        return ((RubyNode) delegateNode).getSourceLength();
     }
 
     @Override
     protected void setSourceLength(int sourceLength) {
-        this.delegateNode.setSourceLength(sourceLength);
+        ((RubyNode) delegateNode).setSourceLength(sourceLength);
     }
 
     @Override
     protected byte getFlags() {
-        return this.delegateNode.getFlags();
+        return ((RubyNode) delegateNode).getFlags();
     }
 
     @Override
     protected void setFlags(byte flags) {
-        this.delegateNode.setFlags(flags);
+        ((RubyNode) delegateNode).setFlags(flags);
     }
 
     @Override

--- a/src/main/java/org/truffleruby/language/RubyNode.java
+++ b/src/main/java/org/truffleruby/language/RubyNode.java
@@ -317,4 +317,7 @@ public abstract class RubyNode extends RubyBaseNodeWithExecute implements Instru
                 method);
     }
 
+    public boolean needsBooleanCastNode() {
+        return true;
+    }
 }

--- a/src/main/java/org/truffleruby/language/control/IfElseNode.java
+++ b/src/main/java/org/truffleruby/language/control/IfElseNode.java
@@ -10,7 +10,7 @@
 package org.truffleruby.language.control;
 
 import org.truffleruby.core.cast.BooleanCastNode;
-import org.truffleruby.core.cast.BooleanCastNodeGen;
+import org.truffleruby.core.cast.BooleanExecute;
 import org.truffleruby.language.RubyContextSourceNode;
 import org.truffleruby.language.RubyNode;
 
@@ -19,19 +19,19 @@ import com.oracle.truffle.api.profiles.ConditionProfile;
 
 public class IfElseNode extends RubyContextSourceNode {
 
-    @Child private BooleanCastNode condition;
+    @Child private BooleanExecute condition;
     @Child private RubyNode thenBody;
     @Child private RubyNode elseBody;
 
     private final ConditionProfile conditionProfile = ConditionProfile.createCountingProfile();
 
     public IfElseNode(RubyNode condition, RubyNode thenBody, RubyNode elseBody) {
-        this.condition = BooleanCastNodeGen.create(condition);
+        this.condition = BooleanCastNode.createIfNeeded(condition);
         this.thenBody = thenBody;
         this.elseBody = elseBody;
     }
 
-    IfElseNode(BooleanCastNode condition, RubyNode thenBody, RubyNode elseBody) {
+    IfElseNode(BooleanExecute condition, RubyNode thenBody, RubyNode elseBody) {
         this.condition = condition;
         this.thenBody = thenBody;
         this.elseBody = elseBody;

--- a/src/main/java/org/truffleruby/language/control/IfNode.java
+++ b/src/main/java/org/truffleruby/language/control/IfNode.java
@@ -10,7 +10,7 @@
 package org.truffleruby.language.control;
 
 import org.truffleruby.core.cast.BooleanCastNode;
-import org.truffleruby.core.cast.BooleanCastNodeGen;
+import org.truffleruby.core.cast.BooleanExecute;
 import org.truffleruby.language.RubyContextSourceNode;
 import org.truffleruby.language.RubyNode;
 
@@ -19,16 +19,16 @@ import com.oracle.truffle.api.profiles.ConditionProfile;
 
 public class IfNode extends RubyContextSourceNode {
 
-    @Child private BooleanCastNode condition;
+    @Child private BooleanExecute condition;
     @Child private RubyNode thenBody;
 
     private final ConditionProfile conditionProfile = ConditionProfile.createCountingProfile();
 
     public IfNode(RubyNode condition, RubyNode thenBody) {
-        this(BooleanCastNodeGen.create(condition), thenBody);
+        this(BooleanCastNode.createIfNeeded(condition), thenBody);
     }
 
-    private IfNode(BooleanCastNode condition, RubyNode thenBody) {
+    private IfNode(BooleanExecute condition, RubyNode thenBody) {
         this.condition = condition;
         this.thenBody = thenBody;
     }


### PR DESCRIPTION
[This is more of a discussion starter, not sure this is a great idea, but wanted to put it out there]

Currently, the cast nodes are used when ever a boolean is expected, though, for a number of inlined operations, we know that they return a boolean anyway, and the cast node is redundant.

This change tags these known nodes with the new `BooleanExecute` interface (which has `executeBoolean` and some helpers, and adds a boolean field to mark the relevant nodes as having avoided inserting the cast node. This is needed to reinsert the cast node when we end up falling back to a normal ruby call.

The main benefit of this should be a minor footprint improvement.

The drawback is the added complexity, especially for instrumentation.
The normal RubyWrapper is not compatible with `BooleanExecute`/`BooleanCastNode`, and the fields in IfThen, IfElseThen for the cast nodes now become possible targets for instrumentation. With the DSL not being able to handle this case, I needed to add a manual wrapper implementation, which implements the `BooleanExecute` interface in addition to what the ruby wrapper normally does.


Performance details here: https://rebench.stefan-marr.de/compare/TruffleRuby/057d7e8897a13da3fe3beee0e718b134201c0682/38c5e4808007b7566e9531c01797bce0c3cc7fd3

There seems to be a small benefit in the interpreter, but the rest seems unaffected (or is too noisy to be sure of anything). 