### PR TITLE
Override freeze-related behaviour in RubyRange for compatibility with Ruby 3.0

### DIFF
--- a/spec/ruby/language/range_spec.rb
+++ b/spec/ruby/language/range_spec.rb
@@ -19,12 +19,38 @@ describe "Literal Ranges" do
     it "is frozen" do
       (42..).should.frozen?
     end
+
+    it "is not frozen if duplicated" do
+      (42..).dup.should_not.frozen?
+    end
   end
 
   ruby_version_is "2.7" do
     it "creates beginless ranges" do
       eval("(..1)").should == Range.new(nil, 1)
       eval("(...1)").should == Range.new(nil, 1, true)
+    end
+  end
+end
+
+describe "Object Ranges" do
+  ruby_version_is "3.0" do
+
+    it "is frozen" do
+      Range.new(1, 2).should.frozen?
+    end
+
+    it "is not frozen if duplicated" do
+      Range.new(1, 2).dup.should_not.frozen?
+    end
+
+    it "is not frozen if it is a subclass of Range" do
+      change_range = Class.new(Range).new(1, 2)
+      change_range.should_not.frozen?
+    end
+
+    it "is not frozen if it is created through allocate" do
+      Range.allocate.should_not.frozen?
     end
   end
 end

--- a/spec/tags/language/range_tags.txt
+++ b/spec/tags/language/range_tags.txt
@@ -1,1 +1,0 @@
-fails:Literal Ranges is frozen

--- a/src/main/java/org/truffleruby/core/range/RubyIntRange.java
+++ b/src/main/java/org/truffleruby/core/range/RubyIntRange.java
@@ -17,8 +17,8 @@ public final class RubyIntRange extends RubyRange {
     public final int begin;
     public final int end;
 
-    public RubyIntRange(RubyClass rubyClass, Shape shape, boolean excludedEnd, int begin, int end) {
-        super(rubyClass, shape, excludedEnd);
+    public RubyIntRange(RubyClass rubyClass, Shape shape, boolean excludedEnd, int begin, int end, boolean frozen) {
+        super(rubyClass, shape, excludedEnd, frozen);
         this.begin = begin;
         this.end = end;
     }

--- a/src/main/java/org/truffleruby/core/range/RubyLongRange.java
+++ b/src/main/java/org/truffleruby/core/range/RubyLongRange.java
@@ -17,8 +17,8 @@ public final class RubyLongRange extends RubyRange {
     public final long begin;
     public final long end;
 
-    public RubyLongRange(RubyClass rubyClass, Shape shape, boolean excludedEnd, long begin, long end) {
-        super(rubyClass, shape, excludedEnd);
+    public RubyLongRange(RubyClass rubyClass, Shape shape, boolean excludedEnd, long begin, long end, boolean frozen) {
+        super(rubyClass, shape, excludedEnd, frozen);
         this.begin = begin;
         this.end = end;
     }

--- a/src/main/java/org/truffleruby/core/range/RubyObjectRange.java
+++ b/src/main/java/org/truffleruby/core/range/RubyObjectRange.java
@@ -23,8 +23,14 @@ public final class RubyObjectRange extends RubyRange implements ObjectGraphNode 
     public Object begin;
     public Object end;
 
-    public RubyObjectRange(RubyClass rubyClass, Shape shape, boolean excludedEnd, Object begin, Object end) {
-        super(rubyClass, shape, excludedEnd);
+    public RubyObjectRange(
+            RubyClass rubyClass,
+            Shape shape,
+            boolean excludedEnd,
+            Object begin,
+            Object end,
+            boolean frozen) {
+        super(rubyClass, shape, excludedEnd, frozen);
         this.begin = begin;
         this.end = end;
     }

--- a/src/main/java/org/truffleruby/core/range/RubyRange.java
+++ b/src/main/java/org/truffleruby/core/range/RubyRange.java
@@ -9,17 +9,32 @@
  */
 package org.truffleruby.core.range;
 
+import com.oracle.truffle.api.library.ExportLibrary;
+import com.oracle.truffle.api.library.ExportMessage;
 import com.oracle.truffle.api.object.Shape;
 import org.truffleruby.core.klass.RubyClass;
 import org.truffleruby.language.RubyDynamicObject;
+import org.truffleruby.language.library.RubyLibrary;
 
+@ExportLibrary(RubyLibrary.class)
 public abstract class RubyRange extends RubyDynamicObject {
 
     public boolean excludedEnd;
+    public boolean frozen;
 
-    public RubyRange(RubyClass rubyClass, Shape shape, boolean excludedEnd) {
+    public RubyRange(RubyClass rubyClass, Shape shape, boolean excludedEnd, boolean frozen) {
         super(rubyClass, shape);
         this.excludedEnd = excludedEnd;
+        this.frozen = frozen;
     }
 
+    @ExportMessage
+    protected void freeze() {
+        frozen = true;
+    }
+
+    @ExportMessage
+    protected boolean isFrozen() {
+        return frozen;
+    }
 }


### PR DESCRIPTION
**Update**
As stated in the discussion below, this PR is now an optimization + compatibility change that modifies the behaviour of RubyRange and how it is used.

---

While working on https://github.com/oracle/truffleruby/issues/2453 and updating `Range`'s behaviour to comply with 3.0, I discovered that `RubyRange` inherits from `RubyDynamicObject`, which exports `freeze` and `isFrozen` methods that dynamically set the `frozen?` property on the object.  

![image](https://user-images.githubusercontent.com/19317416/149010861-22c36cea-f6ca-4df0-a475-3078ae03963d.png)


This proposed change implements the same pattern as seen in `RubyString`, which exposes a `frozen` parameter in the constructor and overrides the `freeze` and `isFrozen` methods to explicitly work on the `boolean frozen` field. By doing so, the field is always present on the object and can default to `true`, rather than needing to be instantiated as a dynamic property. This also allows us to set the property at the appropriate call sites (i.e. to `false` when creating an object in Ruby that inherits from `Range`).