### PR TITLE
Add Truffle::Graal.total_compilation_time

### DIFF
--- a/src/main/java/org/truffleruby/extra/TruffleGraalNodes.java
+++ b/src/main/java/org/truffleruby/extra/TruffleGraalNodes.java
@@ -41,6 +41,9 @@ import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.MaterializedFrame;
 import com.oracle.truffle.api.nodes.NodeUtil;
 
+import java.lang.management.CompilationMXBean;
+import java.lang.management.ManagementFactory;
+
 @CoreModule("Truffle::Graal")
 public abstract class TruffleGraalNodes {
 
@@ -222,4 +225,18 @@ public abstract class TruffleGraalNodes {
 
     }
 
+    @CoreMethod(names = "total_compilation_time", onSingleton = true)
+    public abstract static class TotalCompilationTimeNode extends CoreMethodArrayArgumentsNode {
+        private static CompilationMXBean bean;
+
+        @TruffleBoundary
+        @Specialization
+        protected final long totalCompilationTime() {
+            if (bean == null) {
+                bean = ManagementFactory.getCompilationMXBean();
+            }
+
+            return bean.getTotalCompilationTime();
+        }
+    }
 }

--- a/tool/jt.rb
+++ b/tool/jt.rb
@@ -2854,7 +2854,7 @@ module Commands
   end
 
   def format_specializations_check
-    abort 'Some Specializations do not use the protected visibility.' if format_specializations_visibility
+    abort 'Some Specializations did not use the protected visibility.' if format_specializations_visibility
     abort 'Some Specializations were not properly formatted.' if format_specializations_arguments
     abort 'There were extra blank lines around imports.' if Formatting.format_imports
   end

--- a/tool/jt.rb
+++ b/tool/jt.rb
@@ -2854,7 +2854,7 @@ module Commands
   end
 
   def format_specializations_check
-    abort 'Some Specializations were not protected.' if format_specializations_visibility
+    abort 'Some Specializations do not use the protected visibility.' if format_specializations_visibility
     abort 'Some Specializations were not properly formatted.' if format_specializations_arguments
     abort 'There were extra blank lines around imports.' if Formatting.format_imports
   end


### PR DESCRIPTION
This is an initial attempt to use `ManagementFactory.getCompilationMXBean().getTotalCompilationTime()`.

On HotSpot, it seems to include Graal time.
Though, I didn't look at the code. I infer it from the compilation times being much higher when Graal compilation is enabled compared to when it is disabled.

Not sure how to support this on SVM.
Happy to add it if there's an idea of how.

This PR also changes a message of the linter, which I didn't understand.