### PR TITLE
Introduce arguments descriptors to the calling convention

### DIFF
--- a/src/main/java/org/truffleruby/language/arguments/ArgumentsDescriptor.java
+++ b/src/main/java/org/truffleruby/language/arguments/ArgumentsDescriptor.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved. This
+ * code is released under a tri EPL/GPL/LGPL license. You can use it,
+ * redistribute it and/or modify it under the terms of the:
+ *
+ * Eclipse Public License version 2.0, or
+ * GNU General Public License version 2, or
+ * GNU Lesser General Public License version 2.1.
+ */
+package org.truffleruby.language.arguments;
+
+/** An arguments descriptor is an object that describes something about the arguments being passed. Argument descriptors
+ * are stable, immutable objects, suitable to be cached and guarded by identity. They'd normally convey some kind of
+ * static information from call site to callee. */
+public abstract class ArgumentsDescriptor {
+}

--- a/src/main/java/org/truffleruby/language/arguments/EmptyArgumentsDescriptor.java
+++ b/src/main/java/org/truffleruby/language/arguments/EmptyArgumentsDescriptor.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2021 Oracle and/or its affiliates. All rights reserved. This
+ * code is released under a tri EPL/GPL/LGPL license. You can use it,
+ * redistribute it and/or modify it under the terms of the:
+ *
+ * Eclipse Public License version 2.0, or
+ * GNU General Public License version 2, or
+ * GNU Lesser General Public License version 2.1.
+ */
+package org.truffleruby.language.arguments;
+
+/** An arguments descriptor which conveys no information. */
+public class EmptyArgumentsDescriptor extends ArgumentsDescriptor {
+
+    public static final EmptyArgumentsDescriptor INSTANCE = new EmptyArgumentsDescriptor();
+
+    private EmptyArgumentsDescriptor() {
+    }
+
+}

--- a/src/main/java/org/truffleruby/language/dispatch/DispatchNode.java
+++ b/src/main/java/org/truffleruby/language/dispatch/DispatchNode.java
@@ -24,6 +24,7 @@ import org.truffleruby.core.symbol.RubySymbol;
 import org.truffleruby.language.FrameAndVariablesSendingNode;
 import org.truffleruby.language.RubyGuards;
 import org.truffleruby.language.RubyRootNode;
+import org.truffleruby.language.arguments.EmptyArgumentsDescriptor;
 import org.truffleruby.language.arguments.RubyArguments;
 import org.truffleruby.language.control.RaiseException;
 import org.truffleruby.language.methods.CallForeignMethodNode;
@@ -108,6 +109,7 @@ public class DispatchNode extends FrameAndVariablesSendingNode {
         final Object[] rubyArgs = RubyArguments.allocate(0);
         RubyArguments.setSelf(rubyArgs, receiver);
         RubyArguments.setBlock(rubyArgs, nil);
+        RubyArguments.setDescriptor(rubyArgs, EmptyArgumentsDescriptor.INSTANCE);
         return dispatch(null, receiver, method, rubyArgs);
     }
 
@@ -115,6 +117,7 @@ public class DispatchNode extends FrameAndVariablesSendingNode {
         final Object[] rubyArgs = RubyArguments.allocate(1);
         RubyArguments.setSelf(rubyArgs, receiver);
         RubyArguments.setBlock(rubyArgs, nil);
+        RubyArguments.setDescriptor(rubyArgs, EmptyArgumentsDescriptor.INSTANCE);
         RubyArguments.setArgument(rubyArgs, 0, arg1);
         return dispatch(null, receiver, method, rubyArgs);
     }
@@ -123,6 +126,7 @@ public class DispatchNode extends FrameAndVariablesSendingNode {
         final Object[] rubyArgs = RubyArguments.allocate(2);
         RubyArguments.setSelf(rubyArgs, receiver);
         RubyArguments.setBlock(rubyArgs, nil);
+        RubyArguments.setDescriptor(rubyArgs, EmptyArgumentsDescriptor.INSTANCE);
         RubyArguments.setArgument(rubyArgs, 0, arg1);
         RubyArguments.setArgument(rubyArgs, 1, arg2);
         return dispatch(null, receiver, method, rubyArgs);
@@ -132,6 +136,7 @@ public class DispatchNode extends FrameAndVariablesSendingNode {
         final Object[] rubyArgs = RubyArguments.allocate(3);
         RubyArguments.setSelf(rubyArgs, receiver);
         RubyArguments.setBlock(rubyArgs, nil);
+        RubyArguments.setDescriptor(rubyArgs, EmptyArgumentsDescriptor.INSTANCE);
         RubyArguments.setArgument(rubyArgs, 0, arg1);
         RubyArguments.setArgument(rubyArgs, 1, arg2);
         RubyArguments.setArgument(rubyArgs, 2, arg3);
@@ -142,6 +147,7 @@ public class DispatchNode extends FrameAndVariablesSendingNode {
         final Object[] rubyArgs = RubyArguments.allocate(arguments.length);
         RubyArguments.setSelf(rubyArgs, receiver);
         RubyArguments.setBlock(rubyArgs, nil);
+        RubyArguments.setDescriptor(rubyArgs, EmptyArgumentsDescriptor.INSTANCE);
         RubyArguments.setArguments(rubyArgs, arguments);
         return dispatch(null, receiver, method, rubyArgs);
     }
@@ -150,6 +156,7 @@ public class DispatchNode extends FrameAndVariablesSendingNode {
         final Object[] rubyArgs = RubyArguments.allocate(0);
         RubyArguments.setSelf(rubyArgs, receiver);
         RubyArguments.setBlock(rubyArgs, block);
+        RubyArguments.setDescriptor(rubyArgs, EmptyArgumentsDescriptor.INSTANCE);
         return dispatch(null, receiver, method, rubyArgs);
     }
 
@@ -157,6 +164,7 @@ public class DispatchNode extends FrameAndVariablesSendingNode {
         final Object[] rubyArgs = RubyArguments.allocate(1);
         RubyArguments.setSelf(rubyArgs, receiver);
         RubyArguments.setBlock(rubyArgs, block);
+        RubyArguments.setDescriptor(rubyArgs, EmptyArgumentsDescriptor.INSTANCE);
         RubyArguments.setArgument(rubyArgs, 0, arg1);
         return dispatch(null, receiver, method, rubyArgs);
     }
@@ -165,6 +173,7 @@ public class DispatchNode extends FrameAndVariablesSendingNode {
         final Object[] rubyArgs = RubyArguments.allocate(2);
         RubyArguments.setSelf(rubyArgs, receiver);
         RubyArguments.setBlock(rubyArgs, block);
+        RubyArguments.setDescriptor(rubyArgs, EmptyArgumentsDescriptor.INSTANCE);
         RubyArguments.setArgument(rubyArgs, 0, arg1);
         RubyArguments.setArgument(rubyArgs, 1, arg2);
         return dispatch(null, receiver, method, rubyArgs);
@@ -174,6 +183,7 @@ public class DispatchNode extends FrameAndVariablesSendingNode {
         final Object[] rubyArgs = RubyArguments.allocate(3);
         RubyArguments.setSelf(rubyArgs, receiver);
         RubyArguments.setBlock(rubyArgs, block);
+        RubyArguments.setDescriptor(rubyArgs, EmptyArgumentsDescriptor.INSTANCE);
         RubyArguments.setArgument(rubyArgs, 0, arg1);
         RubyArguments.setArgument(rubyArgs, 1, arg2);
         RubyArguments.setArgument(rubyArgs, 2, arg3);
@@ -184,6 +194,7 @@ public class DispatchNode extends FrameAndVariablesSendingNode {
         final Object[] rubyArgs = RubyArguments.allocate(arguments.length);
         RubyArguments.setSelf(rubyArgs, receiver);
         RubyArguments.setBlock(rubyArgs, block);
+        RubyArguments.setDescriptor(rubyArgs, EmptyArgumentsDescriptor.INSTANCE);
         RubyArguments.setArguments(rubyArgs, arguments);
         return dispatch(null, receiver, method, rubyArgs);
     }
@@ -192,6 +203,7 @@ public class DispatchNode extends FrameAndVariablesSendingNode {
         final Object[] rubyArgs = RubyArguments.allocate(0);
         RubyArguments.setSelf(rubyArgs, receiver);
         RubyArguments.setBlock(rubyArgs, nil);
+        RubyArguments.setDescriptor(rubyArgs, EmptyArgumentsDescriptor.INSTANCE);
         return dispatch(frame, receiver, method, rubyArgs);
     }
 
@@ -199,6 +211,7 @@ public class DispatchNode extends FrameAndVariablesSendingNode {
         final Object[] rubyArgs = RubyArguments.allocate(1);
         RubyArguments.setSelf(rubyArgs, receiver);
         RubyArguments.setBlock(rubyArgs, nil);
+        RubyArguments.setDescriptor(rubyArgs, EmptyArgumentsDescriptor.INSTANCE);
         RubyArguments.setArgument(rubyArgs, 0, arg1);
         return dispatch(frame, receiver, method, rubyArgs);
     }
@@ -207,6 +220,7 @@ public class DispatchNode extends FrameAndVariablesSendingNode {
         final Object[] rubyArgs = RubyArguments.allocate(2);
         RubyArguments.setSelf(rubyArgs, receiver);
         RubyArguments.setBlock(rubyArgs, nil);
+        RubyArguments.setDescriptor(rubyArgs, EmptyArgumentsDescriptor.INSTANCE);
         RubyArguments.setArgument(rubyArgs, 0, arg1);
         RubyArguments.setArgument(rubyArgs, 1, arg2);
         return dispatch(frame, receiver, method, rubyArgs);
@@ -216,6 +230,7 @@ public class DispatchNode extends FrameAndVariablesSendingNode {
         final Object[] rubyArgs = RubyArguments.allocate(3);
         RubyArguments.setSelf(rubyArgs, receiver);
         RubyArguments.setBlock(rubyArgs, nil);
+        RubyArguments.setDescriptor(rubyArgs, EmptyArgumentsDescriptor.INSTANCE);
         RubyArguments.setArgument(rubyArgs, 0, arg1);
         RubyArguments.setArgument(rubyArgs, 1, arg2);
         RubyArguments.setArgument(rubyArgs, 2, arg3);
@@ -226,6 +241,7 @@ public class DispatchNode extends FrameAndVariablesSendingNode {
         final Object[] rubyArgs = RubyArguments.allocate(arguments.length);
         RubyArguments.setSelf(rubyArgs, receiver);
         RubyArguments.setBlock(rubyArgs, nil);
+        RubyArguments.setDescriptor(rubyArgs, EmptyArgumentsDescriptor.INSTANCE);
         RubyArguments.setArguments(rubyArgs, arguments);
         return dispatch(frame, receiver, method, rubyArgs);
     }
@@ -235,6 +251,7 @@ public class DispatchNode extends FrameAndVariablesSendingNode {
         final Object[] rubyArgs = RubyArguments.allocate(arguments.length);
         RubyArguments.setSelf(rubyArgs, receiver);
         RubyArguments.setBlock(rubyArgs, block);
+        RubyArguments.setDescriptor(rubyArgs, EmptyArgumentsDescriptor.INSTANCE);
         RubyArguments.setArguments(rubyArgs, arguments);
         return dispatch(frame, receiver, methodName, rubyArgs);
     }

--- a/src/main/java/org/truffleruby/language/dispatch/RubyCallNode.java
+++ b/src/main/java/org/truffleruby/language/dispatch/RubyCallNode.java
@@ -23,6 +23,7 @@ import org.truffleruby.language.RubyBaseNode;
 import org.truffleruby.language.RubyContextSourceNode;
 import org.truffleruby.language.RubyGuards;
 import org.truffleruby.language.RubyNode;
+import org.truffleruby.language.arguments.EmptyArgumentsDescriptor;
 import org.truffleruby.language.arguments.RubyArguments;
 import org.truffleruby.language.arguments.SplatToArgsNode;
 import org.truffleruby.language.literal.NilLiteralNode;
@@ -94,6 +95,7 @@ public class RubyCallNode extends RubyContextSourceNode implements AssignableNod
         }
         Object[] rubyArgs = RubyArguments.allocate(arguments.length);
         RubyArguments.setSelf(rubyArgs, receiverObject);
+        RubyArguments.setDescriptor(rubyArgs, EmptyArgumentsDescriptor.INSTANCE);
 
         executeArguments(frame, rubyArgs);
 
@@ -155,6 +157,7 @@ public class RubyCallNode extends RubyContextSourceNode implements AssignableNod
         Object[] rubyArgs = RubyArguments.allocate(argumentsObjects.length);
         RubyArguments.setSelf(rubyArgs, receiverObject);
         RubyArguments.setBlock(rubyArgs, blockObject);
+        RubyArguments.setDescriptor(rubyArgs, EmptyArgumentsDescriptor.INSTANCE);
         RubyArguments.setArguments(rubyArgs, argumentsObjects);
         return executeWithArgumentsEvaluated(frame, receiverObject, rubyArgs);
     }


### PR DESCRIPTION
Not currently used for anything.

Co-authored with @wildmaples.

Extracted from #2597.