### PR TITLE
Added Seafoam generated illustrations to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,7 +101,7 @@ doc/user/README.md
 /*.rb
 
 # Ignore Seafoam generated illustrations
-graph.pdf
+/*.pdf
 
 # Jacoco
 jacoco.exec

--- a/.gitignore
+++ b/.gitignore
@@ -100,6 +100,9 @@ doc/user/README.md
 # Ignore .rb files at the root, it's temporary files to debug some issue
 /*.rb
 
+# Ignore Seafoam generated illustrations
+graph.pdf
+
 # Jacoco
 jacoco.exec
 /coverage/


### PR DESCRIPTION
Currently limited to `graph.pdf`﻿. Similar to how we ignore `rb` files at the root.
