### PR TITLE
Static argument descriptor

### DIFF
--- a/spec/tags/truffle/arguments_descriptor_tags.txt
+++ b/spec/tags/truffle/arguments_descriptor_tags.txt
@@ -1,0 +1,2 @@
+fails:Arguments descriptors work for a mixture of arguments
+fails:Arguments descriptors work for a call like our Struct.new

--- a/spec/truffle/arguments_descriptor_spec.rb
+++ b/spec/truffle/arguments_descriptor_spec.rb
@@ -3,6 +3,8 @@
 require_relative '../ruby/spec_helper'
 
 module ArgumentsDescriptorSpecs
+  Info = Struct.new(:values, :descriptor, :arguments)
+
   def self.tr?
     RUBY_ENGINE == 'truffleruby'
   end
@@ -20,77 +22,77 @@ module ArgumentsDescriptorSpecs
   end
 
   def self.no_kws(a, b)
-    [a, b, Primitive.arguments_descriptor, Primitive.arguments]
+    Info.new([a, b], Primitive.arguments_descriptor, Primitive.arguments)
   end
 
   def self.only_kws(a:, b:)
-    [a, b, Primitive.arguments_descriptor, Primitive.arguments]
+    Info.new([a, b], Primitive.arguments_descriptor, Primitive.arguments)
   end
 
   def self.only_kws_and_opt(a:, b: 101)
-    [a, b, Primitive.arguments_descriptor, Primitive.arguments]
+    Info.new([a, b], Primitive.arguments_descriptor, Primitive.arguments)
   end
 
   def self.posn_kws(a, b:)
-    [a, b, Primitive.arguments_descriptor, Primitive.arguments]
+    Info.new([a, b], Primitive.arguments_descriptor, Primitive.arguments)
   end
 
   def self.posn_kws_defaults(a, b: 101, c: 102)
-    [a, b, c, Primitive.arguments_descriptor, Primitive.arguments]
+    Info.new([a, b, c], Primitive.arguments_descriptor, Primitive.arguments)
   end
 
   def self.opt_and_kws(a, b=2, c: nil)
-    [a, b, c, Primitive.arguments_descriptor, Primitive.arguments]
+    Info.new([a, b, c], Primitive.arguments_descriptor, Primitive.arguments)
   end
 
   def self.struct_new_like(a, *b, c: 101)
-    [a, b, c, Primitive.arguments_descriptor, Primitive.arguments]
+    Info.new([a, b, c], Primitive.arguments_descriptor, Primitive.arguments)
   end
 
   def self.describe_like(a, b = nil)
-    [a, b, Primitive.arguments_descriptor, Primitive.arguments]
+    Info.new([a, b], Primitive.arguments_descriptor, Primitive.arguments)
   end
 
   def self.single(a)
-    [a, Primitive.arguments_descriptor, Primitive.arguments]
+    Info.new([a], Primitive.arguments_descriptor, Primitive.arguments)
   end
 
   def self.rest(*a)
-    [a, Primitive.arguments_descriptor, Primitive.arguments]
+    Info.new([a], Primitive.arguments_descriptor, Primitive.arguments)
   end
 
   def self.kw_rest(**a)
-    [a, Primitive.arguments_descriptor, Primitive.arguments]
+    Info.new([a], Primitive.arguments_descriptor, Primitive.arguments)
   end
 
   def self.kw_and_kw_rest(a:, **b)
-    [a, b, Primitive.arguments_descriptor, Primitive.arguments]
+    Info.new([a, b], Primitive.arguments_descriptor, Primitive.arguments)
   end
 
   def self.mixture(a, b = nil, c = nil, d, e: nil, **f)
-    [a, b, c, d, e, f, Primitive.arguments_descriptor, Primitive.arguments]
+    Info.new([a, b, c, d, e, f], Primitive.arguments_descriptor, Primitive.arguments)
   end
 
   class NewKW
     def self.new(a:, b:)
-      [a, b, Primitive.arguments_descriptor, Primitive.arguments]
+      Info.new([a, b], Primitive.arguments_descriptor, Primitive.arguments)
     end
   end
 
   class NewRest
     def self.new(*a)
-      [a, Primitive.arguments_descriptor, Primitive.arguments]
+      Info.new([a], Primitive.arguments_descriptor, Primitive.arguments)
     end
   end
 
   class A
     def implicit_super(a:, b:)
-      [a, b, Primitive.arguments_descriptor, Primitive.arguments]
+      Info.new([a, b], Primitive.arguments_descriptor, Primitive.arguments)
 
     end
 
     def explicit_super(a:, b:)
-      [a, b, Primitive.arguments_descriptor, Primitive.arguments]
+      Info.new([a, b], Primitive.arguments_descriptor, Primitive.arguments)
     end
   end
 
@@ -110,58 +112,58 @@ module ArgumentsDescriptorSpecs
 
   def self.use_yielder(x, y)
     yielder(x, y) do |a:, b:|
-      [a, b, Primitive.arguments_descriptor, Primitive.arguments]
+      Info.new([a, b], Primitive.arguments_descriptor, Primitive.arguments)
     end
   end
 end
 
 describe "Arguments descriptors" do
   it "are empty for simple calls" do
-    ArgumentsDescriptorSpecs.no_kws(1, 2).should == [1, 2, [], ArgumentsDescriptorSpecs.tr? ? [1, 2]: []]
+    ArgumentsDescriptorSpecs.no_kws(1, 2).should == ArgumentsDescriptorSpecs::Info.new([1, 2], [], ArgumentsDescriptorSpecs.tr? ? [1, 2]: [])
   end
 
   it "contain keyword arguments" do
-    ArgumentsDescriptorSpecs.only_kws(a: 1, b: 2).should == [1, 2, ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : []]
+    ArgumentsDescriptorSpecs.only_kws(a: 1, b: 2).should == ArgumentsDescriptorSpecs::Info.new([1, 2], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
   end
 
   it "contain optional keyword arguments" do
-    ArgumentsDescriptorSpecs.only_kws_and_opt(a: 1, b: 2).should == [1, 2, ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : []]
-    ArgumentsDescriptorSpecs.only_kws_and_opt(a: 1).should == [1, 101, ArgumentsDescriptorSpecs.tr? ? [:a, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1}] : []]
+    ArgumentsDescriptorSpecs.only_kws_and_opt(a: 1, b: 2).should == ArgumentsDescriptorSpecs::Info.new([1, 2], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
+    ArgumentsDescriptorSpecs.only_kws_and_opt(a: 1).should == ArgumentsDescriptorSpecs::Info.new([1, 101], ArgumentsDescriptorSpecs.tr? ? [:a, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1}] : [])
   end
 
   it "contain keyword arguments with positional arguments" do
-    ArgumentsDescriptorSpecs.posn_kws(1, b: 2).should == [1, 2, ArgumentsDescriptorSpecs.tr? ? [:b, 1, true] : [], ArgumentsDescriptorSpecs.tr? ? [1, {b: 2}] : []]
+    ArgumentsDescriptorSpecs.posn_kws(1, b: 2).should == ArgumentsDescriptorSpecs::Info.new([1, 2], ArgumentsDescriptorSpecs.tr? ? [:b, 1, true] : [], ArgumentsDescriptorSpecs.tr? ? [1, {b: 2}] : [])
   end
 
   it "contain optional keyword arguments with positional arguments" do
-    ArgumentsDescriptorSpecs.posn_kws_defaults(1, b: 2, c: 3).should == [1, 2, 3, ArgumentsDescriptorSpecs.tr? ? [:b, :c, 1, true] : [], ArgumentsDescriptorSpecs.tr? ? [1, {b: 2, c: 3}] : []]
+    ArgumentsDescriptorSpecs.posn_kws_defaults(1, b: 2, c: 3).should == ArgumentsDescriptorSpecs::Info.new([1, 2, 3], ArgumentsDescriptorSpecs.tr? ? [:b, :c, 1, true] : [], ArgumentsDescriptorSpecs.tr? ? [1, {b: 2, c: 3}] : [])
   end
 
   it "do not contain missing optional keyword arguments" do
-    ArgumentsDescriptorSpecs.posn_kws_defaults(1, b: 2).should == [1, 2, 102, ArgumentsDescriptorSpecs.tr? ? [:b, 1, true] : [], ArgumentsDescriptorSpecs.tr? ? [1, {b: 2}] : []]
-    ArgumentsDescriptorSpecs.posn_kws_defaults(1, c: 3).should == [1, 101, 3, ArgumentsDescriptorSpecs.tr? ? [:c, 1, true] : [], ArgumentsDescriptorSpecs.tr? ? [1, {c: 3}] : []]
+    ArgumentsDescriptorSpecs.posn_kws_defaults(1, b: 2).should == ArgumentsDescriptorSpecs::Info.new([1, 2, 102], ArgumentsDescriptorSpecs.tr? ? [:b, 1, true] : [], ArgumentsDescriptorSpecs.tr? ? [1, {b: 2}] : [])
+    ArgumentsDescriptorSpecs.posn_kws_defaults(1, c: 3).should == ArgumentsDescriptorSpecs::Info.new([1, 101, 3], ArgumentsDescriptorSpecs.tr? ? [:c, 1, true] : [], ArgumentsDescriptorSpecs.tr? ? [1, {c: 3}] : [])
   end
 
   it "do not contain the name of distant explicitly splatted keyword arguments" do
     distant = {b: 2}
-    ArgumentsDescriptorSpecs.only_kws(a: 1, **distant).should == [1, 2, ArgumentsDescriptorSpecs.tr? ? [:a, 0, false] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : []]
+    ArgumentsDescriptorSpecs.only_kws(a: 1, **distant).should == ArgumentsDescriptorSpecs::Info.new([1, 2], ArgumentsDescriptorSpecs.tr? ? [:a, 0, false] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
   end
 
   it "do not contain the name of near explicitly splatted keyword arguments" do
-    ArgumentsDescriptorSpecs.only_kws(a: 1, **{b: 2}).should == [1, 2, ArgumentsDescriptorSpecs.tr? ? [:a, 0, false] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : []]
+    ArgumentsDescriptorSpecs.only_kws(a: 1, **{b: 2}).should == ArgumentsDescriptorSpecs::Info.new([1, 2], ArgumentsDescriptorSpecs.tr? ? [:a, 0, false] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
   end
 
   it "contain the name of present optional keyword arguments without the optional positional" do
-    ArgumentsDescriptorSpecs.opt_and_kws(1, c: 3).should == [1, 2, 3, ArgumentsDescriptorSpecs.tr? ? [:c, 1, true] : [], ArgumentsDescriptorSpecs.tr? ? [1, {c: 3}] : []]
+    ArgumentsDescriptorSpecs.opt_and_kws(1, c: 3).should == ArgumentsDescriptorSpecs::Info.new([1, 2, 3], ArgumentsDescriptorSpecs.tr? ? [:c, 1, true] : [], ArgumentsDescriptorSpecs.tr? ? [1, {c: 3}] : [])
   end
 
   it "work for a call like our Struct.new" do
-    ArgumentsDescriptorSpecs.struct_new_like('A', :a, :b).should == ['A', [:a, :b], 101, [], ArgumentsDescriptorSpecs.tr? ? ['A', :a, :b] : []]
-    ArgumentsDescriptorSpecs.struct_new_like('A', :a, :b, c: 1).should == ['A', [:a, :b], 1, ArgumentsDescriptorSpecs.tr? ? [:c, 3, true] : [], ArgumentsDescriptorSpecs.tr? ? ['A', :a, :b, {c: 1}] : []]
-    ArgumentsDescriptorSpecs.struct_new_like('A', :a, :b, {c: 1}).should == ['A', [:a, :b, {c: 1}], 101, [], ArgumentsDescriptorSpecs.tr? ? ['A', :a, :b, {c: 1}] : []]
-    ArgumentsDescriptorSpecs.struct_new_like('A', :a, :b, **{c: 1}).should == ['A', [:a, :b], 1, [], ArgumentsDescriptorSpecs.tr? ? ['A', :a, :b, {c: 1}] : []]
+    ArgumentsDescriptorSpecs.struct_new_like('A', :a, :b).should == ArgumentsDescriptorSpecs::Info.new(['A', [:a, :b], 101], [], ArgumentsDescriptorSpecs.tr? ? ['A', :a, :b] : [])
+    ArgumentsDescriptorSpecs.struct_new_like('A', :a, :b, c: 1).should == ArgumentsDescriptorSpecs::Info.new(['A', [:a, :b], 1], ArgumentsDescriptorSpecs.tr? ? [:c, 3, true] : [], ArgumentsDescriptorSpecs.tr? ? ['A', :a, :b, {c: 1}] : [])
+    ArgumentsDescriptorSpecs.struct_new_like('A', :a, :b, {c: 1}).should == ArgumentsDescriptorSpecs::Info.new(['A', [:a, :b, {c: 1}], 101], [], ArgumentsDescriptorSpecs.tr? ? ['A', :a, :b, {c: 1}] : [])
+    ArgumentsDescriptorSpecs.struct_new_like('A', :a, :b, **{c: 1}).should == ArgumentsDescriptorSpecs::Info.new(['A', [:a, :b], 1], [], ArgumentsDescriptorSpecs.tr? ? ['A', :a, :b, {c: 1}] : [])
     distant = {c: 1}
-    ArgumentsDescriptorSpecs.struct_new_like('A', :a, :b, **distant).should == ['A', [:a, :b], 1, [], ArgumentsDescriptorSpecs.tr? ? ['A', :a, :b, {c: 1}] : []]
+    ArgumentsDescriptorSpecs.struct_new_like('A', :a, :b, **distant).should == ArgumentsDescriptorSpecs::Info.new(['A', [:a, :b], 1], [], ArgumentsDescriptorSpecs.tr? ? ['A', :a, :b, {c: 1}] : [])
     -> { ArgumentsDescriptorSpecs.struct_new_like('A', :a, :b, d: 1) }.should raise_error(ArgumentError)
     -> { ArgumentsDescriptorSpecs.struct_new_like('A', :a, :b, **{d: 1}) }.should raise_error(ArgumentError)
     distant = {d: 1}
@@ -178,32 +180,32 @@ describe "Arguments descriptors" do
   end
 
   it "work for a call like MSpec #describe" do
-    ArgumentsDescriptorSpecs.describe_like(1, b: 2).should == [1, {b: 2}, ArgumentsDescriptorSpecs.tr? ? [:b, 1, true] : [], ArgumentsDescriptorSpecs.tr? ? [1, {b: 2}] : []]
+    ArgumentsDescriptorSpecs.describe_like(1, b: 2).should == ArgumentsDescriptorSpecs::Info.new([1, {b: 2}], ArgumentsDescriptorSpecs.tr? ? [:b, 1, true] : [], ArgumentsDescriptorSpecs.tr? ? [1, {b: 2}] : [])
   end
 
   it "expand a hash not used for keyword arguments" do
-    ArgumentsDescriptorSpecs.single({a: 1, b: 2}).should == [{a: 1, b: 2}, [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : []]
+    ArgumentsDescriptorSpecs.single({a: 1, b: 2}).should == ArgumentsDescriptorSpecs::Info.new([{a: 1, b: 2}], [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
   end
 
   it "contain keyword argument names passed to a rest" do
-    ArgumentsDescriptorSpecs.rest(a: 1, b: 2).should == [[{a: 1, b: 2}], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : []]
+    ArgumentsDescriptorSpecs.rest(a: 1, b: 2).should == ArgumentsDescriptorSpecs::Info.new([[{a: 1, b: 2}]], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
   end
 
   it "contain keyword argument names passed to a keyword rest" do
-    ArgumentsDescriptorSpecs.kw_rest(a: 1, b: 2).should == [{a: 1, b: 2}, ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : []]
+    ArgumentsDescriptorSpecs.kw_rest(a: 1, b: 2).should == ArgumentsDescriptorSpecs::Info.new([{a: 1, b: 2}], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
   end
 
   it "contain keyword argument names passed to a combined keyword rest" do
-    ArgumentsDescriptorSpecs.kw_and_kw_rest(a: 1).should == [1, {}, ArgumentsDescriptorSpecs.tr? ? [:a, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1}] : []]
-    ArgumentsDescriptorSpecs.kw_and_kw_rest(a: 1, b: 2, c: 3).should == [1, {b: 2, c: 3}, ArgumentsDescriptorSpecs.tr? ? [:a, :b, :c, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2, c: 3}] : []]
-    ArgumentsDescriptorSpecs.kw_and_kw_rest("abc" => 123, a: 1, b: 2).should == [1, {"abc" => 123, b: 2}, ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, false] : [], ArgumentsDescriptorSpecs.tr? ? [{"abc" => 123, a: 1, b: 2}] : []]
+    ArgumentsDescriptorSpecs.kw_and_kw_rest(a: 1).should == ArgumentsDescriptorSpecs::Info.new([1, {}], ArgumentsDescriptorSpecs.tr? ? [:a, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1}] : [])
+    ArgumentsDescriptorSpecs.kw_and_kw_rest(a: 1, b: 2, c: 3).should == ArgumentsDescriptorSpecs::Info.new([1, {b: 2, c: 3}], ArgumentsDescriptorSpecs.tr? ? [:a, :b, :c, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2, c: 3}] : [])
+    ArgumentsDescriptorSpecs.kw_and_kw_rest("abc" => 123, a: 1, b: 2).should == ArgumentsDescriptorSpecs::Info.new([1, {"abc" => 123, b: 2}], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, false] : [], ArgumentsDescriptorSpecs.tr? ? [{"abc" => 123, a: 1, b: 2}] : [])
   end
 
   it "work for a mixture of arguments" do
-    ArgumentsDescriptorSpecs.mixture(1, 2).should == [1, nil, nil, 2, nil, {}, ArgumentsDescriptorSpecs.tr? ? [] : [], ArgumentsDescriptorSpecs.tr? ? [1, 2] : []]
-    ArgumentsDescriptorSpecs.mixture(1, 2, e: 3).should == [1, nil, nil, 2, 3, {}, ArgumentsDescriptorSpecs.tr? ? [:e, 2, true] : [], ArgumentsDescriptorSpecs.tr? ? [1, 2, {e: 3}] : []]
-    ArgumentsDescriptorSpecs.mixture(1, 2, {foo: :bar}).should == [1, 2, nil, {:foo=>:bar}, nil, {}, ArgumentsDescriptorSpecs.tr? ? [] : [], ArgumentsDescriptorSpecs.tr? ? [1, 2, {foo: :bar}] : []]
-    ArgumentsDescriptorSpecs.mixture(1, {foo: :bar}).should == [1, nil, nil, {foo: :bar}, nil, {}, ArgumentsDescriptorSpecs.tr? ? [-1] : [], ArgumentsDescriptorSpecs.tr? ? [1, {foo: :bar}] : []]
+    ArgumentsDescriptorSpecs.mixture(1, 2).should == ArgumentsDescriptorSpecs::Info.new([1, nil, nil, 2, nil, {}], ArgumentsDescriptorSpecs.tr? ? [] : [], ArgumentsDescriptorSpecs.tr? ? [1, 2] : [])
+    ArgumentsDescriptorSpecs.mixture(1, 2, e: 3).should == ArgumentsDescriptorSpecs::Info.new([1, nil, nil, 2, 3, {}], ArgumentsDescriptorSpecs.tr? ? [:e, 2, true] : [], ArgumentsDescriptorSpecs.tr? ? [1, 2, {e: 3}] : [])
+    ArgumentsDescriptorSpecs.mixture(1, 2, {foo: :bar}).should == ArgumentsDescriptorSpecs::Info.new([1, 2, nil, {:foo=>:bar}, nil, {}], ArgumentsDescriptorSpecs.tr? ? [] : [], ArgumentsDescriptorSpecs.tr? ? [1, 2, {foo: :bar}] : [])
+    ArgumentsDescriptorSpecs.mixture(1, {foo: :bar}).should == ArgumentsDescriptorSpecs::Info.new([1, nil, nil, {foo: :bar}, nil, {}], ArgumentsDescriptorSpecs.tr? ? [-1] : [], ArgumentsDescriptorSpecs.tr? ? [1, {foo: :bar}] : [])
   end
 
   it "work through an inlined call abstraction" do
@@ -219,22 +221,22 @@ describe "Arguments descriptors" do
   end
 
   it "work through custom new with keyword arguments" do
-    ArgumentsDescriptorSpecs::NewKW.new(a: 1, b: 2).should == [1, 2, ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : []]
+    ArgumentsDescriptorSpecs::NewKW.new(a: 1, b: 2).should == ArgumentsDescriptorSpecs::Info.new([1, 2], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
   end
 
   it "work through custom new with rest" do
-    ArgumentsDescriptorSpecs::NewRest.new(a: 1, b: 2).should == [[{a: 1, b: 2}], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : []]
+    ArgumentsDescriptorSpecs::NewRest.new(a: 1, b: 2).should == ArgumentsDescriptorSpecs::Info.new([[{a: 1, b: 2}]], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
   end
 
   it "work through implicit super" do
-    ArgumentsDescriptorSpecs::A.new.implicit_super(a: 1, b: 2).should == [1, 2, ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : []]
+    ArgumentsDescriptorSpecs::A.new.implicit_super(a: 1, b: 2).should == ArgumentsDescriptorSpecs::Info.new([1, 2], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
   end
 
   it "work through explicit super" do
-    ArgumentsDescriptorSpecs::A.new.explicit_super(a: 1, b: 2).should == [1, 2, ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : []]
+    ArgumentsDescriptorSpecs::A.new.explicit_super(a: 1, b: 2).should == ArgumentsDescriptorSpecs::Info.new([1, 2], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
   end
 
   it "work through yield" do
-    ArgumentsDescriptorSpecs.use_yielder(1, 2).should == [1, 2, ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : []]
+    ArgumentsDescriptorSpecs.use_yielder(1, 2).should == ArgumentsDescriptorSpecs::Info.new([1, 2], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
   end
 end

--- a/spec/truffle/arguments_descriptor_spec.rb
+++ b/spec/truffle/arguments_descriptor_spec.rb
@@ -122,6 +122,7 @@ describe "Arguments descriptors" do
     info = ArgumentsDescriptorSpecs.no_kws(1, 2)
     info.values.should == [1, 2]
     info.descriptor.should == [] if ArgumentsDescriptorSpecs.tr?
+    info.arguments.should == [1, 2] if ArgumentsDescriptorSpecs.tr?
     info.should == ArgumentsDescriptorSpecs::Info.new([1, 2], [], ArgumentsDescriptorSpecs.tr? ? [1, 2]: [])
   end
 
@@ -129,6 +130,7 @@ describe "Arguments descriptors" do
     info = ArgumentsDescriptorSpecs.only_kws(a: 1, b: 2)
     info.values.should == [1, 2]
     info.descriptor.should == [:a, :b, 0, true] if ArgumentsDescriptorSpecs.tr?
+    info.arguments.should == [{a: 1, b: 2}] if ArgumentsDescriptorSpecs.tr?
     info.should == ArgumentsDescriptorSpecs::Info.new([1, 2], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
   end
 
@@ -136,11 +138,13 @@ describe "Arguments descriptors" do
     info = ArgumentsDescriptorSpecs.only_kws_and_opt(a: 1, b: 2)
     info.values.should == [1, 2]
     info.descriptor.should == [:a, :b, 0, true] if ArgumentsDescriptorSpecs.tr?
+    info.arguments.should == [{a: 1, b: 2}] if ArgumentsDescriptorSpecs.tr?
     info.should == ArgumentsDescriptorSpecs::Info.new([1, 2], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
     
     info = ArgumentsDescriptorSpecs.only_kws_and_opt(a: 1)
     info.values.should == [1, 101]
     info.descriptor.should == [:a, 0, true] if ArgumentsDescriptorSpecs.tr?
+    info.arguments.should == [{a: 1}] if ArgumentsDescriptorSpecs.tr?
     info.should == ArgumentsDescriptorSpecs::Info.new([1, 101], ArgumentsDescriptorSpecs.tr? ? [:a, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1}] : [])
   end
 
@@ -148,6 +152,7 @@ describe "Arguments descriptors" do
     info = ArgumentsDescriptorSpecs.posn_kws(1, b: 2)
     info.values.should == [1, 2]
     info.descriptor.should == [:b, 1, true] if ArgumentsDescriptorSpecs.tr?
+    info.arguments.should == [1, {b: 2}] if ArgumentsDescriptorSpecs.tr?
     info.should == ArgumentsDescriptorSpecs::Info.new([1, 2], ArgumentsDescriptorSpecs.tr? ? [:b, 1, true] : [], ArgumentsDescriptorSpecs.tr? ? [1, {b: 2}] : [])
   end
 
@@ -155,6 +160,7 @@ describe "Arguments descriptors" do
     info = ArgumentsDescriptorSpecs.posn_kws_defaults(1, b: 2, c: 3)
     info.values.should == [1, 2, 3]
     info.descriptor.should == [:b, :c, 1, true] if ArgumentsDescriptorSpecs.tr?
+    info.arguments.should == [1, {b: 2, c: 3}] if ArgumentsDescriptorSpecs.tr?
     info.should == ArgumentsDescriptorSpecs::Info.new([1, 2, 3], ArgumentsDescriptorSpecs.tr? ? [:b, :c, 1, true] : [], ArgumentsDescriptorSpecs.tr? ? [1, {b: 2, c: 3}] : [])
   end
 
@@ -162,11 +168,13 @@ describe "Arguments descriptors" do
     info = ArgumentsDescriptorSpecs.posn_kws_defaults(1, b: 2)
     info.values.should == [1, 2, 102]
     info.descriptor.should == [:b, 1, true] if ArgumentsDescriptorSpecs.tr?
+    info.arguments.should == [1, {b: 2}] if ArgumentsDescriptorSpecs.tr?
     info.should == ArgumentsDescriptorSpecs::Info.new([1, 2, 102], ArgumentsDescriptorSpecs.tr? ? [:b, 1, true] : [], ArgumentsDescriptorSpecs.tr? ? [1, {b: 2}] : [])
     
     info = ArgumentsDescriptorSpecs.posn_kws_defaults(1, c: 3)
     info.values.should == [1, 101, 3]
     info.descriptor.should == [:c, 1, true] if ArgumentsDescriptorSpecs.tr?
+    info.arguments.should == [1, {c: 3}] if ArgumentsDescriptorSpecs.tr?
     info.should == ArgumentsDescriptorSpecs::Info.new([1, 101, 3], ArgumentsDescriptorSpecs.tr? ? [:c, 1, true] : [], ArgumentsDescriptorSpecs.tr? ? [1, {c: 3}] : [])
   end
 
@@ -175,6 +183,7 @@ describe "Arguments descriptors" do
     info = ArgumentsDescriptorSpecs.only_kws(a: 1, **distant)
     info.values.should == [1, 2]
     info.descriptor.should == [:a, 0, false] if ArgumentsDescriptorSpecs.tr?
+    info.arguments.should == [{a: 1, b: 2}] if ArgumentsDescriptorSpecs.tr?
     info.should == ArgumentsDescriptorSpecs::Info.new([1, 2], ArgumentsDescriptorSpecs.tr? ? [:a, 0, false] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
   end
 
@@ -182,6 +191,7 @@ describe "Arguments descriptors" do
     info = ArgumentsDescriptorSpecs.only_kws(a: 1, **{b: 2})
     info.values.should == [1, 2]
     info.descriptor.should == [:a, 0, false] if ArgumentsDescriptorSpecs.tr?
+    info.arguments.should == [{a: 1, b: 2}] if ArgumentsDescriptorSpecs.tr?
     info.should == ArgumentsDescriptorSpecs::Info.new([1, 2], ArgumentsDescriptorSpecs.tr? ? [:a, 0, false] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
   end
 
@@ -189,6 +199,7 @@ describe "Arguments descriptors" do
     info = ArgumentsDescriptorSpecs.opt_and_kws(1, c: 3)
     info.values.should == [1, 2, 3]
     info.descriptor.should == [:c, 1, true] if ArgumentsDescriptorSpecs.tr?
+    info.arguments.should == [1, {c: 3}] if ArgumentsDescriptorSpecs.tr?
     info.should == ArgumentsDescriptorSpecs::Info.new([1, 2, 3], ArgumentsDescriptorSpecs.tr? ? [:c, 1, true] : [], ArgumentsDescriptorSpecs.tr? ? [1, {c: 3}] : [])
   end
 
@@ -196,27 +207,32 @@ describe "Arguments descriptors" do
     info = ArgumentsDescriptorSpecs.struct_new_like('A', :a, :b)
     info.values.should == ['A', [:a, :b], 101]
     info.descriptor.should == [] if ArgumentsDescriptorSpecs.tr?
+    info.arguments.should == ['A', :a, :b] if ArgumentsDescriptorSpecs.tr?
     info.should == ArgumentsDescriptorSpecs::Info.new(['A', [:a, :b], 101], [], ArgumentsDescriptorSpecs.tr? ? ['A', :a, :b] : [])
     
     info = ArgumentsDescriptorSpecs.struct_new_like('A', :a, :b, c: 1)
     info.values.should == ['A', [:a, :b], 1]
     info.descriptor.should == [:c, 3, true] if ArgumentsDescriptorSpecs.tr?
+    info.arguments.should == ['A', :a, :b, {c: 1}] if ArgumentsDescriptorSpecs.tr?
     info.should == ArgumentsDescriptorSpecs::Info.new(['A', [:a, :b], 1], ArgumentsDescriptorSpecs.tr? ? [:c, 3, true] : [], ArgumentsDescriptorSpecs.tr? ? ['A', :a, :b, {c: 1}] : [])
     
     info = ArgumentsDescriptorSpecs.struct_new_like('A', :a, :b, {c: 1})
     info.values.should == ['A', [:a, :b, {c: 1}], 101]
     info.descriptor.should == [] if ArgumentsDescriptorSpecs.tr?
+    info.arguments.should == ['A', :a, :b, {c: 1}] if ArgumentsDescriptorSpecs.tr?
     info.should == ArgumentsDescriptorSpecs::Info.new(['A', [:a, :b, {c: 1}], 101], [], ArgumentsDescriptorSpecs.tr? ? ['A', :a, :b, {c: 1}] : [])
     
     info = ArgumentsDescriptorSpecs.struct_new_like('A', :a, :b, **{c: 1})
     info.values.should == ['A', [:a, :b], 1]
     info.descriptor.should == [] if ArgumentsDescriptorSpecs.tr?
+    info.arguments.should == ['A', :a, :b, {c: 1}] if ArgumentsDescriptorSpecs.tr?
     info.should == ArgumentsDescriptorSpecs::Info.new(['A', [:a, :b], 1], [], ArgumentsDescriptorSpecs.tr? ? ['A', :a, :b, {c: 1}] : [])
     
     distant = {c: 1}
     info = ArgumentsDescriptorSpecs.struct_new_like('A', :a, :b, **distant)
     info.values.should == ['A', [:a, :b], 1]
     info.descriptor.should == [] if ArgumentsDescriptorSpecs.tr?
+    info.arguments.should == ['A', :a, :b, {c: 1}] if ArgumentsDescriptorSpecs.tr?
     info.should == ArgumentsDescriptorSpecs::Info.new(['A', [:a, :b], 1], [], ArgumentsDescriptorSpecs.tr? ? ['A', :a, :b, {c: 1}] : [])
     
     -> { ArgumentsDescriptorSpecs.struct_new_like('A', :a, :b, d: 1) }.should raise_error(ArgumentError)
@@ -240,6 +256,7 @@ describe "Arguments descriptors" do
     info = ArgumentsDescriptorSpecs.describe_like(1, b: 2)
     info.values.should == [1, {b: 2}]
     info.descriptor.should == [:b, 1, true] if ArgumentsDescriptorSpecs.tr?
+    info.arguments.should == [1, {b: 2}] if ArgumentsDescriptorSpecs.tr?
     info.should == ArgumentsDescriptorSpecs::Info.new([1, {b: 2}], ArgumentsDescriptorSpecs.tr? ? [:b, 1, true] : [], ArgumentsDescriptorSpecs.tr? ? [1, {b: 2}] : [])
   end
 
@@ -247,6 +264,7 @@ describe "Arguments descriptors" do
     info = ArgumentsDescriptorSpecs.single({a: 1, b: 2})
     info.values.should == [{a: 1, b: 2}]
     info.descriptor.should == [] if ArgumentsDescriptorSpecs.tr?
+    info.arguments.should == [{a: 1, b: 2}] if ArgumentsDescriptorSpecs.tr?
     info.should == ArgumentsDescriptorSpecs::Info.new([{a: 1, b: 2}], [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
   end
 
@@ -254,6 +272,7 @@ describe "Arguments descriptors" do
     info = ArgumentsDescriptorSpecs.rest(a: 1, b: 2)
     info.values.should == [[{a: 1, b: 2}]]
     info.descriptor.should == [:a, :b, 0, true] if ArgumentsDescriptorSpecs.tr?
+    info.arguments.should == [{a: 1, b: 2}] if ArgumentsDescriptorSpecs.tr?
     info.should == ArgumentsDescriptorSpecs::Info.new([[{a: 1, b: 2}]], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
   end
 
@@ -261,6 +280,7 @@ describe "Arguments descriptors" do
     info = ArgumentsDescriptorSpecs.kw_rest(a: 1, b: 2)
     info.values.should == [{a: 1, b: 2}]
     info.descriptor.should == [:a, :b, 0, true] if ArgumentsDescriptorSpecs.tr?
+    info.arguments.should == [{a: 1, b: 2}] if ArgumentsDescriptorSpecs.tr?
     info.should == ArgumentsDescriptorSpecs::Info.new([{a: 1, b: 2}], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
   end
 
@@ -268,16 +288,19 @@ describe "Arguments descriptors" do
     info = ArgumentsDescriptorSpecs.kw_and_kw_rest(a: 1)
     info.values.should == [1, {}]
     info.descriptor.should == [:a, 0, true] if ArgumentsDescriptorSpecs.tr?
+    info.arguments.should == [{a: 1}] if ArgumentsDescriptorSpecs.tr?
     info.should == ArgumentsDescriptorSpecs::Info.new([1, {}], ArgumentsDescriptorSpecs.tr? ? [:a, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1}] : [])
     
     info = ArgumentsDescriptorSpecs.kw_and_kw_rest(a: 1, b: 2, c: 3)
     info.values.should == [1, {b: 2, c: 3}]
     info.descriptor.should == [:a, :b, :c, 0, true] if ArgumentsDescriptorSpecs.tr?
+    info.arguments.should == [{a: 1, b: 2, c: 3}] if ArgumentsDescriptorSpecs.tr?
     info.should == ArgumentsDescriptorSpecs::Info.new([1, {b: 2, c: 3}], ArgumentsDescriptorSpecs.tr? ? [:a, :b, :c, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2, c: 3}] : [])
     
     info = ArgumentsDescriptorSpecs.kw_and_kw_rest("abc" => 123, a: 1, b: 2)
     info.values.should == [1, {"abc" => 123, b: 2}]
     info.descriptor.should == [:a, :b, 0, false] if ArgumentsDescriptorSpecs.tr?
+    info.arguments.should == [{"abc" => 123, a: 1, b: 2}] if ArgumentsDescriptorSpecs.tr?
     info.should == ArgumentsDescriptorSpecs::Info.new([1, {"abc" => 123, b: 2}], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, false] : [], ArgumentsDescriptorSpecs.tr? ? [{"abc" => 123, a: 1, b: 2}] : [])
   end
 
@@ -285,21 +308,25 @@ describe "Arguments descriptors" do
     info = ArgumentsDescriptorSpecs.mixture(1, 2)
     info.values.should == [1, nil, nil, 2, nil, {}]
     info.descriptor.should == []  if ArgumentsDescriptorSpecs.tr?
+    info.arguments.should == [1, 2] if ArgumentsDescriptorSpecs.tr?
     info.should == ArgumentsDescriptorSpecs::Info.new([1, nil, nil, 2, nil, {}], ArgumentsDescriptorSpecs.tr? ? [] : [], ArgumentsDescriptorSpecs.tr? ? [1, 2] : [])
     
     info = ArgumentsDescriptorSpecs.mixture(1, 2, e: 3)
     info.values.should == [1, nil, nil, 2, 3, {}]
     info.descriptor.should == [:e, 2, true] if ArgumentsDescriptorSpecs.tr?
+    info.arguments.should == [1, 2, {e: 3}] if ArgumentsDescriptorSpecs.tr?
     info.should == ArgumentsDescriptorSpecs::Info.new([1, nil, nil, 2, 3, {}], ArgumentsDescriptorSpecs.tr? ? [:e, 2, true] : [], ArgumentsDescriptorSpecs.tr? ? [1, 2, {e: 3}] : [])
     
     info = ArgumentsDescriptorSpecs.mixture(1, 2, {foo: :bar})
     info.values.should == [1, 2, nil, {:foo=>:bar}, nil, {}]
     info.descriptor.should == [] if ArgumentsDescriptorSpecs.tr?
+    info.arguments.should == [1, 2, {foo: :bar}] if ArgumentsDescriptorSpecs.tr?
     info.should == ArgumentsDescriptorSpecs::Info.new([1, 2, nil, {:foo=>:bar}, nil, {}], ArgumentsDescriptorSpecs.tr? ? [] : [], ArgumentsDescriptorSpecs.tr? ? [1, 2, {foo: :bar}] : [])
     
     info = ArgumentsDescriptorSpecs.mixture(1, {foo: :bar})
     info.values.should == [1, nil, nil, {foo: :bar}, nil, {}]
     info.descriptor.should == [-1] if ArgumentsDescriptorSpecs.tr?
+    info.arguments.should == [1, {foo: :bar}] if ArgumentsDescriptorSpecs.tr?
     info.should == ArgumentsDescriptorSpecs::Info.new([1, nil, nil, {foo: :bar}, nil, {}], ArgumentsDescriptorSpecs.tr? ? [-1] : [], ArgumentsDescriptorSpecs.tr? ? [1, {foo: :bar}] : [])
   end
 
@@ -319,6 +346,7 @@ describe "Arguments descriptors" do
     info = ArgumentsDescriptorSpecs::NewKW.new(a: 1, b: 2)
     info.values.should == [1, 2]
     info.descriptor.should == [:a, :b, 0, true] if ArgumentsDescriptorSpecs.tr?
+    info.arguments.should == [{a: 1, b: 2}] if ArgumentsDescriptorSpecs.tr?
     info.should == ArgumentsDescriptorSpecs::Info.new([1, 2], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
   end
 
@@ -326,6 +354,7 @@ describe "Arguments descriptors" do
     info = ArgumentsDescriptorSpecs::NewRest.new(a: 1, b: 2)
     info.values.should == [[{a: 1, b: 2}]]
     info.descriptor.should == [:a, :b, 0, true] if ArgumentsDescriptorSpecs.tr?
+    info.arguments.should == [{a: 1, b: 2}] if ArgumentsDescriptorSpecs.tr?
     info.should == ArgumentsDescriptorSpecs::Info.new([[{a: 1, b: 2}]], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
   end
 
@@ -333,6 +362,7 @@ describe "Arguments descriptors" do
     info = ArgumentsDescriptorSpecs::A.new.implicit_super(a: 1, b: 2)
     info.values.should == [1, 2]
     info.descriptor.should == [:a, :b, 0, true] if ArgumentsDescriptorSpecs.tr?
+    info.arguments.should == [{a: 1, b: 2}] if ArgumentsDescriptorSpecs.tr?
     info.should == ArgumentsDescriptorSpecs::Info.new([1, 2], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
   end
 
@@ -340,6 +370,7 @@ describe "Arguments descriptors" do
     info = ArgumentsDescriptorSpecs::A.new.explicit_super(a: 1, b: 2)
     info.values.should == [1, 2]
     info.descriptor.should == [:a, :b, 0, true] if ArgumentsDescriptorSpecs.tr?
+    info.arguments.should == [{a: 1, b: 2}] if ArgumentsDescriptorSpecs.tr?
     info.should == ArgumentsDescriptorSpecs::Info.new([1, 2], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
   end
 
@@ -347,6 +378,7 @@ describe "Arguments descriptors" do
     info = ArgumentsDescriptorSpecs.use_yielder(1, 2)
     info.values.should == [1, 2]
     info.descriptor.should == [:a, :b, 0, true] if ArgumentsDescriptorSpecs.tr?
+    info.arguments.should == [{a: 1, b: 2}] if ArgumentsDescriptorSpecs.tr?
     info.should == ArgumentsDescriptorSpecs::Info.new([1, 2], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
   end
 end

--- a/spec/truffle/arguments_descriptor_spec.rb
+++ b/spec/truffle/arguments_descriptor_spec.rb
@@ -120,71 +120,87 @@ end
 describe "Arguments descriptors" do
   it "are empty for simple calls" do
     info = ArgumentsDescriptorSpecs.no_kws(1, 2)
+    info.values.should == [1, 2]
     info.should == ArgumentsDescriptorSpecs::Info.new([1, 2], [], ArgumentsDescriptorSpecs.tr? ? [1, 2]: [])
   end
 
   it "contain keyword arguments" do
     info = ArgumentsDescriptorSpecs.only_kws(a: 1, b: 2)
+    info.values.should == [1, 2]
     info.should == ArgumentsDescriptorSpecs::Info.new([1, 2], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
   end
 
   it "contain optional keyword arguments" do
     info = ArgumentsDescriptorSpecs.only_kws_and_opt(a: 1, b: 2)
+    info.values.should == [1, 2]
     info.should == ArgumentsDescriptorSpecs::Info.new([1, 2], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
     
     info = ArgumentsDescriptorSpecs.only_kws_and_opt(a: 1)
+    info.values.should == [1, 101]
     info.should == ArgumentsDescriptorSpecs::Info.new([1, 101], ArgumentsDescriptorSpecs.tr? ? [:a, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1}] : [])
   end
 
   it "contain keyword arguments with positional arguments" do
     info = ArgumentsDescriptorSpecs.posn_kws(1, b: 2)
+    info.values.should == [1, 2]
     info.should == ArgumentsDescriptorSpecs::Info.new([1, 2], ArgumentsDescriptorSpecs.tr? ? [:b, 1, true] : [], ArgumentsDescriptorSpecs.tr? ? [1, {b: 2}] : [])
   end
 
   it "contain optional keyword arguments with positional arguments" do
     info = ArgumentsDescriptorSpecs.posn_kws_defaults(1, b: 2, c: 3)
+    info.values.should == [1, 2, 3]
     info.should == ArgumentsDescriptorSpecs::Info.new([1, 2, 3], ArgumentsDescriptorSpecs.tr? ? [:b, :c, 1, true] : [], ArgumentsDescriptorSpecs.tr? ? [1, {b: 2, c: 3}] : [])
   end
 
   it "do not contain missing optional keyword arguments" do
     info = ArgumentsDescriptorSpecs.posn_kws_defaults(1, b: 2)
+    info.values.should == [1, 2, 102]
     info.should == ArgumentsDescriptorSpecs::Info.new([1, 2, 102], ArgumentsDescriptorSpecs.tr? ? [:b, 1, true] : [], ArgumentsDescriptorSpecs.tr? ? [1, {b: 2}] : [])
     
     info = ArgumentsDescriptorSpecs.posn_kws_defaults(1, c: 3)
+    info.values.should == [1, 101, 3]
     info.should == ArgumentsDescriptorSpecs::Info.new([1, 101, 3], ArgumentsDescriptorSpecs.tr? ? [:c, 1, true] : [], ArgumentsDescriptorSpecs.tr? ? [1, {c: 3}] : [])
   end
 
   it "do not contain the name of distant explicitly splatted keyword arguments" do
     distant = {b: 2}
     info = ArgumentsDescriptorSpecs.only_kws(a: 1, **distant)
+    info.values.should == [1, 2]
     info.should == ArgumentsDescriptorSpecs::Info.new([1, 2], ArgumentsDescriptorSpecs.tr? ? [:a, 0, false] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
   end
 
   it "do not contain the name of near explicitly splatted keyword arguments" do
     info = ArgumentsDescriptorSpecs.only_kws(a: 1, **{b: 2})
+    info.values.should == [1, 2]
     info.should == ArgumentsDescriptorSpecs::Info.new([1, 2], ArgumentsDescriptorSpecs.tr? ? [:a, 0, false] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
   end
 
   it "contain the name of present optional keyword arguments without the optional positional" do
     info = ArgumentsDescriptorSpecs.opt_and_kws(1, c: 3)
+    info.values.should == [1, 2, 3]
     info.should == ArgumentsDescriptorSpecs::Info.new([1, 2, 3], ArgumentsDescriptorSpecs.tr? ? [:c, 1, true] : [], ArgumentsDescriptorSpecs.tr? ? [1, {c: 3}] : [])
   end
 
   it "work for a call like our Struct.new" do
     info = ArgumentsDescriptorSpecs.struct_new_like('A', :a, :b)
+    info.values.should == ['A', [:a, :b], 101]
     info.should == ArgumentsDescriptorSpecs::Info.new(['A', [:a, :b], 101], [], ArgumentsDescriptorSpecs.tr? ? ['A', :a, :b] : [])
     
     info = ArgumentsDescriptorSpecs.struct_new_like('A', :a, :b, c: 1)
+    info.values.should == ['A', [:a, :b], 1]
     info.should == ArgumentsDescriptorSpecs::Info.new(['A', [:a, :b], 1], ArgumentsDescriptorSpecs.tr? ? [:c, 3, true] : [], ArgumentsDescriptorSpecs.tr? ? ['A', :a, :b, {c: 1}] : [])
     
     info = ArgumentsDescriptorSpecs.struct_new_like('A', :a, :b, {c: 1})
+    info.values.should == ['A', [:a, :b, {c: 1}], 101]
     info.should == ArgumentsDescriptorSpecs::Info.new(['A', [:a, :b, {c: 1}], 101], [], ArgumentsDescriptorSpecs.tr? ? ['A', :a, :b, {c: 1}] : [])
     
     info = ArgumentsDescriptorSpecs.struct_new_like('A', :a, :b, **{c: 1})
+    info.values.should == ['A', [:a, :b], 1]
     info.should == ArgumentsDescriptorSpecs::Info.new(['A', [:a, :b], 1], [], ArgumentsDescriptorSpecs.tr? ? ['A', :a, :b, {c: 1}] : [])
     
     distant = {c: 1}
     info = ArgumentsDescriptorSpecs.struct_new_like('A', :a, :b, **distant)
+    info.values.should == ['A', [:a, :b], 1]
     info.should == ArgumentsDescriptorSpecs::Info.new(['A', [:a, :b], 1], [], ArgumentsDescriptorSpecs.tr? ? ['A', :a, :b, {c: 1}] : [])
     
     -> { ArgumentsDescriptorSpecs.struct_new_like('A', :a, :b, d: 1) }.should raise_error(ArgumentError)
@@ -206,46 +222,57 @@ describe "Arguments descriptors" do
 
   it "work for a call like MSpec #describe" do
     info = ArgumentsDescriptorSpecs.describe_like(1, b: 2)
+    info.values.should == [1, {b: 2}]
     info.should == ArgumentsDescriptorSpecs::Info.new([1, {b: 2}], ArgumentsDescriptorSpecs.tr? ? [:b, 1, true] : [], ArgumentsDescriptorSpecs.tr? ? [1, {b: 2}] : [])
   end
 
   it "expand a hash not used for keyword arguments" do
     info = ArgumentsDescriptorSpecs.single({a: 1, b: 2})
+    info.values.should == [{a: 1, b: 2}]
     info.should == ArgumentsDescriptorSpecs::Info.new([{a: 1, b: 2}], [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
   end
 
   it "contain keyword argument names passed to a rest" do
     info = ArgumentsDescriptorSpecs.rest(a: 1, b: 2)
+    info.values.should == [[{a: 1, b: 2}]]
     info.should == ArgumentsDescriptorSpecs::Info.new([[{a: 1, b: 2}]], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
   end
 
   it "contain keyword argument names passed to a keyword rest" do
     info = ArgumentsDescriptorSpecs.kw_rest(a: 1, b: 2)
+    info.values.should == [{a: 1, b: 2}]
     info.should == ArgumentsDescriptorSpecs::Info.new([{a: 1, b: 2}], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
   end
 
   it "contain keyword argument names passed to a combined keyword rest" do
     info = ArgumentsDescriptorSpecs.kw_and_kw_rest(a: 1)
+    info.values.should == [1, {}]
     info.should == ArgumentsDescriptorSpecs::Info.new([1, {}], ArgumentsDescriptorSpecs.tr? ? [:a, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1}] : [])
     
     info = ArgumentsDescriptorSpecs.kw_and_kw_rest(a: 1, b: 2, c: 3)
+    info.values.should == [1, {b: 2, c: 3}]
     info.should == ArgumentsDescriptorSpecs::Info.new([1, {b: 2, c: 3}], ArgumentsDescriptorSpecs.tr? ? [:a, :b, :c, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2, c: 3}] : [])
     
     info = ArgumentsDescriptorSpecs.kw_and_kw_rest("abc" => 123, a: 1, b: 2)
+    info.values.should == [1, {"abc" => 123, b: 2}]
     info.should == ArgumentsDescriptorSpecs::Info.new([1, {"abc" => 123, b: 2}], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, false] : [], ArgumentsDescriptorSpecs.tr? ? [{"abc" => 123, a: 1, b: 2}] : [])
   end
 
   it "work for a mixture of arguments" do
     info = ArgumentsDescriptorSpecs.mixture(1, 2)
+    info.values.should == [1, nil, nil, 2, nil, {}]
     info.should == ArgumentsDescriptorSpecs::Info.new([1, nil, nil, 2, nil, {}], ArgumentsDescriptorSpecs.tr? ? [] : [], ArgumentsDescriptorSpecs.tr? ? [1, 2] : [])
     
     info = ArgumentsDescriptorSpecs.mixture(1, 2, e: 3)
+    info.values.should == [1, nil, nil, 2, 3, {}]
     info.should == ArgumentsDescriptorSpecs::Info.new([1, nil, nil, 2, 3, {}], ArgumentsDescriptorSpecs.tr? ? [:e, 2, true] : [], ArgumentsDescriptorSpecs.tr? ? [1, 2, {e: 3}] : [])
     
     info = ArgumentsDescriptorSpecs.mixture(1, 2, {foo: :bar})
+    info.values.should == [1, 2, nil, {:foo=>:bar}, nil, {}]
     info.should == ArgumentsDescriptorSpecs::Info.new([1, 2, nil, {:foo=>:bar}, nil, {}], ArgumentsDescriptorSpecs.tr? ? [] : [], ArgumentsDescriptorSpecs.tr? ? [1, 2, {foo: :bar}] : [])
     
     info = ArgumentsDescriptorSpecs.mixture(1, {foo: :bar})
+    info.values.should == [1, nil, nil, {foo: :bar}, nil, {}]
     info.should == ArgumentsDescriptorSpecs::Info.new([1, nil, nil, {foo: :bar}, nil, {}], ArgumentsDescriptorSpecs.tr? ? [-1] : [], ArgumentsDescriptorSpecs.tr? ? [1, {foo: :bar}] : [])
   end
 
@@ -263,26 +290,31 @@ describe "Arguments descriptors" do
 
   it "work through custom new with keyword arguments" do
     info = ArgumentsDescriptorSpecs::NewKW.new(a: 1, b: 2)
+    info.values.should == [1, 2]
     info.should == ArgumentsDescriptorSpecs::Info.new([1, 2], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
   end
 
   it "work through custom new with rest" do
     info = ArgumentsDescriptorSpecs::NewRest.new(a: 1, b: 2)
+    info.values.should == [[{a: 1, b: 2}]]
     info.should == ArgumentsDescriptorSpecs::Info.new([[{a: 1, b: 2}]], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
   end
 
   it "work through implicit super" do
     info = ArgumentsDescriptorSpecs::A.new.implicit_super(a: 1, b: 2)
+    info.values.should == [1, 2]
     info.should == ArgumentsDescriptorSpecs::Info.new([1, 2], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
   end
 
   it "work through explicit super" do
     info = ArgumentsDescriptorSpecs::A.new.explicit_super(a: 1, b: 2)
+    info.values.should == [1, 2]
     info.should == ArgumentsDescriptorSpecs::Info.new([1, 2], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
   end
 
   it "work through yield" do
     info = ArgumentsDescriptorSpecs.use_yielder(1, 2)
+    info.values.should == [1, 2]
     info.should == ArgumentsDescriptorSpecs::Info.new([1, 2], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
   end
 end

--- a/spec/truffle/arguments_descriptor_spec.rb
+++ b/spec/truffle/arguments_descriptor_spec.rb
@@ -82,6 +82,37 @@ module ArgumentsDescriptorSpecs
       [a, Primitive.arguments_descriptor, Primitive.arguments]
     end
   end
+
+  class A
+    def implicit_super(a:, b:)
+      [a, b, Primitive.arguments_descriptor, Primitive.arguments]
+
+    end
+
+    def explicit_super(a:, b:)
+      [a, b, Primitive.arguments_descriptor, Primitive.arguments]
+    end
+  end
+
+  class B < A
+    def implicit_super(a:, b:)
+      super
+    end
+
+    def explicit_super(a:, b:)
+      super(a: a, b: b)
+    end
+  end
+
+  def self.yielder(a, b)
+    yield(a: a, b: b)
+  end
+
+  def self.use_yielder(x, y)
+    yielder(x, y) do |a:, b:|
+      [a, b, Primitive.arguments_descriptor, Primitive.arguments]
+    end
+  end
 end
 
 describe "Arguments descriptors" do
@@ -193,5 +224,17 @@ describe "Arguments descriptors" do
 
   it "work through custom new with rest" do
     ArgumentsDescriptorSpecs::NewRest.new(a: 1, b: 2).should == [[{a: 1, b: 2}], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : []]
+  end
+
+  it "work through implicit super" do
+    ArgumentsDescriptorSpecs::A.new.implicit_super(a: 1, b: 2).should == [1, 2, ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : []]
+  end
+
+  it "work through explicit super" do
+    ArgumentsDescriptorSpecs::A.new.explicit_super(a: 1, b: 2).should == [1, 2, ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : []]
+  end
+
+  it "work through yield" do
+    ArgumentsDescriptorSpecs.use_yielder(1, 2).should == [1, 2, ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : []]
   end
 end

--- a/spec/truffle/arguments_descriptor_spec.rb
+++ b/spec/truffle/arguments_descriptor_spec.rb
@@ -121,44 +121,52 @@ describe "Arguments descriptors" do
   it "are empty for simple calls" do
     info = ArgumentsDescriptorSpecs.no_kws(1, 2)
     info.values.should == [1, 2]
+    info.descriptor.should == [] if ArgumentsDescriptorSpecs.tr?
     info.should == ArgumentsDescriptorSpecs::Info.new([1, 2], [], ArgumentsDescriptorSpecs.tr? ? [1, 2]: [])
   end
 
   it "contain keyword arguments" do
     info = ArgumentsDescriptorSpecs.only_kws(a: 1, b: 2)
     info.values.should == [1, 2]
+    info.descriptor.should == [:a, :b, 0, true] if ArgumentsDescriptorSpecs.tr?
     info.should == ArgumentsDescriptorSpecs::Info.new([1, 2], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
   end
 
   it "contain optional keyword arguments" do
     info = ArgumentsDescriptorSpecs.only_kws_and_opt(a: 1, b: 2)
     info.values.should == [1, 2]
+    info.descriptor.should == [:a, :b, 0, true] if ArgumentsDescriptorSpecs.tr?
     info.should == ArgumentsDescriptorSpecs::Info.new([1, 2], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
     
     info = ArgumentsDescriptorSpecs.only_kws_and_opt(a: 1)
     info.values.should == [1, 101]
+    info.descriptor.should == [:a, 0, true] if ArgumentsDescriptorSpecs.tr?
     info.should == ArgumentsDescriptorSpecs::Info.new([1, 101], ArgumentsDescriptorSpecs.tr? ? [:a, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1}] : [])
   end
 
   it "contain keyword arguments with positional arguments" do
     info = ArgumentsDescriptorSpecs.posn_kws(1, b: 2)
     info.values.should == [1, 2]
+    info.descriptor.should == [:b, 1, true] if ArgumentsDescriptorSpecs.tr?
     info.should == ArgumentsDescriptorSpecs::Info.new([1, 2], ArgumentsDescriptorSpecs.tr? ? [:b, 1, true] : [], ArgumentsDescriptorSpecs.tr? ? [1, {b: 2}] : [])
   end
 
   it "contain optional keyword arguments with positional arguments" do
     info = ArgumentsDescriptorSpecs.posn_kws_defaults(1, b: 2, c: 3)
     info.values.should == [1, 2, 3]
+    info.descriptor.should == [:b, :c, 1, true] if ArgumentsDescriptorSpecs.tr?
     info.should == ArgumentsDescriptorSpecs::Info.new([1, 2, 3], ArgumentsDescriptorSpecs.tr? ? [:b, :c, 1, true] : [], ArgumentsDescriptorSpecs.tr? ? [1, {b: 2, c: 3}] : [])
   end
 
   it "do not contain missing optional keyword arguments" do
     info = ArgumentsDescriptorSpecs.posn_kws_defaults(1, b: 2)
     info.values.should == [1, 2, 102]
+    info.descriptor.should == [:b, 1, true] if ArgumentsDescriptorSpecs.tr?
     info.should == ArgumentsDescriptorSpecs::Info.new([1, 2, 102], ArgumentsDescriptorSpecs.tr? ? [:b, 1, true] : [], ArgumentsDescriptorSpecs.tr? ? [1, {b: 2}] : [])
     
     info = ArgumentsDescriptorSpecs.posn_kws_defaults(1, c: 3)
     info.values.should == [1, 101, 3]
+    info.descriptor.should == [:c, 1, true] if ArgumentsDescriptorSpecs.tr?
     info.should == ArgumentsDescriptorSpecs::Info.new([1, 101, 3], ArgumentsDescriptorSpecs.tr? ? [:c, 1, true] : [], ArgumentsDescriptorSpecs.tr? ? [1, {c: 3}] : [])
   end
 
@@ -166,41 +174,49 @@ describe "Arguments descriptors" do
     distant = {b: 2}
     info = ArgumentsDescriptorSpecs.only_kws(a: 1, **distant)
     info.values.should == [1, 2]
+    info.descriptor.should == [:a, 0, false] if ArgumentsDescriptorSpecs.tr?
     info.should == ArgumentsDescriptorSpecs::Info.new([1, 2], ArgumentsDescriptorSpecs.tr? ? [:a, 0, false] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
   end
 
   it "do not contain the name of near explicitly splatted keyword arguments" do
     info = ArgumentsDescriptorSpecs.only_kws(a: 1, **{b: 2})
     info.values.should == [1, 2]
+    info.descriptor.should == [:a, 0, false] if ArgumentsDescriptorSpecs.tr?
     info.should == ArgumentsDescriptorSpecs::Info.new([1, 2], ArgumentsDescriptorSpecs.tr? ? [:a, 0, false] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
   end
 
   it "contain the name of present optional keyword arguments without the optional positional" do
     info = ArgumentsDescriptorSpecs.opt_and_kws(1, c: 3)
     info.values.should == [1, 2, 3]
+    info.descriptor.should == [:c, 1, true] if ArgumentsDescriptorSpecs.tr?
     info.should == ArgumentsDescriptorSpecs::Info.new([1, 2, 3], ArgumentsDescriptorSpecs.tr? ? [:c, 1, true] : [], ArgumentsDescriptorSpecs.tr? ? [1, {c: 3}] : [])
   end
 
   it "work for a call like our Struct.new" do
     info = ArgumentsDescriptorSpecs.struct_new_like('A', :a, :b)
     info.values.should == ['A', [:a, :b], 101]
+    info.descriptor.should == [] if ArgumentsDescriptorSpecs.tr?
     info.should == ArgumentsDescriptorSpecs::Info.new(['A', [:a, :b], 101], [], ArgumentsDescriptorSpecs.tr? ? ['A', :a, :b] : [])
     
     info = ArgumentsDescriptorSpecs.struct_new_like('A', :a, :b, c: 1)
     info.values.should == ['A', [:a, :b], 1]
+    info.descriptor.should == [:c, 3, true] if ArgumentsDescriptorSpecs.tr?
     info.should == ArgumentsDescriptorSpecs::Info.new(['A', [:a, :b], 1], ArgumentsDescriptorSpecs.tr? ? [:c, 3, true] : [], ArgumentsDescriptorSpecs.tr? ? ['A', :a, :b, {c: 1}] : [])
     
     info = ArgumentsDescriptorSpecs.struct_new_like('A', :a, :b, {c: 1})
     info.values.should == ['A', [:a, :b, {c: 1}], 101]
+    info.descriptor.should == [] if ArgumentsDescriptorSpecs.tr?
     info.should == ArgumentsDescriptorSpecs::Info.new(['A', [:a, :b, {c: 1}], 101], [], ArgumentsDescriptorSpecs.tr? ? ['A', :a, :b, {c: 1}] : [])
     
     info = ArgumentsDescriptorSpecs.struct_new_like('A', :a, :b, **{c: 1})
     info.values.should == ['A', [:a, :b], 1]
+    info.descriptor.should == [] if ArgumentsDescriptorSpecs.tr?
     info.should == ArgumentsDescriptorSpecs::Info.new(['A', [:a, :b], 1], [], ArgumentsDescriptorSpecs.tr? ? ['A', :a, :b, {c: 1}] : [])
     
     distant = {c: 1}
     info = ArgumentsDescriptorSpecs.struct_new_like('A', :a, :b, **distant)
     info.values.should == ['A', [:a, :b], 1]
+    info.descriptor.should == [] if ArgumentsDescriptorSpecs.tr?
     info.should == ArgumentsDescriptorSpecs::Info.new(['A', [:a, :b], 1], [], ArgumentsDescriptorSpecs.tr? ? ['A', :a, :b, {c: 1}] : [])
     
     -> { ArgumentsDescriptorSpecs.struct_new_like('A', :a, :b, d: 1) }.should raise_error(ArgumentError)
@@ -223,56 +239,67 @@ describe "Arguments descriptors" do
   it "work for a call like MSpec #describe" do
     info = ArgumentsDescriptorSpecs.describe_like(1, b: 2)
     info.values.should == [1, {b: 2}]
+    info.descriptor.should == [:b, 1, true] if ArgumentsDescriptorSpecs.tr?
     info.should == ArgumentsDescriptorSpecs::Info.new([1, {b: 2}], ArgumentsDescriptorSpecs.tr? ? [:b, 1, true] : [], ArgumentsDescriptorSpecs.tr? ? [1, {b: 2}] : [])
   end
 
   it "expand a hash not used for keyword arguments" do
     info = ArgumentsDescriptorSpecs.single({a: 1, b: 2})
     info.values.should == [{a: 1, b: 2}]
+    info.descriptor.should == [] if ArgumentsDescriptorSpecs.tr?
     info.should == ArgumentsDescriptorSpecs::Info.new([{a: 1, b: 2}], [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
   end
 
   it "contain keyword argument names passed to a rest" do
     info = ArgumentsDescriptorSpecs.rest(a: 1, b: 2)
     info.values.should == [[{a: 1, b: 2}]]
+    info.descriptor.should == [:a, :b, 0, true] if ArgumentsDescriptorSpecs.tr?
     info.should == ArgumentsDescriptorSpecs::Info.new([[{a: 1, b: 2}]], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
   end
 
   it "contain keyword argument names passed to a keyword rest" do
     info = ArgumentsDescriptorSpecs.kw_rest(a: 1, b: 2)
     info.values.should == [{a: 1, b: 2}]
+    info.descriptor.should == [:a, :b, 0, true] if ArgumentsDescriptorSpecs.tr?
     info.should == ArgumentsDescriptorSpecs::Info.new([{a: 1, b: 2}], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
   end
 
   it "contain keyword argument names passed to a combined keyword rest" do
     info = ArgumentsDescriptorSpecs.kw_and_kw_rest(a: 1)
     info.values.should == [1, {}]
+    info.descriptor.should == [:a, 0, true] if ArgumentsDescriptorSpecs.tr?
     info.should == ArgumentsDescriptorSpecs::Info.new([1, {}], ArgumentsDescriptorSpecs.tr? ? [:a, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1}] : [])
     
     info = ArgumentsDescriptorSpecs.kw_and_kw_rest(a: 1, b: 2, c: 3)
     info.values.should == [1, {b: 2, c: 3}]
+    info.descriptor.should == [:a, :b, :c, 0, true] if ArgumentsDescriptorSpecs.tr?
     info.should == ArgumentsDescriptorSpecs::Info.new([1, {b: 2, c: 3}], ArgumentsDescriptorSpecs.tr? ? [:a, :b, :c, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2, c: 3}] : [])
     
     info = ArgumentsDescriptorSpecs.kw_and_kw_rest("abc" => 123, a: 1, b: 2)
     info.values.should == [1, {"abc" => 123, b: 2}]
+    info.descriptor.should == [:a, :b, 0, false] if ArgumentsDescriptorSpecs.tr?
     info.should == ArgumentsDescriptorSpecs::Info.new([1, {"abc" => 123, b: 2}], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, false] : [], ArgumentsDescriptorSpecs.tr? ? [{"abc" => 123, a: 1, b: 2}] : [])
   end
 
   it "work for a mixture of arguments" do
     info = ArgumentsDescriptorSpecs.mixture(1, 2)
     info.values.should == [1, nil, nil, 2, nil, {}]
+    info.descriptor.should == []  if ArgumentsDescriptorSpecs.tr?
     info.should == ArgumentsDescriptorSpecs::Info.new([1, nil, nil, 2, nil, {}], ArgumentsDescriptorSpecs.tr? ? [] : [], ArgumentsDescriptorSpecs.tr? ? [1, 2] : [])
     
     info = ArgumentsDescriptorSpecs.mixture(1, 2, e: 3)
     info.values.should == [1, nil, nil, 2, 3, {}]
+    info.descriptor.should == [:e, 2, true] if ArgumentsDescriptorSpecs.tr?
     info.should == ArgumentsDescriptorSpecs::Info.new([1, nil, nil, 2, 3, {}], ArgumentsDescriptorSpecs.tr? ? [:e, 2, true] : [], ArgumentsDescriptorSpecs.tr? ? [1, 2, {e: 3}] : [])
     
     info = ArgumentsDescriptorSpecs.mixture(1, 2, {foo: :bar})
     info.values.should == [1, 2, nil, {:foo=>:bar}, nil, {}]
+    info.descriptor.should == [] if ArgumentsDescriptorSpecs.tr?
     info.should == ArgumentsDescriptorSpecs::Info.new([1, 2, nil, {:foo=>:bar}, nil, {}], ArgumentsDescriptorSpecs.tr? ? [] : [], ArgumentsDescriptorSpecs.tr? ? [1, 2, {foo: :bar}] : [])
     
     info = ArgumentsDescriptorSpecs.mixture(1, {foo: :bar})
     info.values.should == [1, nil, nil, {foo: :bar}, nil, {}]
+    info.descriptor.should == [-1] if ArgumentsDescriptorSpecs.tr?
     info.should == ArgumentsDescriptorSpecs::Info.new([1, nil, nil, {foo: :bar}, nil, {}], ArgumentsDescriptorSpecs.tr? ? [-1] : [], ArgumentsDescriptorSpecs.tr? ? [1, {foo: :bar}] : [])
   end
 
@@ -291,30 +318,35 @@ describe "Arguments descriptors" do
   it "work through custom new with keyword arguments" do
     info = ArgumentsDescriptorSpecs::NewKW.new(a: 1, b: 2)
     info.values.should == [1, 2]
+    info.descriptor.should == [:a, :b, 0, true] if ArgumentsDescriptorSpecs.tr?
     info.should == ArgumentsDescriptorSpecs::Info.new([1, 2], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
   end
 
   it "work through custom new with rest" do
     info = ArgumentsDescriptorSpecs::NewRest.new(a: 1, b: 2)
     info.values.should == [[{a: 1, b: 2}]]
+    info.descriptor.should == [:a, :b, 0, true] if ArgumentsDescriptorSpecs.tr?
     info.should == ArgumentsDescriptorSpecs::Info.new([[{a: 1, b: 2}]], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
   end
 
   it "work through implicit super" do
     info = ArgumentsDescriptorSpecs::A.new.implicit_super(a: 1, b: 2)
     info.values.should == [1, 2]
+    info.descriptor.should == [:a, :b, 0, true] if ArgumentsDescriptorSpecs.tr?
     info.should == ArgumentsDescriptorSpecs::Info.new([1, 2], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
   end
 
   it "work through explicit super" do
     info = ArgumentsDescriptorSpecs::A.new.explicit_super(a: 1, b: 2)
     info.values.should == [1, 2]
+    info.descriptor.should == [:a, :b, 0, true] if ArgumentsDescriptorSpecs.tr?
     info.should == ArgumentsDescriptorSpecs::Info.new([1, 2], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
   end
 
   it "work through yield" do
     info = ArgumentsDescriptorSpecs.use_yielder(1, 2)
     info.values.should == [1, 2]
+    info.descriptor.should == [:a, :b, 0, true] if ArgumentsDescriptorSpecs.tr?
     info.should == ArgumentsDescriptorSpecs::Info.new([1, 2], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
   end
 end

--- a/spec/truffle/arguments_descriptor_spec.rb
+++ b/spec/truffle/arguments_descriptor_spec.rb
@@ -12,11 +12,11 @@ module ArgumentsDescriptorSpecs
   unless tr?
     module Primitive
       def self.arguments_descriptor
-        []
+        nil
       end
 
       def self.arguments
-        []
+        nil
       end
     end
   end
@@ -123,7 +123,6 @@ describe "Arguments descriptors" do
     info.values.should == [1, 2]
     info.descriptor.should == [] if ArgumentsDescriptorSpecs.tr?
     info.arguments.should == [1, 2] if ArgumentsDescriptorSpecs.tr?
-    info.should == ArgumentsDescriptorSpecs::Info.new([1, 2], [], ArgumentsDescriptorSpecs.tr? ? [1, 2]: [])
   end
 
   it "contain keyword arguments" do
@@ -131,7 +130,6 @@ describe "Arguments descriptors" do
     info.values.should == [1, 2]
     info.descriptor.should == [:a, :b, 0, true] if ArgumentsDescriptorSpecs.tr?
     info.arguments.should == [{a: 1, b: 2}] if ArgumentsDescriptorSpecs.tr?
-    info.should == ArgumentsDescriptorSpecs::Info.new([1, 2], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
   end
 
   it "contain optional keyword arguments" do
@@ -139,13 +137,11 @@ describe "Arguments descriptors" do
     info.values.should == [1, 2]
     info.descriptor.should == [:a, :b, 0, true] if ArgumentsDescriptorSpecs.tr?
     info.arguments.should == [{a: 1, b: 2}] if ArgumentsDescriptorSpecs.tr?
-    info.should == ArgumentsDescriptorSpecs::Info.new([1, 2], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
-    
+
     info = ArgumentsDescriptorSpecs.only_kws_and_opt(a: 1)
     info.values.should == [1, 101]
     info.descriptor.should == [:a, 0, true] if ArgumentsDescriptorSpecs.tr?
     info.arguments.should == [{a: 1}] if ArgumentsDescriptorSpecs.tr?
-    info.should == ArgumentsDescriptorSpecs::Info.new([1, 101], ArgumentsDescriptorSpecs.tr? ? [:a, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1}] : [])
   end
 
   it "contain keyword arguments with positional arguments" do
@@ -153,7 +149,6 @@ describe "Arguments descriptors" do
     info.values.should == [1, 2]
     info.descriptor.should == [:b, 1, true] if ArgumentsDescriptorSpecs.tr?
     info.arguments.should == [1, {b: 2}] if ArgumentsDescriptorSpecs.tr?
-    info.should == ArgumentsDescriptorSpecs::Info.new([1, 2], ArgumentsDescriptorSpecs.tr? ? [:b, 1, true] : [], ArgumentsDescriptorSpecs.tr? ? [1, {b: 2}] : [])
   end
 
   it "contain optional keyword arguments with positional arguments" do
@@ -161,7 +156,6 @@ describe "Arguments descriptors" do
     info.values.should == [1, 2, 3]
     info.descriptor.should == [:b, :c, 1, true] if ArgumentsDescriptorSpecs.tr?
     info.arguments.should == [1, {b: 2, c: 3}] if ArgumentsDescriptorSpecs.tr?
-    info.should == ArgumentsDescriptorSpecs::Info.new([1, 2, 3], ArgumentsDescriptorSpecs.tr? ? [:b, :c, 1, true] : [], ArgumentsDescriptorSpecs.tr? ? [1, {b: 2, c: 3}] : [])
   end
 
   it "do not contain missing optional keyword arguments" do
@@ -169,13 +163,11 @@ describe "Arguments descriptors" do
     info.values.should == [1, 2, 102]
     info.descriptor.should == [:b, 1, true] if ArgumentsDescriptorSpecs.tr?
     info.arguments.should == [1, {b: 2}] if ArgumentsDescriptorSpecs.tr?
-    info.should == ArgumentsDescriptorSpecs::Info.new([1, 2, 102], ArgumentsDescriptorSpecs.tr? ? [:b, 1, true] : [], ArgumentsDescriptorSpecs.tr? ? [1, {b: 2}] : [])
-    
+
     info = ArgumentsDescriptorSpecs.posn_kws_defaults(1, c: 3)
     info.values.should == [1, 101, 3]
     info.descriptor.should == [:c, 1, true] if ArgumentsDescriptorSpecs.tr?
     info.arguments.should == [1, {c: 3}] if ArgumentsDescriptorSpecs.tr?
-    info.should == ArgumentsDescriptorSpecs::Info.new([1, 101, 3], ArgumentsDescriptorSpecs.tr? ? [:c, 1, true] : [], ArgumentsDescriptorSpecs.tr? ? [1, {c: 3}] : [])
   end
 
   it "do not contain the name of distant explicitly splatted keyword arguments" do
@@ -184,7 +176,6 @@ describe "Arguments descriptors" do
     info.values.should == [1, 2]
     info.descriptor.should == [:a, 0, false] if ArgumentsDescriptorSpecs.tr?
     info.arguments.should == [{a: 1, b: 2}] if ArgumentsDescriptorSpecs.tr?
-    info.should == ArgumentsDescriptorSpecs::Info.new([1, 2], ArgumentsDescriptorSpecs.tr? ? [:a, 0, false] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
   end
 
   it "do not contain the name of near explicitly splatted keyword arguments" do
@@ -192,7 +183,6 @@ describe "Arguments descriptors" do
     info.values.should == [1, 2]
     info.descriptor.should == [:a, 0, false] if ArgumentsDescriptorSpecs.tr?
     info.arguments.should == [{a: 1, b: 2}] if ArgumentsDescriptorSpecs.tr?
-    info.should == ArgumentsDescriptorSpecs::Info.new([1, 2], ArgumentsDescriptorSpecs.tr? ? [:a, 0, false] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
   end
 
   it "contain the name of present optional keyword arguments without the optional positional" do
@@ -200,7 +190,6 @@ describe "Arguments descriptors" do
     info.values.should == [1, 2, 3]
     info.descriptor.should == [:c, 1, true] if ArgumentsDescriptorSpecs.tr?
     info.arguments.should == [1, {c: 3}] if ArgumentsDescriptorSpecs.tr?
-    info.should == ArgumentsDescriptorSpecs::Info.new([1, 2, 3], ArgumentsDescriptorSpecs.tr? ? [:c, 1, true] : [], ArgumentsDescriptorSpecs.tr? ? [1, {c: 3}] : [])
   end
 
   it "work for a call like our Struct.new" do
@@ -208,37 +197,32 @@ describe "Arguments descriptors" do
     info.values.should == ['A', [:a, :b], 101]
     info.descriptor.should == [] if ArgumentsDescriptorSpecs.tr?
     info.arguments.should == ['A', :a, :b] if ArgumentsDescriptorSpecs.tr?
-    info.should == ArgumentsDescriptorSpecs::Info.new(['A', [:a, :b], 101], [], ArgumentsDescriptorSpecs.tr? ? ['A', :a, :b] : [])
-    
+
     info = ArgumentsDescriptorSpecs.struct_new_like('A', :a, :b, c: 1)
     info.values.should == ['A', [:a, :b], 1]
     info.descriptor.should == [:c, 3, true] if ArgumentsDescriptorSpecs.tr?
     info.arguments.should == ['A', :a, :b, {c: 1}] if ArgumentsDescriptorSpecs.tr?
-    info.should == ArgumentsDescriptorSpecs::Info.new(['A', [:a, :b], 1], ArgumentsDescriptorSpecs.tr? ? [:c, 3, true] : [], ArgumentsDescriptorSpecs.tr? ? ['A', :a, :b, {c: 1}] : [])
-    
+
     info = ArgumentsDescriptorSpecs.struct_new_like('A', :a, :b, {c: 1})
     info.values.should == ['A', [:a, :b, {c: 1}], 101]
     info.descriptor.should == [] if ArgumentsDescriptorSpecs.tr?
     info.arguments.should == ['A', :a, :b, {c: 1}] if ArgumentsDescriptorSpecs.tr?
-    info.should == ArgumentsDescriptorSpecs::Info.new(['A', [:a, :b, {c: 1}], 101], [], ArgumentsDescriptorSpecs.tr? ? ['A', :a, :b, {c: 1}] : [])
-    
+
     info = ArgumentsDescriptorSpecs.struct_new_like('A', :a, :b, **{c: 1})
     info.values.should == ['A', [:a, :b], 1]
     info.descriptor.should == [] if ArgumentsDescriptorSpecs.tr?
     info.arguments.should == ['A', :a, :b, {c: 1}] if ArgumentsDescriptorSpecs.tr?
-    info.should == ArgumentsDescriptorSpecs::Info.new(['A', [:a, :b], 1], [], ArgumentsDescriptorSpecs.tr? ? ['A', :a, :b, {c: 1}] : [])
-    
+
     distant = {c: 1}
     info = ArgumentsDescriptorSpecs.struct_new_like('A', :a, :b, **distant)
     info.values.should == ['A', [:a, :b], 1]
     info.descriptor.should == [] if ArgumentsDescriptorSpecs.tr?
     info.arguments.should == ['A', :a, :b, {c: 1}] if ArgumentsDescriptorSpecs.tr?
-    info.should == ArgumentsDescriptorSpecs::Info.new(['A', [:a, :b], 1], [], ArgumentsDescriptorSpecs.tr? ? ['A', :a, :b, {c: 1}] : [])
-    
+
     -> { ArgumentsDescriptorSpecs.struct_new_like('A', :a, :b, d: 1) }.should raise_error(ArgumentError)
 
     -> { ArgumentsDescriptorSpecs.struct_new_like('A', :a, :b, **{d: 1}) }.should raise_error(ArgumentError)
-    
+
     distant = {d: 1}
     -> { ArgumentsDescriptorSpecs.struct_new_like('A', :a, :b, **distant) }.should raise_error(ArgumentError)
   end
@@ -257,7 +241,6 @@ describe "Arguments descriptors" do
     info.values.should == [1, {b: 2}]
     info.descriptor.should == [:b, 1, true] if ArgumentsDescriptorSpecs.tr?
     info.arguments.should == [1, {b: 2}] if ArgumentsDescriptorSpecs.tr?
-    info.should == ArgumentsDescriptorSpecs::Info.new([1, {b: 2}], ArgumentsDescriptorSpecs.tr? ? [:b, 1, true] : [], ArgumentsDescriptorSpecs.tr? ? [1, {b: 2}] : [])
   end
 
   it "expand a hash not used for keyword arguments" do
@@ -265,7 +248,6 @@ describe "Arguments descriptors" do
     info.values.should == [{a: 1, b: 2}]
     info.descriptor.should == [] if ArgumentsDescriptorSpecs.tr?
     info.arguments.should == [{a: 1, b: 2}] if ArgumentsDescriptorSpecs.tr?
-    info.should == ArgumentsDescriptorSpecs::Info.new([{a: 1, b: 2}], [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
   end
 
   it "contain keyword argument names passed to a rest" do
@@ -273,7 +255,6 @@ describe "Arguments descriptors" do
     info.values.should == [[{a: 1, b: 2}]]
     info.descriptor.should == [:a, :b, 0, true] if ArgumentsDescriptorSpecs.tr?
     info.arguments.should == [{a: 1, b: 2}] if ArgumentsDescriptorSpecs.tr?
-    info.should == ArgumentsDescriptorSpecs::Info.new([[{a: 1, b: 2}]], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
   end
 
   it "contain keyword argument names passed to a keyword rest" do
@@ -281,7 +262,6 @@ describe "Arguments descriptors" do
     info.values.should == [{a: 1, b: 2}]
     info.descriptor.should == [:a, :b, 0, true] if ArgumentsDescriptorSpecs.tr?
     info.arguments.should == [{a: 1, b: 2}] if ArgumentsDescriptorSpecs.tr?
-    info.should == ArgumentsDescriptorSpecs::Info.new([{a: 1, b: 2}], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
   end
 
   it "contain keyword argument names passed to a combined keyword rest" do
@@ -289,19 +269,16 @@ describe "Arguments descriptors" do
     info.values.should == [1, {}]
     info.descriptor.should == [:a, 0, true] if ArgumentsDescriptorSpecs.tr?
     info.arguments.should == [{a: 1}] if ArgumentsDescriptorSpecs.tr?
-    info.should == ArgumentsDescriptorSpecs::Info.new([1, {}], ArgumentsDescriptorSpecs.tr? ? [:a, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1}] : [])
-    
+
     info = ArgumentsDescriptorSpecs.kw_and_kw_rest(a: 1, b: 2, c: 3)
     info.values.should == [1, {b: 2, c: 3}]
     info.descriptor.should == [:a, :b, :c, 0, true] if ArgumentsDescriptorSpecs.tr?
     info.arguments.should == [{a: 1, b: 2, c: 3}] if ArgumentsDescriptorSpecs.tr?
-    info.should == ArgumentsDescriptorSpecs::Info.new([1, {b: 2, c: 3}], ArgumentsDescriptorSpecs.tr? ? [:a, :b, :c, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2, c: 3}] : [])
-    
+
     info = ArgumentsDescriptorSpecs.kw_and_kw_rest("abc" => 123, a: 1, b: 2)
     info.values.should == [1, {"abc" => 123, b: 2}]
     info.descriptor.should == [:a, :b, 0, false] if ArgumentsDescriptorSpecs.tr?
     info.arguments.should == [{"abc" => 123, a: 1, b: 2}] if ArgumentsDescriptorSpecs.tr?
-    info.should == ArgumentsDescriptorSpecs::Info.new([1, {"abc" => 123, b: 2}], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, false] : [], ArgumentsDescriptorSpecs.tr? ? [{"abc" => 123, a: 1, b: 2}] : [])
   end
 
   it "work for a mixture of arguments" do
@@ -309,25 +286,21 @@ describe "Arguments descriptors" do
     info.values.should == [1, nil, nil, 2, nil, {}]
     info.descriptor.should == []  if ArgumentsDescriptorSpecs.tr?
     info.arguments.should == [1, 2] if ArgumentsDescriptorSpecs.tr?
-    info.should == ArgumentsDescriptorSpecs::Info.new([1, nil, nil, 2, nil, {}], ArgumentsDescriptorSpecs.tr? ? [] : [], ArgumentsDescriptorSpecs.tr? ? [1, 2] : [])
-    
+
     info = ArgumentsDescriptorSpecs.mixture(1, 2, e: 3)
     info.values.should == [1, nil, nil, 2, 3, {}]
     info.descriptor.should == [:e, 2, true] if ArgumentsDescriptorSpecs.tr?
     info.arguments.should == [1, 2, {e: 3}] if ArgumentsDescriptorSpecs.tr?
-    info.should == ArgumentsDescriptorSpecs::Info.new([1, nil, nil, 2, 3, {}], ArgumentsDescriptorSpecs.tr? ? [:e, 2, true] : [], ArgumentsDescriptorSpecs.tr? ? [1, 2, {e: 3}] : [])
-    
+
     info = ArgumentsDescriptorSpecs.mixture(1, 2, {foo: :bar})
     info.values.should == [1, 2, nil, {:foo=>:bar}, nil, {}]
     info.descriptor.should == [] if ArgumentsDescriptorSpecs.tr?
     info.arguments.should == [1, 2, {foo: :bar}] if ArgumentsDescriptorSpecs.tr?
-    info.should == ArgumentsDescriptorSpecs::Info.new([1, 2, nil, {:foo=>:bar}, nil, {}], ArgumentsDescriptorSpecs.tr? ? [] : [], ArgumentsDescriptorSpecs.tr? ? [1, 2, {foo: :bar}] : [])
-    
+
     info = ArgumentsDescriptorSpecs.mixture(1, {foo: :bar})
     info.values.should == [1, nil, nil, {foo: :bar}, nil, {}]
     info.descriptor.should == [-1] if ArgumentsDescriptorSpecs.tr?
     info.arguments.should == [1, {foo: :bar}] if ArgumentsDescriptorSpecs.tr?
-    info.should == ArgumentsDescriptorSpecs::Info.new([1, nil, nil, {foo: :bar}, nil, {}], ArgumentsDescriptorSpecs.tr? ? [-1] : [], ArgumentsDescriptorSpecs.tr? ? [1, {foo: :bar}] : [])
   end
 
   it "work through an inlined call abstraction" do
@@ -347,7 +320,6 @@ describe "Arguments descriptors" do
     info.values.should == [1, 2]
     info.descriptor.should == [:a, :b, 0, true] if ArgumentsDescriptorSpecs.tr?
     info.arguments.should == [{a: 1, b: 2}] if ArgumentsDescriptorSpecs.tr?
-    info.should == ArgumentsDescriptorSpecs::Info.new([1, 2], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
   end
 
   it "work through custom new with rest" do
@@ -355,7 +327,6 @@ describe "Arguments descriptors" do
     info.values.should == [[{a: 1, b: 2}]]
     info.descriptor.should == [:a, :b, 0, true] if ArgumentsDescriptorSpecs.tr?
     info.arguments.should == [{a: 1, b: 2}] if ArgumentsDescriptorSpecs.tr?
-    info.should == ArgumentsDescriptorSpecs::Info.new([[{a: 1, b: 2}]], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
   end
 
   it "work through implicit super" do
@@ -363,7 +334,6 @@ describe "Arguments descriptors" do
     info.values.should == [1, 2]
     info.descriptor.should == [:a, :b, 0, true] if ArgumentsDescriptorSpecs.tr?
     info.arguments.should == [{a: 1, b: 2}] if ArgumentsDescriptorSpecs.tr?
-    info.should == ArgumentsDescriptorSpecs::Info.new([1, 2], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
   end
 
   it "work through explicit super" do
@@ -371,7 +341,6 @@ describe "Arguments descriptors" do
     info.values.should == [1, 2]
     info.descriptor.should == [:a, :b, 0, true] if ArgumentsDescriptorSpecs.tr?
     info.arguments.should == [{a: 1, b: 2}] if ArgumentsDescriptorSpecs.tr?
-    info.should == ArgumentsDescriptorSpecs::Info.new([1, 2], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
   end
 
   it "work through yield" do
@@ -379,6 +348,5 @@ describe "Arguments descriptors" do
     info.values.should == [1, 2]
     info.descriptor.should == [:a, :b, 0, true] if ArgumentsDescriptorSpecs.tr?
     info.arguments.should == [{a: 1, b: 2}] if ArgumentsDescriptorSpecs.tr?
-    info.should == ArgumentsDescriptorSpecs::Info.new([1, 2], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
   end
 end

--- a/spec/truffle/arguments_descriptor_spec.rb
+++ b/spec/truffle/arguments_descriptor_spec.rb
@@ -2,229 +2,166 @@
 
 require_relative '../ruby/spec_helper'
 
-module ArgumentsDescriptorSpecs
-  Info = Struct.new(:values, :descriptor, :arguments)
-
-  def self.tr?
-    RUBY_ENGINE == 'truffleruby'
-  end
-
-  unless tr?
-    module Primitive
-      def self.arguments_descriptor
-        nil
-      end
-
-      def self.arguments
-        nil
-      end
-    end
-  end
-
-  def self.no_kws(a, b)
-    Info.new([a, b], Primitive.arguments_descriptor, Primitive.arguments)
-  end
-
-  def self.only_kws(a:, b:)
-    Info.new([a, b], Primitive.arguments_descriptor, Primitive.arguments)
-  end
-
-  def self.only_kws_and_opt(a:, b: 101)
-    Info.new([a, b], Primitive.arguments_descriptor, Primitive.arguments)
-  end
-
-  def self.posn_kws(a, b:)
-    Info.new([a, b], Primitive.arguments_descriptor, Primitive.arguments)
-  end
-
-  def self.posn_kws_defaults(a, b: 101, c: 102)
-    Info.new([a, b, c], Primitive.arguments_descriptor, Primitive.arguments)
-  end
-
-  def self.opt_and_kws(a, b=2, c: nil)
-    Info.new([a, b, c], Primitive.arguments_descriptor, Primitive.arguments)
-  end
-
-  def self.struct_new_like(a, *b, c: 101)
-    Info.new([a, b, c], Primitive.arguments_descriptor, Primitive.arguments)
-  end
-
-  def self.describe_like(a, b = nil)
-    Info.new([a, b], Primitive.arguments_descriptor, Primitive.arguments)
-  end
-
-  def self.single(a)
-    Info.new([a], Primitive.arguments_descriptor, Primitive.arguments)
-  end
-
-  def self.rest(*a)
-    Info.new([a], Primitive.arguments_descriptor, Primitive.arguments)
-  end
-
-  def self.kw_rest(**a)
-    Info.new([a], Primitive.arguments_descriptor, Primitive.arguments)
-  end
-
-  def self.kw_and_kw_rest(a:, **b)
-    Info.new([a, b], Primitive.arguments_descriptor, Primitive.arguments)
-  end
-
-  def self.mixture(a, b = nil, c = nil, d, e: nil, **f)
-    Info.new([a, b, c, d, e, f], Primitive.arguments_descriptor, Primitive.arguments)
-  end
-
-  class NewKW
-    def self.new(a:, b:)
-      Info.new([a, b], Primitive.arguments_descriptor, Primitive.arguments)
-    end
-  end
-
-  class NewRest
-    def self.new(*a)
-      Info.new([a], Primitive.arguments_descriptor, Primitive.arguments)
-    end
-  end
-
-  class A
-    def implicit_super(a:, b:)
-      Info.new([a, b], Primitive.arguments_descriptor, Primitive.arguments)
-
+unless defined?(::TruffleRuby)
+  module Primitive
+    def self.arguments_descriptor
+      nil
     end
 
-    def explicit_super(a:, b:)
-      Info.new([a, b], Primitive.arguments_descriptor, Primitive.arguments)
-    end
-  end
-
-  class B < A
-    def implicit_super(a:, b:)
-      super
-    end
-
-    def explicit_super(a:, b:)
-      super(a: a, b: b)
-    end
-  end
-
-  def self.yielder(a, b)
-    yield(a: a, b: b)
-  end
-
-  def self.use_yielder(x, y)
-    yielder(x, y) do |a:, b:|
-      Info.new([a, b], Primitive.arguments_descriptor, Primitive.arguments)
+    def self.arguments
+      nil
     end
   end
 end
 
+module ArgumentsDescriptorSpecs
+  Info = Struct.new(:values, :descriptor, :arguments)
+end
+
 describe "Arguments descriptors" do
+  def truffleruby?
+    defined?(::TruffleRuby)
+  end
+
+  def info(*args)
+    ArgumentsDescriptorSpecs::Info.new(*args)
+  end
+
+  def only_kws(a:, b:)
+    info([a, b], Primitive.arguments_descriptor, Primitive.arguments)
+  end
+
   it "are empty for simple calls" do
-    info = ArgumentsDescriptorSpecs.no_kws(1, 2)
+    def no_kws(a, b)
+      info([a, b], Primitive.arguments_descriptor, Primitive.arguments)
+    end
+
+    info = no_kws(1, 2)
     info.values.should == [1, 2]
-    info.descriptor.should == [] if ArgumentsDescriptorSpecs.tr?
-    info.arguments.should == [1, 2] if ArgumentsDescriptorSpecs.tr?
+    info.descriptor.should == [] if truffleruby?
+    info.arguments.should == [1, 2] if truffleruby?
   end
 
   it "contain keyword arguments" do
-    info = ArgumentsDescriptorSpecs.only_kws(a: 1, b: 2)
+    info = only_kws(a: 1, b: 2)
     info.values.should == [1, 2]
-    info.descriptor.should == [:a, :b, 0, true] if ArgumentsDescriptorSpecs.tr?
-    info.arguments.should == [{a: 1, b: 2}] if ArgumentsDescriptorSpecs.tr?
+    info.descriptor.should == [:a, :b, 0, true] if truffleruby?
+    info.arguments.should == [{a: 1, b: 2}] if truffleruby?
   end
 
   it "contain optional keyword arguments" do
-    info = ArgumentsDescriptorSpecs.only_kws_and_opt(a: 1, b: 2)
-    info.values.should == [1, 2]
-    info.descriptor.should == [:a, :b, 0, true] if ArgumentsDescriptorSpecs.tr?
-    info.arguments.should == [{a: 1, b: 2}] if ArgumentsDescriptorSpecs.tr?
+    def only_kws_and_opt(a:, b: 101)
+      info([a, b], Primitive.arguments_descriptor, Primitive.arguments)
+    end
 
-    info = ArgumentsDescriptorSpecs.only_kws_and_opt(a: 1)
+    info = only_kws_and_opt(a: 1, b: 2)
+    info.values.should == [1, 2]
+    info.descriptor.should == [:a, :b, 0, true] if truffleruby?
+    info.arguments.should == [{a: 1, b: 2}] if truffleruby?
+
+    info = only_kws_and_opt(a: 1)
     info.values.should == [1, 101]
-    info.descriptor.should == [:a, 0, true] if ArgumentsDescriptorSpecs.tr?
-    info.arguments.should == [{a: 1}] if ArgumentsDescriptorSpecs.tr?
+    info.descriptor.should == [:a, 0, true] if truffleruby?
+    info.arguments.should == [{a: 1}] if truffleruby?
   end
 
   it "contain keyword arguments with positional arguments" do
-    info = ArgumentsDescriptorSpecs.posn_kws(1, b: 2)
+    def posn_kws(a, b:)
+      info([a, b], Primitive.arguments_descriptor, Primitive.arguments)
+    end
+
+    info = posn_kws(1, b: 2)
     info.values.should == [1, 2]
-    info.descriptor.should == [:b, 1, true] if ArgumentsDescriptorSpecs.tr?
-    info.arguments.should == [1, {b: 2}] if ArgumentsDescriptorSpecs.tr?
+    info.descriptor.should == [:b, 1, true] if truffleruby?
+    info.arguments.should == [1, {b: 2}] if truffleruby?
+  end
+
+  def posn_kws_defaults(a, b: 101, c: 102)
+    info([a, b, c], Primitive.arguments_descriptor, Primitive.arguments)
   end
 
   it "contain optional keyword arguments with positional arguments" do
-    info = ArgumentsDescriptorSpecs.posn_kws_defaults(1, b: 2, c: 3)
+    info = posn_kws_defaults(1, b: 2, c: 3)
     info.values.should == [1, 2, 3]
-    info.descriptor.should == [:b, :c, 1, true] if ArgumentsDescriptorSpecs.tr?
-    info.arguments.should == [1, {b: 2, c: 3}] if ArgumentsDescriptorSpecs.tr?
+    info.descriptor.should == [:b, :c, 1, true] if truffleruby?
+    info.arguments.should == [1, {b: 2, c: 3}] if truffleruby?
   end
 
   it "do not contain missing optional keyword arguments" do
-    info = ArgumentsDescriptorSpecs.posn_kws_defaults(1, b: 2)
+    info = posn_kws_defaults(1, b: 2)
     info.values.should == [1, 2, 102]
-    info.descriptor.should == [:b, 1, true] if ArgumentsDescriptorSpecs.tr?
-    info.arguments.should == [1, {b: 2}] if ArgumentsDescriptorSpecs.tr?
+    info.descriptor.should == [:b, 1, true] if truffleruby?
+    info.arguments.should == [1, {b: 2}] if truffleruby?
 
-    info = ArgumentsDescriptorSpecs.posn_kws_defaults(1, c: 3)
+    info = posn_kws_defaults(1, c: 3)
     info.values.should == [1, 101, 3]
-    info.descriptor.should == [:c, 1, true] if ArgumentsDescriptorSpecs.tr?
-    info.arguments.should == [1, {c: 3}] if ArgumentsDescriptorSpecs.tr?
+    info.descriptor.should == [:c, 1, true] if truffleruby?
+    info.arguments.should == [1, {c: 3}] if truffleruby?
   end
 
   it "do not contain the name of distant explicitly splatted keyword arguments" do
     distant = {b: 2}
-    info = ArgumentsDescriptorSpecs.only_kws(a: 1, **distant)
+    info = only_kws(a: 1, **distant)
     info.values.should == [1, 2]
-    info.descriptor.should == [:a, 0, false] if ArgumentsDescriptorSpecs.tr?
-    info.arguments.should == [{a: 1, b: 2}] if ArgumentsDescriptorSpecs.tr?
+    info.descriptor.should == [:a, 0, false] if truffleruby?
+    info.arguments.should == [{a: 1, b: 2}] if truffleruby?
   end
 
   it "do not contain the name of near explicitly splatted keyword arguments" do
-    info = ArgumentsDescriptorSpecs.only_kws(a: 1, **{b: 2})
+    info = only_kws(a: 1, **{b: 2})
     info.values.should == [1, 2]
-    info.descriptor.should == [:a, 0, false] if ArgumentsDescriptorSpecs.tr?
-    info.arguments.should == [{a: 1, b: 2}] if ArgumentsDescriptorSpecs.tr?
+    info.descriptor.should == [:a, 0, false] if truffleruby?
+    info.arguments.should == [{a: 1, b: 2}] if truffleruby?
   end
 
   it "contain the name of present optional keyword arguments without the optional positional" do
-    info = ArgumentsDescriptorSpecs.opt_and_kws(1, c: 3)
+    def opt_and_kws(a, b=2, c: nil)
+      info([a, b, c], Primitive.arguments_descriptor, Primitive.arguments)
+    end
+
+    info = opt_and_kws(1, c: 3)
     info.values.should == [1, 2, 3]
-    info.descriptor.should == [:c, 1, true] if ArgumentsDescriptorSpecs.tr?
-    info.arguments.should == [1, {c: 3}] if ArgumentsDescriptorSpecs.tr?
+    info.descriptor.should == [:c, 1, true] if truffleruby?
+    info.arguments.should == [1, {c: 3}] if truffleruby?
   end
 
   it "work for a call like our Struct.new" do
-    info = ArgumentsDescriptorSpecs.struct_new_like('A', :a, :b)
+    def struct_new_like(a, *b, c: 101)
+      info([a, b, c], Primitive.arguments_descriptor, Primitive.arguments)
+    end
+
+    info = struct_new_like('A', :a, :b)
     info.values.should == ['A', [:a, :b], 101]
-    info.descriptor.should == [] if ArgumentsDescriptorSpecs.tr?
-    info.arguments.should == ['A', :a, :b] if ArgumentsDescriptorSpecs.tr?
+    info.descriptor.should == [] if truffleruby?
+    info.arguments.should == ['A', :a, :b] if truffleruby?
 
-    info = ArgumentsDescriptorSpecs.struct_new_like('A', :a, :b, c: 1)
+    info = struct_new_like('A', :a, :b, c: 1)
     info.values.should == ['A', [:a, :b], 1]
-    info.descriptor.should == [:c, 3, true] if ArgumentsDescriptorSpecs.tr?
-    info.arguments.should == ['A', :a, :b, {c: 1}] if ArgumentsDescriptorSpecs.tr?
+    info.descriptor.should == [:c, 3, true] if truffleruby?
+    info.arguments.should == ['A', :a, :b, {c: 1}] if truffleruby?
 
-    info = ArgumentsDescriptorSpecs.struct_new_like('A', :a, :b, {c: 1})
+    info = struct_new_like('A', :a, :b, {c: 1})
     info.values.should == ['A', [:a, :b, {c: 1}], 101]
-    info.descriptor.should == [] if ArgumentsDescriptorSpecs.tr?
-    info.arguments.should == ['A', :a, :b, {c: 1}] if ArgumentsDescriptorSpecs.tr?
+    info.descriptor.should == [] if truffleruby?
+    info.arguments.should == ['A', :a, :b, {c: 1}] if truffleruby?
 
-    info = ArgumentsDescriptorSpecs.struct_new_like('A', :a, :b, **{c: 1})
+    info = struct_new_like('A', :a, :b, **{c: 1})
     info.values.should == ['A', [:a, :b], 1]
-    info.descriptor.should == [] if ArgumentsDescriptorSpecs.tr?
-    info.arguments.should == ['A', :a, :b, {c: 1}] if ArgumentsDescriptorSpecs.tr?
+    info.descriptor.should == [] if truffleruby?
+    info.arguments.should == ['A', :a, :b, {c: 1}] if truffleruby?
 
     distant = {c: 1}
-    info = ArgumentsDescriptorSpecs.struct_new_like('A', :a, :b, **distant)
+    info = struct_new_like('A', :a, :b, **distant)
     info.values.should == ['A', [:a, :b], 1]
-    info.descriptor.should == [] if ArgumentsDescriptorSpecs.tr?
-    info.arguments.should == ['A', :a, :b, {c: 1}] if ArgumentsDescriptorSpecs.tr?
+    info.descriptor.should == [] if truffleruby?
+    info.arguments.should == ['A', :a, :b, {c: 1}] if truffleruby?
 
-    -> { ArgumentsDescriptorSpecs.struct_new_like('A', :a, :b, d: 1) }.should raise_error(ArgumentError)
+    -> { struct_new_like('A', :a, :b, d: 1) }.should raise_error(ArgumentError)
 
-    -> { ArgumentsDescriptorSpecs.struct_new_like('A', :a, :b, **{d: 1}) }.should raise_error(ArgumentError)
+    -> { struct_new_like('A', :a, :b, **{d: 1}) }.should raise_error(ArgumentError)
 
     distant = {d: 1}
-    -> { ArgumentsDescriptorSpecs.struct_new_like('A', :a, :b, **distant) }.should raise_error(ArgumentError)
+    -> { struct_new_like('A', :a, :b, **distant) }.should raise_error(ArgumentError)
   end
 
   it "work for a call like a Struct's new" do
@@ -237,70 +174,94 @@ describe "Arguments descriptors" do
   end
 
   it "work for a call like MSpec #describe" do
-    info = ArgumentsDescriptorSpecs.describe_like(1, b: 2)
+    def describe_like(a, b = nil)
+      info([a, b], Primitive.arguments_descriptor, Primitive.arguments)
+    end
+
+    info = describe_like(1, b: 2)
     info.values.should == [1, {b: 2}]
-    info.descriptor.should == [:b, 1, true] if ArgumentsDescriptorSpecs.tr?
-    info.arguments.should == [1, {b: 2}] if ArgumentsDescriptorSpecs.tr?
+    info.descriptor.should == [:b, 1, true] if truffleruby?
+    info.arguments.should == [1, {b: 2}] if truffleruby?
   end
 
   it "expand a hash not used for keyword arguments" do
-    info = ArgumentsDescriptorSpecs.single({a: 1, b: 2})
+    def single(a)
+      info([a], Primitive.arguments_descriptor, Primitive.arguments)
+    end
+
+    info = single({a: 1, b: 2})
     info.values.should == [{a: 1, b: 2}]
-    info.descriptor.should == [] if ArgumentsDescriptorSpecs.tr?
-    info.arguments.should == [{a: 1, b: 2}] if ArgumentsDescriptorSpecs.tr?
+    info.descriptor.should == [] if truffleruby?
+    info.arguments.should == [{a: 1, b: 2}] if truffleruby?
   end
 
   it "contain keyword argument names passed to a rest" do
-    info = ArgumentsDescriptorSpecs.rest(a: 1, b: 2)
+    def rest(*a)
+      info([a], Primitive.arguments_descriptor, Primitive.arguments)
+    end
+
+    info = rest(a: 1, b: 2)
     info.values.should == [[{a: 1, b: 2}]]
-    info.descriptor.should == [:a, :b, 0, true] if ArgumentsDescriptorSpecs.tr?
-    info.arguments.should == [{a: 1, b: 2}] if ArgumentsDescriptorSpecs.tr?
+    info.descriptor.should == [:a, :b, 0, true] if truffleruby?
+    info.arguments.should == [{a: 1, b: 2}] if truffleruby?
   end
 
   it "contain keyword argument names passed to a keyword rest" do
-    info = ArgumentsDescriptorSpecs.kw_rest(a: 1, b: 2)
+    def kw_rest(**a)
+      info([a], Primitive.arguments_descriptor, Primitive.arguments)
+    end
+
+    info = kw_rest(a: 1, b: 2)
     info.values.should == [{a: 1, b: 2}]
-    info.descriptor.should == [:a, :b, 0, true] if ArgumentsDescriptorSpecs.tr?
-    info.arguments.should == [{a: 1, b: 2}] if ArgumentsDescriptorSpecs.tr?
+    info.descriptor.should == [:a, :b, 0, true] if truffleruby?
+    info.arguments.should == [{a: 1, b: 2}] if truffleruby?
   end
 
   it "contain keyword argument names passed to a combined keyword rest" do
-    info = ArgumentsDescriptorSpecs.kw_and_kw_rest(a: 1)
+    def kw_and_kw_rest(a:, **b)
+      info([a, b], Primitive.arguments_descriptor, Primitive.arguments)
+    end
+
+    info = kw_and_kw_rest(a: 1)
     info.values.should == [1, {}]
-    info.descriptor.should == [:a, 0, true] if ArgumentsDescriptorSpecs.tr?
-    info.arguments.should == [{a: 1}] if ArgumentsDescriptorSpecs.tr?
+    info.descriptor.should == [:a, 0, true] if truffleruby?
+    info.arguments.should == [{a: 1}] if truffleruby?
 
-    info = ArgumentsDescriptorSpecs.kw_and_kw_rest(a: 1, b: 2, c: 3)
+    info = kw_and_kw_rest(a: 1, b: 2, c: 3)
     info.values.should == [1, {b: 2, c: 3}]
-    info.descriptor.should == [:a, :b, :c, 0, true] if ArgumentsDescriptorSpecs.tr?
-    info.arguments.should == [{a: 1, b: 2, c: 3}] if ArgumentsDescriptorSpecs.tr?
+    info.descriptor.should == [:a, :b, :c, 0, true] if truffleruby?
+    info.arguments.should == [{a: 1, b: 2, c: 3}] if truffleruby?
 
-    info = ArgumentsDescriptorSpecs.kw_and_kw_rest("abc" => 123, a: 1, b: 2)
+    info = kw_and_kw_rest("abc" => 123, a: 1, b: 2)
     info.values.should == [1, {"abc" => 123, b: 2}]
-    info.descriptor.should == [:a, :b, 0, false] if ArgumentsDescriptorSpecs.tr?
-    info.arguments.should == [{"abc" => 123, a: 1, b: 2}] if ArgumentsDescriptorSpecs.tr?
+    info.descriptor.should == [:a, :b, 0, false] if truffleruby?
+    info.arguments.should == [{"abc" => 123, a: 1, b: 2}] if truffleruby?
   end
 
   it "work for a mixture of arguments" do
-    info = ArgumentsDescriptorSpecs.mixture(1, 2)
+    def mixture(a, b = nil, c = nil, d, e: nil, **f)
+      info([a, b, c, d, e, f], Primitive.arguments_descriptor, Primitive.arguments)
+    end
+
+    info = mixture(1, 2)
     info.values.should == [1, nil, nil, 2, nil, {}]
-    info.descriptor.should == []  if ArgumentsDescriptorSpecs.tr?
-    info.arguments.should == [1, 2] if ArgumentsDescriptorSpecs.tr?
+    info.descriptor.should == []  if truffleruby?
+    info.arguments.should == [1, 2] if truffleruby?
 
-    info = ArgumentsDescriptorSpecs.mixture(1, 2, e: 3)
+    info = mixture(1, 2, e: 3)
     info.values.should == [1, nil, nil, 2, 3, {}]
-    info.descriptor.should == [:e, 2, true] if ArgumentsDescriptorSpecs.tr?
-    info.arguments.should == [1, 2, {e: 3}] if ArgumentsDescriptorSpecs.tr?
+    info.descriptor.should == [:e, 2, true] if truffleruby?
+    info.arguments.should == [1, 2, {e: 3}] if truffleruby?
 
-    info = ArgumentsDescriptorSpecs.mixture(1, 2, {foo: :bar})
+    info = mixture(1, 2, {foo: :bar})
     info.values.should == [1, 2, nil, {:foo=>:bar}, nil, {}]
-    info.descriptor.should == [] if ArgumentsDescriptorSpecs.tr?
-    info.arguments.should == [1, 2, {foo: :bar}] if ArgumentsDescriptorSpecs.tr?
+    info.descriptor.should == [] if truffleruby?
+    info.arguments.should == [1, 2, {foo: :bar}] if truffleruby?
 
-    info = ArgumentsDescriptorSpecs.mixture(1, {foo: :bar})
+    info = mixture(1, {foo: :bar})
     info.values.should == [1, nil, nil, {foo: :bar}, nil, {}]
-    info.descriptor.should == [-1] if ArgumentsDescriptorSpecs.tr?
-    info.arguments.should == [1, {foo: :bar}] if ArgumentsDescriptorSpecs.tr?
+    info.descriptor.should == [-1] if truffleruby?
+    info.arguments.should == [1, {foo: :bar}] if truffleruby?
   end
 
   it "work through an inlined call abstraction" do
@@ -309,44 +270,90 @@ describe "Arguments descriptors" do
     -> { foo.() }.should raise_error(ArgumentError)
   end
 
-  guard -> { RUBY_ENGINE == 'truffleruby' } do
+  guard -> { truffleruby? } do
     it "pass keyword arguments into foreign calls as a Hash" do
       Truffle::Debug.foreign_identity_function.call(a: 1, b: 2).should == {a: 1, b: 2}
     end
   end
 
   it "work through custom new with keyword arguments" do
-    info = ArgumentsDescriptorSpecs::NewKW.new(a: 1, b: 2)
+    new_kw = Class.new do
+      def self.new(a:, b:)
+        ArgumentsDescriptorSpecs::Info.new([a, b], Primitive.arguments_descriptor, Primitive.arguments)
+      end
+    end
+
+    info = new_kw.new(a: 1, b: 2)
     info.values.should == [1, 2]
-    info.descriptor.should == [:a, :b, 0, true] if ArgumentsDescriptorSpecs.tr?
-    info.arguments.should == [{a: 1, b: 2}] if ArgumentsDescriptorSpecs.tr?
+    info.descriptor.should == [:a, :b, 0, true] if truffleruby?
+    info.arguments.should == [{a: 1, b: 2}] if truffleruby?
   end
 
   it "work through custom new with rest" do
-    info = ArgumentsDescriptorSpecs::NewRest.new(a: 1, b: 2)
+    new_rest = Class.new do
+      def self.new(*a)
+        ArgumentsDescriptorSpecs::Info.new([a], Primitive.arguments_descriptor, Primitive.arguments)
+      end
+    end
+
+    info = new_rest.new(a: 1, b: 2)
     info.values.should == [[{a: 1, b: 2}]]
-    info.descriptor.should == [:a, :b, 0, true] if ArgumentsDescriptorSpecs.tr?
-    info.arguments.should == [{a: 1, b: 2}] if ArgumentsDescriptorSpecs.tr?
+    info.descriptor.should == [:a, :b, 0, true] if truffleruby?
+    info.arguments.should == [{a: 1, b: 2}] if truffleruby?
   end
 
   it "work through implicit super" do
-    info = ArgumentsDescriptorSpecs::A.new.implicit_super(a: 1, b: 2)
+    parent = Class.new do
+      def implicit_super(a:, b:)
+        ArgumentsDescriptorSpecs::Info.new([a, b], Primitive.arguments_descriptor, Primitive.arguments)
+      end
+    end
+
+    child = Class.new(parent) do
+      def implicit_super(a:, b:)
+        super
+      end
+    end
+
+    info = child.new.implicit_super(a: 1, b: 2)
     info.values.should == [1, 2]
-    info.descriptor.should == [:a, :b, 0, true] if ArgumentsDescriptorSpecs.tr?
-    info.arguments.should == [{a: 1, b: 2}] if ArgumentsDescriptorSpecs.tr?
+    info.descriptor.should == [:a, :b, 0, true] if truffleruby?
+    info.arguments.should == [{a: 1, b: 2}] if truffleruby?
   end
 
   it "work through explicit super" do
-    info = ArgumentsDescriptorSpecs::A.new.explicit_super(a: 1, b: 2)
+    parent = Class.new do
+      def explicit_super(a:, b:)
+        ArgumentsDescriptorSpecs::Info.new([a, b], Primitive.arguments_descriptor, Primitive.arguments)
+      end
+    end
+
+    child = Class.new(parent) do
+      def explicit_super(a:, b:)
+        super(a: a, b: b)
+      end
+    end
+
+    info = child.new.explicit_super(a: 1, b: 2)
     info.values.should == [1, 2]
-    info.descriptor.should == [:a, :b, 0, true] if ArgumentsDescriptorSpecs.tr?
-    info.arguments.should == [{a: 1, b: 2}] if ArgumentsDescriptorSpecs.tr?
+    info.descriptor.should == [:a, :b, 0, true] if truffleruby?
+    info.arguments.should == [{a: 1, b: 2}] if truffleruby?
   end
 
   it "work through yield" do
-    info = ArgumentsDescriptorSpecs.use_yielder(1, 2)
+    def yielder(a, b)
+      yield(a: a, b: b)
+    end
+
+    def use_yielder(x, y)
+      yielder(x, y) do |a:, b:|
+        info([a, b], Primitive.arguments_descriptor, Primitive.arguments)
+      end
+    end
+
+    info = use_yielder(1, 2)
     info.values.should == [1, 2]
-    info.descriptor.should == [:a, :b, 0, true] if ArgumentsDescriptorSpecs.tr?
-    info.arguments.should == [{a: 1, b: 2}] if ArgumentsDescriptorSpecs.tr?
+    info.descriptor.should == [:a, :b, 0, true] if truffleruby?
+    info.arguments.should == [{a: 1, b: 2}] if truffleruby?
   end
 end

--- a/spec/truffle/arguments_descriptor_spec.rb
+++ b/spec/truffle/arguments_descriptor_spec.rb
@@ -119,53 +119,78 @@ end
 
 describe "Arguments descriptors" do
   it "are empty for simple calls" do
-    ArgumentsDescriptorSpecs.no_kws(1, 2).should == ArgumentsDescriptorSpecs::Info.new([1, 2], [], ArgumentsDescriptorSpecs.tr? ? [1, 2]: [])
+    info = ArgumentsDescriptorSpecs.no_kws(1, 2)
+    info.should == ArgumentsDescriptorSpecs::Info.new([1, 2], [], ArgumentsDescriptorSpecs.tr? ? [1, 2]: [])
   end
 
   it "contain keyword arguments" do
-    ArgumentsDescriptorSpecs.only_kws(a: 1, b: 2).should == ArgumentsDescriptorSpecs::Info.new([1, 2], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
+    info = ArgumentsDescriptorSpecs.only_kws(a: 1, b: 2)
+    info.should == ArgumentsDescriptorSpecs::Info.new([1, 2], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
   end
 
   it "contain optional keyword arguments" do
-    ArgumentsDescriptorSpecs.only_kws_and_opt(a: 1, b: 2).should == ArgumentsDescriptorSpecs::Info.new([1, 2], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
-    ArgumentsDescriptorSpecs.only_kws_and_opt(a: 1).should == ArgumentsDescriptorSpecs::Info.new([1, 101], ArgumentsDescriptorSpecs.tr? ? [:a, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1}] : [])
+    info = ArgumentsDescriptorSpecs.only_kws_and_opt(a: 1, b: 2)
+    info.should == ArgumentsDescriptorSpecs::Info.new([1, 2], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
+    
+    info = ArgumentsDescriptorSpecs.only_kws_and_opt(a: 1)
+    info.should == ArgumentsDescriptorSpecs::Info.new([1, 101], ArgumentsDescriptorSpecs.tr? ? [:a, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1}] : [])
   end
 
   it "contain keyword arguments with positional arguments" do
-    ArgumentsDescriptorSpecs.posn_kws(1, b: 2).should == ArgumentsDescriptorSpecs::Info.new([1, 2], ArgumentsDescriptorSpecs.tr? ? [:b, 1, true] : [], ArgumentsDescriptorSpecs.tr? ? [1, {b: 2}] : [])
+    info = ArgumentsDescriptorSpecs.posn_kws(1, b: 2)
+    info.should == ArgumentsDescriptorSpecs::Info.new([1, 2], ArgumentsDescriptorSpecs.tr? ? [:b, 1, true] : [], ArgumentsDescriptorSpecs.tr? ? [1, {b: 2}] : [])
   end
 
   it "contain optional keyword arguments with positional arguments" do
-    ArgumentsDescriptorSpecs.posn_kws_defaults(1, b: 2, c: 3).should == ArgumentsDescriptorSpecs::Info.new([1, 2, 3], ArgumentsDescriptorSpecs.tr? ? [:b, :c, 1, true] : [], ArgumentsDescriptorSpecs.tr? ? [1, {b: 2, c: 3}] : [])
+    info = ArgumentsDescriptorSpecs.posn_kws_defaults(1, b: 2, c: 3)
+    info.should == ArgumentsDescriptorSpecs::Info.new([1, 2, 3], ArgumentsDescriptorSpecs.tr? ? [:b, :c, 1, true] : [], ArgumentsDescriptorSpecs.tr? ? [1, {b: 2, c: 3}] : [])
   end
 
   it "do not contain missing optional keyword arguments" do
-    ArgumentsDescriptorSpecs.posn_kws_defaults(1, b: 2).should == ArgumentsDescriptorSpecs::Info.new([1, 2, 102], ArgumentsDescriptorSpecs.tr? ? [:b, 1, true] : [], ArgumentsDescriptorSpecs.tr? ? [1, {b: 2}] : [])
-    ArgumentsDescriptorSpecs.posn_kws_defaults(1, c: 3).should == ArgumentsDescriptorSpecs::Info.new([1, 101, 3], ArgumentsDescriptorSpecs.tr? ? [:c, 1, true] : [], ArgumentsDescriptorSpecs.tr? ? [1, {c: 3}] : [])
+    info = ArgumentsDescriptorSpecs.posn_kws_defaults(1, b: 2)
+    info.should == ArgumentsDescriptorSpecs::Info.new([1, 2, 102], ArgumentsDescriptorSpecs.tr? ? [:b, 1, true] : [], ArgumentsDescriptorSpecs.tr? ? [1, {b: 2}] : [])
+    
+    info = ArgumentsDescriptorSpecs.posn_kws_defaults(1, c: 3)
+    info.should == ArgumentsDescriptorSpecs::Info.new([1, 101, 3], ArgumentsDescriptorSpecs.tr? ? [:c, 1, true] : [], ArgumentsDescriptorSpecs.tr? ? [1, {c: 3}] : [])
   end
 
   it "do not contain the name of distant explicitly splatted keyword arguments" do
     distant = {b: 2}
-    ArgumentsDescriptorSpecs.only_kws(a: 1, **distant).should == ArgumentsDescriptorSpecs::Info.new([1, 2], ArgumentsDescriptorSpecs.tr? ? [:a, 0, false] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
+    info = ArgumentsDescriptorSpecs.only_kws(a: 1, **distant)
+    info.should == ArgumentsDescriptorSpecs::Info.new([1, 2], ArgumentsDescriptorSpecs.tr? ? [:a, 0, false] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
   end
 
   it "do not contain the name of near explicitly splatted keyword arguments" do
-    ArgumentsDescriptorSpecs.only_kws(a: 1, **{b: 2}).should == ArgumentsDescriptorSpecs::Info.new([1, 2], ArgumentsDescriptorSpecs.tr? ? [:a, 0, false] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
+    info = ArgumentsDescriptorSpecs.only_kws(a: 1, **{b: 2})
+    info.should == ArgumentsDescriptorSpecs::Info.new([1, 2], ArgumentsDescriptorSpecs.tr? ? [:a, 0, false] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
   end
 
   it "contain the name of present optional keyword arguments without the optional positional" do
-    ArgumentsDescriptorSpecs.opt_and_kws(1, c: 3).should == ArgumentsDescriptorSpecs::Info.new([1, 2, 3], ArgumentsDescriptorSpecs.tr? ? [:c, 1, true] : [], ArgumentsDescriptorSpecs.tr? ? [1, {c: 3}] : [])
+    info = ArgumentsDescriptorSpecs.opt_and_kws(1, c: 3)
+    info.should == ArgumentsDescriptorSpecs::Info.new([1, 2, 3], ArgumentsDescriptorSpecs.tr? ? [:c, 1, true] : [], ArgumentsDescriptorSpecs.tr? ? [1, {c: 3}] : [])
   end
 
   it "work for a call like our Struct.new" do
-    ArgumentsDescriptorSpecs.struct_new_like('A', :a, :b).should == ArgumentsDescriptorSpecs::Info.new(['A', [:a, :b], 101], [], ArgumentsDescriptorSpecs.tr? ? ['A', :a, :b] : [])
-    ArgumentsDescriptorSpecs.struct_new_like('A', :a, :b, c: 1).should == ArgumentsDescriptorSpecs::Info.new(['A', [:a, :b], 1], ArgumentsDescriptorSpecs.tr? ? [:c, 3, true] : [], ArgumentsDescriptorSpecs.tr? ? ['A', :a, :b, {c: 1}] : [])
-    ArgumentsDescriptorSpecs.struct_new_like('A', :a, :b, {c: 1}).should == ArgumentsDescriptorSpecs::Info.new(['A', [:a, :b, {c: 1}], 101], [], ArgumentsDescriptorSpecs.tr? ? ['A', :a, :b, {c: 1}] : [])
-    ArgumentsDescriptorSpecs.struct_new_like('A', :a, :b, **{c: 1}).should == ArgumentsDescriptorSpecs::Info.new(['A', [:a, :b], 1], [], ArgumentsDescriptorSpecs.tr? ? ['A', :a, :b, {c: 1}] : [])
+    info = ArgumentsDescriptorSpecs.struct_new_like('A', :a, :b)
+    info.should == ArgumentsDescriptorSpecs::Info.new(['A', [:a, :b], 101], [], ArgumentsDescriptorSpecs.tr? ? ['A', :a, :b] : [])
+    
+    info = ArgumentsDescriptorSpecs.struct_new_like('A', :a, :b, c: 1)
+    info.should == ArgumentsDescriptorSpecs::Info.new(['A', [:a, :b], 1], ArgumentsDescriptorSpecs.tr? ? [:c, 3, true] : [], ArgumentsDescriptorSpecs.tr? ? ['A', :a, :b, {c: 1}] : [])
+    
+    info = ArgumentsDescriptorSpecs.struct_new_like('A', :a, :b, {c: 1})
+    info.should == ArgumentsDescriptorSpecs::Info.new(['A', [:a, :b, {c: 1}], 101], [], ArgumentsDescriptorSpecs.tr? ? ['A', :a, :b, {c: 1}] : [])
+    
+    info = ArgumentsDescriptorSpecs.struct_new_like('A', :a, :b, **{c: 1})
+    info.should == ArgumentsDescriptorSpecs::Info.new(['A', [:a, :b], 1], [], ArgumentsDescriptorSpecs.tr? ? ['A', :a, :b, {c: 1}] : [])
+    
     distant = {c: 1}
-    ArgumentsDescriptorSpecs.struct_new_like('A', :a, :b, **distant).should == ArgumentsDescriptorSpecs::Info.new(['A', [:a, :b], 1], [], ArgumentsDescriptorSpecs.tr? ? ['A', :a, :b, {c: 1}] : [])
+    info = ArgumentsDescriptorSpecs.struct_new_like('A', :a, :b, **distant)
+    info.should == ArgumentsDescriptorSpecs::Info.new(['A', [:a, :b], 1], [], ArgumentsDescriptorSpecs.tr? ? ['A', :a, :b, {c: 1}] : [])
+    
     -> { ArgumentsDescriptorSpecs.struct_new_like('A', :a, :b, d: 1) }.should raise_error(ArgumentError)
+
     -> { ArgumentsDescriptorSpecs.struct_new_like('A', :a, :b, **{d: 1}) }.should raise_error(ArgumentError)
+    
     distant = {d: 1}
     -> { ArgumentsDescriptorSpecs.struct_new_like('A', :a, :b, **distant) }.should raise_error(ArgumentError)
   end
@@ -180,32 +205,48 @@ describe "Arguments descriptors" do
   end
 
   it "work for a call like MSpec #describe" do
-    ArgumentsDescriptorSpecs.describe_like(1, b: 2).should == ArgumentsDescriptorSpecs::Info.new([1, {b: 2}], ArgumentsDescriptorSpecs.tr? ? [:b, 1, true] : [], ArgumentsDescriptorSpecs.tr? ? [1, {b: 2}] : [])
+    info = ArgumentsDescriptorSpecs.describe_like(1, b: 2)
+    info.should == ArgumentsDescriptorSpecs::Info.new([1, {b: 2}], ArgumentsDescriptorSpecs.tr? ? [:b, 1, true] : [], ArgumentsDescriptorSpecs.tr? ? [1, {b: 2}] : [])
   end
 
   it "expand a hash not used for keyword arguments" do
-    ArgumentsDescriptorSpecs.single({a: 1, b: 2}).should == ArgumentsDescriptorSpecs::Info.new([{a: 1, b: 2}], [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
+    info = ArgumentsDescriptorSpecs.single({a: 1, b: 2})
+    info.should == ArgumentsDescriptorSpecs::Info.new([{a: 1, b: 2}], [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
   end
 
   it "contain keyword argument names passed to a rest" do
-    ArgumentsDescriptorSpecs.rest(a: 1, b: 2).should == ArgumentsDescriptorSpecs::Info.new([[{a: 1, b: 2}]], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
+    info = ArgumentsDescriptorSpecs.rest(a: 1, b: 2)
+    info.should == ArgumentsDescriptorSpecs::Info.new([[{a: 1, b: 2}]], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
   end
 
   it "contain keyword argument names passed to a keyword rest" do
-    ArgumentsDescriptorSpecs.kw_rest(a: 1, b: 2).should == ArgumentsDescriptorSpecs::Info.new([{a: 1, b: 2}], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
+    info = ArgumentsDescriptorSpecs.kw_rest(a: 1, b: 2)
+    info.should == ArgumentsDescriptorSpecs::Info.new([{a: 1, b: 2}], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
   end
 
   it "contain keyword argument names passed to a combined keyword rest" do
-    ArgumentsDescriptorSpecs.kw_and_kw_rest(a: 1).should == ArgumentsDescriptorSpecs::Info.new([1, {}], ArgumentsDescriptorSpecs.tr? ? [:a, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1}] : [])
-    ArgumentsDescriptorSpecs.kw_and_kw_rest(a: 1, b: 2, c: 3).should == ArgumentsDescriptorSpecs::Info.new([1, {b: 2, c: 3}], ArgumentsDescriptorSpecs.tr? ? [:a, :b, :c, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2, c: 3}] : [])
-    ArgumentsDescriptorSpecs.kw_and_kw_rest("abc" => 123, a: 1, b: 2).should == ArgumentsDescriptorSpecs::Info.new([1, {"abc" => 123, b: 2}], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, false] : [], ArgumentsDescriptorSpecs.tr? ? [{"abc" => 123, a: 1, b: 2}] : [])
+    info = ArgumentsDescriptorSpecs.kw_and_kw_rest(a: 1)
+    info.should == ArgumentsDescriptorSpecs::Info.new([1, {}], ArgumentsDescriptorSpecs.tr? ? [:a, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1}] : [])
+    
+    info = ArgumentsDescriptorSpecs.kw_and_kw_rest(a: 1, b: 2, c: 3)
+    info.should == ArgumentsDescriptorSpecs::Info.new([1, {b: 2, c: 3}], ArgumentsDescriptorSpecs.tr? ? [:a, :b, :c, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2, c: 3}] : [])
+    
+    info = ArgumentsDescriptorSpecs.kw_and_kw_rest("abc" => 123, a: 1, b: 2)
+    info.should == ArgumentsDescriptorSpecs::Info.new([1, {"abc" => 123, b: 2}], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, false] : [], ArgumentsDescriptorSpecs.tr? ? [{"abc" => 123, a: 1, b: 2}] : [])
   end
 
   it "work for a mixture of arguments" do
-    ArgumentsDescriptorSpecs.mixture(1, 2).should == ArgumentsDescriptorSpecs::Info.new([1, nil, nil, 2, nil, {}], ArgumentsDescriptorSpecs.tr? ? [] : [], ArgumentsDescriptorSpecs.tr? ? [1, 2] : [])
-    ArgumentsDescriptorSpecs.mixture(1, 2, e: 3).should == ArgumentsDescriptorSpecs::Info.new([1, nil, nil, 2, 3, {}], ArgumentsDescriptorSpecs.tr? ? [:e, 2, true] : [], ArgumentsDescriptorSpecs.tr? ? [1, 2, {e: 3}] : [])
-    ArgumentsDescriptorSpecs.mixture(1, 2, {foo: :bar}).should == ArgumentsDescriptorSpecs::Info.new([1, 2, nil, {:foo=>:bar}, nil, {}], ArgumentsDescriptorSpecs.tr? ? [] : [], ArgumentsDescriptorSpecs.tr? ? [1, 2, {foo: :bar}] : [])
-    ArgumentsDescriptorSpecs.mixture(1, {foo: :bar}).should == ArgumentsDescriptorSpecs::Info.new([1, nil, nil, {foo: :bar}, nil, {}], ArgumentsDescriptorSpecs.tr? ? [-1] : [], ArgumentsDescriptorSpecs.tr? ? [1, {foo: :bar}] : [])
+    info = ArgumentsDescriptorSpecs.mixture(1, 2)
+    info.should == ArgumentsDescriptorSpecs::Info.new([1, nil, nil, 2, nil, {}], ArgumentsDescriptorSpecs.tr? ? [] : [], ArgumentsDescriptorSpecs.tr? ? [1, 2] : [])
+    
+    info = ArgumentsDescriptorSpecs.mixture(1, 2, e: 3)
+    info.should == ArgumentsDescriptorSpecs::Info.new([1, nil, nil, 2, 3, {}], ArgumentsDescriptorSpecs.tr? ? [:e, 2, true] : [], ArgumentsDescriptorSpecs.tr? ? [1, 2, {e: 3}] : [])
+    
+    info = ArgumentsDescriptorSpecs.mixture(1, 2, {foo: :bar})
+    info.should == ArgumentsDescriptorSpecs::Info.new([1, 2, nil, {:foo=>:bar}, nil, {}], ArgumentsDescriptorSpecs.tr? ? [] : [], ArgumentsDescriptorSpecs.tr? ? [1, 2, {foo: :bar}] : [])
+    
+    info = ArgumentsDescriptorSpecs.mixture(1, {foo: :bar})
+    info.should == ArgumentsDescriptorSpecs::Info.new([1, nil, nil, {foo: :bar}, nil, {}], ArgumentsDescriptorSpecs.tr? ? [-1] : [], ArgumentsDescriptorSpecs.tr? ? [1, {foo: :bar}] : [])
   end
 
   it "work through an inlined call abstraction" do
@@ -221,22 +262,27 @@ describe "Arguments descriptors" do
   end
 
   it "work through custom new with keyword arguments" do
-    ArgumentsDescriptorSpecs::NewKW.new(a: 1, b: 2).should == ArgumentsDescriptorSpecs::Info.new([1, 2], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
+    info = ArgumentsDescriptorSpecs::NewKW.new(a: 1, b: 2)
+    info.should == ArgumentsDescriptorSpecs::Info.new([1, 2], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
   end
 
   it "work through custom new with rest" do
-    ArgumentsDescriptorSpecs::NewRest.new(a: 1, b: 2).should == ArgumentsDescriptorSpecs::Info.new([[{a: 1, b: 2}]], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
+    info = ArgumentsDescriptorSpecs::NewRest.new(a: 1, b: 2)
+    info.should == ArgumentsDescriptorSpecs::Info.new([[{a: 1, b: 2}]], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
   end
 
   it "work through implicit super" do
-    ArgumentsDescriptorSpecs::A.new.implicit_super(a: 1, b: 2).should == ArgumentsDescriptorSpecs::Info.new([1, 2], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
+    info = ArgumentsDescriptorSpecs::A.new.implicit_super(a: 1, b: 2)
+    info.should == ArgumentsDescriptorSpecs::Info.new([1, 2], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
   end
 
   it "work through explicit super" do
-    ArgumentsDescriptorSpecs::A.new.explicit_super(a: 1, b: 2).should == ArgumentsDescriptorSpecs::Info.new([1, 2], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
+    info = ArgumentsDescriptorSpecs::A.new.explicit_super(a: 1, b: 2)
+    info.should == ArgumentsDescriptorSpecs::Info.new([1, 2], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
   end
 
   it "work through yield" do
-    ArgumentsDescriptorSpecs.use_yielder(1, 2).should == ArgumentsDescriptorSpecs::Info.new([1, 2], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
+    info = ArgumentsDescriptorSpecs.use_yielder(1, 2)
+    info.should == ArgumentsDescriptorSpecs::Info.new([1, 2], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : [])
   end
 end

--- a/spec/truffle/arguments_descriptor_spec.rb
+++ b/spec/truffle/arguments_descriptor_spec.rb
@@ -1,0 +1,197 @@
+# truffleruby_primitives: true
+
+require_relative '../ruby/spec_helper'
+
+module ArgumentsDescriptorSpecs
+  def self.tr?
+    RUBY_ENGINE == 'truffleruby'
+  end
+
+  unless tr?
+    module Primitive
+      def self.arguments_descriptor
+        []
+      end
+
+      def self.arguments
+        []
+      end
+    end
+  end
+
+  def self.no_kws(a, b)
+    [a, b, Primitive.arguments_descriptor, Primitive.arguments]
+  end
+
+  def self.only_kws(a:, b:)
+    [a, b, Primitive.arguments_descriptor, Primitive.arguments]
+  end
+
+  def self.only_kws_and_opt(a:, b: 101)
+    [a, b, Primitive.arguments_descriptor, Primitive.arguments]
+  end
+
+  def self.posn_kws(a, b:)
+    [a, b, Primitive.arguments_descriptor, Primitive.arguments]
+  end
+
+  def self.posn_kws_defaults(a, b: 101, c: 102)
+    [a, b, c, Primitive.arguments_descriptor, Primitive.arguments]
+  end
+
+  def self.opt_and_kws(a, b=2, c: nil)
+    [a, b, c, Primitive.arguments_descriptor, Primitive.arguments]
+  end
+
+  def self.struct_new_like(a, *b, c: 101)
+    [a, b, c, Primitive.arguments_descriptor, Primitive.arguments]
+  end
+
+  def self.describe_like(a, b = nil)
+    [a, b, Primitive.arguments_descriptor, Primitive.arguments]
+  end
+
+  def self.single(a)
+    [a, Primitive.arguments_descriptor, Primitive.arguments]
+  end
+
+  def self.rest(*a)
+    [a, Primitive.arguments_descriptor, Primitive.arguments]
+  end
+
+  def self.kw_rest(**a)
+    [a, Primitive.arguments_descriptor, Primitive.arguments]
+  end
+
+  def self.kw_and_kw_rest(a:, **b)
+    [a, b, Primitive.arguments_descriptor, Primitive.arguments]
+  end
+
+  def self.mixture(a, b = nil, c = nil, d, e: nil, **f)
+    [a, b, c, d, e, f, Primitive.arguments_descriptor, Primitive.arguments]
+  end
+
+  class NewKW
+    def self.new(a:, b:)
+      [a, b, Primitive.arguments_descriptor, Primitive.arguments]
+    end
+  end
+
+  class NewRest
+    def self.new(*a)
+      [a, Primitive.arguments_descriptor, Primitive.arguments]
+    end
+  end
+end
+
+describe "Arguments descriptors" do
+  it "are empty for simple calls" do
+    ArgumentsDescriptorSpecs.no_kws(1, 2).should == [1, 2, [], ArgumentsDescriptorSpecs.tr? ? [1, 2]: []]
+  end
+
+  it "contain keyword arguments" do
+    ArgumentsDescriptorSpecs.only_kws(a: 1, b: 2).should == [1, 2, ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : []]
+  end
+
+  it "contain optional keyword arguments" do
+    ArgumentsDescriptorSpecs.only_kws_and_opt(a: 1, b: 2).should == [1, 2, ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : []]
+    ArgumentsDescriptorSpecs.only_kws_and_opt(a: 1).should == [1, 101, ArgumentsDescriptorSpecs.tr? ? [:a, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1}] : []]
+  end
+
+  it "contain keyword arguments with positional arguments" do
+    ArgumentsDescriptorSpecs.posn_kws(1, b: 2).should == [1, 2, ArgumentsDescriptorSpecs.tr? ? [:b, 1, true] : [], ArgumentsDescriptorSpecs.tr? ? [1, {b: 2}] : []]
+  end
+
+  it "contain optional keyword arguments with positional arguments" do
+    ArgumentsDescriptorSpecs.posn_kws_defaults(1, b: 2, c: 3).should == [1, 2, 3, ArgumentsDescriptorSpecs.tr? ? [:b, :c, 1, true] : [], ArgumentsDescriptorSpecs.tr? ? [1, {b: 2, c: 3}] : []]
+  end
+
+  it "do not contain missing optional keyword arguments" do
+    ArgumentsDescriptorSpecs.posn_kws_defaults(1, b: 2).should == [1, 2, 102, ArgumentsDescriptorSpecs.tr? ? [:b, 1, true] : [], ArgumentsDescriptorSpecs.tr? ? [1, {b: 2}] : []]
+    ArgumentsDescriptorSpecs.posn_kws_defaults(1, c: 3).should == [1, 101, 3, ArgumentsDescriptorSpecs.tr? ? [:c, 1, true] : [], ArgumentsDescriptorSpecs.tr? ? [1, {c: 3}] : []]
+  end
+
+  it "do not contain the name of distant explicitly splatted keyword arguments" do
+    distant = {b: 2}
+    ArgumentsDescriptorSpecs.only_kws(a: 1, **distant).should == [1, 2, ArgumentsDescriptorSpecs.tr? ? [:a, 0, false] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : []]
+  end
+
+  it "do not contain the name of near explicitly splatted keyword arguments" do
+    ArgumentsDescriptorSpecs.only_kws(a: 1, **{b: 2}).should == [1, 2, ArgumentsDescriptorSpecs.tr? ? [:a, 0, false] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : []]
+  end
+
+  it "contain the name of present optional keyword arguments without the optional positional" do
+    ArgumentsDescriptorSpecs.opt_and_kws(1, c: 3).should == [1, 2, 3, ArgumentsDescriptorSpecs.tr? ? [:c, 1, true] : [], ArgumentsDescriptorSpecs.tr? ? [1, {c: 3}] : []]
+  end
+
+  it "work for a call like our Struct.new" do
+    ArgumentsDescriptorSpecs.struct_new_like('A', :a, :b).should == ['A', [:a, :b], 101, [], ArgumentsDescriptorSpecs.tr? ? ['A', :a, :b] : []]
+    ArgumentsDescriptorSpecs.struct_new_like('A', :a, :b, c: 1).should == ['A', [:a, :b], 1, ArgumentsDescriptorSpecs.tr? ? [:c, 3, true] : [], ArgumentsDescriptorSpecs.tr? ? ['A', :a, :b, {c: 1}] : []]
+    ArgumentsDescriptorSpecs.struct_new_like('A', :a, :b, {c: 1}).should == ['A', [:a, :b, {c: 1}], 101, [], ArgumentsDescriptorSpecs.tr? ? ['A', :a, :b, {c: 1}] : []]
+    ArgumentsDescriptorSpecs.struct_new_like('A', :a, :b, **{c: 1}).should == ['A', [:a, :b], 1, [], ArgumentsDescriptorSpecs.tr? ? ['A', :a, :b, {c: 1}] : []]
+    distant = {c: 1}
+    ArgumentsDescriptorSpecs.struct_new_like('A', :a, :b, **distant).should == ['A', [:a, :b], 1, [], ArgumentsDescriptorSpecs.tr? ? ['A', :a, :b, {c: 1}] : []]
+    -> { ArgumentsDescriptorSpecs.struct_new_like('A', :a, :b, d: 1) }.should raise_error(ArgumentError)
+    -> { ArgumentsDescriptorSpecs.struct_new_like('A', :a, :b, **{d: 1}) }.should raise_error(ArgumentError)
+    distant = {d: 1}
+    -> { ArgumentsDescriptorSpecs.struct_new_like('A', :a, :b, **distant) }.should raise_error(ArgumentError)
+  end
+
+  it "work for a call like a Struct's new" do
+    klass = Struct.new(:a)
+    a = klass.new({b: [1, 2, 3]})
+    a.a.should == {b: [1, 2, 3]}
+    b = klass.new(a)
+    b.a.should == a
+    a.dig(:a, :b).should == [1, 2, 3]
+  end
+
+  it "work for a call like MSpec #describe" do
+    ArgumentsDescriptorSpecs.describe_like(1, b: 2).should == [1, {b: 2}, ArgumentsDescriptorSpecs.tr? ? [:b, 1, true] : [], ArgumentsDescriptorSpecs.tr? ? [1, {b: 2}] : []]
+  end
+
+  it "expand a hash not used for keyword arguments" do
+    ArgumentsDescriptorSpecs.single({a: 1, b: 2}).should == [{a: 1, b: 2}, [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : []]
+  end
+
+  it "contain keyword argument names passed to a rest" do
+    ArgumentsDescriptorSpecs.rest(a: 1, b: 2).should == [[{a: 1, b: 2}], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : []]
+  end
+
+  it "contain keyword argument names passed to a keyword rest" do
+    ArgumentsDescriptorSpecs.kw_rest(a: 1, b: 2).should == [{a: 1, b: 2}, ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : []]
+  end
+
+  it "contain keyword argument names passed to a combined keyword rest" do
+    ArgumentsDescriptorSpecs.kw_and_kw_rest(a: 1).should == [1, {}, ArgumentsDescriptorSpecs.tr? ? [:a, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1}] : []]
+    ArgumentsDescriptorSpecs.kw_and_kw_rest(a: 1, b: 2, c: 3).should == [1, {b: 2, c: 3}, ArgumentsDescriptorSpecs.tr? ? [:a, :b, :c, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2, c: 3}] : []]
+    ArgumentsDescriptorSpecs.kw_and_kw_rest("abc" => 123, a: 1, b: 2).should == [1, {"abc" => 123, b: 2}, ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, false] : [], ArgumentsDescriptorSpecs.tr? ? [{"abc" => 123, a: 1, b: 2}] : []]
+  end
+
+  it "work for a mixture of arguments" do
+    ArgumentsDescriptorSpecs.mixture(1, 2).should == [1, nil, nil, 2, nil, {}, ArgumentsDescriptorSpecs.tr? ? [] : [], ArgumentsDescriptorSpecs.tr? ? [1, 2] : []]
+    ArgumentsDescriptorSpecs.mixture(1, 2, e: 3).should == [1, nil, nil, 2, 3, {}, ArgumentsDescriptorSpecs.tr? ? [:e, 2, true] : [], ArgumentsDescriptorSpecs.tr? ? [1, 2, {e: 3}] : []]
+    ArgumentsDescriptorSpecs.mixture(1, 2, {foo: :bar}).should == [1, 2, nil, {:foo=>:bar}, nil, {}, ArgumentsDescriptorSpecs.tr? ? [] : [], ArgumentsDescriptorSpecs.tr? ? [1, 2, {foo: :bar}] : []]
+    ArgumentsDescriptorSpecs.mixture(1, {foo: :bar}).should == [1, nil, nil, {foo: :bar}, nil, {}, ArgumentsDescriptorSpecs.tr? ? [-1] : [], ArgumentsDescriptorSpecs.tr? ? [1, {foo: :bar}] : []]
+  end
+
+  it "work through an inlined call abstraction" do
+    foo = -> (a:) { a }
+    foo.(a: 1).should == 1
+    -> { foo.() }.should raise_error(ArgumentError)
+  end
+
+  guard -> { RUBY_ENGINE == 'truffleruby' } do
+    it "pass keyword arguments into foreign calls as a Hash" do
+      Truffle::Debug.foreign_identity_function.call(a: 1, b: 2).should == {a: 1, b: 2}
+    end
+  end
+
+  it "work through custom new with keyword arguments" do
+    ArgumentsDescriptorSpecs::NewKW.new(a: 1, b: 2).should == [1, 2, ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : []]
+  end
+
+  it "work through custom new with rest" do
+    ArgumentsDescriptorSpecs::NewRest.new(a: 1, b: 2).should == [[{a: 1, b: 2}], ArgumentsDescriptorSpecs.tr? ? [:a, :b, 0, true] : [], ArgumentsDescriptorSpecs.tr? ? [{a: 1, b: 2}] : []]
+  end
+end

--- a/src/main/java/org/truffleruby/RubyLanguage.java
+++ b/src/main/java/org/truffleruby/RubyLanguage.java
@@ -104,6 +104,7 @@ import org.truffleruby.language.RubyDynamicObject;
 import org.truffleruby.language.RubyEvalInteractiveRootNode;
 import org.truffleruby.language.RubyInlineParsingRequestNode;
 import org.truffleruby.language.RubyParsingRequestNode;
+import org.truffleruby.language.arguments.ArgumentsDescriptorManager;
 import org.truffleruby.language.objects.RubyObjectType;
 import org.truffleruby.language.objects.classvariables.ClassVariableStorage;
 import org.truffleruby.language.threadlocal.SpecialVariableStorage;
@@ -207,6 +208,7 @@ public final class RubyLanguage extends TruffleLanguage<RubyContext> {
     public final RopeCache ropeCache;
     public final RegexpTable regexpTable;
     public final SymbolTable symbolTable;
+    public final ArgumentsDescriptorManager argumentsDescriptorManager = new ArgumentsDescriptorManager();
     public final FrozenStringLiterals frozenStringLiterals;
 
     public final ReferenceQueue<Object> sharedReferenceQueue = new ReferenceQueue<>();

--- a/src/main/java/org/truffleruby/core/VMPrimitiveNodes.java
+++ b/src/main/java/org/truffleruby/core/VMPrimitiveNodes.java
@@ -50,7 +50,6 @@ import org.truffleruby.RubyLanguage;
 import org.truffleruby.builtins.CoreModule;
 import org.truffleruby.builtins.Primitive;
 import org.truffleruby.builtins.PrimitiveArrayArgumentsNode;
-import org.truffleruby.core.array.ArrayHelpers;
 import org.truffleruby.core.array.RubyArray;
 import org.truffleruby.core.basicobject.BasicObjectNodes.ReferenceEqualNode;
 import org.truffleruby.core.cast.NameToJavaStringNode;
@@ -581,10 +580,7 @@ public abstract class VMPrimitiveNodes {
 
         @Specialization
         protected RubyArray arguments(VirtualFrame frame) {
-            return ArrayHelpers.createArray(
-                    getContext(),
-                    getLanguage(),
-                    RubyArguments.getArguments(frame));
+            return createArray(RubyArguments.getArguments(frame));
         }
 
     }
@@ -600,7 +596,7 @@ public abstract class VMPrimitiveNodes {
         @TruffleBoundary
         private RubyArray descriptorToArray(ArgumentsDescriptor descriptor) {
             if (descriptor == EmptyArgumentsDescriptor.INSTANCE) {
-                return ArrayHelpers.createEmptyArray(getContext(), getLanguage());
+                return createEmptyArray();
             } else if (descriptor instanceof NonEmptyArgumentsDescriptor) {
                 final NonEmptyArgumentsDescriptor nonEmpty = (NonEmptyArgumentsDescriptor) descriptor;
 
@@ -611,10 +607,7 @@ public abstract class VMPrimitiveNodes {
                 final Stream<Object> other = Stream.of(nonEmpty.getKeywordHashIndex(),
                         nonEmpty.isKeywordHashElidable());
 
-                return ArrayHelpers.createArray(
-                        getContext(),
-                        getLanguage(),
-                        Stream.concat(keywordArguments, other).toArray());
+                return createArray(Stream.concat(keywordArguments, other).toArray());
             } else {
                 throw CompilerDirectives.shouldNotReachHere();
             }

--- a/src/main/java/org/truffleruby/core/VMPrimitiveNodes.java
+++ b/src/main/java/org/truffleruby/core/VMPrimitiveNodes.java
@@ -270,7 +270,7 @@ public abstract class VMPrimitiveNodes {
                 case "IGNORE":
                     return registerIgnoreHandler(signalName);
                 default:
-                    throw new UnsupportedOperationException(actionString);
+                    throw CompilerDirectives.shouldNotReachHere(actionString);
             }
         }
 
@@ -616,7 +616,7 @@ public abstract class VMPrimitiveNodes {
                         getLanguage(),
                         Stream.concat(keywordArguments, other).toArray());
             } else {
-                throw new UnsupportedOperationException();
+                throw CompilerDirectives.shouldNotReachHere();
             }
         }
 

--- a/src/main/java/org/truffleruby/core/basicobject/BasicObjectNodes.java
+++ b/src/main/java/org/truffleruby/core/basicobject/BasicObjectNodes.java
@@ -43,6 +43,7 @@ import org.truffleruby.language.RubyGuards;
 import org.truffleruby.language.RubyNode;
 import org.truffleruby.language.RubySourceNode;
 import org.truffleruby.language.Visibility;
+import org.truffleruby.language.arguments.EmptyArgumentsDescriptor;
 import org.truffleruby.language.arguments.ReadCallerFrameNode;
 import org.truffleruby.language.arguments.RubyArguments;
 import org.truffleruby.language.control.RaiseException;
@@ -442,7 +443,8 @@ public abstract class BasicObjectNodes {
                     new SingletonClassOfSelfDefaultDefinee(receiver),
                     block.declarationContext.getRefinements());
             return callBlockNode
-                    .executeCallBlock(declarationContext, block, receiver, block.block, arguments);
+                    .executeCallBlock(declarationContext, block, receiver, block.block,
+                            EmptyArgumentsDescriptor.INSTANCE, arguments);
         }
 
         @Specialization

--- a/src/main/java/org/truffleruby/core/module/ModuleNodes.java
+++ b/src/main/java/org/truffleruby/core/module/ModuleNodes.java
@@ -87,6 +87,7 @@ import org.truffleruby.language.RubyNode;
 import org.truffleruby.language.RubyRootNode;
 import org.truffleruby.language.Visibility;
 import org.truffleruby.language.WarningNode.UncachedWarningNode;
+import org.truffleruby.language.arguments.EmptyArgumentsDescriptor;
 import org.truffleruby.language.arguments.ReadCallerFrameNode;
 import org.truffleruby.language.arguments.RubyArguments;
 import org.truffleruby.language.backtrace.BacktraceFormatter;
@@ -800,7 +801,8 @@ public abstract class ModuleNodes {
                     new FixedDefaultDefinee(self),
                     block.declarationContext.getRefinements());
 
-            return callBlockNode.executeCallBlock(declarationContext, block, self, block.block, args);
+            return callBlockNode.executeCallBlock(declarationContext, block, self, block.block,
+                    EmptyArgumentsDescriptor.INSTANCE, args);
         }
 
         @Specialization
@@ -2256,6 +2258,7 @@ public abstract class ModuleNodes {
                     block,
                     refinement,
                     block.block,
+                    EmptyArgumentsDescriptor.INSTANCE,
                     EMPTY_ARGUMENTS);
             return refinement;
         }

--- a/src/main/java/org/truffleruby/core/proc/ProcNodes.java
+++ b/src/main/java/org/truffleruby/core/proc/ProcNodes.java
@@ -33,6 +33,7 @@ import org.truffleruby.language.Nil;
 import org.truffleruby.language.Visibility;
 import org.truffleruby.language.WarnNode;
 import org.truffleruby.language.arguments.ArgumentDescriptorUtils;
+import org.truffleruby.language.arguments.EmptyArgumentsDescriptor;
 import org.truffleruby.language.arguments.ReadCallerFrameNode;
 import org.truffleruby.language.arguments.RubyArguments;
 import org.truffleruby.language.control.RaiseException;
@@ -202,6 +203,7 @@ public abstract class ProcNodes {
                     proc,
                     ProcOperations.getSelf(proc),
                     RubyArguments.getBlock(rubyArgs),
+                    EmptyArgumentsDescriptor.INSTANCE,
                     RubyArguments.getArguments(rubyArgs));
         }
     }

--- a/src/main/java/org/truffleruby/language/arguments/ArgumentsDescriptor.java
+++ b/src/main/java/org/truffleruby/language/arguments/ArgumentsDescriptor.java
@@ -10,7 +10,7 @@
 package org.truffleruby.language.arguments;
 
 /** An arguments descriptor is an object that describes something about the arguments being passed, regardless of what
- * the caller expects or accepts. Argument descriptors are stable, immutable objects, suitable to be cached and guarded
+ * the callee expects or accepts. Argument descriptors are stable, immutable objects, suitable to be cached and guarded
  * by identity. They'd normally convey some kind of static information from call site to callee. TruffleRuby uses
  * arguments descriptors to describe passed keyword arguments. */
 public abstract class ArgumentsDescriptor {

--- a/src/main/java/org/truffleruby/language/arguments/ArgumentsDescriptor.java
+++ b/src/main/java/org/truffleruby/language/arguments/ArgumentsDescriptor.java
@@ -9,8 +9,9 @@
  */
 package org.truffleruby.language.arguments;
 
-/** An arguments descriptor is an object that describes something about the arguments being passed. Argument descriptors
- * are stable, immutable objects, suitable to be cached and guarded by identity. They'd normally convey some kind of
- * static information from call site to callee. */
+/** An arguments descriptor is an object that describes something about the arguments being passed, regardless of what
+ * the caller expects or accepts. Argument descriptors are stable, immutable objects, suitable to be cached and guarded
+ * by identity. They'd normally convey some kind of static information from call site to callee. TruffleRuby uses
+ * arguments descriptors to describe passed keyword arguments. */
 public abstract class ArgumentsDescriptor {
 }

--- a/src/main/java/org/truffleruby/language/arguments/ArgumentsDescriptorManager.java
+++ b/src/main/java/org/truffleruby/language/arguments/ArgumentsDescriptorManager.java
@@ -9,15 +9,14 @@
  */
 package org.truffleruby.language.arguments;
 
-import java.lang.ref.WeakReference;
-import java.util.Collections;
-import java.util.Map;
-import java.util.WeakHashMap;
+import org.truffleruby.collections.WeakValueCache;
+
+import java.util.Arrays;
+import java.util.Objects;
 
 public class ArgumentsDescriptorManager {
 
-    private final Map<NonEmptyArgumentsDescriptor, WeakReference<NonEmptyArgumentsDescriptor>> CANONICAL_NON_EMPTY_DESCRIPTORS = Collections
-            .synchronizedMap(new WeakHashMap<>());
+    private final WeakValueCache<Key, NonEmptyArgumentsDescriptor> CANONICAL_NON_EMPTY_DESCRIPTORS = new WeakValueCache<>();
 
     public ArgumentsDescriptor getArgumentsDescriptor(String[] keywordArgumentsNames, int keywordHashIndex,
             boolean keywordHashElidable) {
@@ -27,17 +26,49 @@ public class ArgumentsDescriptorManager {
             return EmptyArgumentsDescriptor.INSTANCE;
         }
 
-        final NonEmptyArgumentsDescriptor reference = new NonEmptyArgumentsDescriptor(keywordArgumentsNames,
+        final Key key = new Key(keywordArgumentsNames, keywordHashIndex, keywordHashElidable);
+
+        final NonEmptyArgumentsDescriptor descriptor = new NonEmptyArgumentsDescriptor(keywordArgumentsNames,
                 keywordHashIndex, keywordHashElidable);
 
-        final WeakReference<NonEmptyArgumentsDescriptor> canonical = CANONICAL_NON_EMPTY_DESCRIPTORS
-                .putIfAbsent(reference, new WeakReference<>(reference));
+        return CANONICAL_NON_EMPTY_DESCRIPTORS.addInCacheIfAbsent(key, descriptor);
+    }
 
-        if (canonical == null) {
-            return reference;
-        } else {
-            return canonical.get();
+    public static class Key {
+
+        private final String[] keywordArgumentNames;
+        private final int keywordHashIndex;
+        private final boolean keywordHashElidable;
+
+        public Key(
+                String[] keywordArgumentNames,
+                int keywordHashIndex,
+                boolean keywordHashElidable) {
+            this.keywordArgumentNames = keywordArgumentNames;
+            this.keywordHashIndex = keywordHashIndex;
+            this.keywordHashElidable = keywordHashElidable;
         }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            Key that = (Key) o;
+            return keywordHashIndex == that.keywordHashIndex && keywordHashElidable == that.keywordHashElidable &&
+                    Arrays.equals(keywordArgumentNames, that.keywordArgumentNames);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = Objects.hash(keywordHashIndex, keywordHashElidable);
+            result = 31 * result + Arrays.hashCode(keywordArgumentNames);
+            return result;
+        }
+
     }
 
 }

--- a/src/main/java/org/truffleruby/language/arguments/ArgumentsDescriptorManager.java
+++ b/src/main/java/org/truffleruby/language/arguments/ArgumentsDescriptorManager.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved. This
+ * code is released under a tri EPL/GPL/LGPL license. You can use it,
+ * redistribute it and/or modify it under the terms of the:
+ *
+ * Eclipse Public License version 2.0, or
+ * GNU General Public License version 2, or
+ * GNU Lesser General Public License version 2.1.
+ */
+package org.truffleruby.language.arguments;
+
+import java.lang.ref.WeakReference;
+import java.util.Collections;
+import java.util.Map;
+import java.util.WeakHashMap;
+
+public class ArgumentsDescriptorManager {
+
+    private final Map<NonEmptyArgumentsDescriptor, WeakReference<NonEmptyArgumentsDescriptor>> CANONICAL_NON_EMPTY_DESCRIPTORS = Collections
+            .synchronizedMap(new WeakHashMap<>());
+
+    public ArgumentsDescriptor getArgumentsDescriptor(String[] keywordArgumentsNames, int keywordHashIndex,
+            boolean keywordHashElidable) {
+        assert !(keywordHashIndex == NonEmptyArgumentsDescriptor.NO_KEYWORD_HASH && keywordHashElidable);
+
+        if (keywordArgumentsNames.length == 0 && keywordHashIndex == NonEmptyArgumentsDescriptor.NO_KEYWORD_HASH) {
+            return EmptyArgumentsDescriptor.INSTANCE;
+        }
+
+        final NonEmptyArgumentsDescriptor reference = new NonEmptyArgumentsDescriptor(keywordArgumentsNames,
+                keywordHashIndex, keywordHashElidable);
+
+        final WeakReference<NonEmptyArgumentsDescriptor> canonical = CANONICAL_NON_EMPTY_DESCRIPTORS
+                .putIfAbsent(reference, new WeakReference<>(reference));
+
+        if (canonical == null) {
+            return reference;
+        } else {
+            return canonical.get();
+        }
+    }
+
+}

--- a/src/main/java/org/truffleruby/language/arguments/EmptyArgumentsDescriptor.java
+++ b/src/main/java/org/truffleruby/language/arguments/EmptyArgumentsDescriptor.java
@@ -9,7 +9,7 @@
  */
 package org.truffleruby.language.arguments;
 
-/** An arguments descriptor which conveys no information. */
+/** An arguments descriptor for where we're providing no information about the value of arguments being passed. */
 public class EmptyArgumentsDescriptor extends ArgumentsDescriptor {
 
     public static final EmptyArgumentsDescriptor INSTANCE = new EmptyArgumentsDescriptor();

--- a/src/main/java/org/truffleruby/language/arguments/NonEmptyArgumentsDescriptor.java
+++ b/src/main/java/org/truffleruby/language/arguments/NonEmptyArgumentsDescriptor.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved. This
+ * code is released under a tri EPL/GPL/LGPL license. You can use it,
+ * redistribute it and/or modify it under the terms of the:
+ *
+ * Eclipse Public License version 2.0, or
+ * GNU General Public License version 2, or
+ * GNU Lesser General Public License version 2.1.
+ */
+package org.truffleruby.language.arguments;
+
+import java.util.Arrays;
+
+public class NonEmptyArgumentsDescriptor extends ArgumentsDescriptor {
+
+    public static final int NO_KEYWORD_HASH = -1;
+
+    private final String[] keywordArgumentNames;
+    private final int keywordHashIndex;
+    private final boolean keywordHashElidable;
+
+    public NonEmptyArgumentsDescriptor(
+            String[] keywordArgumentNames,
+            int keywordHashIndex,
+            boolean keywordHashElidable) {
+        this.keywordArgumentNames = keywordArgumentNames;
+        this.keywordHashIndex = keywordHashIndex;
+        this.keywordHashElidable = keywordHashElidable;
+    }
+
+    public String[] getKeywordArgumentNames() {
+        return keywordArgumentNames;
+    }
+
+    public int getKeywordHashIndex() {
+        return keywordHashIndex;
+    }
+
+    public boolean isKeywordHashElidable() {
+        return keywordHashElidable;
+    }
+
+    public boolean equals(Object other) {
+        if (other instanceof NonEmptyArgumentsDescriptor) {
+            final NonEmptyArgumentsDescriptor nonEmpty = (NonEmptyArgumentsDescriptor) other;
+            return Arrays.equals(keywordArgumentNames, nonEmpty.keywordArgumentNames) &&
+                    keywordHashIndex == nonEmpty.keywordHashIndex &&
+                    keywordHashElidable == nonEmpty.keywordHashElidable;
+        } else {
+            return false;
+        }
+    }
+
+    public int hashCode() {
+        return Arrays.hashCode(keywordArgumentNames) ^ (keywordHashIndex << 32) ^
+                (keywordHashElidable ? (1 << 24) : (1 << 12));
+    }
+
+}

--- a/src/main/java/org/truffleruby/language/arguments/NonEmptyArgumentsDescriptor.java
+++ b/src/main/java/org/truffleruby/language/arguments/NonEmptyArgumentsDescriptor.java
@@ -10,6 +10,7 @@
 package org.truffleruby.language.arguments;
 
 import java.util.Arrays;
+import java.util.Objects;
 
 public class NonEmptyArgumentsDescriptor extends ArgumentsDescriptor {
 
@@ -40,20 +41,23 @@ public class NonEmptyArgumentsDescriptor extends ArgumentsDescriptor {
         return keywordHashElidable;
     }
 
-    public boolean equals(Object other) {
-        if (other instanceof NonEmptyArgumentsDescriptor) {
-            final NonEmptyArgumentsDescriptor nonEmpty = (NonEmptyArgumentsDescriptor) other;
-            return Arrays.equals(keywordArgumentNames, nonEmpty.keywordArgumentNames) &&
-                    keywordHashIndex == nonEmpty.keywordHashIndex &&
-                    keywordHashElidable == nonEmpty.keywordHashElidable;
-        } else {
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
             return false;
         }
+        NonEmptyArgumentsDescriptor that = (NonEmptyArgumentsDescriptor) o;
+        return keywordHashIndex == that.keywordHashIndex && keywordHashElidable == that.keywordHashElidable &&
+                Arrays.equals(keywordArgumentNames, that.keywordArgumentNames);
     }
 
+    @Override
     public int hashCode() {
-        return Arrays.hashCode(keywordArgumentNames) ^ (keywordHashIndex << 32) ^
-                (keywordHashElidable ? (1 << 24) : (1 << 12));
+        int result = Objects.hash(keywordHashIndex, keywordHashElidable);
+        result = 31 * result + Arrays.hashCode(keywordArgumentNames);
+        return result;
     }
-
 }

--- a/src/main/java/org/truffleruby/language/arguments/RubyArguments.java
+++ b/src/main/java/org/truffleruby/language/arguments/RubyArguments.java
@@ -97,8 +97,9 @@ public final class RubyArguments {
                 frameOnStackMarker,
                 self,
                 block,
+                EmptyArgumentsDescriptor.INSTANCE,
                 arguments);
-    }
+    };
 
     public static Object[] pack(
             MaterializedFrame declarationFrame,
@@ -109,6 +110,28 @@ public final class RubyArguments {
             Object self,
             Object block,
             Object[] arguments) {
+        return pack(
+                declarationFrame,
+                callerFrameOrVariables,
+                method,
+                declarationContext,
+                frameOnStackMarker,
+                self,
+                block,
+                EmptyArgumentsDescriptor.INSTANCE,
+                arguments);
+    };
+
+    public static Object[] pack(
+            MaterializedFrame declarationFrame,
+            Object callerFrameOrVariables,
+            InternalMethod method,
+            DeclarationContext declarationContext,
+            FrameOnStackMarker frameOnStackMarker,
+            Object self,
+            Object block,
+            ArgumentsDescriptor descriptor,
+            Object[] arguments) {
         final Object[] packed = new Object[RUNTIME_ARGUMENT_COUNT + arguments.length];
 
         packed[ArgumentIndicies.DECLARATION_FRAME.ordinal()] = declarationFrame;
@@ -118,7 +141,7 @@ public final class RubyArguments {
         packed[ArgumentIndicies.FRAME_ON_STACK_MARKER.ordinal()] = frameOnStackMarker;
         packed[ArgumentIndicies.SELF.ordinal()] = self;
         packed[ArgumentIndicies.BLOCK.ordinal()] = block;
-        packed[ArgumentIndicies.DESCRIPTOR.ordinal()] = EmptyArgumentsDescriptor.INSTANCE;
+        packed[ArgumentIndicies.DESCRIPTOR.ordinal()] = descriptor;
 
         ArrayUtils.arraycopy(arguments, 0, packed, RUNTIME_ARGUMENT_COUNT, arguments.length);
 

--- a/src/main/java/org/truffleruby/language/arguments/RubyArguments.java
+++ b/src/main/java/org/truffleruby/language/arguments/RubyArguments.java
@@ -281,6 +281,10 @@ public final class RubyArguments {
         args[ArgumentIndicies.DESCRIPTOR.ordinal()] = descriptor;
     }
 
+    public static ArgumentsDescriptor getDescriptor(Frame frame) {
+        return getDescriptor(frame.getArguments());
+    }
+
     public static ArgumentsDescriptor getDescriptor(Object[] args) {
         return (ArgumentsDescriptor) args[ArgumentIndicies.DESCRIPTOR.ordinal()];
     }

--- a/src/main/java/org/truffleruby/language/dispatch/RubyCallNode.java
+++ b/src/main/java/org/truffleruby/language/dispatch/RubyCallNode.java
@@ -23,7 +23,7 @@ import org.truffleruby.language.RubyBaseNode;
 import org.truffleruby.language.RubyContextSourceNode;
 import org.truffleruby.language.RubyGuards;
 import org.truffleruby.language.RubyNode;
-import org.truffleruby.language.arguments.EmptyArgumentsDescriptor;
+import org.truffleruby.language.arguments.ArgumentsDescriptor;
 import org.truffleruby.language.arguments.RubyArguments;
 import org.truffleruby.language.arguments.SplatToArgsNode;
 import org.truffleruby.language.literal.NilLiteralNode;
@@ -50,6 +50,7 @@ public class RubyCallNode extends RubyContextSourceNode implements AssignableNod
     @Child private RubyNode receiver;
     @Child private RubyNode block;
     private final boolean hasLiteralBlock;
+    private final ArgumentsDescriptor descriptor;
     @Children private final RubyNode[] arguments;
 
     private final boolean isSplatted;
@@ -73,6 +74,7 @@ public class RubyCallNode extends RubyContextSourceNode implements AssignableNod
         final RubyNode block = parameters.getBlock();
         this.block = parameters.getBlock();
         this.hasLiteralBlock = block instanceof BlockDefinitionNode || block instanceof LambdaToProcNode;
+        this.descriptor = parameters.getDescriptor();
 
         this.isSplatted = parameters.isSplatted();
         this.dispatchConfig = parameters.isIgnoreVisibility() ? PRIVATE : PROTECTED;
@@ -95,7 +97,7 @@ public class RubyCallNode extends RubyContextSourceNode implements AssignableNod
         }
         Object[] rubyArgs = RubyArguments.allocate(arguments.length);
         RubyArguments.setSelf(rubyArgs, receiverObject);
-        RubyArguments.setDescriptor(rubyArgs, EmptyArgumentsDescriptor.INSTANCE);
+        RubyArguments.setDescriptor(rubyArgs, descriptor);
 
         executeArguments(frame, rubyArgs);
 
@@ -124,6 +126,7 @@ public class RubyCallNode extends RubyContextSourceNode implements AssignableNod
         executeArguments(frame, rubyArgs);
 
         RubyArguments.setBlock(rubyArgs, executeBlock(frame));
+        RubyArguments.setDescriptor(rubyArgs, descriptor);
 
         if (isSplatted) {
             rubyArgs = splatArgs(receiverObject, rubyArgs);
@@ -158,7 +161,7 @@ public class RubyCallNode extends RubyContextSourceNode implements AssignableNod
         Object[] rubyArgs = RubyArguments.allocate(argumentsObjects.length);
         RubyArguments.setSelf(rubyArgs, receiverObject);
         RubyArguments.setBlock(rubyArgs, blockObject);
-        RubyArguments.setDescriptor(rubyArgs, EmptyArgumentsDescriptor.INSTANCE);
+        RubyArguments.setDescriptor(rubyArgs, descriptor);
         RubyArguments.setArguments(rubyArgs, argumentsObjects);
         return executeWithArgumentsEvaluated(frame, receiverObject, rubyArgs);
     }

--- a/src/main/java/org/truffleruby/language/dispatch/RubyCallNodeParameters.java
+++ b/src/main/java/org/truffleruby/language/dispatch/RubyCallNodeParameters.java
@@ -10,12 +10,15 @@
 package org.truffleruby.language.dispatch;
 
 import org.truffleruby.language.RubyNode;
+import org.truffleruby.language.arguments.ArgumentsDescriptor;
+import org.truffleruby.language.arguments.EmptyArgumentsDescriptor;
 
 public class RubyCallNodeParameters {
 
     private final RubyNode receiver;
     private final String methodName;
     private final RubyNode block;
+    private final ArgumentsDescriptor descriptor;
     private final RubyNode[] arguments;
     private final boolean isSplatted;
     private final boolean ignoreVisibility;
@@ -30,13 +33,35 @@ public class RubyCallNodeParameters {
             RubyNode[] arguments,
             boolean isSplatted,
             boolean ignoreVisibility) {
-        this(receiver, methodName, block, arguments, isSplatted, ignoreVisibility, false, false, false);
+        this(
+                receiver,
+                methodName,
+                block,
+                EmptyArgumentsDescriptor.INSTANCE,
+                arguments,
+                isSplatted,
+                ignoreVisibility,
+                false,
+                false,
+                false);
     }
 
     public RubyCallNodeParameters(
             RubyNode receiver,
             String methodName,
             RubyNode block,
+            ArgumentsDescriptor descriptor,
+            RubyNode[] arguments,
+            boolean isSplatted,
+            boolean ignoreVisibility) {
+        this(receiver, methodName, block, descriptor, arguments, isSplatted, ignoreVisibility, false, false, false);
+    }
+
+    public RubyCallNodeParameters(
+            RubyNode receiver,
+            String methodName,
+            RubyNode block,
+            ArgumentsDescriptor descriptor,
             RubyNode[] arguments,
             boolean isSplatted,
             boolean ignoreVisibility,
@@ -46,6 +71,7 @@ public class RubyCallNodeParameters {
         this.receiver = receiver;
         this.methodName = methodName;
         this.block = block;
+        this.descriptor = descriptor;
         this.arguments = arguments;
         this.isSplatted = isSplatted;
         this.ignoreVisibility = ignoreVisibility;
@@ -59,6 +85,7 @@ public class RubyCallNodeParameters {
                 receiver,
                 methodName,
                 block,
+                descriptor,
                 arguments,
                 isSplatted,
                 ignoreVisibility,
@@ -81,6 +108,10 @@ public class RubyCallNodeParameters {
 
     public RubyNode getBlock() {
         return block;
+    }
+
+    public ArgumentsDescriptor getDescriptor() {
+        return descriptor;
     }
 
     public RubyNode[] getArguments() {

--- a/src/main/java/org/truffleruby/language/supercall/SuperCallNode.java
+++ b/src/main/java/org/truffleruby/language/supercall/SuperCallNode.java
@@ -14,6 +14,7 @@ import org.truffleruby.RubyLanguage;
 import org.truffleruby.core.string.FrozenStrings;
 import org.truffleruby.language.RubyContextSourceNode;
 import org.truffleruby.language.RubyNode;
+import org.truffleruby.language.arguments.ArgumentsDescriptor;
 import org.truffleruby.language.arguments.RubyArguments;
 import org.truffleruby.language.methods.InternalMethod;
 
@@ -24,12 +25,14 @@ public class SuperCallNode extends RubyContextSourceNode {
 
     @Child private RubyNode arguments;
     @Child private RubyNode block;
+    private final ArgumentsDescriptor descriptor;
     @Child private LookupSuperMethodNode lookupSuperMethodNode;
     @Child private CallSuperMethodNode callSuperMethodNode;
 
-    public SuperCallNode(RubyNode arguments, RubyNode block) {
+    public SuperCallNode(RubyNode arguments, RubyNode block, ArgumentsDescriptor descriptor) {
         this.arguments = arguments;
         this.block = block;
+        this.descriptor = descriptor;
     }
 
     @Override

--- a/src/main/java/org/truffleruby/language/yield/CallBlockNode.java
+++ b/src/main/java/org/truffleruby/language/yield/CallBlockNode.java
@@ -13,6 +13,8 @@ import org.truffleruby.core.proc.ProcOperations;
 import org.truffleruby.core.proc.RubyProc;
 import org.truffleruby.language.RubyBaseNode;
 import org.truffleruby.language.RubyRootNode;
+import org.truffleruby.language.arguments.ArgumentsDescriptor;
+import org.truffleruby.language.arguments.EmptyArgumentsDescriptor;
 import org.truffleruby.language.arguments.RubyArguments;
 import org.truffleruby.language.methods.DeclarationContext;
 
@@ -37,12 +39,17 @@ public abstract class CallBlockNode extends RubyBaseNode {
         return CallBlockNodeGen.getUncached();
     }
 
+    public final Object yield(RubyProc block, ArgumentsDescriptor descriptor, Object... args) {
+        return executeCallBlock(block.declarationContext, block, ProcOperations.getSelf(block), nil, descriptor, args);
+    }
+
     public final Object yield(RubyProc block, Object... args) {
-        return executeCallBlock(block.declarationContext, block, ProcOperations.getSelf(block), nil, args);
+        return executeCallBlock(block.declarationContext, block, ProcOperations.getSelf(block), nil,
+                EmptyArgumentsDescriptor.INSTANCE, args);
     }
 
     public abstract Object executeCallBlock(DeclarationContext declarationContext, RubyProc block, Object self,
-            Object blockArgument, Object[] arguments);
+            Object blockArgument, ArgumentsDescriptor descriptor, Object[] arguments);
 
     @Specialization(guards = "block.callTarget == cachedCallTarget", limit = "getCacheLimit()")
     protected Object callBlockCached(
@@ -50,10 +57,12 @@ public abstract class CallBlockNode extends RubyBaseNode {
             RubyProc block,
             Object self,
             Object blockArgument,
+            ArgumentsDescriptor descriptor,
             Object[] arguments,
             @Cached("block.callTarget") RootCallTarget cachedCallTarget,
             @Cached("createBlockCallNode(cachedCallTarget)") DirectCallNode callNode) {
-        final Object[] frameArguments = packArguments(declarationContext, block, self, blockArgument, arguments);
+        final Object[] frameArguments = packArguments(declarationContext, block, self, blockArgument, descriptor,
+                arguments);
         return callNode.call(frameArguments);
     }
 
@@ -63,14 +72,16 @@ public abstract class CallBlockNode extends RubyBaseNode {
             RubyProc block,
             Object self,
             Object blockArgument,
+            ArgumentsDescriptor descriptor,
             Object[] arguments,
             @Cached IndirectCallNode callNode) {
-        final Object[] frameArguments = packArguments(declarationContext, block, self, blockArgument, arguments);
+        final Object[] frameArguments = packArguments(declarationContext, block, self, blockArgument, descriptor,
+                arguments);
         return callNode.call(block.callTarget, frameArguments);
     }
 
     private Object[] packArguments(DeclarationContext declarationContext, RubyProc block, Object self,
-            Object blockArgument, Object[] arguments) {
+            Object blockArgument, ArgumentsDescriptor descriptor, Object[] arguments) {
         return RubyArguments.pack(
                 block.declarationFrame,
                 null,
@@ -79,6 +90,7 @@ public abstract class CallBlockNode extends RubyBaseNode {
                 block.frameOnStackMarker,
                 self,
                 blockArgument,
+                descriptor,
                 arguments);
     }
 

--- a/src/main/java/org/truffleruby/language/yield/YieldExpressionNode.java
+++ b/src/main/java/org/truffleruby/language/yield/YieldExpressionNode.java
@@ -79,7 +79,7 @@ public class YieldExpressionNode extends RubyContextSourceNode {
             argumentsObjects = unsplat(argumentsObjects);
         }
 
-        return getYieldNode().yield((RubyProc) block, argumentsObjects);
+        return getYieldNode().yield((RubyProc) block, descriptor, argumentsObjects);
     }
 
     private Object readBlock(VirtualFrame frame) {

--- a/src/main/java/org/truffleruby/language/yield/YieldExpressionNode.java
+++ b/src/main/java/org/truffleruby/language/yield/YieldExpressionNode.java
@@ -18,6 +18,7 @@ import org.truffleruby.core.string.FrozenStrings;
 import org.truffleruby.language.RubyContextSourceNode;
 import org.truffleruby.language.RubyNode;
 import org.truffleruby.language.WarnNode;
+import org.truffleruby.language.arguments.ArgumentsDescriptor;
 import org.truffleruby.language.arguments.RubyArguments;
 import org.truffleruby.language.control.RaiseException;
 
@@ -30,6 +31,7 @@ public class YieldExpressionNode extends RubyContextSourceNode {
 
     private final boolean unsplat;
     private final boolean warnInModuleBody;
+    private final ArgumentsDescriptor descriptor;
 
     @Children private final RubyNode[] arguments;
     @Child private CallBlockNode yieldNode;
@@ -42,10 +44,12 @@ public class YieldExpressionNode extends RubyContextSourceNode {
 
     public YieldExpressionNode(
             boolean unsplat,
+            ArgumentsDescriptor descriptor,
             RubyNode[] arguments,
             RubyNode readBlockNode,
             boolean warnInModuleBody) {
         this.unsplat = unsplat;
+        this.descriptor = descriptor;
         this.arguments = arguments;
         this.readBlockNode = readBlockNode;
         this.warnInModuleBody = warnInModuleBody;

--- a/src/main/java/org/truffleruby/parser/MethodTranslator.java
+++ b/src/main/java/org/truffleruby/parser/MethodTranslator.java
@@ -446,7 +446,7 @@ public class MethodTranslator extends BodyTranslator {
                 argumentsAndBlock.isSplatted());
         final RubyNode block = executeOrInheritBlock(argumentsAndBlock.getBlock(), node);
 
-        RubyNode callNode = new SuperCallNode(arguments, block);
+        RubyNode callNode = new SuperCallNode(arguments, block, argumentsAndBlock.getArgumentsDescriptor());
         callNode = wrapCallWithLiteralBlock(argumentsAndBlock, callNode);
 
         return withSourceSection(sourceSection, callNode);
@@ -491,7 +491,7 @@ public class MethodTranslator extends BodyTranslator {
                 reloadSequence.getSequence());
         final RubyNode block = executeOrInheritBlock(argumentsAndBlock.getBlock(), node);
 
-        RubyNode callNode = new SuperCallNode(arguments, block);
+        RubyNode callNode = new SuperCallNode(arguments, block, argumentsAndBlock.getArgumentsDescriptor());
         callNode = wrapCallWithLiteralBlock(argumentsAndBlock, callNode);
 
         return withSourceSection(sourceSection, callNode);


### PR DESCRIPTION
This is all the static information about arguments needed to be sent from the calleer to the callee in order to implement call-target-agnostic keyword arguments. It's also the most wide-ranging change needed to the calling convention.

Co-authored with @wildmaples.