### PR TITLE
Dont call IO#flush from within IO#close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Compatibility:
 * Handle encoding conversion errors when reading directory entries (@aardvark179).
 * Follow symlinks when processing `*/` directory glob patterns. (#2589, @aardvark179).
 * Set `@gem_prelude_index` variable on the default load paths (#2586 , @bjfish)
+* Do not call `IO#flush` dynamically from `IO#close` (#2594, @gogainda).
 
 Performance:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,3 +42,11 @@ When opening a Pull Request, please add a ChangeLog entry with the format:
 ```
 
 See the [the ChangeLog](CHANGELOG.md) for examples.
+
+GitHub might show on the Pull Request:
+```
+Conflicting files
+CHANGELOG.md
+```
+This is a bug in GitHub's UI, there is never any conflict as `CHANGELOG.md` uses union merge.
+Please do not use the `Resolve conflicts` button as that will create a redundant merge commit.

--- a/spec/ruby/core/io/close_spec.rb
+++ b/spec/ruby/core/io/close_spec.rb
@@ -44,6 +44,12 @@ describe "IO#close" do
     @io.close.should be_nil
   end
 
+  it "does not call the #flush method but flushes the stream internally" do
+    @io.should_not_receive(:flush)
+    @io.close
+    @io.should.closed?
+  end
+
   it 'raises an IOError with a clear message' do
     matching_exception = nil
 

--- a/src/main/ruby/truffleruby/core/io.rb
+++ b/src/main/ruby/truffleruby/core/io.rb
@@ -2415,7 +2415,7 @@ class IO
     return nil if closed?
 
     begin
-      flush
+      ensure_open # IO#flush but inlined, to not call user-defined #flush
     ensure
       fd = Primitive.io_fd(self)
       if fd >= 0


### PR DESCRIPTION
Issue happens when File is mocked and then flush and close are executed in order.
Number of captured invocations for flush should be 1 in this scenario, but before fix it was reporting 2

Originally issue found [here](https://github.com/rspec/rspec-core/blob/0ec584793d2977c3fd728e4070f83ec82e96b436/spec/rspec/core/formatters/base_text_formatter_spec.rb#L23-L27)