### PR TITLE
Fix crash caused by mutating an array within the .each call block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Compatibility:
 * Follow symlinks when processing `*/` directory glob patterns. (#2589, @aardvark179).
 * Set `@gem_prelude_index` variable on the default load paths (#2586 , @bjfish)
 * Do not call `IO#flush` dynamically from `IO#close` (#2594, @gogainda).
+* Rewrote `ArrayEachIteratorNode` and re-introduced `each` specs for MRI parity when mutating arrays whilst iterating, rather than crashing (#2587, @MattAlp)
 
 Performance:
 
@@ -35,6 +36,7 @@ Performance:
 * Removed extra array allocations for method calls in the interpreter to improve warmup performance (@aardvark179).
 * Optimize `Dir[]` by sorting entries as they are found and grouping syscalls (#2092, @aardvark179).
 * Reduce memory footprint by tracking `VALUE`s created during C extension init separately (@aardvark179).
+* Rewrote `ArrayEachIteratorNode` to optimize performance for a constant-sized array and reduce specializations to 1 general case (#2587, @MattAlp)
 
 Changes:
 

--- a/spec/ruby/core/array/each_spec.rb
+++ b/spec/ruby/core/array/each_spec.rb
@@ -5,7 +5,7 @@ require_relative '../enumerable/shared/enumeratorized'
 
 # Mutating the array while it is being iterated is discouraged as it can result in confusing behavior.
 # Yet a Ruby implementation must not crash in such a case, and following the simple CRuby behavior makes sense.
-# CRuby simply reads the array storage and check the size for every iteration;
+# CRuby simply reads the array storage and checks the size for every iteration;
 # like `i = 0; while i < size; yield self[i]; end`
 
 describe "Array#each" do
@@ -18,23 +18,23 @@ describe "Array#each" do
 
   it "yields each element to the block even if the array is changed during iteration" do
     a = [1, 2, 3, 4, 5]
-    b = []
-    a.each {|x| b << x; a << x+5 if (x%2).zero? }
-    b.should == [1, 2, 3, 4, 5, 7, 9]
+    iterated = []
+    a.each { |x| iterated << x; a << x+5 if x.even? }
+    iterated.should == [1, 2, 3, 4, 5, 7, 9]
   end
 
   it "yields only elements that are still in the array" do
     a = [0, 1, 2, 3, 4]
-    b = []
-    a.each {|x| b << x; a.pop if (x%2).zero? }
-    b.should == [0, 1, 2]
+    iterated = []
+    a.each { |x| iterated << x; a.pop if x.even? }
+    iterated.should == [0, 1, 2]
   end
 
   it "yields elements based on an internal index" do
     a = [0, 1, 2, 3, 4]
-    b = []
-    a.each {|x| b << x; a.shift if (x%2).zero? }
-    b.should == [0, 2, 4]
+    iterated = []
+    a.each { |x| iterated << x; a.shift if x.even? }
+    iterated.should == [0, 2, 4]
   end
 
   it "yields each element to a block that takes multiple arguments" do

--- a/spec/ruby/core/array/each_spec.rb
+++ b/spec/ruby/core/array/each_spec.rb
@@ -37,6 +37,13 @@ describe "Array#each" do
     iterated.should == [0, 2, 4]
   end
 
+  it "yields the same element multiple times if inserting while iterating" do
+    a = [1, 2]
+    iterated = []
+    a.each { |x| iterated << x; a.unshift(0) if a.size == 2 }
+    iterated.should == [1, 1, 2]
+  end
+
   it "yields each element to a block that takes multiple arguments" do
     a = [[1, 2], :a, [3, 4]]
     b = []

--- a/spec/ruby/core/array/each_spec.rb
+++ b/spec/ruby/core/array/each_spec.rb
@@ -3,9 +3,10 @@ require_relative 'fixtures/classes'
 require_relative 'shared/enumeratorize'
 require_relative '../enumerable/shared/enumeratorized'
 
-# Modifying a collection while the contents are being iterated
-# gives undefined behavior. See
-# http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-core/23633
+# Mutating the array while it is being iterated is discouraged as it can result in confusing behavior.
+# Yet a Ruby implementation must not crash in such a case, and following the simple CRuby behavior makes sense.
+# CRuby simply reads the array storage and check the size for every iteration;
+# like `i = 0; while i < size; yield self[i]; end`
 
 describe "Array#each" do
   it "yields each element to the block" do
@@ -13,6 +14,27 @@ describe "Array#each" do
     x = [1, 2, 3]
     x.each { |item| a << item }.should equal(x)
     a.should == [1, 2, 3]
+  end
+
+  it "yields each element to the block even if the array is changed during iteration" do
+    a = [1, 2, 3, 4, 5]
+    b = []
+    a.each {|x| b << x; a << x+5 if (x%2).zero? }
+    b.should == [1, 2, 3, 4, 5, 7, 9]
+  end
+
+  it "yields only elements that are still in the array" do
+    a = [0, 1, 2, 3, 4]
+    b = []
+    a.each {|x| b << x; a.pop if (x%2).zero? }
+    b.should == [0, 1, 2]
+  end
+
+  it "yields elements based on an internal index" do
+    a = [0, 1, 2, 3, 4]
+    b = []
+    a.each {|x| b << x; a.shift if (x%2).zero? }
+    b.should == [0, 2, 4]
   end
 
   it "yields each element to a block that takes multiple arguments" do

--- a/src/main/java/org/truffleruby/core/array/ArrayEachIteratorNode.java
+++ b/src/main/java/org/truffleruby/core/array/ArrayEachIteratorNode.java
@@ -44,7 +44,7 @@ public abstract class ArrayEachIteratorNode extends RubyBaseNode {
 
     @Specialization(limit = "storageStrategyLimit()")
     protected RubyArray iterateMany(RubyArray array, RubyProc block, int startAt, ArrayElementConsumerNode consumerNode,
-            // Checkstyle: stop -- Verified @Bind is not necessary here due to use of `accept`.
+            // Checkstyle: stop -- Verified @Bind is not necessary here due to using `Library#accepts()`.
             @CachedLibrary("array.store") ArrayStoreLibrary stores,
             // Checkstyle: resume
             @Cached LoopConditionProfile loopProfile,

--- a/src/main/java/org/truffleruby/core/array/ArrayEachIteratorNode.java
+++ b/src/main/java/org/truffleruby/core/array/ArrayEachIteratorNode.java
@@ -44,7 +44,9 @@ public abstract class ArrayEachIteratorNode extends RubyBaseNode {
 
     @Specialization(limit = "storageStrategyLimit()")
     protected RubyArray iterateMany(RubyArray array, RubyProc block, int startAt, ArrayElementConsumerNode consumerNode,
+            // Checkstyle: stop -- Verified @Bind is not necessary here due to use of `accept`.
             @CachedLibrary("array.store") ArrayStoreLibrary stores,
+            // Checkstyle: resume
             @Cached LoopConditionProfile loopProfile,
             @Cached("createIdentityProfile()") IntValueProfile arraySizeProfile,
             @Cached ConditionProfile strategyMatchProfile) {

--- a/src/main/java/org/truffleruby/core/array/ArrayEachIteratorNode.java
+++ b/src/main/java/org/truffleruby/core/array/ArrayEachIteratorNode.java
@@ -51,8 +51,9 @@ public abstract class ArrayEachIteratorNode extends RubyBaseNode {
         int i = startAt;
         try {
             for (; loopProfile.inject(i < arraySizeProfile.profile(array.size)); i++) {
-                if (strategyMatchProfile.profile(stores.accepts(array.store))) {
-                    consumerNode.accept(array, block, stores.read(array.store, i), i);
+                Object store = array.store;
+                if (strategyMatchProfile.profile(stores.accepts(store))) {
+                    consumerNode.accept(array, block, stores.read(store, i), i);
                 } else {
                     return getRecurseNode().execute(array, block, i, consumerNode);
                 }


### PR DESCRIPTION
# What

This PR updates the current specialization to run on par with MRI and not crash the interpreter when increasing the array size in an each block. It also supports loop unfolding by Graal when running a constant number of times, which was not the case before. Prior to this, running code such as the first example below would bail out of TR, because the backing store was bound and an out-of-bounds array read was attempted. With this PR, we can also remove the other specialization for iterating on an array with a single element, so this node now has a single general form.

cc @eregon @chrisseaton 

# Code examples
I'd also like to add some `each` specs, illustrating the behaviour of modifying an array's backing store while iterating. Officially, this is undefined, but not unsupported.

https://github.com/ruby/spec/blob/master/core/array/each_spec.rb#L6-L8
https://github.com/ruby/ruby/blob/d66e7ec77b0067b113e1b9f584e7f5f741d6cd78/array.c#L2516-L2524

## Growing white iterating
```ruby
def foo(z)
  z.each do |element|
    # repeatedly append elements while iterating up to some size
    if z.size < 10
      # puts z.size
      z.append element
    end
  end
  # puts "done foo"
end
```

## Shrinking while iterating
```ruby
a = [1, 2, 3, 4, 5, 6]
a.each { |n| puts n; a.delete(n) if n.odd? }
```

Note the element order in the latter example. We never `puts 6`.

```ruby
a = [1, 2, 3, 4, 5, 6]
a.each { |n| puts n; a.delete(1) if n == 4 }
```