### PR TITLE
Unwrap ropes in StringEqualNode to avoid need for StringAreComparableNode

### DIFF
--- a/src/main/java/org/truffleruby/core/inlined/InlinedEqualNode.java
+++ b/src/main/java/org/truffleruby/core/inlined/InlinedEqualNode.java
@@ -71,7 +71,7 @@ public abstract class InlinedEqualNode extends BinaryInlinedOperationNode {
             @CachedLibrary(limit = "LIBSTRING_CACHE") RubyStringLibrary stringsB,
             @Cached LookupMethodOnSelfNode lookupNode,
             @Cached StringNodes.StringEqualNode stringEqualNode) {
-        return stringEqualNode.executeStringEqual(self, b);
+        return stringEqualNode.executeStringEqual(stringsSelf.getRope(self), stringsB.getRope(b));
     }
 
     @Specialization


### PR DESCRIPTION
StringAreComparableNode doesn't really do anything but getting the ropes out of strings, which is something `StringEqualNode` already does, too.

So, this PR removes the now redundant node.
~It also uses `@Bind` to reduce the number of getRope() calls per specialization.~
It also makes `StringEqualNode` require Rope objects, which reduces the number of used `RubyStringLibrary` objects further. 