### PR TITLE
Make sure there are no sequence nodes with a single entry

### DIFF
--- a/src/main/java/org/truffleruby/language/control/SequenceNode.java
+++ b/src/main/java/org/truffleruby/language/control/SequenceNode.java
@@ -23,6 +23,8 @@ public final class SequenceNode extends RubyContextSourceNode {
     @Children private final RubyNode[] body;
 
     public SequenceNode(RubyNode... body) {
+        assert body.length != 1 : "sequences can be empty or need to have more than but element, but got: " +
+                body.length;
         this.body = body;
     }
 

--- a/src/main/java/org/truffleruby/language/control/SequenceNode.java
+++ b/src/main/java/org/truffleruby/language/control/SequenceNode.java
@@ -23,8 +23,7 @@ public final class SequenceNode extends RubyContextSourceNode {
     @Children private final RubyNode[] body;
 
     public SequenceNode(RubyNode... body) {
-        assert body.length != 1 : "sequences can be empty or need to have more than but element, but got: " +
-                body.length;
+        assert body.length != 1 : "sequences must not be created for a single element";
         this.body = body;
     }
 

--- a/src/main/java/org/truffleruby/language/control/SequenceNode.java
+++ b/src/main/java/org/truffleruby/language/control/SequenceNode.java
@@ -22,8 +22,8 @@ public final class SequenceNode extends RubyContextSourceNode {
 
     @Children private final RubyNode[] body;
 
-    public SequenceNode(RubyNode... body) {
-        assert body.length != 1 : "sequences must not be created for a single element";
+    public SequenceNode(RubyNode[] body) {
+        assert body.length >= 2 : "sequences must have 2+ elements, but was " + body.length;
         this.body = body;
     }
 

--- a/src/main/java/org/truffleruby/parser/MethodTranslator.java
+++ b/src/main/java/org/truffleruby/parser/MethodTranslator.java
@@ -496,14 +496,18 @@ public class MethodTranslator extends BodyTranslator {
                 this,
                 argsNode);
 
-        final SequenceNode reloadSequence = (SequenceNode) reloadTranslator.visitArgsNode(argsNode);
+        final RubyNode reloadSequence = reloadTranslator.visitArgsNode(argsNode);
 
         final ArgumentsDescriptor descriptor = argsNode.hasKwargs()
                 ? KeywordArgumentsDescriptorManager.EMPTY
                 : EmptyArgumentsDescriptor.INSTANCE;
-        final RubyNode arguments = new ReadZSuperArgumentsNode(
-                reloadTranslator.getRestParameterIndex(),
-                reloadSequence.getSequence());
+        final RubyNode arguments;
+        final int restParamIndex = reloadTranslator.getRestParameterIndex();
+        if (reloadSequence instanceof SequenceNode) {
+            arguments = new ReadZSuperArgumentsNode(restParamIndex, ((SequenceNode) reloadSequence).getSequence());
+        } else {
+            arguments = new ReadZSuperArgumentsNode(restParamIndex, new RubyNode[]{ reloadSequence });
+        }
         final RubyNode block = executeOrInheritBlock(argumentsAndBlock.getBlock(), node);
         final boolean isSplatted = reloadTranslator.getRestParameterIndex() != -1;
 

--- a/src/main/java/org/truffleruby/parser/MethodTranslator.java
+++ b/src/main/java/org/truffleruby/parser/MethodTranslator.java
@@ -37,7 +37,6 @@ import org.truffleruby.language.control.IfElseNode;
 import org.truffleruby.language.control.InvalidReturnNode;
 import org.truffleruby.language.control.NotNode;
 import org.truffleruby.language.control.ReturnID;
-import org.truffleruby.language.control.SequenceNode;
 import org.truffleruby.language.locals.FlipFlopStateNode;
 import org.truffleruby.language.locals.LocalVariableType;
 import org.truffleruby.language.locals.ReadLocalVariableNode;
@@ -496,18 +495,13 @@ public class MethodTranslator extends BodyTranslator {
                 this,
                 argsNode);
 
-        final RubyNode reloadSequence = reloadTranslator.visitArgsNode(argsNode);
+        final RubyNode[] reloadSequence = reloadTranslator.reload(argsNode);
 
         final ArgumentsDescriptor descriptor = argsNode.hasKwargs()
                 ? KeywordArgumentsDescriptorManager.EMPTY
                 : EmptyArgumentsDescriptor.INSTANCE;
-        final RubyNode arguments;
         final int restParamIndex = reloadTranslator.getRestParameterIndex();
-        if (reloadSequence instanceof SequenceNode) {
-            arguments = new ReadZSuperArgumentsNode(restParamIndex, ((SequenceNode) reloadSequence).getSequence());
-        } else {
-            arguments = new ReadZSuperArgumentsNode(restParamIndex, new RubyNode[]{ reloadSequence });
-        }
+        final RubyNode arguments = new ReadZSuperArgumentsNode(restParamIndex, reloadSequence);
         final RubyNode block = executeOrInheritBlock(argumentsAndBlock.getBlock(), node);
         final boolean isSplatted = reloadTranslator.getRestParameterIndex() != -1;
 

--- a/src/main/java/org/truffleruby/parser/ReloadArgumentsTranslator.java
+++ b/src/main/java/org/truffleruby/parser/ReloadArgumentsTranslator.java
@@ -19,7 +19,6 @@ import org.truffleruby.language.RubyNode;
 import org.truffleruby.language.SourceIndexLength;
 import org.truffleruby.language.arguments.MissingArgumentBehavior;
 import org.truffleruby.language.arguments.ReadPreArgumentNode;
-import org.truffleruby.language.control.SequenceNode;
 import org.truffleruby.language.literal.ObjectLiteralNode;
 import org.truffleruby.parser.ast.ArgsParseNode;
 import org.truffleruby.parser.ast.ArgumentParseNode;
@@ -63,8 +62,7 @@ public class ReloadArgumentsTranslator extends Translator {
         return restParameterIndex;
     }
 
-    @Override
-    public RubyNode visitArgsNode(ArgsParseNode node) {
+    public RubyNode[] reload(ArgsParseNode node) {
         final List<RubyNode> sequence = new ArrayList<>();
         final ParseNode[] args = node.getArgs();
         final int preCount = node.getPreCount();
@@ -133,10 +131,7 @@ public class ReloadArgumentsTranslator extends Translator {
             sequence.add(kwArgsNode);
         }
 
-        if (sequence.size() == 1) {
-            return sequence.get(0);
-        }
-        return new SequenceNode(sequence.toArray(RubyNode.EMPTY_ARRAY));
+        return sequence.toArray(RubyNode.EMPTY_ARRAY);
     }
 
     @Override

--- a/src/main/java/org/truffleruby/parser/ReloadArgumentsTranslator.java
+++ b/src/main/java/org/truffleruby/parser/ReloadArgumentsTranslator.java
@@ -133,6 +133,9 @@ public class ReloadArgumentsTranslator extends Translator {
             sequence.add(kwArgsNode);
         }
 
+        if (sequence.size() == 1) {
+            return sequence.get(0);
+        }
         return new SequenceNode(sequence.toArray(RubyNode.EMPTY_ARRAY));
     }
 

--- a/src/main/java/org/truffleruby/parser/Translator.java
+++ b/src/main/java/org/truffleruby/parser/Translator.java
@@ -101,7 +101,11 @@ public abstract class Translator extends AbstractNodeVisitor<RubyNode> {
                 flattened.addAll(flatten(Arrays.asList(((SequenceNode) node).getSequence()), lastNode));
             } else if (node.canSubsumeFollowing() && !lastNode) {
                 List<RubyNode> rest = flattenFromN(sequence, allowTrailingNil, n + 1);
-                flattened.add(node.subsumeFollowing(new SequenceNode(rest.toArray(RubyNode.EMPTY_ARRAY))));
+                if (rest.size() == 1) {
+                    flattened.add(node.subsumeFollowing(rest.get(0)));
+                } else {
+                    flattened.add(node.subsumeFollowing(new SequenceNode(rest.toArray(RubyNode.EMPTY_ARRAY))));
+                }
                 return flattened;
             } else {
                 flattened.add(node);


### PR DESCRIPTION
It can happen, probably rarely, that a `SequenceNode` has a single entry.
This PR tries a little harder to unwrap such nodes.

Unfortunately, there are some other assumptions scattered through the code base that do make that a little tricky at least in `visitZSuperNode(.)`.

It also can still happen that there are instances of `SequenceNode` without any nodes, which seems a little odd. So, the assert only checks for `body.length != 1`.