### PR TITLE
Add additional specs for #ruby2_keywords

### DIFF
--- a/spec/ruby/core/module/ruby2_keywords_spec.rb
+++ b/spec/ruby/core/module/ruby2_keywords_spec.rb
@@ -15,6 +15,32 @@ ruby_version_is "2.7" do
       Hash.ruby2_keywords_hash?(last).should == true
     end
 
+    it "applies to the underlying method and applies across aliasing" do
+      obj = Object.new
+
+      obj.singleton_class.class_exec do
+        def foo(*a) a.last end
+        alias_method :bar, :foo
+        ruby2_keywords :foo
+
+        def baz(*a) a.last end
+        ruby2_keywords :baz
+        alias_method :bob, :baz
+      end
+
+      last = obj.foo(1, 2, a: "a")
+      Hash.ruby2_keywords_hash?(last).should == true
+
+      last = obj.bar(1, 2, a: "a")
+      Hash.ruby2_keywords_hash?(last).should == true
+
+      last = obj.baz(1, 2, a: "a")
+      Hash.ruby2_keywords_hash?(last).should == true
+
+      last = obj.bob(1, 2, a: "a")
+      Hash.ruby2_keywords_hash?(last).should == true
+    end
+
     ruby_version_is "2.7" ... "3.0" do
       it "fixes delegation warnings when calling a method accepting keywords" do
         obj = Object.new

--- a/spec/ruby/core/proc/ruby2_keywords_spec.rb
+++ b/spec/ruby/core/proc/ruby2_keywords_spec.rb
@@ -10,6 +10,22 @@ ruby_version_is "2.7" do
       Hash.ruby2_keywords_hash?(last).should == true
     end
 
+    it "applies to the underlying method and applies across duplication" do
+      f1 = -> *a { a.last }
+      f1.ruby2_keywords
+      f2 = f1.dup
+
+      Hash.ruby2_keywords_hash?(f1.call(1, 2, a: "a")).should == true
+      Hash.ruby2_keywords_hash?(f2.call(1, 2, a: "a")).should == true
+
+      f3 = -> *a { a.last }
+      f4 = f3.dup
+      f3.ruby2_keywords
+
+      Hash.ruby2_keywords_hash?(f3.call(1, 2, a: "a")).should == true
+      Hash.ruby2_keywords_hash?(f4.call(1, 2, a: "a")).should == true
+    end
+
     ruby_version_is "2.7" ... "3.0" do
       it "fixes delegation warnings when calling a method accepting keywords" do
         obj = Object.new

--- a/spec/tags/core/module/ruby2_keywords_tags.txt
+++ b/spec/tags/core/module/ruby2_keywords_tags.txt
@@ -1,3 +1,3 @@
 fails:Module#ruby2_keywords marks the final hash argument as keyword hash
-fails:Module#ruby2_keywords fixes delegation warnings when calling a method accepting keywords
+fails:Module#ruby2_keywords applies to the underlying method and applies across aliasing
 fails:Module#ruby2_keywords acceps String as well

--- a/spec/tags/core/proc/ruby2_keywords_tags.txt
+++ b/spec/tags/core/proc/ruby2_keywords_tags.txt
@@ -1,3 +1,2 @@
 fails:Proc#ruby2_keywords marks the final hash argument as keyword hash
-fails:Proc#ruby2_keywords fixes delegation warnings when calling a method accepting keywords
-fails:Proc#ruby2_keywords fixes delegation warnings when calling a proc accepting keywords
+fails:Proc#ruby2_keywords applies to the underlying method and applies across duplication


### PR DESCRIPTION
These specs explore whether the `ruby2_keywords` annotation applies to a Ruby-level object or the underlying VM object.

Co-authored with @wildmaples.