### PR TITLE
Truffle::Debug.foreign_identity_function

### DIFF
--- a/src/main/java/org/truffleruby/debug/TruffleDebugNodes.java
+++ b/src/main/java/org/truffleruby/debug/TruffleDebugNodes.java
@@ -1166,4 +1166,27 @@ public abstract class TruffleDebugNodes {
         }
     }
 
+    @CoreMethod(names = "foreign_identity_function", onSingleton = true)
+    @ImportStatic(ArrayGuards.class)
+    public abstract static class ForeignIdentityFunctionNode extends CoreMethodArrayArgumentsNode {
+        @ExportLibrary(InteropLibrary.class)
+        public static class ForeignIdentityFunction implements TruffleObject {
+            @ExportMessage
+            protected final boolean isExecutable() {
+                return true;
+            }
+
+            @ExportMessage
+            protected final Object execute(Object[] args) {
+                return args[0];
+            }
+        }
+
+        @TruffleBoundary
+        @Specialization
+        protected Object foreignIdentityFunction() {
+            return new ForeignIdentityFunction();
+        }
+    }
+
 }

--- a/src/main/java/org/truffleruby/debug/TruffleDebugNodes.java
+++ b/src/main/java/org/truffleruby/debug/TruffleDebugNodes.java
@@ -960,6 +960,28 @@ public abstract class TruffleDebugNodes {
         }
     }
 
+    @CoreMethod(names = "foreign_identity_function", onSingleton = true)
+    public abstract static class ForeignIdentityFunctionNode extends CoreMethodArrayArgumentsNode {
+        @ExportLibrary(InteropLibrary.class)
+        public static class ForeignIdentityFunction implements TruffleObject {
+            @ExportMessage
+            protected final boolean isExecutable() {
+                return true;
+            }
+
+            @ExportMessage
+            protected final Object execute(Object[] args) {
+                return args[0];
+            }
+        }
+
+        @TruffleBoundary
+        @Specialization
+        protected Object foreignIdentityFunction() {
+            return new ForeignIdentityFunction();
+        }
+    }
+
     @CoreMethod(names = "foreign_string", onSingleton = true, required = 1)
     public abstract static class ForeignStringNode extends CoreMethodArrayArgumentsNode {
         @ExportLibrary(InteropLibrary.class)
@@ -1163,29 +1185,6 @@ public abstract class TruffleDebugNodes {
             Runnable runnable = (Runnable) getContext().getEnv().asHostObject(hostRunnable);
             final Thread thread = getContext().getEnv().createThread(runnable);
             return getContext().getEnv().asGuestValue(thread);
-        }
-    }
-
-    @CoreMethod(names = "foreign_identity_function", onSingleton = true)
-    @ImportStatic(ArrayGuards.class)
-    public abstract static class ForeignIdentityFunctionNode extends CoreMethodArrayArgumentsNode {
-        @ExportLibrary(InteropLibrary.class)
-        public static class ForeignIdentityFunction implements TruffleObject {
-            @ExportMessage
-            protected final boolean isExecutable() {
-                return true;
-            }
-
-            @ExportMessage
-            protected final Object execute(Object[] args) {
-                return args[0];
-            }
-        }
-
-        @TruffleBoundary
-        @Specialization
-        protected Object foreignIdentityFunction() {
-            return new ForeignIdentityFunction();
         }
     }
 


### PR DESCRIPTION
This debug method returns a foreign identity function. This is useful for various debugging and specification applications.