### PR TITLE
Update list of CRuby versions to run the Ruby Spec Suite with in CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,7 +192,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.6, 2.7, '3.0']
+        ruby: [2.7, '3.0', 3.1]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
CRuby 2.6 is no longer supported with the Ruby Spec Suite. CRuby 3.1 is supported, so we should test with it in CI to ensure spec changes don't fail with that CRuby version.