### PR TITLE
Pull out CallMethodWithDeclaredReceiverNode and SetDeclarationFrameNode

### DIFF
--- a/src/main/java/org/truffleruby/core/module/ModuleNodes.java
+++ b/src/main/java/org/truffleruby/core/module/ModuleNodes.java
@@ -79,7 +79,6 @@ import org.truffleruby.language.NotProvided;
 import org.truffleruby.language.RubyBaseNode;
 import org.truffleruby.language.RubyBaseNodeWithExecute;
 import org.truffleruby.language.RubyConstant;
-import org.truffleruby.language.RubyContextSourceNode;
 import org.truffleruby.language.RubyDynamicObject;
 import org.truffleruby.language.RubyGuards;
 import org.truffleruby.language.RubyLambdaRootNode;
@@ -106,6 +105,7 @@ import org.truffleruby.language.methods.CanBindMethodToModuleNode;
 import org.truffleruby.language.methods.DeclarationContext;
 import org.truffleruby.language.methods.DeclarationContext.FixedDefaultDefinee;
 import org.truffleruby.language.methods.InternalMethod;
+import org.truffleruby.language.methods.SetDeclarationFrameNode;
 import org.truffleruby.language.methods.SharedMethodInfo;
 import org.truffleruby.language.methods.Split;
 import org.truffleruby.language.methods.UsingNode;
@@ -1314,7 +1314,7 @@ public abstract class ModuleNodes {
             final RubyLambdaRootNode rootNode = RubyLambdaRootNode.of(callTargetForLambda);
             final SharedMethodInfo info = proc.sharedMethodInfo.forDefineMethod(module, name);
             final RubyNode body = rootNode.copyBody();
-            final RubyNode newBody = new CallMethodWithLambdaBody(proc.declarationFrame, body);
+            final RubyNode newBody = new SetDeclarationFrameNode(proc.declarationFrame, body);
 
             final RubyLambdaRootNode newRootNode = rootNode.copyRootNode(info, newBody);
             final RootCallTarget newCallTarget = newRootNode.getCallTarget();
@@ -1329,24 +1329,6 @@ public abstract class ModuleNodes {
                     proc,
                     newCallTarget);
             return addMethod(module, name, method, callerFrame);
-        }
-
-        private static class CallMethodWithLambdaBody extends RubyContextSourceNode {
-
-            private final MaterializedFrame declarationFrame;
-            @Child private RubyNode lambdaBody;
-
-            public CallMethodWithLambdaBody(MaterializedFrame declarationFrame, RubyNode lambdaBody) {
-                this.declarationFrame = declarationFrame;
-                this.lambdaBody = lambdaBody;
-            }
-
-            @Override
-            public Object execute(VirtualFrame frame) {
-                RubyArguments.setDeclarationFrame(frame, declarationFrame);
-                return lambdaBody.execute(frame);
-            }
-
         }
 
         @TruffleBoundary
@@ -2331,4 +2313,5 @@ public abstract class ModuleNodes {
             return rubyClass.isSingleton;
         }
     }
+
 }

--- a/src/main/java/org/truffleruby/language/arguments/RubyArguments.java
+++ b/src/main/java/org/truffleruby/language/arguments/RubyArguments.java
@@ -131,6 +131,18 @@ public final class RubyArguments {
         return new Object[RUNTIME_ARGUMENT_COUNT + count];
     }
 
+    public static Object[] repack(Object[] rubyArgs, InternalMethod method, Object receiver) {
+        // Duplicate logic for this case since it is significantly simpler
+        final Object[] newArgs = new Object[rubyArgs.length];
+        newArgs[ArgumentIndicies.METHOD.ordinal()] = method;
+        newArgs[ArgumentIndicies.SELF.ordinal()] = receiver;
+        newArgs[ArgumentIndicies.BLOCK.ordinal()] = getBlock(rubyArgs);
+        newArgs[ArgumentIndicies.DESCRIPTOR.ordinal()] = getDescriptor(rubyArgs);
+        int count = rubyArgs.length - RUNTIME_ARGUMENT_COUNT;
+        System.arraycopy(rubyArgs, RUNTIME_ARGUMENT_COUNT, newArgs, RUNTIME_ARGUMENT_COUNT, count);
+        return newArgs;
+    }
+
     public static Object[] repack(Object[] rubyArgs, Object receiver) {
         // Duplicate logic for this case since it is significantly simpler
         final Object[] newArgs = new Object[rubyArgs.length];

--- a/src/main/java/org/truffleruby/language/methods/CallMethodWithDeclaredReceiverNode.java
+++ b/src/main/java/org/truffleruby/language/methods/CallMethodWithDeclaredReceiverNode.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2015, 2021 Oracle and/or its affiliates. All rights reserved. This
+ * code is released under a tri EPL/GPL/LGPL license. You can use it,
+ * redistribute it and/or modify it under the terms of the:
+ *
+ * Eclipse Public License version 2.0, or
+ * GNU General Public License version 2, or
+ * GNU Lesser General Public License version 2.1.
+ */
+package org.truffleruby.language.methods;
+
+import com.oracle.truffle.api.frame.VirtualFrame;
+import org.truffleruby.language.RubyContextSourceNode;
+import org.truffleruby.language.arguments.RubyArguments;
+
+public class CallMethodWithDeclaredReceiverNode extends RubyContextSourceNode {
+
+    private final InternalMethod method;
+
+    @Child private CallInternalMethodNode callInternalMethodNode = CallInternalMethodNode.create();
+
+    public CallMethodWithDeclaredReceiverNode(InternalMethod method) {
+        this.method = method;
+    }
+
+    @Override
+    public Object execute(VirtualFrame frame) {
+        final Object receiver = RubyArguments.getSelf(RubyArguments.getDeclarationFrame(frame));
+        final Object[] repackedArgs = RubyArguments.repack(frame.getArguments(), method, receiver);
+        return callInternalMethodNode.execute(frame, method, receiver, repackedArgs);
+    }
+
+}

--- a/src/main/java/org/truffleruby/language/methods/SetDeclarationFrameNode.java
+++ b/src/main/java/org/truffleruby/language/methods/SetDeclarationFrameNode.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2013, 2021 Oracle and/or its affiliates. All rights reserved. This
+ * code is released under a tri EPL/GPL/LGPL license. You can use it,
+ * redistribute it and/or modify it under the terms of the:
+ *
+ * Eclipse Public License version 2.0, or
+ * GNU General Public License version 2, or
+ * GNU Lesser General Public License version 2.1.
+ */
+package org.truffleruby.language.methods;
+
+import com.oracle.truffle.api.frame.MaterializedFrame;
+import com.oracle.truffle.api.frame.VirtualFrame;
+import org.truffleruby.language.RubyContextSourceNode;
+import org.truffleruby.language.RubyNode;
+import org.truffleruby.language.arguments.RubyArguments;
+
+public class SetDeclarationFrameNode extends RubyContextSourceNode {
+
+    private final MaterializedFrame declarationFrame;
+
+    @Child private RubyNode body;
+
+    public SetDeclarationFrameNode(MaterializedFrame declarationFrame, RubyNode body) {
+        this.declarationFrame = declarationFrame;
+        this.body = body;
+    }
+
+    @Override
+    public Object execute(VirtualFrame frame) {
+        RubyArguments.setDeclarationFrame(frame, declarationFrame);
+        return body.execute(frame);
+    }
+
+}


### PR DESCRIPTION
Naming these nodes with what they do makes it easier to understand when you read an AST.