### PR TITLE
Mark keyword argument hashes in the parser

### DIFF
--- a/src/main/java/org/truffleruby/Layouts.java
+++ b/src/main/java/org/truffleruby/Layouts.java
@@ -11,7 +11,6 @@ package org.truffleruby;
 
 import com.oracle.truffle.api.object.HiddenKey;
 
-import org.truffleruby.parser.TranslatorEnvironment;
 
 public abstract class Layouts {
 

--- a/src/main/java/org/truffleruby/Layouts.java
+++ b/src/main/java/org/truffleruby/Layouts.java
@@ -11,7 +11,6 @@ package org.truffleruby;
 
 import com.oracle.truffle.api.object.HiddenKey;
 
-
 public abstract class Layouts {
 
     // Standard identifiers

--- a/src/main/java/org/truffleruby/Layouts.java
+++ b/src/main/java/org/truffleruby/Layouts.java
@@ -28,6 +28,6 @@ public abstract class Layouts {
 
     // Frame slot name for special variable storage.
 
-    public static final String SPECIAL_VARIABLES_STORAGE = TranslatorEnvironment.TEMP_PREFIX + "$~_";
+    public static final String SPECIAL_VARIABLES_STORAGE = "%$~_";
 
 }

--- a/src/main/java/org/truffleruby/Layouts.java
+++ b/src/main/java/org/truffleruby/Layouts.java
@@ -16,6 +16,7 @@ public abstract class Layouts {
     // Special variables
 
     public static final String TEMP_PREFIX = "%";
+    public static final char TEMP_PREFIX_CHAR = TEMP_PREFIX.charAt(0);
 
     // Standard identifiers
 

--- a/src/main/java/org/truffleruby/Layouts.java
+++ b/src/main/java/org/truffleruby/Layouts.java
@@ -13,6 +13,10 @@ import com.oracle.truffle.api.object.HiddenKey;
 
 public abstract class Layouts {
 
+    // Special variables
+
+    public static final String TEMP_PREFIX = "%";
+
     // Standard identifiers
 
     public static final HiddenKey OBJECT_ID_IDENTIFIER = new HiddenKey("object_id"); // long
@@ -26,6 +30,6 @@ public abstract class Layouts {
 
     // Frame slot name for special variable storage.
 
-    public static final String SPECIAL_VARIABLES_STORAGE = "%$~_";
+    public static final String SPECIAL_VARIABLES_STORAGE = TEMP_PREFIX + "$~_";
 
 }

--- a/src/main/java/org/truffleruby/core/binding/BindingNodes.java
+++ b/src/main/java/org/truffleruby/core/binding/BindingNodes.java
@@ -48,7 +48,6 @@ import org.truffleruby.language.locals.FindDeclarationVariableNodes.FindAndReadD
 import org.truffleruby.language.locals.FindDeclarationVariableNodes.FrameSlotAndDepth;
 import org.truffleruby.language.locals.WriteFrameSlotNode;
 import org.truffleruby.language.locals.WriteFrameSlotNodeGen;
-import org.truffleruby.parser.TranslatorEnvironment;
 
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.Truffle;

--- a/src/main/java/org/truffleruby/core/binding/BindingNodes.java
+++ b/src/main/java/org/truffleruby/core/binding/BindingNodes.java
@@ -18,6 +18,7 @@ import com.oracle.truffle.api.dsl.GenerateNodeFactory;
 import com.oracle.truffle.api.dsl.GenerateUncached;
 import com.oracle.truffle.api.frame.FrameInstance.FrameAccess;
 import com.oracle.truffle.api.profiles.ConditionProfile;
+import org.truffleruby.Layouts;
 import org.truffleruby.RubyContext;
 import org.truffleruby.RubyLanguage;
 import org.truffleruby.builtins.CoreMethod;
@@ -146,7 +147,7 @@ public abstract class BindingNodes {
     private static boolean isHiddenVariable(String name) {
         assert !name.isEmpty();
         return name.charAt(0) == '$' || // Frame-local global variable
-                name.charAt(0) == '%';
+                name.charAt(0) == Layouts.TEMP_PREFIX_CHAR;
     }
 
     @CoreMethod(names = { "dup", "clone" })

--- a/src/main/java/org/truffleruby/core/binding/BindingNodes.java
+++ b/src/main/java/org/truffleruby/core/binding/BindingNodes.java
@@ -147,7 +147,7 @@ public abstract class BindingNodes {
     private static boolean isHiddenVariable(String name) {
         assert !name.isEmpty();
         return name.charAt(0) == '$' || // Frame-local global variable
-                name.charAt(0) == TranslatorEnvironment.TEMP_PREFIX;
+                name.charAt(0) == '%';
     }
 
     @CoreMethod(names = { "dup", "clone" })

--- a/src/main/java/org/truffleruby/parser/TranslatorEnvironment.java
+++ b/src/main/java/org/truffleruby/parser/TranslatorEnvironment.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.truffleruby.Layouts;
 import org.truffleruby.language.LexicalScope;
 import org.truffleruby.language.Nil;
 import org.truffleruby.language.RubyNode;
@@ -31,7 +32,7 @@ import com.oracle.truffle.api.frame.FrameSlot;
 
 public class TranslatorEnvironment {
 
-    public static final String METHOD_BLOCK_NAME = "%__method_block_arg__";
+    public static final String METHOD_BLOCK_NAME = Layouts.TEMP_PREFIX + "method_block_arg";
 
     private final ParseEnvironment parseEnvironment;
 
@@ -180,7 +181,7 @@ public class TranslatorEnvironment {
     }
 
     public String allocateLocalTemp(String indicator) {
-        final String name = "%" + indicator + "_" + tempIndex.getAndIncrement();
+        final String name = Layouts.TEMP_PREFIX + indicator + "_" + tempIndex.getAndIncrement();
         declareVar(name);
         return name;
     }

--- a/src/main/java/org/truffleruby/parser/TranslatorEnvironment.java
+++ b/src/main/java/org/truffleruby/parser/TranslatorEnvironment.java
@@ -28,7 +28,6 @@ import org.truffleruby.language.methods.SharedMethodInfo;
 
 import com.oracle.truffle.api.frame.FrameDescriptor;
 import com.oracle.truffle.api.frame.FrameSlot;
-import org.truffleruby.parser.parser.ParserSupport;
 
 public class TranslatorEnvironment {
 

--- a/src/main/java/org/truffleruby/parser/TranslatorEnvironment.java
+++ b/src/main/java/org/truffleruby/parser/TranslatorEnvironment.java
@@ -32,8 +32,7 @@ import org.truffleruby.parser.parser.ParserSupport;
 
 public class TranslatorEnvironment {
 
-    public static final char TEMP_PREFIX = ParserSupport.TEMP_PREFIX;
-    public static final String METHOD_BLOCK_NAME = TEMP_PREFIX + "__method_block_arg__";
+    public static final String METHOD_BLOCK_NAME = "%__method_block_arg__";
 
     private final ParseEnvironment parseEnvironment;
 
@@ -182,7 +181,7 @@ public class TranslatorEnvironment {
     }
 
     public String allocateLocalTemp(String indicator) {
-        final String name = TEMP_PREFIX + indicator + "_" + tempIndex.getAndIncrement();
+        final String name = "%" + indicator + "_" + tempIndex.getAndIncrement();
         declareVar(name);
         return name;
     }

--- a/src/main/java/org/truffleruby/parser/ast/HashParseNode.java
+++ b/src/main/java/org/truffleruby/parser/ast/HashParseNode.java
@@ -44,7 +44,7 @@ import org.truffleruby.parser.parser.ParseNodeTuple;
 public class HashParseNode extends ParseNode implements ILiteralNode {
     private final List<ParseNodeTuple> pairs;
 
-    /** Does this hash parse node represent formal keyword arguments? */
+    /** Does this hash parse node represent keyword arguments? */
     private boolean keywordArguments = false;
 
     public HashParseNode(SourceIndexLength position) {

--- a/src/main/java/org/truffleruby/parser/ast/HashParseNode.java
+++ b/src/main/java/org/truffleruby/parser/ast/HashParseNode.java
@@ -44,6 +44,9 @@ import org.truffleruby.parser.parser.ParseNodeTuple;
 public class HashParseNode extends ParseNode implements ILiteralNode {
     private final List<ParseNodeTuple> pairs;
 
+    /** Does this hash parse node represent formal keyword arguments? */
+    private boolean keywordArguments = false;
+
     public HashParseNode(SourceIndexLength position) {
         super(position);
 
@@ -93,5 +96,13 @@ public class HashParseNode extends ParseNode implements ILiteralNode {
         }
 
         return children;
+    }
+
+    public boolean isKeywordArguments() {
+        return keywordArguments;
+    }
+
+    public void setKeywordArguments(boolean keywordArguments) {
+        this.keywordArguments = keywordArguments;
     }
 }

--- a/src/main/java/org/truffleruby/parser/parser/ParserSupport.java
+++ b/src/main/java/org/truffleruby/parser/parser/ParserSupport.java
@@ -152,8 +152,6 @@ import org.truffleruby.parser.scope.StaticScope;
 
 public class ParserSupport {
 
-    public static final String UNNAMED_REST_VAR = "%unnamed_rest";
-    public static final String ANONYMOUS_REST_VAR = "%anon_rest";
     public static final String FORWARD_ARGS_REST_VAR = "%forward_rest";
     public static final String FORWARD_ARGS_BLOCK_VAR = "%forward_block";
 

--- a/src/main/java/org/truffleruby/parser/parser/ParserSupport.java
+++ b/src/main/java/org/truffleruby/parser/parser/ParserSupport.java
@@ -152,7 +152,10 @@ import org.truffleruby.parser.scope.StaticScope;
 
 public class ParserSupport {
 
+    /** The local variable to store ... arguments in */
     public static final String FORWARD_ARGS_REST_VAR = "%forward_rest";
+
+    /** The local variable to store the block from ... in */
     public static final String FORWARD_ARGS_BLOCK_VAR = "%forward_block";
 
     // Parser states:

--- a/src/main/java/org/truffleruby/parser/parser/ParserSupport.java
+++ b/src/main/java/org/truffleruby/parser/parser/ParserSupport.java
@@ -47,6 +47,7 @@ import org.jcodings.specific.EUCJPEncoding;
 import org.jcodings.specific.SJISEncoding;
 import org.jcodings.specific.USASCIIEncoding;
 import org.jcodings.specific.UTF8Encoding;
+import org.truffleruby.Layouts;
 import org.truffleruby.RubyLanguage;
 import org.truffleruby.SuppressFBWarnings;
 import org.truffleruby.core.encoding.EncodingManager;
@@ -153,10 +154,10 @@ import org.truffleruby.parser.scope.StaticScope;
 public class ParserSupport {
 
     /** The local variable to store ... arguments in */
-    public static final String FORWARD_ARGS_REST_VAR = "%forward_rest";
+    public static final String FORWARD_ARGS_REST_VAR = Layouts.TEMP_PREFIX + "forward_rest";
 
     /** The local variable to store the block from ... in */
-    public static final String FORWARD_ARGS_BLOCK_VAR = "%forward_block";
+    public static final String FORWARD_ARGS_BLOCK_VAR = Layouts.TEMP_PREFIX + "forward_block";
 
     // Parser states:
     protected StaticScope currentScope;
@@ -1438,7 +1439,7 @@ public class ParserSupport {
 
         final String restKwargsName;
         if (keywordRestArgNameRope.isEmpty()) {
-            restKwargsName = "%kwrest";
+            restKwargsName = Layouts.TEMP_PREFIX + "kwrest";
         } else {
             restKwargsName = keywordRestArgNameRope.getJavaString().intern();
         }

--- a/src/main/java/org/truffleruby/parser/parser/ParserSupport.java
+++ b/src/main/java/org/truffleruby/parser/parser/ParserSupport.java
@@ -152,16 +152,10 @@ import org.truffleruby.parser.scope.StaticScope;
 
 public class ParserSupport {
 
-    public static final char TEMP_PREFIX = '%';
-
-    public static final String UNNAMED_REST_VAR = prefixName("unnamed_rest");
-    public static final String ANONYMOUS_REST_VAR = prefixName("anon_rest");
-    public static final String FORWARD_ARGS_REST_VAR = prefixName("forward_rest");
-    public static final String FORWARD_ARGS_BLOCK_VAR = prefixName("forward_block");
-
-    private static String prefixName(String name) {
-        return (TEMP_PREFIX + name).intern();
-    }
+    public static final String UNNAMED_REST_VAR = "%unnamed_rest";
+    public static final String ANONYMOUS_REST_VAR = "%anon_rest";
+    public static final String FORWARD_ARGS_REST_VAR = "%forward_rest";
+    public static final String FORWARD_ARGS_BLOCK_VAR = "%forward_block";
 
     // Parser states:
     protected StaticScope currentScope;
@@ -1443,7 +1437,7 @@ public class ParserSupport {
 
         final String restKwargsName;
         if (keywordRestArgNameRope.isEmpty()) {
-            restKwargsName = TEMP_PREFIX + "_kwrest";
+            restKwargsName = "%kwrest";
         } else {
             restKwargsName = keywordRestArgNameRope.getJavaString().intern();
         }

--- a/src/main/java/org/truffleruby/parser/parser/RubyParser.java
+++ b/src/main/java/org/truffleruby/parser/parser/RubyParser.java
@@ -2253,10 +2253,12 @@ states[270] = (support, lexer, yyVal, yyVals, yyTop) -> {
     return yyVal;
 };
 states[271] = (support, lexer, yyVal, yyVals, yyTop) -> {
+    ((HashParseNode)yyVals[-1+yyTop]).setKeywordArguments(true);
     yyVal = support.arg_append(((ParseNode)yyVals[-3+yyTop]), support.remove_duplicate_keys(((HashParseNode)yyVals[-1+yyTop])));
     return yyVal;
 };
 states[272] = (support, lexer, yyVal, yyVals, yyTop) -> {
+    ((HashParseNode)yyVals[-1+yyTop]).setKeywordArguments(true);
     yyVal = support.newArrayNode(((HashParseNode)yyVals[-1+yyTop]).getPosition(), support.remove_duplicate_keys(((HashParseNode)yyVals[-1+yyTop])));
     return yyVal;
 };
@@ -2297,10 +2299,12 @@ states[282] = (support, lexer, yyVal, yyVals, yyTop) -> {
     return yyVal;
 };
 states[283] = (support, lexer, yyVal, yyVals, yyTop) -> {
+    ((HashParseNode)yyVals[-1+yyTop]).setKeywordArguments(true);
     yyVal = support.arg_append(((ParseNode)yyVals[-3+yyTop]), support.remove_duplicate_keys(((HashParseNode)yyVals[-1+yyTop])));
     return yyVal;
 };
 states[284] = (support, lexer, yyVal, yyVals, yyTop) -> {
+    ((HashParseNode)yyVals[-1+yyTop]).setKeywordArguments(true);
     yyVal = support.newArrayNode(((HashParseNode)yyVals[-1+yyTop]).getPosition(), support.remove_duplicate_keys(((HashParseNode)yyVals[-1+yyTop])));
     return yyVal;
 };
@@ -2314,11 +2318,13 @@ states[286] = (support, lexer, yyVal, yyVals, yyTop) -> {
     return yyVal;
 };
 states[287] = (support, lexer, yyVal, yyVals, yyTop) -> {
+    ((HashParseNode)yyVals[-1+yyTop]).setKeywordArguments(true);
     yyVal = support.newArrayNode(((HashParseNode)yyVals[-1+yyTop]).getPosition(), support.remove_duplicate_keys(((HashParseNode)yyVals[-1+yyTop])));
     yyVal = support.arg_blk_pass((ParseNode)yyVal, ((BlockPassParseNode)yyVals[0+yyTop]));
     return yyVal;
 };
 states[288] = (support, lexer, yyVal, yyVals, yyTop) -> {
+    ((HashParseNode)yyVals[-1+yyTop]).setKeywordArguments(true);
     yyVal = support.arg_append(((ParseNode)yyVals[-3+yyTop]), support.remove_duplicate_keys(((HashParseNode)yyVals[-1+yyTop])));
     yyVal = support.arg_blk_pass((ParseNode)yyVal, ((BlockPassParseNode)yyVals[0+yyTop]));
     return yyVal;
@@ -3970,7 +3976,7 @@ states[671] = (support, lexer, yyVal, yyVals, yyTop) -> {
     return yyVal;
 };
 }
-// line 2819 "RubyParser.y"
+// line 2825 "RubyParser.y"
 
     /** The parse method use an lexer stream and parse it to an AST node 
      * structure
@@ -3987,4 +3993,4 @@ states[671] = (support, lexer, yyVal, yyVals, yyTop) -> {
 }
 // CheckStyle: stop generated
 // @formatter:on
-// line 10872 "-"
+// line 10878 "-"

--- a/src/main/java/org/truffleruby/parser/parser/RubyParser.java
+++ b/src/main/java/org/truffleruby/parser/parser/RubyParser.java
@@ -2828,7 +2828,7 @@ states[407] = (support, lexer, yyVal, yyVals, yyTop) -> {
     return yyVal;
 };
 states[408] = (support, lexer, yyVal, yyVals, yyTop) -> {
-    RestArgParseNode rest = new UnnamedRestArgParseNode(((ListParseNode)yyVals[-1+yyTop]).getPosition(), ParserSupport.ANONYMOUS_REST_VAR, support.getCurrentScope().addVariable("*"), false);
+    RestArgParseNode rest = new UnnamedRestArgParseNode(((ListParseNode)yyVals[-1+yyTop]).getPosition(), "%anonymous_rest", support.getCurrentScope().addVariable("*"), false);
     yyVal = support.new_args(((ListParseNode)yyVals[-1+yyTop]).getPosition(), ((ListParseNode)yyVals[-1+yyTop]), null, rest, null, (ArgsTailHolder) null);
     return yyVal;
 };
@@ -3805,7 +3805,7 @@ states[623] = (support, lexer, yyVal, yyVals, yyTop) -> {
 };
 states[624] = (support, lexer, yyVal, yyVals, yyTop) -> {
   /* FIXME: bytelist_love: somewhat silly to remake the empty bytelist over and over but this type should change (using null vs "" is a strange distinction).*/
-  yyVal = new UnnamedRestArgParseNode(lexer.getPosition(), ParserSupport.UNNAMED_REST_VAR, support.getCurrentScope().addVariable("*"), true);
+  yyVal = new UnnamedRestArgParseNode(lexer.getPosition(), "%unnamed_rest", support.getCurrentScope().addVariable("*"), true);
     return yyVal;
 };
 states[625] = (support, lexer, yyVal, yyVals, yyTop) -> {

--- a/src/main/java/org/truffleruby/parser/parser/RubyParser.java
+++ b/src/main/java/org/truffleruby/parser/parser/RubyParser.java
@@ -42,6 +42,7 @@ package org.truffleruby.parser.parser;
 
 import org.jcodings.Encoding;
 import org.jcodings.specific.UTF8Encoding;
+import org.truffleruby.Layouts;
 import org.truffleruby.SuppressFBWarnings;
 import org.truffleruby.core.rope.CodeRange;
 import org.truffleruby.core.rope.Rope;
@@ -158,7 +159,7 @@ public class RubyParser {
         this.lexer = new RubyLexer(support, source, warnings);
         support.setLexer(lexer);
     }
-// line 126 "-"
+// line 127 "-"
   // %token constants
   public static final int keyword_class = 257;
   public static final int keyword_module = 258;
@@ -2834,7 +2835,7 @@ states[407] = (support, lexer, yyVal, yyVals, yyTop) -> {
     return yyVal;
 };
 states[408] = (support, lexer, yyVal, yyVals, yyTop) -> {
-    RestArgParseNode rest = new UnnamedRestArgParseNode(((ListParseNode)yyVals[-1+yyTop]).getPosition(), "%anonymous_rest", support.getCurrentScope().addVariable("*"), false);
+    RestArgParseNode rest = new UnnamedRestArgParseNode(((ListParseNode)yyVals[-1+yyTop]).getPosition(), Layouts.TEMP_PREFIX + "anonymous_rest", support.getCurrentScope().addVariable("*"), false);
     yyVal = support.new_args(((ListParseNode)yyVals[-1+yyTop]).getPosition(), ((ListParseNode)yyVals[-1+yyTop]), null, rest, null, (ArgsTailHolder) null);
     return yyVal;
 };
@@ -3811,7 +3812,7 @@ states[623] = (support, lexer, yyVal, yyVals, yyTop) -> {
 };
 states[624] = (support, lexer, yyVal, yyVals, yyTop) -> {
   /* FIXME: bytelist_love: somewhat silly to remake the empty bytelist over and over but this type should change (using null vs "" is a strange distinction).*/
-  yyVal = new UnnamedRestArgParseNode(lexer.getPosition(), "%unnamed_rest", support.getCurrentScope().addVariable("*"), true);
+  yyVal = new UnnamedRestArgParseNode(lexer.getPosition(), Layouts.TEMP_PREFIX + "unnamed_rest", support.getCurrentScope().addVariable("*"), true);
     return yyVal;
 };
 states[625] = (support, lexer, yyVal, yyVals, yyTop) -> {
@@ -3976,7 +3977,7 @@ states[671] = (support, lexer, yyVal, yyVals, yyTop) -> {
     return yyVal;
 };
 }
-// line 2825 "RubyParser.y"
+// line 2826 "RubyParser.y"
 
     /** The parse method use an lexer stream and parse it to an AST node 
      * structure
@@ -3993,4 +3994,4 @@ states[671] = (support, lexer, yyVal, yyVals, yyTop) -> {
 }
 // CheckStyle: stop generated
 // @formatter:on
-// line 10878 "-"
+// line 10879 "-"

--- a/src/main/java/org/truffleruby/parser/parser/RubyParser.y
+++ b/src/main/java/org/truffleruby/parser/parser/RubyParser.y
@@ -3,6 +3,7 @@ package org.truffleruby.parser.parser;
 
 import org.jcodings.Encoding;
 import org.jcodings.specific.UTF8Encoding;
+import org.truffleruby.Layouts;
 import org.truffleruby.SuppressFBWarnings;
 import org.truffleruby.core.rope.CodeRange;
 import org.truffleruby.core.rope.Rope;
@@ -1799,7 +1800,7 @@ block_param     : f_arg ',' f_block_optarg ',' f_rest_arg opt_block_args_tail {
                     $$ = support.new_args($1.getPosition(), $1, null, $3, null, $4);
                 }
                 | f_arg ',' {
-                    RestArgParseNode rest = new UnnamedRestArgParseNode($1.getPosition(), "%anonymous_rest", support.getCurrentScope().addVariable("*"), false);
+                    RestArgParseNode rest = new UnnamedRestArgParseNode($1.getPosition(), Layouts.TEMP_PREFIX + "anonymous_rest", support.getCurrentScope().addVariable("*"), false);
                     $$ = support.new_args($1.getPosition(), $1, null, rest, null, (ArgsTailHolder) null);
                 }
                 | f_arg ',' f_rest_arg ',' f_arg opt_block_args_tail {
@@ -2663,7 +2664,7 @@ f_rest_arg      : restarg_mark tIDENTIFIER {
                 }
                 | restarg_mark {
   // FIXME: bytelist_love: somewhat silly to remake the empty bytelist over and over but this type should change (using null vs "" is a strange distinction).
-  $$ = new UnnamedRestArgParseNode(lexer.getPosition(), "%unnamed_rest", support.getCurrentScope().addVariable("*"), true);
+  $$ = new UnnamedRestArgParseNode(lexer.getPosition(), Layouts.TEMP_PREFIX + "unnamed_rest", support.getCurrentScope().addVariable("*"), true);
                 }
 
 // [!null]

--- a/src/main/java/org/truffleruby/parser/parser/RubyParser.y
+++ b/src/main/java/org/truffleruby/parser/parser/RubyParser.y
@@ -1793,7 +1793,7 @@ block_param     : f_arg ',' f_block_optarg ',' f_rest_arg opt_block_args_tail {
                     $$ = support.new_args($1.getPosition(), $1, null, $3, null, $4);
                 }
                 | f_arg ',' {
-                    RestArgParseNode rest = new UnnamedRestArgParseNode($1.getPosition(), ParserSupport.ANONYMOUS_REST_VAR, support.getCurrentScope().addVariable("*"), false);
+                    RestArgParseNode rest = new UnnamedRestArgParseNode($1.getPosition(), "%anonymous_rest", support.getCurrentScope().addVariable("*"), false);
                     $$ = support.new_args($1.getPosition(), $1, null, rest, null, (ArgsTailHolder) null);
                 }
                 | f_arg ',' f_rest_arg ',' f_arg opt_block_args_tail {
@@ -2657,7 +2657,7 @@ f_rest_arg      : restarg_mark tIDENTIFIER {
                 }
                 | restarg_mark {
   // FIXME: bytelist_love: somewhat silly to remake the empty bytelist over and over but this type should change (using null vs "" is a strange distinction).
-  $$ = new UnnamedRestArgParseNode(lexer.getPosition(), ParserSupport.UNNAMED_REST_VAR, support.getCurrentScope().addVariable("*"), true);
+  $$ = new UnnamedRestArgParseNode(lexer.getPosition(), "%unnamed_rest", support.getCurrentScope().addVariable("*"), true);
                 }
 
 // [!null]

--- a/src/main/java/org/truffleruby/parser/parser/RubyParser.y
+++ b/src/main/java/org/truffleruby/parser/parser/RubyParser.y
@@ -1291,9 +1291,11 @@ aref_args       : none
                     $$ = $1;
                 }
                 | args ',' assocs trailer {
+                    $3.setKeywordArguments(true);
                     $$ = support.arg_append($1, support.remove_duplicate_keys($3));
                 }
                 | assocs trailer {
+                    $1.setKeywordArguments(true);
                     $$ = support.newArrayNode($1.getPosition(), support.remove_duplicate_keys($1));
                 }
 
@@ -1334,9 +1336,11 @@ opt_call_args   : none
                     $$ = $1;
                 }
                 | args ',' assocs ',' {
+                    $3.setKeywordArguments(true);
                     $$ = support.arg_append($1, support.remove_duplicate_keys($3));
                 }
                 | assocs ',' {
+                    $1.setKeywordArguments(true);
                     $$ = support.newArrayNode($1.getPosition(), support.remove_duplicate_keys($1));
                 }
    
@@ -1350,10 +1354,12 @@ call_args       : command {
                     $$ = support.arg_blk_pass($1, $2);
                 }
                 | assocs opt_block_arg {
+                    $1.setKeywordArguments(true);
                     $$ = support.newArrayNode($1.getPosition(), support.remove_duplicate_keys($1));
                     $$ = support.arg_blk_pass((ParseNode)$$, $2);
                 }
                 | args ',' assocs opt_block_arg {
+                    $3.setKeywordArguments(true);
                     $$ = support.arg_append($1, support.remove_duplicate_keys($3));
                     $$ = support.arg_blk_pass((ParseNode)$$, $4);
                 }


### PR DESCRIPTION
Needed for Ruby 3 compatibility, but not used yet.

Also tidied up some parser things that were unnecessarily complicated.