### PR TITLE
Traceable nils

### DIFF
--- a/src/main/java/org/truffleruby/RubyLanguage.java
+++ b/src/main/java/org/truffleruby/RubyLanguage.java
@@ -185,7 +185,7 @@ public final class RubyLanguage extends TruffleLanguage<RubyContext> {
     /** This is a truly empty frame descriptor and should only by dummy root nodes which require no variables. Any other
      * root nodes should should use
      * {@link TranslatorEnvironment#newFrameDescriptorBuilder(org.truffleruby.parser.ParentFrameDescriptor, boolean)}. */
-    public static final FrameDescriptor EMPTY_FRAME_DESCRIPTOR = new FrameDescriptor(Nil.INSTANCE);
+    public static final FrameDescriptor EMPTY_FRAME_DESCRIPTOR = new FrameDescriptor(Nil.get());
 
     /** We need an extra indirection added to ContextThreadLocal due to multiple Fibers of different Ruby Threads
      * sharing the same Java Thread when using the fiber pool. */

--- a/src/main/java/org/truffleruby/builtins/CoreMethodNodeManager.java
+++ b/src/main/java/org/truffleruby/builtins/CoreMethodNodeManager.java
@@ -285,7 +285,7 @@ public class CoreMethodNodeManager {
                     null,
                     callTarget,
                     callTargetSupplier,
-                    Nil.INSTANCE));
+                    Nil.get()));
         }
     }
 

--- a/src/main/java/org/truffleruby/builtins/EnumeratorSizeNode.java
+++ b/src/main/java/org/truffleruby/builtins/EnumeratorSizeNode.java
@@ -10,6 +10,7 @@
 package org.truffleruby.builtins;
 
 import org.truffleruby.core.symbol.RubySymbol;
+import org.truffleruby.language.Nil;
 import org.truffleruby.language.RubyContextSourceNode;
 import org.truffleruby.language.RubyNode;
 import org.truffleruby.language.arguments.RubyArguments;
@@ -39,7 +40,7 @@ public class EnumeratorSizeNode extends RubyContextSourceNode {
     public Object execute(VirtualFrame frame) {
         final Object block = RubyArguments.getBlock(frame);
 
-        if (noBlockProfile.profile(block == nil())) {
+        if (noBlockProfile.profile(Nil.is(block))) {
             if (toEnumWithSize == null) {
                 CompilerDirectives.transferToInterpreterAndInvalidate();
                 toEnumWithSize = insert(DispatchNode.create());

--- a/src/main/java/org/truffleruby/builtins/EnumeratorSizeNode.java
+++ b/src/main/java/org/truffleruby/builtins/EnumeratorSizeNode.java
@@ -39,7 +39,7 @@ public class EnumeratorSizeNode extends RubyContextSourceNode {
     public Object execute(VirtualFrame frame) {
         final Object block = RubyArguments.getBlock(frame);
 
-        if (noBlockProfile.profile(block == nil)) {
+        if (noBlockProfile.profile(block == nil())) {
             if (toEnumWithSize == null) {
                 CompilerDirectives.transferToInterpreterAndInvalidate();
                 toEnumWithSize = insert(DispatchNode.create());

--- a/src/main/java/org/truffleruby/builtins/ReturnEnumeratorIfNoBlockNode.java
+++ b/src/main/java/org/truffleruby/builtins/ReturnEnumeratorIfNoBlockNode.java
@@ -10,6 +10,7 @@
 package org.truffleruby.builtins;
 
 import org.truffleruby.core.symbol.RubySymbol;
+import org.truffleruby.language.Nil;
 import org.truffleruby.language.RubyContextSourceNode;
 import org.truffleruby.language.RubyNode;
 import org.truffleruby.language.arguments.RubyArguments;
@@ -37,7 +38,7 @@ public class ReturnEnumeratorIfNoBlockNode extends RubyContextSourceNode {
     public Object execute(VirtualFrame frame) {
         final Object block = RubyArguments.getBlock(frame);
 
-        if (noBlockProfile.profile(block == nil())) {
+        if (noBlockProfile.profile(Nil.is(block))) {
             if (toEnumNode == null) {
                 CompilerDirectives.transferToInterpreterAndInvalidate();
                 toEnumNode = insert(DispatchNode.create());

--- a/src/main/java/org/truffleruby/builtins/ReturnEnumeratorIfNoBlockNode.java
+++ b/src/main/java/org/truffleruby/builtins/ReturnEnumeratorIfNoBlockNode.java
@@ -37,7 +37,7 @@ public class ReturnEnumeratorIfNoBlockNode extends RubyContextSourceNode {
     public Object execute(VirtualFrame frame) {
         final Object block = RubyArguments.getBlock(frame);
 
-        if (noBlockProfile.profile(block == nil)) {
+        if (noBlockProfile.profile(block == nil())) {
             if (toEnumNode == null) {
                 CompilerDirectives.transferToInterpreterAndInvalidate();
                 toEnumNode = insert(DispatchNode.create());

--- a/src/main/java/org/truffleruby/cext/CExtNodes.java
+++ b/src/main/java/org/truffleruby/cext/CExtNodes.java
@@ -1089,7 +1089,7 @@ public class CExtNodes {
             final InternalMethod superMethod = superMethodLookup.getMethod();
             // This C API only passes positional arguments, but maybe it should be influenced by ruby2_keywords hashes?
             return callSuperMethodNode.execute(
-                    frame, callingSelf, superMethod, EmptyArgumentsDescriptor.INSTANCE, args, nil, null);
+                    frame, callingSelf, superMethod, EmptyArgumentsDescriptor.INSTANCE, args, nil(), null);
         }
 
         @TruffleBoundary
@@ -1353,7 +1353,7 @@ public class CExtNodes {
 
                 System.err.printf("%s @ %s: %s%n", object.getClass(), System.identityHashCode(object), representation);
             }
-            return nil;
+            return nil();
         }
 
         private Object callToS(Object object) {
@@ -1377,7 +1377,7 @@ public class CExtNodes {
             try {
                 callBlock(block);
                 noExceptionProfile.enter();
-                return nil;
+                return nil();
             } catch (Throwable e) {
                 exceptionProfile.enter();
                 return new CapturedException(e);
@@ -1395,7 +1395,7 @@ public class CExtNodes {
             if (rubyExceptionProfile.profile(e instanceof RaiseException)) {
                 return ((RaiseException) e).getException();
             } else {
-                return nil;
+                return nil();
             }
         }
     }
@@ -1621,7 +1621,7 @@ public class CExtNodes {
                 @CachedLibrary("object") DynamicObjectLibrary objectLibrary) {
             getContext().getMarkingService().startMarking(
                     (Object[]) objectLibrary.getOrDefault(object, Layouts.MARKED_OBJECTS_IDENTIFIER, null));
-            return nil;
+            return nil();
         }
     }
 
@@ -1640,7 +1640,7 @@ public class CExtNodes {
             // We do nothing here if the handle cannot be resolved. If we are marking an object
             // which is only reachable via weak refs then the handles of objects it is itself
             // marking may have already been removed from the handle map.
-            return nil;
+            return nil();
         }
 
     }
@@ -1658,7 +1658,7 @@ public class CExtNodes {
                 noExceptionProfile.enter();
                 keepAliveNode.execute(wrappedValue);
             }
-            return nil;
+            return nil();
         }
 
     }
@@ -1673,7 +1673,7 @@ public class CExtNodes {
                     structOwner,
                     Layouts.MARKED_OBJECTS_IDENTIFIER,
                     getContext().getMarkingService().finishMarking());
-            return nil;
+            return nil();
         }
     }
 
@@ -1690,7 +1690,7 @@ public class CExtNodes {
             getContext()
                     .getMarkingService()
                     .addMarker(object, (o) -> CallBlockNode.getUncached().yield(marker, o));
-            return nil;
+            return nil();
         }
 
     }
@@ -1701,7 +1701,7 @@ public class CExtNodes {
         @Specialization
         protected Object checkInts() {
             TruffleSafepoint.pollHere(this);
-            return nil;
+            return nil();
         }
     }
 
@@ -1767,7 +1767,7 @@ public class CExtNodes {
             final RubySymbol sym = getLanguage().symbolTable.getSymbolIfExists(
                     strings.getRope(string),
                     strings.getEncoding(string));
-            return sym == null ? nil : sym;
+            return sym == null ? nil() : sym;
         }
     }
 
@@ -1953,7 +1953,7 @@ public class CExtNodes {
         @Specialization
         protected Object setData(DataHolder data, Object address) {
             data.setPointer(address);
-            return nil;
+            return nil();
         }
     }
 

--- a/src/main/java/org/truffleruby/cext/UnwrapNode.java
+++ b/src/main/java/org/truffleruby/cext/UnwrapNode.java
@@ -64,7 +64,7 @@ public abstract class UnwrapNode extends RubyBaseNode {
 
         @Specialization(guards = "handle == NIL_HANDLE")
         protected Object unwrapNil(long handle) {
-            return nil;
+            return nil();
         }
 
         @Specialization(guards = "isTaggedLong(handle)")
@@ -126,7 +126,7 @@ public abstract class UnwrapNode extends RubyBaseNode {
 
         @Specialization(guards = "handle == NIL_HANDLE")
         protected ValueWrapper unwrapNil(long handle) {
-            return nil.getValueWrapper();
+            return nil().getValueWrapper();
         }
 
         @Specialization(guards = "isTaggedLong(handle)")

--- a/src/main/java/org/truffleruby/core/CoreLibrary.java
+++ b/src/main/java/org/truffleruby/core/CoreLibrary.java
@@ -621,7 +621,7 @@ public class CoreLibrary {
     private Object verbosityOption() {
         switch (context.getOptions().VERBOSITY) {
             case NIL:
-                return Nil.INSTANCE;
+                return Nil.get();
             case FALSE:
                 return false;
             case TRUE:
@@ -887,7 +887,7 @@ public class CoreLibrary {
 
     /** true if $VERBOSE is true or false, but not nil */
     public boolean warningsEnabled() {
-        return verbosity() != Nil.INSTANCE;
+        return verbosity() != Nil.get();
     }
 
     /** true only if $VERBOSE is true */

--- a/src/main/java/org/truffleruby/core/CoreLibrary.java
+++ b/src/main/java/org/truffleruby/core/CoreLibrary.java
@@ -887,7 +887,7 @@ public class CoreLibrary {
 
     /** true if $VERBOSE is true or false, but not nil */
     public boolean warningsEnabled() {
-        return verbosity() != Nil.get();
+        return Nil.isNot(verbosity());
     }
 
     /** true only if $VERBOSE is true */

--- a/src/main/java/org/truffleruby/core/DataObjectFinalizationService.java
+++ b/src/main/java/org/truffleruby/core/DataObjectFinalizationService.java
@@ -73,7 +73,7 @@ public class DataObjectFinalizationService extends ReferenceProcessingService<Da
             } else {
                 runFinalizer(ref);
             }
-            return Nil.INSTANCE;
+            return Nil.get();
         }
 
         private void runFinalizer(DataObjectFinalizerReference ref) throws Error {

--- a/src/main/java/org/truffleruby/core/GCNodes.java
+++ b/src/main/java/org/truffleruby/core/GCNodes.java
@@ -45,7 +45,7 @@ public abstract class GCNodes {
         protected Object vmGCStart() {
             getContext().getMarkingService().queueMarking();
             System.gc();
-            return nil;
+            return nil();
         }
 
     }
@@ -77,7 +77,7 @@ public abstract class GCNodes {
             // by making sure the method that allocates the weak value is exited before we run the GC loop;
             initCache(cache, key);
             gcLoop(cache, key);
-            return nil;
+            return nil();
         }
 
         @SuppressFBWarnings("DLS")
@@ -213,7 +213,7 @@ public abstract class GCNodes {
             // Get memory usage values from relevant memory pools (2-3 / ~8 are relevant)
             memoryPools = new Object[memoryPoolNames.length];
             // On Native Image, ManagementFactory.getMemoryPoolMXBeans() is empty
-            Arrays.fill(memoryPools, nil);
+            Arrays.fill(memoryPools, nil());
             for (int i = 0; i < memoryPoolNames.length; i++) {
                 String memoryPoolName = memoryPoolNames[i];
                 for (MemoryPoolMXBean bean : ManagementFactory.getMemoryPoolMXBeans()) {

--- a/src/main/java/org/truffleruby/core/IsNilNode.java
+++ b/src/main/java/org/truffleruby/core/IsNilNode.java
@@ -9,6 +9,7 @@
  */
 package org.truffleruby.core;
 
+import org.truffleruby.language.Nil;
 import org.truffleruby.language.RubyContextSourceNode;
 import org.truffleruby.language.RubyNode;
 
@@ -24,7 +25,7 @@ public class IsNilNode extends RubyContextSourceNode {
 
     @Override
     public Object execute(VirtualFrame frame) {
-        return child.execute(frame) == nil();
+        return Nil.is(child.execute(frame));
     }
 
 }

--- a/src/main/java/org/truffleruby/core/IsNilNode.java
+++ b/src/main/java/org/truffleruby/core/IsNilNode.java
@@ -24,7 +24,7 @@ public class IsNilNode extends RubyContextSourceNode {
 
     @Override
     public Object execute(VirtualFrame frame) {
-        return child.execute(frame) == nil;
+        return child.execute(frame) == nil();
     }
 
 }

--- a/src/main/java/org/truffleruby/core/MainNodes.java
+++ b/src/main/java/org/truffleruby/core/MainNodes.java
@@ -68,7 +68,7 @@ public abstract class MainNodes {
                         coreExceptions().runtimeError("main.using is permitted only at toplevel", this));
             }
             using(callerFrame, refinementModule, errorProfile);
-            return nil;
+            return nil();
         }
 
         @TruffleBoundary

--- a/src/main/java/org/truffleruby/core/TruffleSystemNodes.java
+++ b/src/main/java/org/truffleruby/core/TruffleSystemNodes.java
@@ -107,7 +107,7 @@ public abstract class TruffleSystemNodes {
             final String value = getEnv(javaName);
 
             if (nullValueProfile.profile(value == null)) {
-                return nil;
+                return nil();
             } else {
                 return fromJavaStringNode.executeFromJavaString(value);
             }
@@ -135,7 +135,7 @@ public abstract class TruffleSystemNodes {
                 canonicalFile = truffleFile.getCanonicalFile();
             } catch (NoSuchFileException e) {
                 // Let the following chdir() fail
-                return nil;
+                return nil();
             } catch (IOException e) {
                 throw new RaiseException(getContext(), coreExceptions().ioError(e, this));
             }
@@ -185,7 +185,7 @@ public abstract class TruffleSystemNodes {
                 @CachedLibrary(limit = "LIBSTRING_CACHE") RubyStringLibrary strings) {
             String value = getProperty(strings.getJavaString(property));
             if (value == null) {
-                return nil;
+                return nil();
             } else {
                 return makeStringNode.executeMake(value, Encodings.UTF_8, CodeRange.CR_UNKNOWN);
             }
@@ -230,14 +230,14 @@ public abstract class TruffleSystemNodes {
                 @Cached("level") RubySymbol cachedLevel,
                 @Cached("getLevel(cachedLevel)") Level javaLevel) {
             log(javaLevel, strings.getJavaString(message));
-            return nil;
+            return nil();
         }
 
         @Specialization(guards = "strings.isRubyString(message)", replaces = "logCached")
         protected Object log(RubySymbol level, Object message,
                 @CachedLibrary(limit = "LIBSTRING_CACHE") RubyStringLibrary strings) {
             log(getLevel(level), strings.getJavaString(message));
-            return nil;
+            return nil();
         }
 
         @TruffleBoundary

--- a/src/main/java/org/truffleruby/core/VMPrimitiveNodes.java
+++ b/src/main/java/org/truffleruby/core/VMPrimitiveNodes.java
@@ -153,7 +153,7 @@ public abstract class VMPrimitiveNodes {
                 }
             }
 
-            return nil;
+            return nil();
         }
 
     }
@@ -195,7 +195,7 @@ public abstract class VMPrimitiveNodes {
             final String normalizedName = nameToJavaStringNode.execute(name);
             InternalMethod method = lookupMethodNode.lookupIgnoringVisibility(frame, receiver, normalizedName);
             if (method == null) {
-                return nil;
+                return nil();
             }
             final RubyMethod instance = new RubyMethod(
                     coreLibrary().methodClass,
@@ -389,7 +389,7 @@ public abstract class VMPrimitiveNodes {
             final Object value = getContext().getNativeConfiguration().get(keyString);
 
             if (value == null) {
-                return nil;
+                return nil();
             } else {
                 return value;
             }
@@ -414,7 +414,7 @@ public abstract class VMPrimitiveNodes {
                 yieldNode.yield(block, key, entry.getValue());
             }
 
-            return nil;
+            return nil();
         }
 
     }

--- a/src/main/java/org/truffleruby/core/adapters/InputStreamAdapter.java
+++ b/src/main/java/org/truffleruby/core/adapters/InputStreamAdapter.java
@@ -30,7 +30,7 @@ public class InputStreamAdapter extends NonBlockingInputStream {
     public int read() {
         final Object result = DispatchNode.getUncached().call(object, "getbyte");
 
-        if (result == Nil.INSTANCE) {
+        if (result == Nil.get()) {
             return EOF;
         }
 

--- a/src/main/java/org/truffleruby/core/adapters/InputStreamAdapter.java
+++ b/src/main/java/org/truffleruby/core/adapters/InputStreamAdapter.java
@@ -30,7 +30,7 @@ public class InputStreamAdapter extends NonBlockingInputStream {
     public int read() {
         final Object result = DispatchNode.getUncached().call(object, "getbyte");
 
-        if (result == Nil.get()) {
+        if (Nil.is(result)) {
             return EOF;
         }
 

--- a/src/main/java/org/truffleruby/core/array/ArrayIndexNodes.java
+++ b/src/main/java/org/truffleruby/core/array/ArrayIndexNodes.java
@@ -53,7 +53,7 @@ public abstract class ArrayIndexNodes {
             if (isInBounds.profile(0 <= normalizedIndex && normalizedIndex < size)) {
                 return stores.read(store, normalizedIndex);
             } else {
-                return nil;
+                return nil();
             }
         }
     }
@@ -84,7 +84,7 @@ public abstract class ArrayIndexNodes {
 
         @Specialization(guards = "!isInBounds(array, index)")
         protected Object readOutOfBounds(RubyArray array, int index) {
-            return nil;
+            return nil();
         }
 
         protected static boolean isInBounds(RubyArray array, int index) {
@@ -104,12 +104,12 @@ public abstract class ArrayIndexNodes {
 
         @Specialization(guards = "!indexInBounds(array, index)")
         protected Object readIndexOutOfBounds(RubyArray array, int index, int length) {
-            return nil;
+            return nil();
         }
 
         @Specialization(guards = "length < 0")
         protected Object readNegativeLength(RubyArray array, int index, int length) {
-            return nil;
+            return nil();
         }
 
         @Specialization(guards = { "indexInBounds(array, index)", "length >= 0" })

--- a/src/main/java/org/truffleruby/core/array/ArrayIndexNodes.java
+++ b/src/main/java/org/truffleruby/core/array/ArrayIndexNodes.java
@@ -84,7 +84,7 @@ public abstract class ArrayIndexNodes {
 
         @Specialization(guards = "!isInBounds(array, index)")
         protected Object readOutOfBounds(RubyArray array, int index) {
-            return nil();
+            return nil("out of array bounds");
         }
 
         protected static boolean isInBounds(RubyArray array, int index) {

--- a/src/main/java/org/truffleruby/core/array/ArrayLiteralNode.java
+++ b/src/main/java/org/truffleruby/core/array/ArrayLiteralNode.java
@@ -74,8 +74,8 @@ public abstract class ArrayLiteralNode extends RubyContextSourceNode {
     @Override
     public Object isDefined(VirtualFrame frame, RubyLanguage language, RubyContext context) {
         for (RubyNode value : values) {
-            if (value.isDefined(frame, language, context) == nil) {
-                return nil;
+            if (value.isDefined(frame, language, context) == nil()) {
+                return nil();
             }
         }
 
@@ -337,7 +337,7 @@ public abstract class ArrayLiteralNode extends RubyContextSourceNode {
                 final double[] store = new double[objects.length];
 
                 for (int n = 0; n < objects.length; n++) {
-                    store[n] = CoreLibrary.toDouble(objects[n], nil);
+                    store[n] = CoreLibrary.toDouble(objects[n], nil());
                 }
 
                 return store;

--- a/src/main/java/org/truffleruby/core/array/ArrayLiteralNode.java
+++ b/src/main/java/org/truffleruby/core/array/ArrayLiteralNode.java
@@ -13,6 +13,7 @@ import org.truffleruby.RubyContext;
 import org.truffleruby.RubyLanguage;
 import org.truffleruby.core.CoreLibrary;
 import org.truffleruby.core.array.library.ArrayStoreLibrary;
+import org.truffleruby.language.Nil;
 import org.truffleruby.language.RubyContextSourceNode;
 import org.truffleruby.language.RubyNode;
 
@@ -74,7 +75,7 @@ public abstract class ArrayLiteralNode extends RubyContextSourceNode {
     @Override
     public Object isDefined(VirtualFrame frame, RubyLanguage language, RubyContext context) {
         for (RubyNode value : values) {
-            if (value.isDefined(frame, language, context) == nil()) {
+            if (Nil.is(value.isDefined(frame, language, context))) {
                 return nil();
             }
         }

--- a/src/main/java/org/truffleruby/core/array/ArrayNodes.java
+++ b/src/main/java/org/truffleruby/core/array/ArrayNodes.java
@@ -519,7 +519,7 @@ public abstract class ArrayNodes {
             try {
                 for (; loopProfile.inject(n < size); n++) {
                     Object v = stores.read(store, n);
-                    if (v != nil()) {
+                    if (Nil.isNot(v)) {
                         arrayBuilder.appendValue(state, m, v);
                         m++;
                     }
@@ -567,7 +567,7 @@ public abstract class ArrayNodes {
             try {
                 for (; loopProfile.inject(n < size); n++) {
                     Object v = stores.read(oldStore, n);
-                    if (v != nil()) {
+                    if (Nil.isNot(v)) {
                         mutableStores.write(newStore, m, v);
                         m++;
                     }
@@ -746,7 +746,7 @@ public abstract class ArrayNodes {
                 array.size = i;
                 return found;
             } else {
-                if (maybeBlock == nil()) {
+                if (Nil.is(maybeBlock)) {
                     return nil();
                 } else {
                     return callBlock((RubyProc) maybeBlock, value);
@@ -2461,7 +2461,7 @@ public abstract class ArrayNodes {
                             obj,
                             coreLibrary().arrayClass,
                             coreSymbols().TO_ARY);
-                    if (converted == nil()) {
+                    if (Nil.is(converted)) {
                         append.executeAppendOne(out, obj);
                     } else {
                         modified = true;

--- a/src/main/java/org/truffleruby/core/array/ArrayNodes.java
+++ b/src/main/java/org/truffleruby/core/array/ArrayNodes.java
@@ -243,7 +243,7 @@ public abstract class ArrayNodes {
         @Specialization
         protected Object at(RubyArray array, long index) {
             assert !CoreLibrary.fitsIntoInteger(index);
-            return nil;
+            return nil();
         }
 
         @Specialization(guards = "!isImplicitLong(index)")
@@ -308,7 +308,7 @@ public abstract class ArrayNodes {
                 @Cached ReadSliceNormalizedNode readSliceNode,
                 @Cached ConditionProfile negativeIndexProfile) {
             if (length < 0) {
-                return nil;
+                return nil();
             }
             if (negativeIndexProfile.profile(start < 0)) {
                 start += array.size;
@@ -519,7 +519,7 @@ public abstract class ArrayNodes {
             try {
                 for (; loopProfile.inject(n < size); n++) {
                     Object v = stores.read(store, n);
-                    if (v != nil) {
+                    if (v != nil()) {
                         arrayBuilder.appendValue(state, m, v);
                         m++;
                     }
@@ -543,7 +543,7 @@ public abstract class ArrayNodes {
         protected Object compactNotObjects(RubyArray array,
                 @Bind("array.store") Object store,
                 @CachedLibrary("store") ArrayStoreLibrary stores) {
-            return nil;
+            return nil();
         }
 
         @Specialization(guards = "!stores.isPrimitive(store)", limit = "storageStrategyLimit()")
@@ -567,7 +567,7 @@ public abstract class ArrayNodes {
             try {
                 for (; loopProfile.inject(n < size); n++) {
                     Object v = stores.read(oldStore, n);
-                    if (v != nil) {
+                    if (v != nil()) {
                         mutableStores.write(newStore, m, v);
                         m++;
                     }
@@ -583,7 +583,7 @@ public abstract class ArrayNodes {
             array.size = m;
 
             if (m == size) {
-                return nil;
+                return nil();
             } else {
                 return array;
             }
@@ -714,7 +714,7 @@ public abstract class ArrayNodes {
             assert !sameStores || (oldStore == newStore && oldStores == newStores);
 
             final int size = arraySizeProfile.profile(array.size);
-            Object found = nil;
+            Object found = nil();
 
             int i = 0;
             int n = 0;
@@ -746,8 +746,8 @@ public abstract class ArrayNodes {
                 array.size = i;
                 return found;
             } else {
-                if (maybeBlock == nil) {
-                    return nil;
+                if (maybeBlock == nil()) {
+                    return nil();
                 } else {
                     return callBlock((RubyProc) maybeBlock, value);
                 }
@@ -791,7 +791,7 @@ public abstract class ArrayNodes {
             }
 
             if (notInBoundsProfile.profile(i < 0 || i >= size)) {
-                return nil;
+                return nil();
             } else {
                 final Object value = stores.read(store, i);
                 stores.copyContents(store, i + 1, store, i, size - i - 1);
@@ -818,7 +818,7 @@ public abstract class ArrayNodes {
             }
 
             if (notInBoundsProfile.profile(i < 0 || i >= size)) {
-                return nil;
+                return nil();
             } else {
                 final Object mutableStore = stores.allocator(store).allocate(size - 1);
                 stores.copyContents(store, 0, mutableStore, 0, i);
@@ -1187,7 +1187,7 @@ public abstract class ArrayNodes {
         @Specialization(guards = "size >= 0")
         protected RubyArray initializeWithSizeNoValue(RubyArray array, int size, NotProvided fillingValue, Nil block) {
             final Object[] store = new Object[size];
-            Arrays.fill(store, nil);
+            Arrays.fill(store, nil());
             setStoreAndSize(array, store, size);
             return array;
         }
@@ -1270,10 +1270,10 @@ public abstract class ArrayNodes {
             }
 
             if (copy != null) {
-                return executeInitialize(array, copy, NotProvided.INSTANCE, nil);
+                return executeInitialize(array, copy, NotProvided.INSTANCE, nil());
             } else {
                 int size = toInt(object);
-                return executeInitialize(array, size, NotProvided.INSTANCE, nil);
+                return executeInitialize(array, size, NotProvided.INSTANCE, nil());
             }
         }
 
@@ -1345,7 +1345,7 @@ public abstract class ArrayNodes {
         @ReportPolymorphism.Exclude
         protected Object injectEmptyArrayNoInitial(
                 RubyArray array, NotProvided initialOrSymbol, NotProvided symbol, RubyProc block) {
-            return nil;
+            return nil();
         }
 
         @Specialization(
@@ -1395,7 +1395,7 @@ public abstract class ArrayNodes {
         @Specialization(guards = { "isEmptyArray(array)" })
         protected Object injectSymbolEmptyArrayNoInitial(
                 RubyArray array, RubySymbol initialOrSymbol, NotProvided symbol, Nil block) {
-            return nil;
+            return nil();
         }
 
         @Specialization(
@@ -1813,7 +1813,7 @@ public abstract class ArrayNodes {
 
         @Specialization(guards = "array.size == 0")
         protected Object rejectEmpty(RubyArray array, RubyProc block) {
-            return nil;
+            return nil();
         }
 
         @Specialization(
@@ -1887,7 +1887,7 @@ public abstract class ArrayNodes {
             if (i != n) {
                 return array;
             } else {
-                return nil;
+                return nil();
             }
         }
     }
@@ -2108,7 +2108,7 @@ public abstract class ArrayNodes {
         @Specialization(guards = "isEmptyArray(array)")
         @ReportPolymorphism.Exclude
         protected Object shiftEmpty(RubyArray array, NotProvided n) {
-            return nil;
+            return nil();
         }
 
         @Specialization(guards = "!isEmptyArray(array)", limit = "storageStrategyLimit()")
@@ -2326,7 +2326,7 @@ public abstract class ArrayNodes {
                         pairs.write(pair, 1, bStores.read(b, n));
                         zipped[n] = createArray(pair, 2);
                     } else {
-                        zipped[n] = createArray(new Object[]{ aStores.read(a, n), nil });
+                        zipped[n] = createArray(new Object[]{ aStores.read(a, n), nil() });
                     }
                     TruffleSafepoint.poll(this);
                 }
@@ -2461,7 +2461,7 @@ public abstract class ArrayNodes {
                             obj,
                             coreLibrary().arrayClass,
                             coreSymbols().TO_ARY);
-                    if (converted == nil) {
+                    if (converted == nil()) {
                         append.executeAppendOne(out, obj);
                     } else {
                         modified = true;

--- a/src/main/java/org/truffleruby/core/array/ArrayPopOneNode.java
+++ b/src/main/java/org/truffleruby/core/array/ArrayPopOneNode.java
@@ -28,7 +28,7 @@ public abstract class ArrayPopOneNode extends RubyBaseNode {
 
     @Specialization(guards = "isEmptyArray(array)")
     protected Object popOneEmpty(RubyArray array) {
-        return nil;
+        return nil();
     }
 
     // Pop from a non-empty array

--- a/src/main/java/org/truffleruby/core/array/ArrayPrepareForCopyNode.java
+++ b/src/main/java/org/truffleruby/core/array/ArrayPrepareForCopyNode.java
@@ -55,7 +55,7 @@ public abstract class ArrayPrepareForCopyNode extends RubyBaseNode {
         final int oldSize = dst.size;
         final Object[] newStore = new Object[ArrayUtils.capacity(getLanguage(), oldSize, start + length)];
         dstStores.copyContents(dstStore, 0, newStore, 0, oldSize); // copy the original store
-        Arrays.fill(newStore, oldSize, start, nil); // nil-pad the new empty part
+        Arrays.fill(newStore, oldSize, start, nil()); // nil-pad the new empty part
         dst.store = newStore;
         dst.size = start + length;
         return newStore;

--- a/src/main/java/org/truffleruby/core/array/ArrayWriteNormalizedNode.java
+++ b/src/main/java/org/truffleruby/core/array/ArrayWriteNormalizedNode.java
@@ -89,13 +89,13 @@ public abstract class ArrayWriteNormalizedNode extends RubyBaseNode {
             @CachedLibrary(limit = "1") ArrayStoreLibrary newStores,
             @Cached LoopConditionProfile loopProfile) {
         final int newSize = index + 1;
-        final Object objectStore = stores.allocateForNewValue(store, nil, newSize);
+        final Object objectStore = stores.allocateForNewValue(store, nil(), newSize);
         int oldSize = array.size;
         stores.copyContents(store, 0, objectStore, 0, oldSize);
         int n = oldSize;
         try {
             for (; loopProfile.inject(n < index); n++) {
-                newStores.write(objectStore, n, nil);
+                newStores.write(objectStore, n, nil());
                 TruffleSafepoint.poll(this);
             }
         } finally {
@@ -123,7 +123,7 @@ public abstract class ArrayWriteNormalizedNode extends RubyBaseNode {
         int n = array.size;
         try {
             for (; loopProfile.inject(n < index); n++) {
-                newStores.write(newStore, n, nil);
+                newStores.write(newStore, n, nil());
                 TruffleSafepoint.poll(this);
             }
         } finally {

--- a/src/main/java/org/truffleruby/core/basicobject/BasicObjectNodes.java
+++ b/src/main/java/org/truffleruby/core/basicobject/BasicObjectNodes.java
@@ -310,7 +310,7 @@ public abstract class BasicObjectNodes {
     public abstract static class InitializeNode extends AlwaysInlinedMethodNode {
         @Specialization
         protected Object initialize(Frame callerFrame, Object self, Object[] rubyArgs, RootCallTarget target) {
-            return nil;
+            return nil();
         }
     }
 
@@ -448,7 +448,7 @@ public abstract class BasicObjectNodes {
                     block.declarationContext.getRefinements());
             var descriptor = RubyArguments.getDescriptor(frame);
             return callBlockNode.executeCallBlock(
-                    declarationContext, block, receiver, nil, descriptor, arguments, null);
+                    declarationContext, block, receiver, nil(), descriptor, arguments, null);
         }
 
         @Specialization

--- a/src/main/java/org/truffleruby/core/basicobject/BasicObjectNodes.java
+++ b/src/main/java/org/truffleruby/core/basicobject/BasicObjectNodes.java
@@ -128,6 +128,21 @@ public abstract class BasicObjectNodes {
         public abstract boolean executeReferenceEqual(Object a, Object b);
 
         @Specialization
+        protected boolean equal(Nil a, Nil b) {
+            return true;
+        }
+
+        @Specialization(guards = "!isNil(b)")
+        protected boolean equal(Nil a, Object b) {
+            return false;
+        }
+
+        @Specialization(guards = "!isNil(a)")
+        protected boolean equal(Object a, Nil b) {
+            return false;
+        }
+
+        @Specialization
         protected boolean equal(boolean a, boolean b) {
             return a == b;
         }
@@ -147,17 +162,18 @@ public abstract class BasicObjectNodes {
             return Double.doubleToRawLongBits(a) == Double.doubleToRawLongBits(b);
         }
 
-        @Specialization(guards = { "isNonPrimitiveRubyObject(a)", "isNonPrimitiveRubyObject(b)" })
+        @Specialization(
+                guards = { "isNonPrimitiveRubyObject(a)", "isNonPrimitiveRubyObject(b)", "!isNil(a)", "!isNil(b)" })
         protected boolean equalRubyObjects(Object a, Object b) {
             return a == b;
         }
 
-        @Specialization(guards = { "isNonPrimitiveRubyObject(a)", "isPrimitive(b)" })
+        @Specialization(guards = { "isNonPrimitiveRubyObject(a)", "isPrimitive(b)", "!isNil(a)" })
         protected boolean rubyObjectPrimitive(Object a, Object b) {
             return false;
         }
 
-        @Specialization(guards = { "isPrimitive(a)", "isNonPrimitiveRubyObject(b)" })
+        @Specialization(guards = { "isPrimitive(a)", "isNonPrimitiveRubyObject(b)", "!isNil(b)" })
         protected boolean primitiveRubyObject(Object a, Object b) {
             return false;
         }

--- a/src/main/java/org/truffleruby/core/binding/BindingNodes.java
+++ b/src/main/java/org/truffleruby/core/binding/BindingNodes.java
@@ -481,7 +481,7 @@ public abstract class BindingNodes {
             final SourceSection sourceSection = binding.sourceSection;
 
             if (sourceSection == null) {
-                return nil;
+                return nil();
             } else {
                 final RubyString file = makeStringNode.executeMake(
                         getLanguage().getSourcePath(sourceSection.getSource()),

--- a/src/main/java/org/truffleruby/core/binding/TruffleBindingNodes.java
+++ b/src/main/java/org/truffleruby/core/binding/TruffleBindingNodes.java
@@ -47,7 +47,7 @@ public abstract class TruffleBindingNodes {
             });
 
             if (frame == null) {
-                return nil;
+                return nil();
             }
 
             return BindingNodes.createBinding(getContext(), getLanguage(), frame, sourceSection.get());

--- a/src/main/java/org/truffleruby/core/cast/SingleValueCastNode.java
+++ b/src/main/java/org/truffleruby/core/cast/SingleValueCastNode.java
@@ -23,7 +23,7 @@ public abstract class SingleValueCastNode extends RubyBaseNode {
 
     @Specialization(guards = "noArguments(args)")
     protected Object castNil(Object[] args) {
-        return nil;
+        return nil();
     }
 
     @Specialization(guards = "singleArgument(args)")

--- a/src/main/java/org/truffleruby/core/cast/SplatCastNode.java
+++ b/src/main/java/org/truffleruby/core/cast/SplatCastNode.java
@@ -100,7 +100,7 @@ public abstract class SplatCastNode extends RubyContextSourceNode {
                 object,
                 coreLibrary().arrayClass,
                 conversionMethod);
-        if (array == nil()) {
+        if (Nil.is(array)) {
             return createArray(new Object[]{ object });
         } else {
             if (copy) {

--- a/src/main/java/org/truffleruby/core/cast/SplatCastNode.java
+++ b/src/main/java/org/truffleruby/core/cast/SplatCastNode.java
@@ -100,7 +100,7 @@ public abstract class SplatCastNode extends RubyContextSourceNode {
                 object,
                 coreLibrary().arrayClass,
                 conversionMethod);
-        if (array == nil) {
+        if (array == nil()) {
             return createArray(new Object[]{ object });
         } else {
             if (copy) {

--- a/src/main/java/org/truffleruby/core/encoding/EncodingConverterNodes.java
+++ b/src/main/java/org/truffleruby/core/encoding/EncodingConverterNodes.java
@@ -95,7 +95,7 @@ public abstract class EncodingConverterNodes {
                     .open(sourceEncoding.getName(), destinationEncoding.getName(), toJCodingFlags(options));
 
             if (econv == null) {
-                return nil;
+                return nil();
             }
 
             econv.sourceEncoding = sourceEncoding;
@@ -169,7 +169,7 @@ public abstract class EncodingConverterNodes {
         protected Object search(RubySymbol source) {
             final Set<String> transcoders = TranscodingManager.allDirectTranscoderPaths.get(source.getString());
             if (transcoders == null) {
-                return nil;
+                return nil();
             }
 
             final Object[] destinations = new Object[transcoders.size()];
@@ -252,7 +252,7 @@ public abstract class EncodingConverterNodes {
             // Taken from org.jruby.RubyConverter#primitive_convert.
 
             Rope targetRope = target.rope;
-            final boolean nonNullSource = source != nil;
+            final boolean nonNullSource = source != nil();
             final RopeBuilder outBytes = RopeOperations.toRopeBuilderCopy(targetRope);
 
             final Ptr inPtr = new Ptr();
@@ -382,7 +382,9 @@ public abstract class EncodingConverterNodes {
             ec.putback(bytes, 0, n);
 
             final Object sourceEncoding = (RubyEncoding) sourceEncodingNode.call(encodingConverter, "source_encoding");
-            final RubyEncoding rubyEncoding = sourceEncoding == nil ? Encodings.BINARY : (RubyEncoding) sourceEncoding;
+            final RubyEncoding rubyEncoding = sourceEncoding == nil()
+                    ? Encodings.BINARY
+                    : (RubyEncoding) sourceEncoding;
             return makeStringNode.executeMake(bytes, rubyEncoding, CodeRange.CR_UNKNOWN);
         }
     }
@@ -400,7 +402,7 @@ public abstract class EncodingConverterNodes {
             if (lastError.getResult() != EConvResult.InvalidByteSequence &&
                     lastError.getResult() != EConvResult.IncompleteInput &&
                     lastError.getResult() != EConvResult.UndefinedConversion) {
-                return nil;
+                return nil();
             }
 
             final boolean readAgain = lastError.getReadAgainLength() != 0;
@@ -457,7 +459,7 @@ public abstract class EncodingConverterNodes {
                 @Cached StringNodes.MakeStringNode makeStringNode) {
             final EConv ec = encodingConverter.econv;
 
-            final Object[] ret = { getSymbol(ec.lastError.getResult().symbolicName()), nil, nil, nil, nil };
+            final Object[] ret = { getSymbol(ec.lastError.getResult().symbolicName()), nil(), nil(), nil(), nil() };
 
             if (ec.lastError.getSource() != null) {
                 ret[1] = makeStringNode.executeMake(ec.lastError.getSource(), Encodings.BINARY, CR_UNKNOWN);

--- a/src/main/java/org/truffleruby/core/encoding/EncodingConverterNodes.java
+++ b/src/main/java/org/truffleruby/core/encoding/EncodingConverterNodes.java
@@ -252,7 +252,7 @@ public abstract class EncodingConverterNodes {
             // Taken from org.jruby.RubyConverter#primitive_convert.
 
             Rope targetRope = target.rope;
-            final boolean nonNullSource = source != nil();
+            final boolean nonNullSource = Nil.isNot(source);
             final RopeBuilder outBytes = RopeOperations.toRopeBuilderCopy(targetRope);
 
             final Ptr inPtr = new Ptr();
@@ -382,7 +382,7 @@ public abstract class EncodingConverterNodes {
             ec.putback(bytes, 0, n);
 
             final Object sourceEncoding = (RubyEncoding) sourceEncodingNode.call(encodingConverter, "source_encoding");
-            final RubyEncoding rubyEncoding = sourceEncoding == nil()
+            final RubyEncoding rubyEncoding = Nil.is(sourceEncoding)
                     ? Encodings.BINARY
                     : (RubyEncoding) sourceEncoding;
             return makeStringNode.executeMake(bytes, rubyEncoding, CodeRange.CR_UNKNOWN);

--- a/src/main/java/org/truffleruby/core/encoding/EncodingNodes.java
+++ b/src/main/java/org/truffleruby/core/encoding/EncodingNodes.java
@@ -397,7 +397,7 @@ public abstract class EncodingNodes {
             final RubyEncoding negotiatedEncoding = negotiateCompatibleEncodingNode.executeNegotiate(first, second);
 
             if (noNegotiatedEncodingProfile.profile(negotiatedEncoding == null)) {
-                return nil;
+                return nil();
             }
 
             return negotiatedEncoding;
@@ -469,7 +469,7 @@ public abstract class EncodingNodes {
                         aliasName,
                         Encodings.getBuiltInEncoding(entry.value.getEncoding().getIndex()));
             }
-            return nil;
+            return nil();
         }
     }
 
@@ -551,7 +551,7 @@ public abstract class EncodingNodes {
                 @CachedLibrary(limit = "LIBSTRING_CACHE") RubyStringLibrary stringLibrary) {
             final RubyEncoding encoding = getEncoding(stringLibrary.getJavaString(name));
             if (encoding == null) {
-                return nil;
+                return nil();
             } else {
                 return encoding;
             }
@@ -603,7 +603,7 @@ public abstract class EncodingNodes {
         @Specialization
         protected Object noDefaultInternal(Nil encoding) {
             getContext().getEncodingManager().setDefaultInternalEncoding(null);
-            return nil;
+            return nil();
         }
 
     }
@@ -640,7 +640,7 @@ public abstract class EncodingNodes {
         @Fallback
         protected Object encodingGetObjectEncodingNil(Object object) {
             // TODO(CS, 26 Jan 15) something to do with __encoding__ here?
-            return nil;
+            return nil();
         }
 
     }

--- a/src/main/java/org/truffleruby/core/exception/CoreExceptions.java
+++ b/src/main/java/org/truffleruby/core/exception/CoreExceptions.java
@@ -952,7 +952,7 @@ public class CoreExceptions {
                 null,
                 // FIXME: the name of the method is not known in this case currently
                 language.getSymbol("<unknown>"),
-                Nil.INSTANCE);
+                Nil.get());
     }
 
     public RubyNoMethodError noMethodErrorUnknownIdentifier(Object receiver, String name, Object[] args,
@@ -1258,7 +1258,7 @@ public class CoreExceptions {
         RubyClass exceptionClass = context.getCoreLibrary().systemCallErrorClass;
         Object errorMessage;
         if (message == null) {
-            errorMessage = Nil.INSTANCE;
+            errorMessage = Nil.get();
         } else {
             errorMessage = StringOperations
                     .createUTF8String(context, language, StringOperations.encodeRope(message, UTF8Encoding.INSTANCE));

--- a/src/main/java/org/truffleruby/core/exception/ErrnoErrorNode.java
+++ b/src/main/java/org/truffleruby/core/exception/ErrnoErrorNode.java
@@ -40,7 +40,7 @@ public abstract class ErrnoErrorNode extends RubyBaseNode {
         final RubyClass errnoClass;
         if (errnoName == null) {
             errnoClass = getContext().getCoreLibrary().systemCallErrorClass;
-            errnoDescription = nil;
+            errnoDescription = nil();
         } else {
             if (rubyClass != null && rubyClass != getContext().getCoreLibrary().systemCallErrorClass) {
                 errnoClass = rubyClass;

--- a/src/main/java/org/truffleruby/core/exception/ExceptionNodes.java
+++ b/src/main/java/org/truffleruby/core/exception/ExceptionNodes.java
@@ -46,7 +46,7 @@ public abstract class ExceptionNodes {
         @Specialization
         protected RubyException allocateException(RubyClass rubyClass) {
             final Shape shape = getLanguage().exceptionShape;
-            final RubyException instance = new RubyException(rubyClass, shape, nil, null, nil);
+            final RubyException instance = new RubyException(rubyClass, shape, nil(), null, nil());
             AllocationTracing.trace(instance, this);
             return instance;
         }
@@ -57,7 +57,7 @@ public abstract class ExceptionNodes {
 
         @Specialization
         protected RubyException initialize(RubyException exception, NotProvided message) {
-            exception.message = nil;
+            exception.message = nil();
             return exception;
         }
 
@@ -162,7 +162,7 @@ public abstract class ExceptionNodes {
                 }
                 return backtraceStringArray;
             } else {
-                return nil;
+                return nil();
             }
         }
 
@@ -185,7 +185,7 @@ public abstract class ExceptionNodes {
                 }
                 return backtraceLocations;
             } else {
-                return nil;
+                return nil();
             }
         }
     }
@@ -226,7 +226,7 @@ public abstract class ExceptionNodes {
         @Specialization
         protected Object captureBacktrace(RubyException exception, int offset) {
             exception.backtrace = getContext().getCallStack().getBacktrace(this, offset);
-            return nil;
+            return nil();
         }
 
     }
@@ -238,7 +238,7 @@ public abstract class ExceptionNodes {
         protected Object message(RubyException exception) {
             final Object message = exception.message;
             if (message == null) {
-                return nil;
+                return nil();
             } else {
                 return message;
             }
@@ -252,7 +252,7 @@ public abstract class ExceptionNodes {
         @Specialization
         protected Object setMessage(RubyException exception, Object message) {
             exception.message = message;
-            return nil;
+            return nil();
         }
 
     }
@@ -275,7 +275,7 @@ public abstract class ExceptionNodes {
         protected Object formatter(RubyException exception) {
             final RubyProc formatter = exception.formatter;
             if (formatter == null) {
-                return nil;
+                return nil();
             } else {
                 return formatter;
             }

--- a/src/main/java/org/truffleruby/core/exception/ExceptionOperations.java
+++ b/src/main/java/org/truffleruby/core/exception/ExceptionOperations.java
@@ -99,7 +99,7 @@ public abstract class ExceptionOperations {
     private static String messageFieldToString(RubyException exception) {
         Object message = exception.message;
         RubyStringLibrary strings = RubyStringLibrary.getUncached();
-        if (message == null || message == Nil.get()) {
+        if (message == null || Nil.is(message)) {
             final ModuleFields exceptionClass = exception.getLogicalClass().fields;
             return exceptionClass.getName(); // What Exception#message would return if no message is set
         } else if (strings.isRubyString(message)) {

--- a/src/main/java/org/truffleruby/core/exception/ExceptionOperations.java
+++ b/src/main/java/org/truffleruby/core/exception/ExceptionOperations.java
@@ -99,7 +99,7 @@ public abstract class ExceptionOperations {
     private static String messageFieldToString(RubyException exception) {
         Object message = exception.message;
         RubyStringLibrary strings = RubyStringLibrary.getUncached();
-        if (message == null || message == Nil.INSTANCE) {
+        if (message == null || message == Nil.get()) {
             final ModuleFields exceptionClass = exception.getLogicalClass().fields;
             return exceptionClass.getName(); // What Exception#message would return if no message is set
         } else if (strings.isRubyString(message)) {

--- a/src/main/java/org/truffleruby/core/exception/FrozenErrorNodes.java
+++ b/src/main/java/org/truffleruby/core/exception/FrozenErrorNodes.java
@@ -33,7 +33,7 @@ public abstract class FrozenErrorNodes {
         @Specialization
         protected RubyFrozenError allocateFrozenError(RubyClass rubyClass) {
             final Shape shape = getLanguage().frozenErrorShape;
-            final RubyFrozenError instance = new RubyFrozenError(rubyClass, shape, nil, null, nil, null);
+            final RubyFrozenError instance = new RubyFrozenError(rubyClass, shape, nil(), null, nil(), null);
             AllocationTracing.trace(instance, this);
             return instance;
         }

--- a/src/main/java/org/truffleruby/core/exception/NameErrorNodes.java
+++ b/src/main/java/org/truffleruby/core/exception/NameErrorNodes.java
@@ -31,7 +31,7 @@ public abstract class NameErrorNodes {
         @Specialization
         protected RubyNameError allocateNameError(RubyClass rubyClass) {
             final Shape shape = getLanguage().nameErrorShape;
-            final RubyNameError instance = new RubyNameError(rubyClass, shape, nil, null, nil, null, nil);
+            final RubyNameError instance = new RubyNameError(rubyClass, shape, nil(), null, nil(), null, nil());
             AllocationTracing.trace(instance, this);
             return instance;
         }

--- a/src/main/java/org/truffleruby/core/exception/NoMethodErrorNodes.java
+++ b/src/main/java/org/truffleruby/core/exception/NoMethodErrorNodes.java
@@ -32,7 +32,8 @@ public abstract class NoMethodErrorNodes {
         @Specialization
         protected RubyNoMethodError allocateNoMethodError(RubyClass rubyClass) {
             final Shape shape = getLanguage().noMethodErrorShape;
-            final RubyNoMethodError instance = new RubyNoMethodError(rubyClass, shape, nil, null, nil, null, nil, nil);
+            final RubyNoMethodError instance = new RubyNoMethodError(rubyClass, shape, nil(), null, nil(), null, nil(),
+                    nil());
             AllocationTracing.trace(instance, this);
             return instance;
         }
@@ -54,7 +55,7 @@ public abstract class NoMethodErrorNodes {
 
         @Specialization
         protected Object setArgs(RubyNoMethodError error, Object args) {
-            assert args == Nil.INSTANCE || args instanceof RubyArray;
+            assert args == Nil.get() || args instanceof RubyArray;
             error.args = args;
             return args;
         }

--- a/src/main/java/org/truffleruby/core/exception/NoMethodErrorNodes.java
+++ b/src/main/java/org/truffleruby/core/exception/NoMethodErrorNodes.java
@@ -55,7 +55,7 @@ public abstract class NoMethodErrorNodes {
 
         @Specialization
         protected Object setArgs(RubyNoMethodError error, Object args) {
-            assert args == Nil.get() || args instanceof RubyArray;
+            assert Nil.is(args) || args instanceof RubyArray;
             error.args = args;
             return args;
         }

--- a/src/main/java/org/truffleruby/core/exception/RubyException.java
+++ b/src/main/java/org/truffleruby/core/exception/RubyException.java
@@ -50,7 +50,7 @@ public class RubyException extends RubyDynamicObject implements ObjectGraphNode 
     public RubyException(RubyClass rubyClass, Shape shape, Object message, Backtrace backtrace, Object cause) {
         super(rubyClass, shape);
         // TODO (eregon, 9 Aug 2020): it should probably be null or RubyString, not nil, and the field can then be typed
-        assert message == null || message == Nil.get() || message instanceof RubyString ||
+        assert message == null || Nil.is(message) || message instanceof RubyString ||
                 message instanceof ImmutableRubyString;
         assert cause != null;
         this.message = message;

--- a/src/main/java/org/truffleruby/core/exception/RubyException.java
+++ b/src/main/java/org/truffleruby/core/exception/RubyException.java
@@ -50,7 +50,7 @@ public class RubyException extends RubyDynamicObject implements ObjectGraphNode 
     public RubyException(RubyClass rubyClass, Shape shape, Object message, Backtrace backtrace, Object cause) {
         super(rubyClass, shape);
         // TODO (eregon, 9 Aug 2020): it should probably be null or RubyString, not nil, and the field can then be typed
-        assert message == null || message == Nil.INSTANCE || message instanceof RubyString ||
+        assert message == null || message == Nil.get() || message instanceof RubyString ||
                 message instanceof ImmutableRubyString;
         assert cause != null;
         this.message = message;

--- a/src/main/java/org/truffleruby/core/exception/RubyNoMethodError.java
+++ b/src/main/java/org/truffleruby/core/exception/RubyNoMethodError.java
@@ -34,7 +34,7 @@ public final class RubyNoMethodError extends RubyNameError implements ObjectGrap
             Object name,
             Object args) {
         super(rubyClass, shape, message, backtrace, cause, receiver, name);
-        assert args == Nil.get() || args instanceof RubyArray;
+        assert Nil.is(args) || args instanceof RubyArray;
         this.args = args;
     }
 

--- a/src/main/java/org/truffleruby/core/exception/RubyNoMethodError.java
+++ b/src/main/java/org/truffleruby/core/exception/RubyNoMethodError.java
@@ -34,7 +34,7 @@ public final class RubyNoMethodError extends RubyNameError implements ObjectGrap
             Object name,
             Object args) {
         super(rubyClass, shape, message, backtrace, cause, receiver, name);
-        assert args == Nil.INSTANCE || args instanceof RubyArray;
+        assert args == Nil.get() || args instanceof RubyArray;
         this.args = args;
     }
 

--- a/src/main/java/org/truffleruby/core/exception/SyntaxErrorNodes.java
+++ b/src/main/java/org/truffleruby/core/exception/SyntaxErrorNodes.java
@@ -28,7 +28,7 @@ public abstract class SyntaxErrorNodes {
         @Specialization
         protected RubySyntaxError allocateSyntaxError(RubyClass rubyClass) {
             final Shape shape = getLanguage().syntaxErrorShape;
-            final RubySyntaxError instance = new RubySyntaxError(rubyClass, shape, nil, null, nil, null);
+            final RubySyntaxError instance = new RubySyntaxError(rubyClass, shape, nil(), null, nil(), null);
             AllocationTracing.trace(instance, this);
             return instance;
         }

--- a/src/main/java/org/truffleruby/core/exception/SystemCallErrorNodes.java
+++ b/src/main/java/org/truffleruby/core/exception/SystemCallErrorNodes.java
@@ -30,7 +30,7 @@ public abstract class SystemCallErrorNodes {
         @Specialization
         protected RubySystemCallError allocateNameError(RubyClass rubyClass) {
             final Shape shape = getLanguage().systemCallErrorShape;
-            final RubySystemCallError instance = new RubySystemCallError(rubyClass, shape, nil, null, nil, nil);
+            final RubySystemCallError instance = new RubySystemCallError(rubyClass, shape, nil(), null, nil(), nil());
             AllocationTracing.trace(instance, this);
             return instance;
         }

--- a/src/main/java/org/truffleruby/core/exception/SystemExitNodes.java
+++ b/src/main/java/org/truffleruby/core/exception/SystemExitNodes.java
@@ -30,7 +30,7 @@ public abstract class SystemExitNodes {
         @Specialization
         protected RubySystemExit allocateSytemExit(RubyClass rubyClass) {
             final Shape shape = getLanguage().systemExitShape;
-            final RubySystemExit instance = new RubySystemExit(rubyClass, shape, nil, null, nil, 0);
+            final RubySystemExit instance = new RubySystemExit(rubyClass, shape, nil(), null, nil(), 0);
             AllocationTracing.trace(instance, this);
             return instance;
         }

--- a/src/main/java/org/truffleruby/core/fiber/FiberNodes.java
+++ b/src/main/java/org/truffleruby/core/fiber/FiberNodes.java
@@ -127,7 +127,7 @@ public abstract class FiberNodes {
         protected Object initialize(RubyFiber fiber, boolean blocking, RubyProc block) {
             final RubyThread thread = getLanguage().getCurrentThread();
             getContext().fiberManager.initialize(fiber, blocking, block, this);
-            return nil;
+            return nil();
         }
 
         @Specialization

--- a/src/main/java/org/truffleruby/core/fiber/RubyFiber.java
+++ b/src/main/java/org/truffleruby/core/fiber/RubyFiber.java
@@ -107,7 +107,7 @@ public final class RubyFiber extends RubyDynamicObject implements ObjectGraphNod
         this.catchTags = ArrayHelpers.createEmptyArray(context, language);
         this.rubyThread = rubyThread;
         this.sourceLocation = sourceLocation;
-        extensionCallStack = new MarkingService.ExtensionCallStack(null, Nil.INSTANCE);
+        extensionCallStack = new MarkingService.ExtensionCallStack(null, Nil.get());
         handleData = new ValueWrapperManager.HandleBlockHolder();
     }
 

--- a/src/main/java/org/truffleruby/core/format/FormatFrameDescriptor.java
+++ b/src/main/java/org/truffleruby/core/format/FormatFrameDescriptor.java
@@ -26,7 +26,7 @@ public class FormatFrameDescriptor {
     public static final int ASSOCIATED_SLOT;
     public static final FrameDescriptor FRAME_DESCRIPTOR;
     static {
-        var builder = FrameDescriptor.newBuilder().defaultValue(Nil.INSTANCE);
+        var builder = FrameDescriptor.newBuilder().defaultValue(Nil.get());
         SOURCE_SLOT = builder.addSlot(FrameSlotKind.Object, "source", null);
         SOURCE_LENGTH_SLOT = builder.addSlot(FrameSlotKind.Int, "source-length", null);
         SOURCE_POSITION_SLOT = builder.addSlot(FrameSlotKind.Int, "source-position", null);

--- a/src/main/java/org/truffleruby/core/format/pack/SimplePackTreeBuilder.java
+++ b/src/main/java/org/truffleruby/core/format/pack/SimplePackTreeBuilder.java
@@ -155,7 +155,7 @@ public class SimplePackTreeBuilder implements SimplePackListener {
                         false,
                         "to_str",
                         false,
-                        Nil.INSTANCE,
+                        Nil.get(),
                         new SourceNode())));
     }
 
@@ -181,7 +181,7 @@ public class SimplePackTreeBuilder implements SimplePackListener {
                         true,
                         "to_s",
                         true,
-                        Nil.INSTANCE,
+                        Nil.get(),
                         new SourceNode())));
     }
 
@@ -198,7 +198,7 @@ public class SimplePackTreeBuilder implements SimplePackListener {
                         false,
                         "to_str",
                         false,
-                        Nil.INSTANCE,
+                        Nil.get(),
                         new SourceNode())));
     }
 
@@ -370,7 +370,7 @@ public class SimplePackTreeBuilder implements SimplePackListener {
                         false,
                         "to_str",
                         false,
-                        Nil.INSTANCE,
+                        Nil.get(),
                         new SourceNode())));
 
     }
@@ -386,7 +386,7 @@ public class SimplePackTreeBuilder implements SimplePackListener {
                         false,
                         "to_str",
                         false,
-                        Nil.INSTANCE,
+                        Nil.get(),
                         new SourceNode())));
     }
 
@@ -408,7 +408,7 @@ public class SimplePackTreeBuilder implements SimplePackListener {
                         false,
                         "to_str",
                         false,
-                        Nil.INSTANCE,
+                        Nil.get(),
                         new SourceNode())));
 
     }

--- a/src/main/java/org/truffleruby/core/format/read/bytes/ReadByteNode.java
+++ b/src/main/java/org/truffleruby/core/format/read/bytes/ReadByteNode.java
@@ -33,7 +33,7 @@ public abstract class ReadByteNode extends FormatNode {
         int index = advanceSourcePositionNoThrow(frame);
 
         if (rangeProfile.profile(index == -1)) {
-            return nil;
+            return nil();
         }
 
         return source[index];

--- a/src/main/java/org/truffleruby/core/format/read/bytes/ReadBytesNode.java
+++ b/src/main/java/org/truffleruby/core/format/read/bytes/ReadBytesNode.java
@@ -47,7 +47,7 @@ public abstract class ReadBytesNode extends FormatNode {
             if (consumePartial) {
                 return MissingValue.INSTANCE;
             } else {
-                return nil;
+                return nil();
             }
         }
 

--- a/src/main/java/org/truffleruby/core/hash/HashNodes.java
+++ b/src/main/java/org/truffleruby/core/hash/HashNodes.java
@@ -308,7 +308,11 @@ public abstract class HashNodes {
 
         @Specialization
         protected Object defaultValue(RubyHash hash) {
-            return hash.defaultValue;
+            if (hash.defaultValue == null) {
+                return nil("default hash value");
+            } else {
+                return hash.defaultValue;
+            }
         }
     }
 

--- a/src/main/java/org/truffleruby/core/hash/HashNodes.java
+++ b/src/main/java/org/truffleruby/core/hash/HashNodes.java
@@ -325,7 +325,7 @@ public abstract class HashNodes {
             final Object value = hashes.delete(hash.store, hash, key);
             if (hasValue.profile(value != null)) {
                 return value;
-            } else if (hasBlock.profile(maybeBlock != nil())) {
+            } else if (hasBlock.profile(Nil.isNot(maybeBlock))) {
                 return yieldNode.yield((RubyProc) maybeBlock, key);
             } else {
                 return nil();

--- a/src/main/java/org/truffleruby/core/hash/HashNodes.java
+++ b/src/main/java/org/truffleruby/core/hash/HashNodes.java
@@ -325,10 +325,10 @@ public abstract class HashNodes {
             final Object value = hashes.delete(hash.store, hash, key);
             if (hasValue.profile(value != null)) {
                 return value;
-            } else if (hasBlock.profile(maybeBlock != nil)) {
+            } else if (hasBlock.profile(maybeBlock != nil())) {
                 return yieldNode.yield((RubyProc) maybeBlock, key);
             } else {
-                return nil;
+                return nil();
             }
         }
     }
@@ -369,8 +369,8 @@ public abstract class HashNodes {
         @Specialization
         protected RubyHash initialize(RubyHash hash, NotProvided defaultValue, Nil block) {
             assert HashStoreLibrary.verify(hash);
-            hash.defaultValue = nil;
-            hash.defaultBlock = nil;
+            hash.defaultValue = nil();
+            hash.defaultBlock = nil();
             return hash;
         }
 
@@ -378,7 +378,7 @@ public abstract class HashNodes {
         protected RubyHash initialize(RubyHash hash, NotProvided defaultValue, RubyProc block,
                 @Cached PropagateSharingNode propagateSharingNode) {
             assert HashStoreLibrary.verify(hash);
-            hash.defaultValue = nil;
+            hash.defaultValue = nil();
             propagateSharingNode.executePropagate(hash, block);
             hash.defaultBlock = block;
             return hash;
@@ -390,7 +390,7 @@ public abstract class HashNodes {
             assert HashStoreLibrary.verify(hash);
             propagateSharingNode.executePropagate(hash, defaultValue);
             hash.defaultValue = defaultValue;
-            hash.defaultBlock = nil;
+            hash.defaultBlock = nil();
             return hash;
         }
 
@@ -474,16 +474,16 @@ public abstract class HashNodes {
         protected RubyProc setDefaultProc(RubyHash hash, RubyProc defaultProc,
                 @Cached PropagateSharingNode propagateSharingNode) {
             propagateSharingNode.executePropagate(hash, defaultProc);
-            hash.defaultValue = nil;
+            hash.defaultValue = nil();
             hash.defaultBlock = defaultProc;
             return defaultProc;
         }
 
         @Specialization
         protected Object setDefaultProc(RubyHash hash, Nil defaultProc) {
-            hash.defaultValue = nil;
-            hash.defaultBlock = nil;
-            return nil;
+            hash.defaultValue = nil();
+            hash.defaultBlock = nil();
+            return nil();
         }
     }
 
@@ -496,7 +496,7 @@ public abstract class HashNodes {
             propagateSharingNode.executePropagate(hash, defaultValue);
 
             hash.defaultValue = defaultValue;
-            hash.defaultBlock = nil;
+            hash.defaultBlock = nil();
             return defaultValue;
         }
     }
@@ -508,7 +508,7 @@ public abstract class HashNodes {
         @Specialization(guards = "hash.empty()")
         protected Object shiftEmpty(RubyHash hash,
                 @Cached DispatchNode callDefault) {
-            return callDefault.call(hash, "default", nil);
+            return callDefault.call(hash, "default", nil());
         }
 
         @Specialization(guards = "!hash.empty()", limit = "hashStrategyLimit()")

--- a/src/main/java/org/truffleruby/core/hash/RubyHash.java
+++ b/src/main/java/org/truffleruby/core/hash/RubyHash.java
@@ -60,8 +60,8 @@ public class RubyHash extends RubyDynamicObject implements ObjectGraphNode {
         super(rubyClass, shape);
         this.store = store;
         this.size = size;
-        this.defaultBlock = Nil.INSTANCE;
-        this.defaultValue = Nil.INSTANCE;
+        this.defaultBlock = Nil.get();
+        this.defaultValue = Nil.get();
         this.compareByIdentity = false;
         this.ruby2_keywords = ruby2_keywords;
 

--- a/src/main/java/org/truffleruby/core/hash/RubyHash.java
+++ b/src/main/java/org/truffleruby/core/hash/RubyHash.java
@@ -61,7 +61,7 @@ public class RubyHash extends RubyDynamicObject implements ObjectGraphNode {
         this.store = store;
         this.size = size;
         this.defaultBlock = Nil.get();
-        this.defaultValue = Nil.get();
+        this.defaultValue = null;
         this.compareByIdentity = false;
         this.ruby2_keywords = ruby2_keywords;
 

--- a/src/main/java/org/truffleruby/core/inlined/InlinedOperationNode.java
+++ b/src/main/java/org/truffleruby/core/inlined/InlinedOperationNode.java
@@ -28,7 +28,7 @@ public abstract class InlinedOperationNode extends InlinedReplaceableNode {
     }
 
     protected Object rewriteAndCall(VirtualFrame frame, Object receiver, Object... arguments) {
-        return rewriteAndCallWithBlock(frame, receiver, nil, arguments);
+        return rewriteAndCallWithBlock(frame, receiver, nil(), arguments);
     }
 
     protected Object rewriteAndCallWithBlock(VirtualFrame frame, Object receiver, Object block,

--- a/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
+++ b/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
@@ -267,7 +267,7 @@ public abstract class KernelNodes {
             final String expandedPath = getContext().getFeatureLoader().findFeature(featureString);
             if (expandedPath == null) {
                 notFoundProfile.enter();
-                return nil;
+                return nil();
             }
             return makeStringNode
                     .executeMake(expandedPath, Encodings.UTF_8, CodeRange.CR_UNKNOWN);
@@ -343,7 +343,7 @@ public abstract class KernelNodes {
             if (sameOrEqualNode.executeSameOrEqual(self, other)) {
                 return 0;
             } else {
-                return nil;
+                return nil();
             }
         }
 
@@ -371,7 +371,7 @@ public abstract class KernelNodes {
                 @Cached ConditionProfile blockProfile) {
             needCallerFrame(callerFrame, target);
             return blockProfile
-                    .profile(readNode.execute(callerFrame, TranslatorEnvironment.METHOD_BLOCK_NAME, nil) != nil);
+                    .profile(readNode.execute(callerFrame, TranslatorEnvironment.METHOD_BLOCK_NAME, nil()) != nil());
         }
     }
 
@@ -721,7 +721,7 @@ public abstract class KernelNodes {
 
             final RubyBinding binding;
             final Object self;
-            if (hasBindingArgument.profile(args.length > 1 && args[1] != nil)) {
+            if (hasBindingArgument.profile(args.length > 1 && args[1] != nil())) {
                 final Object bindingArg = args[1];
                 if (!(bindingArg instanceof RubyBinding)) {
                     errorProfile.enter();
@@ -740,10 +740,10 @@ public abstract class KernelNodes {
             final Object file;
             final int line;
 
-            if (fileAndLineProfile.profile(args.length > 3 && args[3] != nil)) {
+            if (fileAndLineProfile.profile(args.length > 3 && args[3] != nil())) {
                 line = toIntNode.execute(args[3]);
                 file = toStrNode.execute(args[2]);
-            } else if (fileNoLineProfile.profile(args.length > 2 && args[2] != nil)) {
+            } else if (fileNoLineProfile.profile(args.length > 2 && args[2] != nil())) {
                 file = toStrNode.execute(args[2]);
                 line = 1;
             } else {
@@ -1053,7 +1053,7 @@ public abstract class KernelNodes {
                 @Cached NameToJavaStringNode nameToJavaStringNode) {
             final String nameString = nameToJavaStringNode.execute(name);
             checkIVarNameNode.execute(object, nameString, name);
-            return objectLibrary.getOrDefault(object, nameString, nil);
+            return objectLibrary.getOrDefault(object, nameString, nil());
         }
 
         @Fallback
@@ -1062,7 +1062,7 @@ public abstract class KernelNodes {
                 @Cached NameToJavaStringNode nameToJavaStringNode) {
             final String nameString = nameToJavaStringNode.execute(name);
             checkIVarNameNode.execute(object, nameString, name);
-            return nil;
+            return nil();
         }
     }
 
@@ -1117,7 +1117,7 @@ public abstract class KernelNodes {
 
         @TruffleBoundary
         private Object removeIVar(RubyDynamicObject object, String name) {
-            final Object value = DynamicObjectLibrary.getUncached().getOrDefault(object, name, nil);
+            final Object value = DynamicObjectLibrary.getUncached().getOrDefault(object, name, nil());
 
             if (SharedObjects.isShared(object)) {
                 synchronized (object) {
@@ -1500,7 +1500,7 @@ public abstract class KernelNodes {
         @Specialization
         protected Object setTraceFunc(Nil traceFunc) {
             getContext().getTraceManager().setTraceFunc(null);
-            return nil;
+            return nil();
         }
 
         @Specialization

--- a/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
+++ b/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
@@ -371,7 +371,7 @@ public abstract class KernelNodes {
                 @Cached ConditionProfile blockProfile) {
             needCallerFrame(callerFrame, target);
             return blockProfile
-                    .profile(readNode.execute(callerFrame, TranslatorEnvironment.METHOD_BLOCK_NAME, nil()) != nil());
+                    .profile(Nil.isNot(readNode.execute(callerFrame, TranslatorEnvironment.METHOD_BLOCK_NAME, nil())));
         }
     }
 
@@ -562,7 +562,7 @@ public abstract class KernelNodes {
                 newObjectMetaClass.fields.initCopy(selfMetaClass);
             }
 
-            final boolean copyFrozen = freeze instanceof Nil;
+            final boolean copyFrozen = Nil.is(freeze);
 
             if (copyFrozen) {
                 initializeCloneNode.call(newObject, "initialize_clone", object);
@@ -721,7 +721,7 @@ public abstract class KernelNodes {
 
             final RubyBinding binding;
             final Object self;
-            if (hasBindingArgument.profile(args.length > 1 && args[1] != nil())) {
+            if (hasBindingArgument.profile(args.length > 1 && Nil.isNot(args[1]))) {
                 final Object bindingArg = args[1];
                 if (!(bindingArg instanceof RubyBinding)) {
                     errorProfile.enter();
@@ -740,10 +740,10 @@ public abstract class KernelNodes {
             final Object file;
             final int line;
 
-            if (fileAndLineProfile.profile(args.length > 3 && args[3] != nil())) {
+            if (fileAndLineProfile.profile(args.length > 3 && Nil.isNot(args[3]))) {
                 line = toIntNode.execute(args[3]);
                 file = toStrNode.execute(args[2]);
-            } else if (fileNoLineProfile.profile(args.length > 2 && args[2] != nil())) {
+            } else if (fileNoLineProfile.profile(args.length > 2 && Nil.isNot(args[2]))) {
                 file = toStrNode.execute(args[2]);
                 line = 1;
             } else {

--- a/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
+++ b/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
@@ -940,7 +940,16 @@ public abstract class KernelNodes {
 
         // Default hash for Kernel#hash, can be overwritten by defining a #hash method
 
-        @Specialization(guards = { "!isRubyBignum(value)", "!isImmutableRubyString(value)", "!isRubySymbol(value)" })
+        @Specialization
+        protected int hashNil(Nil value) {
+            return System.identityHashCode(Nil.class);
+        }
+
+        @Specialization(guards = {
+                "!isRubyBignum(value)",
+                "!isImmutableRubyString(value)",
+                "!isRubySymbol(value)",
+                "!isNil(value)" })
         protected int hashImmutableRubyObject(ImmutableRubyObject value) {
             return System.identityHashCode(value);
         }

--- a/src/main/java/org/truffleruby/core/kernel/TraceManager.java
+++ b/src/main/java/org/truffleruby/core/kernel/TraceManager.java
@@ -158,13 +158,13 @@ public class TraceManager {
                         event,
                         getFile(),
                         getLine(),
-                        Nil.INSTANCE,
+                        Nil.get(),
                         BindingNodes.createBinding(
                                 context,
                                 language,
                                 frame.materialize(),
                                 eventContext.getInstrumentedSourceSection()),
-                        Nil.INSTANCE);
+                        Nil.get());
             } finally {
                 isInTraceFunc = false;
             }

--- a/src/main/java/org/truffleruby/core/kernel/TruffleKernelNodes.java
+++ b/src/main/java/org/truffleruby/core/kernel/TruffleKernelNodes.java
@@ -221,7 +221,7 @@ public abstract class TruffleKernelNodes {
             Object variables;
             if (declarationFrameDepth == 0) {
                 variables = SpecialVariableStorage.get(frame);
-                if (variables == nil()) {
+                if (Nil.is(variables)) {
                     CompilerDirectives.transferToInterpreterAndInvalidate();
                     variables = new SpecialVariableStorage();
                     SpecialVariableStorage.set(frame, (SpecialVariableStorage) variables);
@@ -247,7 +247,7 @@ public abstract class TruffleKernelNodes {
                 }
 
                 variables = SpecialVariableStorage.get(storageFrame);
-                if (variables == nil()) {
+                if (Nil.is(variables)) {
                     CompilerDirectives.transferToInterpreterAndInvalidate();
                     variables = new SpecialVariableStorage();
                     SpecialVariableStorage.set(storageFrame, (SpecialVariableStorage) variables);
@@ -266,7 +266,7 @@ public abstract class TruffleKernelNodes {
         public static SpecialVariableStorage getSlow(MaterializedFrame aFrame) {
             MaterializedFrame frame = FindDeclarationVariableNodes.getOuterDeclarationFrame(aFrame);
             Object variables = SpecialVariableStorage.get(frame);
-            if (variables == Nil.get()) {
+            if (Nil.is(variables)) {
                 variables = new SpecialVariableStorage();
                 SpecialVariableStorage.set(frame, (SpecialVariableStorage) variables);
                 SpecialVariableStorage.getAssumption(frame.getFrameDescriptor()).invalidate();

--- a/src/main/java/org/truffleruby/core/kernel/TruffleKernelNodes.java
+++ b/src/main/java/org/truffleruby/core/kernel/TruffleKernelNodes.java
@@ -80,7 +80,7 @@ public abstract class TruffleKernelNodes {
         @Specialization
         protected Object atExit(boolean always, RubyProc block) {
             getContext().getAtExitManager().add(block, always);
-            return nil;
+            return nil();
         }
     }
 
@@ -191,7 +191,7 @@ public abstract class TruffleKernelNodes {
                     setter,
                     isDefined,
                     this);
-            return nil;
+            return nil();
         }
 
     }
@@ -221,7 +221,7 @@ public abstract class TruffleKernelNodes {
             Object variables;
             if (declarationFrameDepth == 0) {
                 variables = SpecialVariableStorage.get(frame);
-                if (variables == nil) {
+                if (variables == nil()) {
                     CompilerDirectives.transferToInterpreterAndInvalidate();
                     variables = new SpecialVariableStorage();
                     SpecialVariableStorage.set(frame, (SpecialVariableStorage) variables);
@@ -247,7 +247,7 @@ public abstract class TruffleKernelNodes {
                 }
 
                 variables = SpecialVariableStorage.get(storageFrame);
-                if (variables == nil) {
+                if (variables == nil()) {
                     CompilerDirectives.transferToInterpreterAndInvalidate();
                     variables = new SpecialVariableStorage();
                     SpecialVariableStorage.set(storageFrame, (SpecialVariableStorage) variables);
@@ -266,7 +266,7 @@ public abstract class TruffleKernelNodes {
         public static SpecialVariableStorage getSlow(MaterializedFrame aFrame) {
             MaterializedFrame frame = FindDeclarationVariableNodes.getOuterDeclarationFrame(aFrame);
             Object variables = SpecialVariableStorage.get(frame);
-            if (variables == Nil.INSTANCE) {
+            if (variables == Nil.get()) {
                 variables = new SpecialVariableStorage();
                 SpecialVariableStorage.set(frame, (SpecialVariableStorage) variables);
                 SpecialVariableStorage.getAssumption(frame.getFrameDescriptor()).invalidate();
@@ -312,7 +312,7 @@ public abstract class TruffleKernelNodes {
                 @Cached ConditionProfile nullProfile) {
             Object variables = callerVariablesNode.execute(frame);
             if (nullProfile.profile(variables == null)) {
-                return nil;
+                return nil();
             } else {
                 return variables;
             }
@@ -334,7 +334,7 @@ public abstract class TruffleKernelNodes {
                     .getOriginalRequires()
                     .get(strings.getJavaString(string));
             if (originalRequire == null) {
-                return Nil.INSTANCE;
+                return Nil.get();
             } else {
                 return makeStringNode.executeMake(originalRequire, Encodings.UTF_8, CodeRange.CR_UNKNOWN);
             }
@@ -360,7 +360,7 @@ public abstract class TruffleKernelNodes {
                 @Cached("declarationDepth(frame)") int declarationFrameDepth) {
             final Frame storageFrame = RubyArguments.getDeclarationFrame(frame, declarationFrameDepth);
             SpecialVariableStorage.set(storageFrame, storage);
-            return nil;
+            return nil();
         }
 
         @Specialization(replaces = "shareSpecialVariable")
@@ -373,7 +373,7 @@ public abstract class TruffleKernelNodes {
             MaterializedFrame frame = FindDeclarationVariableNodes.getOuterDeclarationFrame(aFrame);
             SpecialVariableStorage.set(frame, storage);
             // TODO: should invalidate here?
-            return nil;
+            return nil();
         }
 
         public static GetSpecialVariableStorage create() {

--- a/src/main/java/org/truffleruby/core/klass/ClassNodes.java
+++ b/src/main/java/org/truffleruby/core/klass/ClassNodes.java
@@ -23,6 +23,7 @@ import org.truffleruby.builtins.UnaryCoreMethodNode;
 import org.truffleruby.core.CoreLibrary;
 import org.truffleruby.core.inlined.AlwaysInlinedMethodNode;
 import org.truffleruby.core.module.RubyModule;
+import org.truffleruby.language.Nil;
 import org.truffleruby.language.RubyDynamicObject;
 import org.truffleruby.language.Visibility;
 import org.truffleruby.language.arguments.RubyArguments;
@@ -38,8 +39,6 @@ import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.profiles.BranchProfile;
 import com.oracle.truffle.api.source.SourceSection;
-
-import static org.truffleruby.language.RubyBaseNode.nil;
 
 @CoreModule(value = "Class", isClass = true)
 public abstract class ClassNodes {
@@ -168,7 +167,7 @@ public abstract class ClassNodes {
     private static RubyClass createSingletonClass(RubyContext context, RubyClass rubyClass) {
         final RubyClass singletonSuperclass;
         final Object superclass = rubyClass.superclass;
-        if (superclass == nil) {
+        if (superclass == Nil.get()) {
             singletonSuperclass = rubyClass.getLogicalClass();
         } else {
             singletonSuperclass = getLazyCreatedSingletonClass(context, (RubyClass) superclass);
@@ -298,7 +297,7 @@ public abstract class ClassNodes {
     public abstract static class InheritedNode extends CoreMethodArrayArgumentsNode {
         @Specialization
         protected Object inherited(Object subclass) {
-            return nil;
+            return nil();
         }
     }
 

--- a/src/main/java/org/truffleruby/core/klass/ClassNodes.java
+++ b/src/main/java/org/truffleruby/core/klass/ClassNodes.java
@@ -167,7 +167,7 @@ public abstract class ClassNodes {
     private static RubyClass createSingletonClass(RubyContext context, RubyClass rubyClass) {
         final RubyClass singletonSuperclass;
         final Object superclass = rubyClass.superclass;
-        if (superclass == Nil.get()) {
+        if (Nil.is(superclass)) {
             singletonSuperclass = rubyClass.getLogicalClass();
         } else {
             singletonSuperclass = getLazyCreatedSingletonClass(context, (RubyClass) superclass);

--- a/src/main/java/org/truffleruby/core/klass/RubyClass.java
+++ b/src/main/java/org/truffleruby/core/klass/RubyClass.java
@@ -16,13 +16,12 @@ import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.source.SourceSection;
 import org.truffleruby.RubyLanguage;
 import org.truffleruby.core.module.RubyModule;
+import org.truffleruby.language.Nil;
 import org.truffleruby.language.RubyDynamicObject;
 import org.truffleruby.language.objects.ObjectGraph;
 import org.truffleruby.language.objects.ObjectGraphNode;
 
 import com.oracle.truffle.api.object.Shape;
-
-import static org.truffleruby.language.RubyBaseNode.nil;
 
 public final class RubyClass extends RubyModule implements ObjectGraphNode {
 
@@ -63,7 +62,7 @@ public final class RubyClass extends RubyModule implements ObjectGraphNode {
             this.depth = ((RubyClass) superclass).depth + 1;
             fields.setSuperClass((RubyClass) superclass);
         } else { // BasicObject (nil superclass)
-            assert superclass == nil;
+            assert superclass == Nil.get();
             this.superclass = superclass;
             this.ancestorClasses = EMPTY_CLASS_ARRAY;
             this.depth = 0;
@@ -80,7 +79,7 @@ public final class RubyClass extends RubyModule implements ObjectGraphNode {
         this.attached = null;
         this.nonSingletonClass = this;
 
-        RubyClass basicObjectClass = ClassNodes.createBootClass(language, this, nil, "BasicObject");
+        RubyClass basicObjectClass = ClassNodes.createBootClass(language, this, Nil.get(), "BasicObject");
         RubyClass objectClass = ClassNodes.createBootClass(language, this, basicObjectClass, "Object");
         RubyClass moduleClass = ClassNodes.createBootClass(language, this, objectClass, "Module");
 

--- a/src/main/java/org/truffleruby/core/klass/RubyClass.java
+++ b/src/main/java/org/truffleruby/core/klass/RubyClass.java
@@ -62,7 +62,7 @@ public final class RubyClass extends RubyModule implements ObjectGraphNode {
             this.depth = ((RubyClass) superclass).depth + 1;
             fields.setSuperClass((RubyClass) superclass);
         } else { // BasicObject (nil superclass)
-            assert superclass == Nil.get();
+            assert Nil.is(superclass);
             this.superclass = superclass;
             this.ancestorClasses = EMPTY_CLASS_ARRAY;
             this.depth = 0;

--- a/src/main/java/org/truffleruby/core/method/MethodNodes.java
+++ b/src/main/java/org/truffleruby/core/method/MethodNodes.java
@@ -220,7 +220,7 @@ public abstract class MethodNodes {
             SourceSection sourceSection = method.method.getSharedMethodInfo().getSourceSection();
 
             if (!sourceSection.isAvailable()) {
-                return nil;
+                return nil();
             } else {
                 RubyString file = makeStringNode.executeMake(
                         getLanguage().getSourcePath(sourceSection.getSource()),
@@ -244,7 +244,7 @@ public abstract class MethodNodes {
             RubyClass selfMetaClass = metaClassNode.execute(receiver);
             MethodLookupResult superMethod = ModuleOperations.lookupSuperMethod(internalMethod, selfMetaClass);
             if (!superMethod.isDefined()) {
-                return nil;
+                return nil();
             } else {
                 final RubyMethod instance = new RubyMethod(
                         coreLibrary().methodClass,
@@ -308,7 +308,8 @@ public abstract class MethodNodes {
 
         private RubyProc createProc(RootCallTarget callTarget, InternalMethod method, Object receiver) {
             final Object[] packedArgs = RubyArguments
-                    .pack(null, null, method, null, receiver, nil, EmptyArgumentsDescriptor.INSTANCE, EMPTY_ARGUMENTS);
+                    .pack(null, null, method, null, receiver, nil(), EmptyArgumentsDescriptor.INSTANCE,
+                            EMPTY_ARGUMENTS);
             final var variables = new SpecialVariableStorage();
             final MaterializedFrame declarationFrame = getLanguage().createEmptyDeclarationFrame(packedArgs, variables);
             return ProcOperations.createRubyProc(
@@ -371,13 +372,13 @@ public abstract class MethodNodes {
         @Specialization
         protected Object bound(RubyMethod rubyMethod) {
             unimplement(rubyMethod.method);
-            return nil;
+            return nil();
         }
 
         @Specialization
         protected Object unbound(RubyUnboundMethod rubyMethod) {
             unimplement(rubyMethod.method);
-            return nil;
+            return nil();
         }
 
         @TruffleBoundary

--- a/src/main/java/org/truffleruby/core/method/RubyMethod.java
+++ b/src/main/java/org/truffleruby/core/method/RubyMethod.java
@@ -13,6 +13,7 @@ import java.util.Set;
 
 import org.truffleruby.core.klass.RubyClass;
 import org.truffleruby.interop.ForeignToRubyArgumentsNode;
+import org.truffleruby.language.Nil;
 import org.truffleruby.language.RubyDynamicObject;
 import org.truffleruby.language.arguments.EmptyArgumentsDescriptor;
 import org.truffleruby.language.arguments.RubyArguments;
@@ -27,8 +28,6 @@ import com.oracle.truffle.api.library.ExportLibrary;
 import com.oracle.truffle.api.library.ExportMessage;
 import com.oracle.truffle.api.object.Shape;
 import com.oracle.truffle.api.source.SourceSection;
-
-import static org.truffleruby.language.RubyBaseNode.nil;
 
 @ExportLibrary(InteropLibrary.class)
 public class RubyMethod extends RubyDynamicObject implements ObjectGraphNode {
@@ -71,7 +70,7 @@ public class RubyMethod extends RubyDynamicObject implements ObjectGraphNode {
             @Cached ForeignToRubyArgumentsNode foreignToRubyArgumentsNode,
             @Cached CallInternalMethodNode callInternalMethodNode) {
         final Object[] convertedArguments = foreignToRubyArgumentsNode.executeConvert(arguments);
-        final Object[] frameArgs = RubyArguments.pack(null, null, method, null, receiver, nil,
+        final Object[] frameArgs = RubyArguments.pack(null, null, method, null, receiver, Nil.get(),
                 EmptyArgumentsDescriptor.INSTANCE, convertedArguments);
         return callInternalMethodNode.execute(null, method, receiver, frameArgs, null);
     }

--- a/src/main/java/org/truffleruby/core/method/UnboundMethodNodes.java
+++ b/src/main/java/org/truffleruby/core/method/UnboundMethodNodes.java
@@ -28,6 +28,7 @@ import org.truffleruby.core.rope.CodeRange;
 import org.truffleruby.core.string.RubyString;
 import org.truffleruby.core.string.StringNodes;
 import org.truffleruby.core.symbol.RubySymbol;
+import org.truffleruby.language.Nil;
 import org.truffleruby.language.RubyGuards;
 import org.truffleruby.language.Visibility;
 import org.truffleruby.language.arguments.ArgumentDescriptorUtils;
@@ -236,7 +237,7 @@ public abstract class UnboundMethodNodes {
         public static Object ruby2Keywords(SharedMethodInfo sharedMethodInfo, RootCallTarget callTarget) {
             final Arity arity = sharedMethodInfo.getArity();
             if (!arity.hasRest() || arity.acceptsKeywords()) {
-                return nil();
+                return Nil.get();
             }
 
             ReadRestArgumentNode readRestArgumentNode = NodeUtil.findFirstNodeInstance(callTarget.getRootNode(),

--- a/src/main/java/org/truffleruby/core/method/UnboundMethodNodes.java
+++ b/src/main/java/org/truffleruby/core/method/UnboundMethodNodes.java
@@ -188,7 +188,7 @@ public abstract class UnboundMethodNodes {
                     .getSourceSection();
 
             if (!sourceSection.isAvailable()) {
-                return nil;
+                return nil();
             } else {
                 RubyString file = makeStringNode.executeMake(
                         getLanguage().getSourcePath(sourceSection.getSource()),
@@ -210,7 +210,7 @@ public abstract class UnboundMethodNodes {
             RubyModule origin = unboundMethod.origin;
             MethodLookupResult superMethod = ModuleOperations.lookupSuperMethod(internalMethod, origin);
             if (!superMethod.isDefined()) {
-                return nil;
+                return nil();
             } else {
                 final RubyUnboundMethod instance = new RubyUnboundMethod(
                         coreLibrary().unboundMethodClass,
@@ -236,7 +236,7 @@ public abstract class UnboundMethodNodes {
         public static Object ruby2Keywords(SharedMethodInfo sharedMethodInfo, RootCallTarget callTarget) {
             final Arity arity = sharedMethodInfo.getArity();
             if (!arity.hasRest() || arity.acceptsKeywords()) {
-                return nil;
+                return nil();
             }
 
             ReadRestArgumentNode readRestArgumentNode = NodeUtil.findFirstNodeInstance(callTarget.getRootNode(),

--- a/src/main/java/org/truffleruby/core/module/ModuleFields.java
+++ b/src/main/java/org/truffleruby/core/module/ModuleFields.java
@@ -734,7 +734,7 @@ public final class ModuleFields extends ModuleChain implements ObjectGraphNode {
             assert rubyStringName != null;
             return rubyStringName;
         } else {
-            return Nil.INSTANCE;
+            return Nil.get();
         }
     }
 

--- a/src/main/java/org/truffleruby/core/module/ModuleNodes.java
+++ b/src/main/java/org/truffleruby/core/module/ModuleNodes.java
@@ -314,7 +314,7 @@ public abstract class ModuleNodes {
 
             final Object isSubclass = isSubclass(self, other);
 
-            if (isSubclass == nil()) {
+            if (Nil.is(isSubclass)) {
                 return nil();
             } else {
                 return (boolean) isSubclass ? -1 : 1;

--- a/src/main/java/org/truffleruby/core/module/ModuleNodes.java
+++ b/src/main/java/org/truffleruby/core/module/ModuleNodes.java
@@ -201,7 +201,7 @@ public abstract class ModuleNodes {
                 return false;
             }
 
-            return nil;
+            return nil();
         }
 
         @Specialization(guards = "!isRubyModule(other)")
@@ -227,7 +227,7 @@ public abstract class ModuleNodes {
                 return false;
             }
 
-            return nil;
+            return nil();
         }
 
         @Specialization(guards = "!isRubyModule(other)")
@@ -257,7 +257,7 @@ public abstract class ModuleNodes {
                 return false;
             }
 
-            return nil;
+            return nil();
         }
 
         @Specialization(guards = "!isRubyModule(other)")
@@ -283,7 +283,7 @@ public abstract class ModuleNodes {
                 return false;
             }
 
-            return nil;
+            return nil();
         }
 
         @Specialization(guards = "!isRubyModule(other)")
@@ -314,8 +314,8 @@ public abstract class ModuleNodes {
 
             final Object isSubclass = isSubclass(self, other);
 
-            if (isSubclass == nil) {
-                return nil;
+            if (isSubclass == nil()) {
+                return nil();
             } else {
                 return (boolean) isSubclass ? -1 : 1;
             }
@@ -323,7 +323,7 @@ public abstract class ModuleNodes {
 
         @Specialization(guards = "!isRubyModule(other)")
         protected Object compareOther(RubyModule self, Object other) {
-            return nil;
+            return nil();
         }
 
     }
@@ -393,7 +393,7 @@ public abstract class ModuleNodes {
                         coreExceptions().typeError("append_features must be called only on modules", this));
             }
             target.fields.include(getContext(), this, features);
-            return nil;
+            return nil();
         }
     }
 
@@ -407,12 +407,12 @@ public abstract class ModuleNodes {
             final String ivarName = RubyRootNode.of(target).getSharedMethodInfo().getNotes();
             CompilerAsserts.partialEvaluationConstant(ivarName);
 
-            return objectLibrary.getOrDefault(self, ivarName, nil);
+            return objectLibrary.getOrDefault(self, ivarName, nil());
         }
 
         @Specialization(guards = "!isRubyDynamicObject(self)")
         protected Object notObject(Frame callerFrame, Object self, Object[] rubyArgs, RootCallTarget target) {
-            return nil;
+            return nil();
         }
     }
 
@@ -523,7 +523,7 @@ public abstract class ModuleNodes {
                     null,
                     callTarget,
                     null,
-                    nil);
+                    nil());
 
             module.fields.addMethod(getContext(), this, method);
             return getLanguage().getSymbol(method.getName());
@@ -624,7 +624,7 @@ public abstract class ModuleNodes {
 
             final String javaStringFilename = libFilename.getJavaString(filename);
             module.fields.setAutoloadConstant(getContext(), this, name, filename, javaStringFilename);
-            return nil;
+            return nil();
         }
     }
 
@@ -659,7 +659,7 @@ public abstract class ModuleNodes {
             if (constant.isAutoload() && !constant.getConstant().getAutoloadConstant().isAutoloadingThread()) {
                 return constant.getConstant().getAutoloadConstant().getFeature();
             } else {
-                return nil;
+                return nil();
             }
         }
     }
@@ -810,7 +810,7 @@ public abstract class ModuleNodes {
                     new FixedDefaultDefinee(self),
                     block.declarationContext.getRefinements());
 
-            return callBlockNode.executeCallBlock(declarationContext, block, self, nil, descriptor, args, null);
+            return callBlockNode.executeCallBlock(declarationContext, block, self, nil(), descriptor, args, null);
         }
     }
 
@@ -1150,7 +1150,7 @@ public abstract class ModuleNodes {
 
         private Object getLocation(ConstantLookupResult lookupResult) {
             if (!lookupResult.isFound()) {
-                return nil;
+                return nil();
             }
 
             final SourceSection sourceSection = lookupResult.getConstant().getSourceSection();
@@ -1267,7 +1267,7 @@ public abstract class ModuleNodes {
         @Specialization
         protected RubySymbol defineMethodBlock(
                 VirtualFrame frame, RubyModule module, String name, NotProvided proc, RubyProc block) {
-            return defineMethodProc(frame, module, name, block, nil);
+            return defineMethodProc(frame, module, name, block, nil());
         }
 
         @Specialization
@@ -1423,7 +1423,7 @@ public abstract class ModuleNodes {
 
         @Specialization
         protected Object extended(RubyModule module, Object object) {
-            return nil;
+            return nil();
         }
 
     }
@@ -1470,7 +1470,7 @@ public abstract class ModuleNodes {
             final RubyClass fromMetaClass = getSingletonClass(from);
             selfMetaClass.fields.initCopy(fromMetaClass);
 
-            return nil;
+            return nil();
         }
 
         @Specialization
@@ -1494,7 +1494,7 @@ public abstract class ModuleNodes {
 
             selfMetaClass.fields.initCopy(fromMetaClass); // copy class methods
 
-            return nil;
+            return nil();
         }
 
         protected RubyClass getSingletonClass(RubyModule object) {
@@ -1513,7 +1513,7 @@ public abstract class ModuleNodes {
 
         @Specialization
         protected Object included(Object subclass) {
-            return nil;
+            return nil();
         }
 
     }
@@ -1731,7 +1731,7 @@ public abstract class ModuleNodes {
                         coreExceptions().typeError("prepend_features must be called only on modules", this));
             }
             target.fields.prepend(getContext(), this, features);
-            return nil;
+            return nil();
         }
     }
 
@@ -2064,7 +2064,7 @@ public abstract class ModuleNodes {
                         coreExceptions().nameErrorConstantNotDefined(module, name, this));
             } else {
                 if (oldConstant.isAutoload() || oldConstant.isUndefined()) {
-                    return nil;
+                    return nil();
                 } else {
                     return oldConstant.getValue();
                 }
@@ -2289,7 +2289,7 @@ public abstract class ModuleNodes {
                     declarationContext,
                     block,
                     refinement,
-                    nil,
+                    nil(),
                     EmptyArgumentsDescriptor.INSTANCE,
                     EMPTY_ARGUMENTS,
                     null);

--- a/src/main/java/org/truffleruby/core/monitor/TruffleMonitorNodes.java
+++ b/src/main/java/org/truffleruby/core/monitor/TruffleMonitorNodes.java
@@ -70,7 +70,7 @@ public abstract class TruffleMonitorNodes {
         protected Object enter(RubyMutex mutex) {
             final RubyThread thread = getLanguage().getCurrentThread();
             MutexOperations.lock(getContext(), mutex.lock, thread, this);
-            return nil;
+            return nil();
         }
     }
 

--- a/src/main/java/org/truffleruby/core/numeric/FloatNodes.java
+++ b/src/main/java/org/truffleruby/core/numeric/FloatNodes.java
@@ -394,12 +394,12 @@ public abstract class FloatNodes {
 
         @Specialization(guards = "isNaN(a)")
         protected Object compareFirstNaN(double a, Object b) {
-            return nil;
+            return nil();
         }
 
         @Specialization(guards = "isNaN(b)")
         protected Object compareSecondNaN(Object a, double b) {
-            return nil;
+            return nil();
         }
 
         @Specialization(guards = { "!isNaN(a)", "!isNaN(b)" })
@@ -512,7 +512,7 @@ public abstract class FloatNodes {
                     return 1;
                 }
             } else {
-                return nil;
+                return nil();
             }
         }
 

--- a/src/main/java/org/truffleruby/core/numeric/IntegerNodes.java
+++ b/src/main/java/org/truffleruby/core/numeric/IntegerNodes.java
@@ -1938,7 +1938,7 @@ public abstract class IntegerNodes {
                 profileAndReportLoopCount(loopProfile, from - i + 1);
             }
 
-            return nil;
+            return nil();
         }
 
         @Specialization
@@ -1957,7 +1957,7 @@ public abstract class IntegerNodes {
                 profileAndReportLoopCount(loopProfile, from - i + 1);
             }
 
-            return nil;
+            return nil();
         }
 
         @Specialization
@@ -2014,7 +2014,7 @@ public abstract class IntegerNodes {
                 profileAndReportLoopCount(loopProfile, i - from + 1);
             }
 
-            return nil;
+            return nil();
         }
 
         @Specialization
@@ -2033,7 +2033,7 @@ public abstract class IntegerNodes {
                 profileAndReportLoopCount(loopProfile, i - from + 1);
             }
 
-            return nil;
+            return nil();
         }
 
         @Specialization

--- a/src/main/java/org/truffleruby/core/objectspace/ObjectSpaceNodes.java
+++ b/src/main/java/org/truffleruby/core/objectspace/ObjectSpaceNodes.java
@@ -57,7 +57,7 @@ public abstract class ObjectSpaceNodes {
 
         @Specialization(guards = "id == NIL")
         protected Object id2RefNil(long id) {
-            return nil;
+            return nil();
         }
 
         @Specialization(guards = "id == TRUE")
@@ -279,7 +279,7 @@ public abstract class ObjectSpaceNodes {
 
             objectLibrary.put(object, Layouts.DATA_OBJECT_FINALIZER_REF_IDENTIFIER, newRef);
 
-            return nil;
+            return nil();
         }
 
 

--- a/src/main/java/org/truffleruby/core/objectspace/WeakMapNodes.java
+++ b/src/main/java/org/truffleruby/core/objectspace/WeakMapNodes.java
@@ -71,7 +71,7 @@ public abstract class WeakMapNodes {
         @Specialization
         protected Object get(RubyWeakMap map, Object key) {
             Object value = map.storage.get(new CompareByRubyIdentityWrapper(key));
-            return value == null ? nil : value;
+            return value == null ? nil() : value;
         }
     }
 

--- a/src/main/java/org/truffleruby/core/proc/ProcNodes.java
+++ b/src/main/java/org/truffleruby/core/proc/ProcNodes.java
@@ -85,7 +85,7 @@ public abstract class ProcNodes {
 
             Object parentBlock = readNode.execute(parentFrame, TranslatorEnvironment.METHOD_BLOCK_NAME, nil());
 
-            if (parentBlock == nil()) {
+            if (Nil.is(parentBlock)) {
                 throw new RaiseException(getContext(), coreExceptions().argumentErrorProcWithoutBlock(this));
             } else {
                 if (warnNode.shouldWarnForDeprecation()) {

--- a/src/main/java/org/truffleruby/core/proc/ProcNodes.java
+++ b/src/main/java/org/truffleruby/core/proc/ProcNodes.java
@@ -83,9 +83,9 @@ public abstract class ProcNodes {
                 @Cached("new()") WarnNode warnNode) {
             final MaterializedFrame parentFrame = readCaller.execute(frame);
 
-            Object parentBlock = readNode.execute(parentFrame, TranslatorEnvironment.METHOD_BLOCK_NAME, nil);
+            Object parentBlock = readNode.execute(parentFrame, TranslatorEnvironment.METHOD_BLOCK_NAME, nil());
 
-            if (parentBlock == nil) {
+            if (parentBlock == nil()) {
                 throw new RaiseException(getContext(), coreExceptions().argumentErrorProcWithoutBlock(this));
             } else {
                 if (warnNode.shouldWarnForDeprecation()) {
@@ -266,7 +266,7 @@ public abstract class ProcNodes {
 
             final String sourcePath = getLanguage().getSourcePath(sourceSection.getSource());
             if (!sourceSection.isAvailable() || sourcePath.endsWith("/lib/truffle/truffle/cext.rb")) {
-                return nil;
+                return nil();
             } else {
                 final RubyString file = makeStringNode.executeMake(
                         sourcePath,
@@ -324,7 +324,7 @@ public abstract class ProcNodes {
             if (proc.arity == SymbolNodes.ToProcNode.ARITY) {
                 return getSymbol(proc.getSharedMethodInfo().getBacktraceName());
             } else {
-                return nil;
+                return nil();
             }
         }
 
@@ -347,7 +347,7 @@ public abstract class ProcNodes {
             int userArgumentCount = RubyArguments.getPositionalArgumentsCount(frame, false);
 
             if (emptyArgsProfile.profile(userArgumentCount == 0)) {
-                return nil;
+                return nil();
             } else {
                 if (singleArgProfile.profile(userArgumentCount == 1)) {
                     return RubyArguments.getArgument(frame, 0);

--- a/src/main/java/org/truffleruby/core/proc/ProcOperations.java
+++ b/src/main/java/org/truffleruby/core/proc/ProcOperations.java
@@ -14,6 +14,7 @@ import com.oracle.truffle.api.object.Shape;
 import org.truffleruby.RubyContext;
 import org.truffleruby.RubyLanguage;
 import org.truffleruby.core.klass.RubyClass;
+import org.truffleruby.language.Nil;
 import org.truffleruby.language.arguments.ArgumentsDescriptor;
 import org.truffleruby.language.arguments.RubyArguments;
 import org.truffleruby.language.control.FrameOnStackMarker;
@@ -25,8 +26,6 @@ import org.truffleruby.language.threadlocal.SpecialVariableStorage;
 import com.oracle.truffle.api.RootCallTarget;
 import com.oracle.truffle.api.frame.MaterializedFrame;
 
-import static org.truffleruby.language.RubyBaseNode.nil;
-
 public abstract class ProcOperations {
 
     private static Object[] packArguments(RubyProc proc, ArgumentsDescriptor descriptor, Object... args) {
@@ -36,7 +35,7 @@ public abstract class ProcOperations {
                 proc.method,
                 proc.frameOnStackMarker,
                 getSelf(proc),
-                nil,
+                Nil.get(),
                 descriptor,
                 args);
     }

--- a/src/main/java/org/truffleruby/core/queue/QueueNodes.java
+++ b/src/main/java/org/truffleruby/core/queue/QueueNodes.java
@@ -84,7 +84,7 @@ public abstract class QueueNodes {
 
             if (value == UnsizedQueue.CLOSED) {
                 closedProfile.enter();
-                return nil;
+                return nil();
             } else {
                 return value;
             }
@@ -147,7 +147,7 @@ public abstract class QueueNodes {
             if (result == null) {
                 return false;
             } else if (result == UnsizedQueue.CLOSED) {
-                return nil;
+                return nil();
             } else {
                 return result;
             }

--- a/src/main/java/org/truffleruby/core/queue/SizedQueueNodes.java
+++ b/src/main/java/org/truffleruby/core/queue/SizedQueueNodes.java
@@ -171,7 +171,7 @@ public abstract class SizedQueueNodes {
             final Object value = doPop(queue);
 
             if (value == SizedQueue.CLOSED) {
-                return nil;
+                return nil();
             } else {
                 return value;
             }

--- a/src/main/java/org/truffleruby/core/range/RangeNodes.java
+++ b/src/main/java/org/truffleruby/core/range/RangeNodes.java
@@ -27,6 +27,7 @@ import org.truffleruby.core.cast.BooleanCastWithDefaultNode;
 import org.truffleruby.core.cast.ToIntNode;
 import org.truffleruby.core.klass.RubyClass;
 import org.truffleruby.core.proc.RubyProc;
+import org.truffleruby.language.Nil;
 import org.truffleruby.language.RubyBaseNode;
 import org.truffleruby.language.RubyBaseNodeWithExecute;
 import org.truffleruby.language.RubyGuards;
@@ -563,7 +564,7 @@ public abstract class RangeNodes {
                 @Cached DispatchNode compare,
                 @Bind("rubyClass == getRangeClass()") boolean standardClass) {
 
-            if (compare.call(begin, "<=>", end) == nil() && end != nil() && begin != nil()) {
+            if (Nil.is(compare.call(begin, "<=>", end)) && Nil.isNot(end) && Nil.isNot(begin)) {
                 throw new RaiseException(getContext(), coreExceptions().argumentError("bad value for range", this));
             }
 

--- a/src/main/java/org/truffleruby/core/range/RangeNodes.java
+++ b/src/main/java/org/truffleruby/core/range/RangeNodes.java
@@ -563,7 +563,7 @@ public abstract class RangeNodes {
                 @Cached DispatchNode compare,
                 @Bind("rubyClass == getRangeClass()") boolean standardClass) {
 
-            if (compare.call(begin, "<=>", end) == nil && end != nil && begin != nil) {
+            if (compare.call(begin, "<=>", end) == nil() && end != nil() && begin != nil()) {
                 throw new RaiseException(getContext(), coreExceptions().argumentError("bad value for range", this));
             }
 
@@ -585,7 +585,7 @@ public abstract class RangeNodes {
         @Specialization
         protected RubyObjectRange allocate(RubyClass rubyClass) {
             final Shape shape = getLanguage().objectRangeShape;
-            final RubyObjectRange range = new RubyObjectRange(rubyClass, shape, false, nil, nil, false);
+            final RubyObjectRange range = new RubyObjectRange(rubyClass, shape, false, nil(), nil(), false);
             AllocationTracing.trace(range, this);
             return range;
         }

--- a/src/main/java/org/truffleruby/core/range/RubyObjectRange.java
+++ b/src/main/java/org/truffleruby/core/range/RubyObjectRange.java
@@ -36,19 +36,19 @@ public final class RubyObjectRange extends RubyRange implements ObjectGraphNode 
     }
 
     public boolean isBoundless() {
-        return begin == Nil.INSTANCE && end == Nil.INSTANCE;
+        return begin == Nil.get() && end == Nil.get();
     }
 
     public boolean isEndless() {
-        return begin != Nil.INSTANCE && end == Nil.INSTANCE;
+        return begin != Nil.get() && end == Nil.get();
     }
 
     public boolean isBeginless() {
-        return begin == Nil.INSTANCE && end != Nil.INSTANCE;
+        return begin == Nil.get() && end != Nil.get();
     }
 
     public boolean isBounded() {
-        return begin != Nil.INSTANCE && end != Nil.INSTANCE;
+        return begin != Nil.get() && end != Nil.get();
     }
 
     @Override

--- a/src/main/java/org/truffleruby/core/range/RubyObjectRange.java
+++ b/src/main/java/org/truffleruby/core/range/RubyObjectRange.java
@@ -36,19 +36,19 @@ public final class RubyObjectRange extends RubyRange implements ObjectGraphNode 
     }
 
     public boolean isBoundless() {
-        return begin == Nil.get() && end == Nil.get();
+        return Nil.is(begin) && Nil.is(end);
     }
 
     public boolean isEndless() {
-        return begin != Nil.get() && end == Nil.get();
+        return Nil.isNot(begin) && Nil.is(end);
     }
 
     public boolean isBeginless() {
-        return begin == Nil.get() && end != Nil.get();
+        return Nil.is(begin) && Nil.isNot(end);
     }
 
     public boolean isBounded() {
-        return begin != Nil.get() && end != Nil.get();
+        return Nil.isNot(begin) && Nil.isNot(end);
     }
 
     @Override

--- a/src/main/java/org/truffleruby/core/regexp/MatchDataNodes.java
+++ b/src/main/java/org/truffleruby/core/regexp/MatchDataNodes.java
@@ -261,7 +261,7 @@ public abstract class MatchDataNodes {
             }
 
             if (indexOutOfBoundsProfile.profile(index < 0 || index >= region.numRegs)) {
-                return nil;
+                return nil();
             } else {
                 final int start = getStart(matchData, index, lazyProfile, interop);
                 final int end = getEnd(matchData, index, lazyProfile, interop);
@@ -279,7 +279,7 @@ public abstract class MatchDataNodes {
                     AllocationTracing.trace(string, this);
                     return string;
                 } else {
-                    return nil;
+                    return nil();
                 }
             }
         }
@@ -295,7 +295,7 @@ public abstract class MatchDataNodes {
                 index += values.length;
 
                 if (indexOutOfBoundsProfile.profile(index < 0)) {
-                    return nil;
+                    return nil();
                 }
             }
 
@@ -470,7 +470,7 @@ public abstract class MatchDataNodes {
             final int begin = getStart(matchData, index, lazyProfile, interop);
 
             if (negativeBeginProfile.profile(begin < 0)) {
-                return nil;
+                return nil();
             }
 
             final Rope matchDataSourceRope = strings.getRope(matchData.source);
@@ -534,7 +534,7 @@ public abstract class MatchDataNodes {
                         AllocationTracing.trace(string, this);
                         values[n] = string;
                     } else {
-                        values[n] = nil;
+                        values[n] = nil();
                     }
 
                     TruffleSafepoint.poll(this);
@@ -562,7 +562,7 @@ public abstract class MatchDataNodes {
             final int end = getEnd(matchData, index, lazyProfile, interop);
 
             if (negativeEndProfile.profile(end < 0)) {
-                return nil;
+                return nil();
             }
 
             final Rope matchDataSourceRope = strings.getRope(matchData.source);
@@ -597,7 +597,7 @@ public abstract class MatchDataNodes {
             final int begin = getStart(matchData, index, lazyProfile, interop);
 
             if (negativeBeginProfile.profile(begin < 0)) {
-                return nil;
+                return nil();
             } else {
                 return begin;
             }
@@ -619,7 +619,7 @@ public abstract class MatchDataNodes {
             final int end = getEnd(matchData, index, lazyProfile, interop);
 
             if (negativeEndProfile.profile(end < 0)) {
-                return nil;
+                return nil();
             } else {
                 return end;
             }

--- a/src/main/java/org/truffleruby/core/regexp/TRegexCache.java
+++ b/src/main/java/org/truffleruby/core/regexp/TRegexCache.java
@@ -68,7 +68,7 @@ public final class TRegexCache {
             TRegexCompileNode node) {
         Object tregex = compileTRegex(context, regexp, atStart, encoding);
         if (tregex == null) {
-            tregex = Nil.INSTANCE;
+            tregex = Nil.get();
             if (context.getOptions().WARN_TRUFFLE_REGEX_COMPILE_FALLBACK) {
                 node.getWarnOnFallbackNode().call(
                         context.getCoreLibrary().truffleRegexpOperationsModule,

--- a/src/main/java/org/truffleruby/core/regexp/TruffleRegexpNodes.java
+++ b/src/main/java/org/truffleruby/core/regexp/TruffleRegexpNodes.java
@@ -70,6 +70,7 @@ import org.truffleruby.core.string.StringOperations;
 import org.truffleruby.core.string.StringUtils;
 import org.truffleruby.interop.TranslateInteropExceptionNode;
 import org.truffleruby.interop.TranslateInteropExceptionNodeGen;
+import org.truffleruby.language.Nil;
 import org.truffleruby.language.RubyBaseNode;
 import org.truffleruby.language.WarnNode;
 import org.truffleruby.language.control.DeferredRaiseException;
@@ -886,10 +887,10 @@ public class TruffleRegexpNodes {
 
             if (tRegexIncompatibleProfile
                     .profile(toPos < fromPos || toPos != rope.byteLength() || fromPos < 0) ||
-                    tRegexCouldNotCompileProfile.profile((tRegex = tRegexCompileNode.executeTRegexCompile(
+                    tRegexCouldNotCompileProfile.profile(Nil.is(tRegex = tRegexCompileNode.executeTRegexCompile(
                             regexp,
                             atStart,
-                            negotiatedEncoding)) == nil())) {
+                            negotiatedEncoding)))) {
                 return fallbackToJoni(
                         regexp,
                         string,

--- a/src/main/java/org/truffleruby/core/regexp/TruffleRegexpNodes.java
+++ b/src/main/java/org/truffleruby/core/regexp/TruffleRegexpNodes.java
@@ -403,7 +403,7 @@ public class TruffleRegexpNodes {
 
         @Fallback
         protected Object other(RubyRegexp regexp, boolean atStart, RubyEncoding encoding) {
-            return nil;
+            return nil();
         }
 
         DispatchNode getWarnOnFallbackNode() {
@@ -889,7 +889,7 @@ public class TruffleRegexpNodes {
                     tRegexCouldNotCompileProfile.profile((tRegex = tRegexCompileNode.executeTRegexCompile(
                             regexp,
                             atStart,
-                            negotiatedEncoding)) == nil)) {
+                            negotiatedEncoding)) == nil())) {
                 return fallbackToJoni(
                         regexp,
                         string,
@@ -964,7 +964,7 @@ public class TruffleRegexpNodes {
 
                     return createMatchData(regexp, dupString(string), region, result);
                 } else {
-                    return nil;
+                    return nil();
                 }
             } else {
                 return result;
@@ -1093,7 +1093,7 @@ public class TruffleRegexpNodes {
 
             if (createMatchDataProfile.profile(createMatchData)) {
                 if (mismatchProfile.profile(match == Matcher.FAILED)) {
-                    return nil;
+                    return nil();
                 }
 
                 assert match >= 0;

--- a/src/main/java/org/truffleruby/core/rope/RopeNodes.java
+++ b/src/main/java/org/truffleruby/core/rope/RopeNodes.java
@@ -764,7 +764,7 @@ public abstract class RopeNodes {
                     rope.getCodeRange(),
                     rope.getEncoding()));
 
-            return nil;
+            return nil();
         }
 
         @TruffleBoundary
@@ -788,7 +788,7 @@ public abstract class RopeNodes {
 
             executeDebugPrint(rope.getChild(), currentLevel + 1, printString);
 
-            return nil;
+            return nil();
         }
 
         @TruffleBoundary
@@ -826,7 +826,7 @@ public abstract class RopeNodes {
                 executeDebugPrint(state.right, currentLevel + 1, printString);
             }
 
-            return nil;
+            return nil();
         }
 
         @TruffleBoundary
@@ -850,7 +850,7 @@ public abstract class RopeNodes {
 
             executeDebugPrint(rope.getChild(), currentLevel + 1, printString);
 
-            return nil;
+            return nil();
         }
 
         @TruffleBoundary
@@ -872,7 +872,7 @@ public abstract class RopeNodes {
                     rope.getValue(),
                     rope.getEncoding()));
 
-            return nil;
+            return nil();
         }
 
         @TruffleBoundary
@@ -891,7 +891,7 @@ public abstract class RopeNodes {
                     rope.getNativePointer().getSize(),
                     rope.getEncoding()));
 
-            return nil;
+            return nil();
         }
 
         private void printPreamble(int level) {

--- a/src/main/java/org/truffleruby/core/string/StringNodes.java
+++ b/src/main/java/org/truffleruby/core/string/StringNodes.java
@@ -830,7 +830,7 @@ public abstract class StringNodes {
                     capture);
 
             final SpecialVariableStorage variables = readCallerStorageNode.execute(frame);
-            if (notMatchedProfile.profile(matchStrPair == nil())) {
+            if (notMatchedProfile.profile(Nil.is(matchStrPair))) {
                 variables.setLastMatch(nil(), getContext(), unsetProfile, sameThreadProfile);
                 return nil();
             } else {
@@ -838,7 +838,7 @@ public abstract class StringNodes {
                 final Object matchData = array[0];
                 final Object captureStringOrNil = array[1];
                 variables.setLastMatch(matchData, getContext(), unsetProfile, sameThreadProfile);
-                if (captureSetProfile.profile(captureStringOrNil != nil())) {
+                if (captureSetProfile.profile(Nil.isNot(captureStringOrNil))) {
                     return dupNode.executeDupAsStringInstance(captureStringOrNil);
                 } else {
                     return nil();
@@ -3646,7 +3646,7 @@ public abstract class StringNodes {
                 ret = addSubstring(ret, storeIndex++, substring, block, executeBlockProfile, growArrayProfile);
             }
 
-            if (block == nil()) {
+            if (Nil.is(block)) {
                 return createArray(ret, storeIndex);
             } else {
                 return string;
@@ -3718,7 +3718,7 @@ public abstract class StringNodes {
                 ret = addSubstring(ret, storeIndex++, substring, block, executeBlockProfile, growArrayProfile);
             }
 
-            if (block == nil()) {
+            if (Nil.is(block)) {
                 return createArray(ret, storeIndex);
             } else {
                 return string;
@@ -3727,7 +3727,7 @@ public abstract class StringNodes {
 
         private Object[] addSubstring(Object[] store, int index, RubyString substring,
                 Object block, ConditionProfile executeBlockProfile, ConditionProfile growArrayProfile) {
-            if (executeBlockProfile.profile(block != nil())) {
+            if (executeBlockProfile.profile(Nil.isNot(block))) {
                 yieldNode.yield((RubyProc) block, substring);
             } else {
                 if (growArrayProfile.profile(index < store.length)) {
@@ -3772,7 +3772,7 @@ public abstract class StringNodes {
                     lengthTooLongProfile,
                     libString);
 
-            if (nilSubstringProfile.profile(subString == nil())) {
+            if (nilSubstringProfile.profile(Nil.is(subString))) {
                 return subString;
             }
 

--- a/src/main/java/org/truffleruby/core/string/StringNodes.java
+++ b/src/main/java/org/truffleruby/core/string/StringNodes.java
@@ -830,18 +830,18 @@ public abstract class StringNodes {
                     capture);
 
             final SpecialVariableStorage variables = readCallerStorageNode.execute(frame);
-            if (notMatchedProfile.profile(matchStrPair == nil)) {
-                variables.setLastMatch(nil, getContext(), unsetProfile, sameThreadProfile);
-                return nil;
+            if (notMatchedProfile.profile(matchStrPair == nil())) {
+                variables.setLastMatch(nil(), getContext(), unsetProfile, sameThreadProfile);
+                return nil();
             } else {
                 final Object[] array = (Object[]) ((RubyArray) matchStrPair).store;
                 final Object matchData = array[0];
                 final Object captureStringOrNil = array[1];
                 variables.setLastMatch(matchData, getContext(), unsetProfile, sameThreadProfile);
-                if (captureSetProfile.profile(captureStringOrNil != nil)) {
+                if (captureSetProfile.profile(captureStringOrNil != nil())) {
                     return dupNode.executeDupAsStringInstance(captureStringOrNil);
                 } else {
-                    return nil;
+                    return nil();
                 }
             }
         }
@@ -862,7 +862,7 @@ public abstract class StringNodes {
                 return dupNode.executeDupAsStringInstance(matchStr);
             }
 
-            return nil;
+            return nil();
         }
 
         // endregion
@@ -870,7 +870,7 @@ public abstract class StringNodes {
 
         private Object outOfBoundsNil() {
             outOfBounds.enter();
-            return nil;
+            return nil();
         }
 
         private Object substring(Object string, int start, int length) {
@@ -1007,7 +1007,7 @@ public abstract class StringNodes {
 
             final RubyEncoding encoding = negotiateCompatibleEncodingNode.executeNegotiate(string, other);
             if (incompatibleEncodingProfile.profile(encoding == null)) {
-                return nil;
+                return nil();
             }
 
             return RopeOperations.caseInsensitiveCmp(strings.getRope(string), stringsOther.getRope(other));
@@ -1022,7 +1022,7 @@ public abstract class StringNodes {
             final RubyEncoding encoding = negotiateCompatibleEncodingNode.executeNegotiate(string, other);
 
             if (incompatibleEncodingProfile.profile(encoding == null)) {
-                return nil;
+                return nil();
             }
 
             return StringSupport
@@ -1309,7 +1309,7 @@ public abstract class StringNodes {
 
         @Specialization(guards = "isEmpty(string.rope)")
         protected Object deleteBangEmpty(RubyString string, Object[] args) {
-            return nil;
+            return nil();
         }
 
         @Specialization(
@@ -1330,7 +1330,7 @@ public abstract class StringNodes {
             final Rope processedRope = processStr(string, squeeze, compatEncoding, tables);
             if (processedRope == null) {
                 nullProfile.enter();
-                return nil;
+                return nil();
             }
 
             string.setRope(processedRope);
@@ -1358,7 +1358,7 @@ public abstract class StringNodes {
 
             final Rope processedRope = processStr(string, squeeze, enc, tables);
             if (processedRope == null) {
-                return nil;
+                return nil();
             }
 
             string.setRope(processedRope);
@@ -1412,7 +1412,7 @@ public abstract class StringNodes {
                         makeLeafRopeNode.executeMake(outputBytes, encoding, cr, characterLengthNode.execute(rope)));
                 return string;
             } else {
-                return nil;
+                return nil();
             }
         }
 
@@ -1443,7 +1443,7 @@ public abstract class StringNodes {
 
                 return string;
             } else {
-                return nil;
+                return nil();
             }
         }
 
@@ -1514,13 +1514,13 @@ public abstract class StringNodes {
         private Object substr(Rope rope, RubyEncoding encoding, int beg, int len, RubyClass logicalClass) {
             int length = rope.byteLength();
             if (len < 0 || beg > length) {
-                return nil;
+                return nil();
             }
 
             if (beg < 0) {
                 beg += length;
                 if (beg < 0) {
-                    return nil;
+                    return nil();
                 }
             }
 
@@ -1602,7 +1602,7 @@ public abstract class StringNodes {
             final int normalizedIndex = normalizeIndexNode.executeNormalize(index, rope.byteLength());
 
             if (indexOutOfBoundsProfile.profile((normalizedIndex < 0) || (normalizedIndex >= rope.byteLength()))) {
-                return nil;
+                return nil();
             }
 
             return ropeGetByteNode.executeGetByte(rope, normalizedIndex);
@@ -1795,7 +1795,7 @@ public abstract class StringNodes {
 
         @Specialization(guards = "isEmpty(string.rope)")
         protected Object lstripBangEmptyString(RubyString string) {
-            return nil;
+            return nil();
         }
 
         @Specialization(
@@ -1813,7 +1813,7 @@ public abstract class StringNodes {
             // this check can avoid having to materialize the entire byte[] (a potentially expensive operation
             // for ropes) and can avoid having to compile the while loop.
             if (noopProfile.profile(!StringSupport.isAsciiSpaceOrNull(firstCodePoint))) {
-                return nil;
+                return nil();
             }
 
             final int end = rope.byteLength();
@@ -1858,7 +1858,7 @@ public abstract class StringNodes {
                 return string;
             }
 
-            return nil;
+            return nil();
         }
 
     }
@@ -1923,7 +1923,7 @@ public abstract class StringNodes {
 
         @Specialization(guards = "isEmpty(string.rope)")
         protected Object rstripBangEmptyString(RubyString string) {
-            return nil;
+            return nil();
         }
 
         @Specialization(
@@ -1942,7 +1942,7 @@ public abstract class StringNodes {
             // for ropes) and can avoid having to compile the while loop.
             final boolean willStrip = StringSupport.isAsciiSpaceOrNull(lastCodePoint);
             if (noopProfile.profile(!willStrip)) {
-                return nil;
+                return nil();
             }
 
             final int end = rope.byteLength();
@@ -1995,7 +1995,7 @@ public abstract class StringNodes {
 
                 return string;
             }
-            return nil;
+            return nil();
         }
 
         @TruffleBoundary
@@ -2205,7 +2205,7 @@ public abstract class StringNodes {
                         makeLeafRopeNode.executeMake(outputBytes, enc, cr, characterLengthNode.execute(rope)));
                 return string;
             } else {
-                return nil;
+                return nil();
             }
         }
 
@@ -2238,7 +2238,7 @@ public abstract class StringNodes {
 
                 return string;
             } else {
-                return nil;
+                return nil();
             }
         }
     }
@@ -2585,7 +2585,7 @@ public abstract class StringNodes {
 
         @Specialization(guards = "isEmpty(string.rope)")
         protected Object squeezeBangEmptyString(RubyString string, Object[] args) {
-            return nil;
+            return nil();
         }
 
         @TruffleBoundary
@@ -2603,7 +2603,7 @@ public abstract class StringNodes {
 
             if (singleByteOptimizableProfile.profile(rope.isSingleByteOptimizable())) {
                 if (!StringSupport.singleByteSqueeze(buffer, squeeze)) {
-                    return nil;
+                    return nil();
                 } else {
                     string.setRope(RopeOperations.ropeFromRopeBuilder(buffer));
                 }
@@ -2617,7 +2617,7 @@ public abstract class StringNodes {
                                 string.rope.getEncoding(),
                                 false,
                                 this)) {
-                    return nil;
+                    return nil();
                 } else {
                     string.setRope(RopeOperations.ropeFromRopeBuilder(buffer));
                 }
@@ -2660,7 +2660,7 @@ public abstract class StringNodes {
             if (singlebyte && otherRope.byteLength() == 1 && otherStrings.length == 1) {
                 squeeze[otherRope.getRawBytes()[0]] = true;
                 if (!StringSupport.singleByteSqueeze(buffer, squeeze)) {
-                    return nil;
+                    return nil();
                 } else {
                     string.setRope(RopeOperations.ropeFromRopeBuilder(buffer));
                     return string;
@@ -2680,14 +2680,14 @@ public abstract class StringNodes {
 
             if (singleByteOptimizableProfile.profile(singlebyte)) {
                 if (!StringSupport.singleByteSqueeze(buffer, squeeze)) {
-                    return nil;
+                    return nil();
                 } else {
                     string.setRope(RopeOperations.ropeFromRopeBuilder(buffer));
                 }
             } else {
                 if (!StringSupport
                         .multiByteSqueeze(buffer, rope.getCodeRange(), squeeze, tables, enc.jcoding, true, this)) {
-                    return nil;
+                    return nil();
                 } else {
                     string.setRope(RopeOperations.ropeFromRopeBuilder(buffer));
                 }
@@ -2972,7 +2972,7 @@ public abstract class StringNodes {
 
         @Specialization(guards = "isEmpty(self.rope)")
         protected Object trBangSelfEmpty(RubyString self, Object fromStr, Object toStr) {
-            return nil;
+            return nil();
         }
 
         @Specialization(
@@ -3038,7 +3038,7 @@ public abstract class StringNodes {
         @Specialization(
                 guards = { "isEmpty(self.rope)" })
         protected Object trSBangEmpty(RubyString self, Object fromStr, Object toStr) {
-            return nil;
+            return nil();
         }
 
         @Specialization(
@@ -3265,7 +3265,7 @@ public abstract class StringNodes {
             byte[] modified = invertNode.executeInvert(bytes, 0);
 
             if (noopProfile.profile(modified == null)) {
-                return nil;
+                return nil();
             } else {
                 final Rope newRope = makeLeafRopeNode.executeMake(
                         modified,
@@ -3319,7 +3319,7 @@ public abstract class StringNodes {
                         makeLeafRopeNode.executeMake(outputBytes, encoding, cr, characterLengthNode.execute(rope)));
                 return string;
             } else {
-                return nil;
+                return nil();
             }
         }
 
@@ -3349,7 +3349,7 @@ public abstract class StringNodes {
 
                 return string;
             } else {
-                return nil;
+                return nil();
             }
         }
 
@@ -3390,7 +3390,7 @@ public abstract class StringNodes {
             final Rope rope = string.rope;
 
             if (emptyStringProfile.profile(rope.isEmpty())) {
-                return nil;
+                return nil();
             }
 
             final byte[] sourceBytes = bytesNode.execute(rope);
@@ -3407,7 +3407,7 @@ public abstract class StringNodes {
                     finalBytes = sourceBytes.clone();
                 } else {
                     // The string is already capitalized.
-                    return nil;
+                    return nil();
                 }
             } else {
                 // At least one char was lowercased when looking at bytes 1..N. We still must check the first byte.
@@ -3446,7 +3446,7 @@ public abstract class StringNodes {
             }
 
             if (emptyStringProfile.profile(rope.isEmpty())) {
-                return nil;
+                return nil();
             }
 
             final CodeRange cr = codeRangeNode.execute(rope);
@@ -3463,7 +3463,7 @@ public abstract class StringNodes {
                 return string;
             }
 
-            return nil;
+            return nil();
         }
 
         @Specialization(guards = "isComplexCaseMapping(string, caseMappingOptions, singleByteOptimizableNode)")
@@ -3482,7 +3482,7 @@ public abstract class StringNodes {
             }
 
             if (emptyStringProfile.profile(rope.isEmpty())) {
-                return nil;
+                return nil();
             }
 
             final RopeBuilder builder = RopeBuilder.createRopeBuilder(bytesNode.execute(rope), rope.getEncoding());
@@ -3494,7 +3494,7 @@ public abstract class StringNodes {
                                 .executeMake(builder.getBytes(), rope.getEncoding(), CR_UNKNOWN, NotProvided.INSTANCE));
                 return string;
             } else {
-                return nil;
+                return nil();
             }
         }
 
@@ -3525,7 +3525,7 @@ public abstract class StringNodes {
             final Rope ret = StringSupport
                     .trTransHelper(selfRope, fromStrRope, toStrRope, e1.jcoding, enc.jcoding, sFlag, node);
             if (ret == null) {
-                return Nil.INSTANCE;
+                return Nil.get();
             }
 
             self.setRope(ret, enc);
@@ -3646,7 +3646,7 @@ public abstract class StringNodes {
                 ret = addSubstring(ret, storeIndex++, substring, block, executeBlockProfile, growArrayProfile);
             }
 
-            if (block == nil) {
+            if (block == nil()) {
                 return createArray(ret, storeIndex);
             } else {
                 return string;
@@ -3718,7 +3718,7 @@ public abstract class StringNodes {
                 ret = addSubstring(ret, storeIndex++, substring, block, executeBlockProfile, growArrayProfile);
             }
 
-            if (block == nil) {
+            if (block == nil()) {
                 return createArray(ret, storeIndex);
             } else {
                 return string;
@@ -3727,7 +3727,7 @@ public abstract class StringNodes {
 
         private Object[] addSubstring(Object[] store, int index, RubyString substring,
                 Object block, ConditionProfile executeBlockProfile, ConditionProfile growArrayProfile) {
-            if (executeBlockProfile.profile(block != nil)) {
+            if (executeBlockProfile.profile(block != nil())) {
                 yieldNode.yield((RubyProc) block, substring);
             } else {
                 if (growArrayProfile.profile(index < store.length)) {
@@ -3772,12 +3772,12 @@ public abstract class StringNodes {
                     lengthTooLongProfile,
                     libString);
 
-            if (nilSubstringProfile.profile(subString == nil)) {
+            if (nilSubstringProfile.profile(subString == nil())) {
                 return subString;
             }
 
             if (emptySubstringProfile.profile(((RubyString) subString).rope.isEmpty())) {
-                return nil;
+                return nil();
             }
 
             return subString;
@@ -3790,7 +3790,7 @@ public abstract class StringNodes {
                 @Cached ConditionProfile lengthTooLongProfile,
                 @CachedLibrary(limit = "LIBSTRING_CACHE") RubyStringLibrary libString) {
             if (negativeLengthProfile.profile(length < 0)) {
-                return nil;
+                return nil();
             }
 
             final Rope rope = libString.getRope(string);
@@ -3798,7 +3798,7 @@ public abstract class StringNodes {
             final int normalizedIndex = normalizeIndexNode.executeNormalize(index, stringByteLength);
 
             if (indexOutOfBoundsProfile.profile(normalizedIndex < 0 || normalizedIndex > stringByteLength)) {
-                return nil;
+                return nil();
             }
 
             if (lengthTooLongProfile.profile(normalizedIndex + length > stringByteLength)) {
@@ -3823,7 +3823,7 @@ public abstract class StringNodes {
                 guards = { "indexOutOfBounds(strings.getRope(string), byteIndex)" })
         protected Object stringChrAtOutOfBounds(Object string, int byteIndex,
                 @CachedLibrary(limit = "LIBSTRING_CACHE") RubyStringLibrary strings) {
-            return nil;
+            return nil();
         }
 
         @Specialization(
@@ -3859,11 +3859,11 @@ public abstract class StringNodes {
                     Bytes.fromRange(bytes, byteIndex, end));
 
             if (!StringSupport.MBCLEN_CHARFOUND_P(c)) {
-                return nil;
+                return nil();
             }
 
             if (c + byteIndex > end) {
-                return nil;
+                return nil();
             }
 
             return makeStringNode.executeMake(
@@ -4061,13 +4061,13 @@ public abstract class StringNodes {
 
         @Specialization(guards = "offset < 0")
         protected Object stringFindCharacterNegativeOffset(Object string, int offset) {
-            return nil;
+            return nil();
         }
 
         @Specialization(guards = "offsetTooLarge(strings.getRope(string), offset)")
         protected Object stringFindCharacterOffsetTooLarge(Object string, int offset,
                 @CachedLibrary(limit = "LIBSTRING_CACHE") RubyStringLibrary strings) {
-            return nil;
+            return nil();
         }
 
         @Specialization(
@@ -4193,7 +4193,7 @@ public abstract class StringNodes {
                 @Cached BytesNode bytesNode) {
             final Rope rope = strings.getRope(string);
             if (rope.isEmpty()) {
-                return nil;
+                return nil();
             }
 
             final String javaString = strings.getJavaString(string);
@@ -4218,14 +4218,14 @@ public abstract class StringNodes {
                     } else if (result instanceof Double) {
                         return result;
                     } else {
-                        return nil;
+                        return nil();
                     }
                 }
             }
             try {
                 return new DoubleConverter().parse(rope, true, true);
             } catch (NumberFormatException e) {
-                return nil;
+                return nil();
             }
         }
 
@@ -4265,7 +4265,7 @@ public abstract class StringNodes {
             final int end = sourceRope.byteLength();
 
             if (offsetTooLargeProfile.profile(byteOffset >= end)) {
-                return nil;
+                return nil();
             }
 
             final byte[] sourceBytes = bytesNode.execute(sourceRope);
@@ -4273,7 +4273,7 @@ public abstract class StringNodes {
 
             final int index = com.oracle.truffle.api.ArrayUtils.indexOf(sourceBytes, byteOffset, end, searchByte);
 
-            return index == -1 ? nil : index;
+            return index == -1 ? nil() : index;
         }
 
         @Specialization(
@@ -4316,7 +4316,7 @@ public abstract class StringNodes {
             }
 
             noMatchProfile.enter();
-            return nil;
+            return nil();
         }
 
         @Specialization(
@@ -4325,7 +4325,7 @@ public abstract class StringNodes {
         protected Object stringIndexBrokenPattern(Object string, Object pattern, int byteOffset,
                 @CachedLibrary(limit = "LIBSTRING_CACHE") RubyStringLibrary stringsPattern) {
             assert byteOffset >= 0;
-            return nil;
+            return nil();
         }
 
         @Specialization(
@@ -4356,7 +4356,7 @@ public abstract class StringNodes {
                     byteIndexFromCharIndexNode);
 
             if (badIndexProfile.profile(index == -1)) {
-                return nil;
+                return nil();
             }
 
             return index;
@@ -4585,7 +4585,7 @@ public abstract class StringNodes {
                 profileAndReportLoopCount(loopProfile, p - offset);
             }
 
-            return nil;
+            return nil();
         }
 
         @TruffleBoundary
@@ -4619,21 +4619,21 @@ public abstract class StringNodes {
                     p += c;
                     index++;
                 } else {
-                    return nil;
+                    return nil();
                 }
             }
 
             for (; p < l; p += c, ++index) {
                 c = calculateCharacterLengthNode.characterLength(enc, cr, Bytes.fromRange(stringBytes, p, e));
                 if (!StringSupport.MBCLEN_CHARFOUND_P(c)) {
-                    return nil;
+                    return nil();
                 }
                 if (ArrayUtils.regionEquals(stringBytes, p, patternBytes, 0, pe)) {
                     return index;
                 }
             }
 
-            return nil;
+            return nil();
         }
     }
 
@@ -4659,7 +4659,7 @@ public abstract class StringNodes {
         @Specialization(guards = "!patternFits(stringRope, patternRope, offset)")
         protected Object patternTooLarge(Rope stringRope, Rope patternRope, int offset) {
             assert offset >= 0;
-            return nil;
+            return nil();
         }
 
         @Specialization(
@@ -4691,7 +4691,7 @@ public abstract class StringNodes {
                 profileAndReportLoopCount(loopProfile, p - offset);
             }
 
-            return nil;
+            return nil();
         }
 
         @TruffleBoundary
@@ -4720,14 +4720,14 @@ public abstract class StringNodes {
             for (; p < l; p += c) {
                 c = calculateCharacterLengthNode.characterLength(enc, cr, Bytes.fromRange(stringBytes, p, e));
                 if (!StringSupport.MBCLEN_CHARFOUND_P(c)) {
-                    return nil;
+                    return nil();
                 }
                 if (ArrayUtils.regionEquals(stringBytes, p, patternBytes, 0, pe)) {
                     return p;
                 }
             }
 
-            return nil;
+            return nil();
         }
 
         protected boolean patternFits(Rope stringRope, Rope patternRope, int offset) {
@@ -4843,7 +4843,7 @@ public abstract class StringNodes {
 
         @Specialization(guards = "index == 0")
         protected Object zeroIndex(Object string, int index) {
-            return nil;
+            return nil();
         }
 
         @Specialization(guards = {
@@ -4892,7 +4892,7 @@ public abstract class StringNodes {
             final int b = rope.getEncoding().prevCharHead(rope.getBytes(), p, p + index, end);
 
             if (b == -1) {
-                return nil;
+                return nil();
             }
 
             return b - p;
@@ -4957,7 +4957,7 @@ public abstract class StringNodes {
             }
 
             noMatchProfile.enter();
-            return nil;
+            return nil();
         }
 
         @Specialization(guards = {
@@ -5012,14 +5012,14 @@ public abstract class StringNodes {
             }
 
             noMatchProfile.enter();
-            return nil;
+            return nil();
         }
 
         @Specialization(guards = { "isBrokenCodeRange(stringsPattern.getRope(pattern), codeRangeNode)" })
         protected Object stringRindexBrokenPattern(Object string, Object pattern, int byteOffset,
                 @CachedLibrary(limit = "LIBSTRING_CACHE") RubyStringLibrary stringsPattern) {
             assert byteOffset >= 0;
-            return nil;
+            return nil();
         }
 
         @Specialization(guards = {
@@ -5063,7 +5063,7 @@ public abstract class StringNodes {
                         pos--;
                     }
 
-                    return nil;
+                    return nil();
                 }
 
                 default: {
@@ -5093,7 +5093,7 @@ public abstract class StringNodes {
                 }
             }
 
-            return nil;
+            return nil();
         }
 
         private void checkEncoding(Object string, Object pattern) {
@@ -5229,7 +5229,7 @@ public abstract class StringNodes {
             } catch (RaiseException e) {
                 exceptionProfile.enter();
                 if (!raiseOnError) {
-                    return nil;
+                    return nil();
                 }
                 throw e;
             }
@@ -5285,7 +5285,7 @@ public abstract class StringNodes {
             int characterLength = length;
 
             if (negativeIndexProfile.profile(normalizedIndex < 0)) {
-                return nil;
+                return nil();
             }
 
             if (tooLargeTotalProfile.profile(normalizedIndex + characterLength > ropeCharacterLength)) {
@@ -5314,7 +5314,7 @@ public abstract class StringNodes {
             int characterLength = length;
 
             if (negativeIndexProfile.profile(normalizedIndex < 0)) {
-                return nil;
+                return nil();
             }
 
             if (tooLargeTotalProfile.profile(normalizedIndex + characterLength > ropeCharacterLength)) {
@@ -5351,7 +5351,7 @@ public abstract class StringNodes {
                 "indexTriviallyOutOfBounds(strings.getRope(string), characterLengthNode, index, length)" })
         protected Object stringSubstringNegativeLength(Object string, int index, int length,
                 @CachedLibrary(limit = "LIBSTRING_CACHE") RubyStringLibrary strings) {
-            return nil;
+            return nil();
         }
 
         private SearchResult searchForSingleByteOptimizableDescendant(Rope base, int index, int characterLength,

--- a/src/main/java/org/truffleruby/core/support/ByteArrayNodes.java
+++ b/src/main/java/org/truffleruby/core/support/ByteArrayNodes.java
@@ -164,7 +164,7 @@ public abstract class ByteArrayNodes {
 
             if (start >= length) {
                 tooLargeStartProfile.enter();
-                return nil;
+                return nil();
             }
 
             if (start < 0) {
@@ -174,7 +174,7 @@ public abstract class ByteArrayNodes {
 
             final int index = ArrayUtils.indexOf(bytes, start, length, searchByte);
 
-            return index == -1 ? nil : index + 1;
+            return index == -1 ? nil() : index + 1;
         }
 
         @Specialization(
@@ -192,7 +192,7 @@ public abstract class ByteArrayNodes {
                     bytesNode.execute(patternRope));
 
             if (notFoundProfile.profile(index == -1)) {
-                return nil;
+                return nil();
             } else {
                 return index + characterLengthNode.execute(patternRope);
             }

--- a/src/main/java/org/truffleruby/core/support/IONodes.java
+++ b/src/main/java/org/truffleruby/core/support/IONodes.java
@@ -424,7 +424,7 @@ public abstract class IONodes {
                 throw new RaiseException(getContext(), coreExceptions().ioError("closed stream", this));
             } else {
                 assert fd >= 0;
-                return nil;
+                return nil();
             }
         }
 
@@ -448,7 +448,7 @@ public abstract class IONodes {
             });
 
             if (bytesRead < 0) {
-                return nil;
+                return nil();
             }
 
             final byte[] bytes;
@@ -529,7 +529,7 @@ public abstract class IONodes {
                 @Cached ConditionProfile freeProfile) {
             RubyThread thread = getLanguage().getCurrentThread();
             thread.ioBuffer.free(thread, pointer.pointer, freeProfile);
-            return nil;
+            return nil();
         }
     }
 

--- a/src/main/java/org/truffleruby/core/support/TypeNodes.java
+++ b/src/main/java/org/truffleruby/core/support/TypeNodes.java
@@ -167,7 +167,7 @@ public abstract class TypeNodes {
     public abstract static class IsNilNode extends PrimitiveArrayArgumentsNode {
         @Specialization
         protected boolean isNil(Object value) {
-            return value == nil;
+            return value == nil();
         }
     }
 
@@ -238,7 +238,7 @@ public abstract class TypeNodes {
         @Specialization(limit = "getDynamicObjectCacheLimit()")
         protected Object ivarGet(RubyDynamicObject object, RubySymbol name,
                 @CachedLibrary("object") DynamicObjectLibrary objectLibrary) {
-            return objectLibrary.getOrDefault(object, name.getString(), nil);
+            return objectLibrary.getOrDefault(object, name.getString(), nil());
         }
     }
 
@@ -271,12 +271,12 @@ public abstract class TypeNodes {
         @Specialization(limit = "getDynamicObjectCacheLimit()")
         protected Object objectHiddenVarGet(RubyDynamicObject object, Object identifier,
                 @CachedLibrary("object") DynamicObjectLibrary objectLibrary) {
-            return objectLibrary.getOrDefault(object, identifier, nil);
+            return objectLibrary.getOrDefault(object, identifier, nil());
         }
 
         @Fallback
         protected Object immutable(Object object, Object identifier) {
-            return nil;
+            return nil();
         }
     }
 

--- a/src/main/java/org/truffleruby/core/support/TypeNodes.java
+++ b/src/main/java/org/truffleruby/core/support/TypeNodes.java
@@ -167,7 +167,7 @@ public abstract class TypeNodes {
     public abstract static class IsNilNode extends PrimitiveArrayArgumentsNode {
         @Specialization
         protected boolean isNil(Object value) {
-            return value == nil();
+            return Nil.is(value);
         }
     }
 

--- a/src/main/java/org/truffleruby/core/support/WeakRefNodes.java
+++ b/src/main/java/org/truffleruby/core/support/WeakRefNodes.java
@@ -49,7 +49,7 @@ public abstract class WeakRefNodes {
             final TruffleWeakReference<?> ref = (TruffleWeakReference<?>) objectLibrary
                     .getOrDefault(weakRef, FIELD_NAME, EMPTY_WEAK_REF);
             final Object object = ref.get();
-            return object == null ? nil : object;
+            return object == null ? nil() : object;
         }
     }
 }

--- a/src/main/java/org/truffleruby/core/symbol/SymbolNodes.java
+++ b/src/main/java/org/truffleruby/core/symbol/SymbolNodes.java
@@ -197,7 +197,7 @@ public abstract class SymbolNodes {
                     : new DeclarationContext(Visibility.PUBLIC, null, refinements);
 
             final Object[] args = RubyArguments
-                    .pack(null, null, method, declarationContext, null, nil, nil,
+                    .pack(null, null, method, declarationContext, null, nil(), nil(),
                             EmptyArgumentsDescriptor.INSTANCE, EMPTY_ARGUMENTS);
             // MRI raises an error on Proc#binding if you attempt to access the binding of a Proc generated
             // by Symbol#to_proc. We generate a declaration frame here so that all procedures will have a
@@ -238,7 +238,7 @@ public abstract class SymbolNodes {
             final RubyLambdaRootNode rootNode = new RubyLambdaRootNode(
                     language,
                     sourceSection,
-                    new FrameDescriptor(nil),
+                    new FrameDescriptor(nil()),
                     sharedMethodInfo,
                     new SymbolProcNode(symbol.getString()),
                     Split.HEURISTIC,

--- a/src/main/java/org/truffleruby/core/symbol/SymbolNodes.java
+++ b/src/main/java/org/truffleruby/core/symbol/SymbolNodes.java
@@ -31,6 +31,7 @@ import org.truffleruby.core.string.ImmutableRubyString;
 import org.truffleruby.core.string.RubyString;
 import org.truffleruby.core.string.StringNodes;
 import org.truffleruby.language.LexicalScope;
+import org.truffleruby.language.Nil;
 import org.truffleruby.language.RubyBaseNode;
 import org.truffleruby.language.RubyLambdaRootNode;
 import org.truffleruby.language.RubyRootNode;
@@ -197,7 +198,7 @@ public abstract class SymbolNodes {
                     : new DeclarationContext(Visibility.PUBLIC, null, refinements);
 
             final Object[] args = RubyArguments
-                    .pack(null, null, method, declarationContext, null, nil(), nil(),
+                    .pack(null, null, method, declarationContext, null, Nil.get(), Nil.get(),
                             EmptyArgumentsDescriptor.INSTANCE, EMPTY_ARGUMENTS);
             // MRI raises an error on Proc#binding if you attempt to access the binding of a Proc generated
             // by Symbol#to_proc. We generate a declaration frame here so that all procedures will have a
@@ -238,7 +239,7 @@ public abstract class SymbolNodes {
             final RubyLambdaRootNode rootNode = new RubyLambdaRootNode(
                     language,
                     sourceSection,
-                    new FrameDescriptor(nil()),
+                    new FrameDescriptor(Nil.get()),
                     sharedMethodInfo,
                     new SymbolProcNode(symbol.getString()),
                     Split.HEURISTIC,

--- a/src/main/java/org/truffleruby/core/thread/RubyThread.java
+++ b/src/main/java/org/truffleruby/core/thread/RubyThread.java
@@ -65,7 +65,7 @@ public final class RubyThread extends RubyDynamicObject implements ObjectGraphNo
     public ThreadLocalBuffer ioBuffer = ThreadLocalBuffer.NULL_BUFFER;
     Object threadGroup;
     public String sourceLocation;
-    Object name = Nil.INSTANCE;
+    Object name = Nil.get();
 
     // Decimal formats are not thread safe, so we'll create them on the thread as we need them.
 

--- a/src/main/java/org/truffleruby/core/thread/ThreadBacktraceLocationNodes.java
+++ b/src/main/java/org/truffleruby/core/thread/ThreadBacktraceLocationNodes.java
@@ -20,6 +20,7 @@ import org.truffleruby.core.rope.Rope;
 import org.truffleruby.core.string.RubyString;
 import org.truffleruby.core.string.StringNodes.MakeStringNode;
 import org.truffleruby.core.string.StringOperations;
+import org.truffleruby.language.Nil;
 import org.truffleruby.language.RubyBaseNode;
 import org.truffleruby.language.backtrace.Backtrace;
 
@@ -68,7 +69,7 @@ public class ThreadBacktraceLocationNodes {
             } else {
                 final Source source = sourceSection.getSource();
                 if (BacktraceFormatter.isRubyCore(language, source)) {
-                    return nil();
+                    return Nil.get();
                 } else if (source.getPath() != null) { // A normal file
                     final String path = language.getSourcePath(source);
                     final String canonicalPath = context.getFeatureLoader().canonicalize(path);

--- a/src/main/java/org/truffleruby/core/thread/ThreadBacktraceLocationNodes.java
+++ b/src/main/java/org/truffleruby/core/thread/ThreadBacktraceLocationNodes.java
@@ -68,7 +68,7 @@ public class ThreadBacktraceLocationNodes {
             } else {
                 final Source source = sourceSection.getSource();
                 if (BacktraceFormatter.isRubyCore(language, source)) {
-                    return nil;
+                    return nil();
                 } else if (source.getPath() != null) { // A normal file
                     final String path = language.getSourcePath(source);
                     final String canonicalPath = context.getFeatureLoader().canonicalize(path);

--- a/src/main/java/org/truffleruby/core/thread/ThreadManager.java
+++ b/src/main/java/org/truffleruby/core/thread/ThreadManager.java
@@ -238,7 +238,7 @@ public class ThreadManager {
                 context.getCoreLibrary().threadClass,
                 language.threadShape,
                 language,
-                Nil.INSTANCE,
+                Nil.get(),
                 info);
     }
 
@@ -310,20 +310,20 @@ public class ThreadManager {
             // Handlers in the same order as in FiberManager
             // Each catch must either setThreadValue() (before rethrowing) or setException()
         } catch (KillException e) {
-            setThreadValue(thread, Nil.INSTANCE);
+            setThreadValue(thread, Nil.get());
         } catch (ThreadDeath e) { // Context#close(true)
-            setThreadValue(thread, Nil.INSTANCE);
+            setThreadValue(thread, Nil.get());
             throw e;
         } catch (RaiseException e) {
             setException(thread, e.getException(), currentNode);
         } catch (DynamicReturnException e) {
             setException(thread, context.getCoreExceptions().unexpectedReturn(currentNode), currentNode);
         } catch (ExitException e) {
-            setThreadValue(thread, Nil.INSTANCE);
+            setThreadValue(thread, Nil.get());
             rethrowOnMainThread(currentNode, e);
         } catch (Throwable e) {
             final RuntimeException runtimeException = printInternalError(e);
-            setThreadValue(thread, Nil.INSTANCE);
+            setThreadValue(thread, Nil.get());
             rethrowOnMainThread(currentNode, runtimeException);
         } finally {
             assert thread.value != null || thread.exception != null;

--- a/src/main/java/org/truffleruby/core/thread/ThreadNodes.java
+++ b/src/main/java/org/truffleruby/core/thread/ThreadNodes.java
@@ -649,7 +649,7 @@ public abstract class ThreadNodes {
                 @Cached("new(receivers, translateInteropExceptionNode)") BlockingCallInterruptible blockingCallInterruptible) {
             final ThreadManager threadManager = getContext().getThreadManager();
             final Interrupter interrupter;
-            if (unblocker == nil()) {
+            if (Nil.is(unblocker)) {
                 interrupter = threadManager.getNativeCallInterrupter();
             } else {
                 interrupter = makeInterrupter(getContext(), unblocker, unblockerArg);

--- a/src/main/java/org/truffleruby/core/thread/ThreadNodes.java
+++ b/src/main/java/org/truffleruby/core/thread/ThreadNodes.java
@@ -169,7 +169,7 @@ public abstract class ThreadNodes {
             // If the thread is dead or aborting the SafepointAction will not run.
             // Must return nil if omitting more entries than available.
             if (backtrace == null || omit > backtrace.getTotalUnderlyingElements()) {
-                return nil;
+                return nil();
             }
 
             if (length < 0) {
@@ -251,7 +251,7 @@ public abstract class ThreadNodes {
 
             // If the thread is dead or aborting the SafepointAction will not run.
             return backtraceLocationsMemo.get() == null
-                    ? nil
+                    ? nil()
                     : backtraceLocationsMemo.get();
         }
     }
@@ -438,7 +438,7 @@ public abstract class ThreadNodes {
                     info,
                     sharingReason,
                     () -> ProcOperations.rootCall(block, descriptor, args));
-            return nil;
+            return nil();
         }
     }
 
@@ -486,7 +486,7 @@ public abstract class ThreadNodes {
             if (doJoinNanos(self, timeoutInNanos)) {
                 return self;
             } else {
-                return nil;
+                return nil();
             }
         }
 
@@ -556,7 +556,7 @@ public abstract class ThreadNodes {
         @Specialization
         protected Object pass() {
             Thread.yield();
-            return nil;
+            return nil();
         }
 
     }
@@ -572,7 +572,7 @@ public abstract class ThreadNodes {
             final ThreadStatus status = self.status;
             if (status == ThreadStatus.DEAD) {
                 if (self.exception != null) {
-                    return nil;
+                    return nil();
                 } else {
                     return false;
                 }
@@ -649,7 +649,7 @@ public abstract class ThreadNodes {
                 @Cached("new(receivers, translateInteropExceptionNode)") BlockingCallInterruptible blockingCallInterruptible) {
             final ThreadManager threadManager = getContext().getThreadManager();
             final Interrupter interrupter;
-            if (unblocker == nil) {
+            if (unblocker == nil()) {
                 interrupter = threadManager.getNativeCallInterrupter();
             } else {
                 interrupter = makeInterrupter(getContext(), unblocker, unblockerArg);
@@ -844,7 +844,7 @@ public abstract class ThreadNodes {
         @Specialization
         protected Object raise(RubyThread thread, RubyException exception) {
             raiseInThread(getLanguage(), getContext(), thread, exception, this);
-            return nil;
+            return nil();
         }
 
         @TruffleBoundary

--- a/src/main/java/org/truffleruby/core/thread/TruffleThreadNodes.java
+++ b/src/main/java/org/truffleruby/core/thread/TruffleThreadNodes.java
@@ -62,7 +62,7 @@ public class TruffleThreadNodes {
                             moduleArray,
                             f -> new FrameAndCallNode(f.getFrame(FrameAccess.MATERIALIZE), f.getCallNode()));
             if (data == null) {
-                return nil;
+                return nil();
             } else {
                 CallerDataReadingNode.notifyCallerToSendData(getContext(), data.callNode, this);
                 Object variables = storageNode.execute(data.frame.materialize());

--- a/src/main/java/org/truffleruby/core/time/GetTimeZoneNode.java
+++ b/src/main/java/org/truffleruby/core/time/GetTimeZoneNode.java
@@ -35,6 +35,7 @@ import java.util.regex.Pattern;
 
 import com.oracle.truffle.api.CompilerDirectives;
 import org.truffleruby.RubyLanguage;
+import org.truffleruby.language.Nil;
 import org.truffleruby.language.RubyBaseNode;
 import org.truffleruby.language.control.RaiseException;
 import org.truffleruby.language.dispatch.DispatchNode;
@@ -79,7 +80,7 @@ public abstract class GetTimeZoneNode extends RubyBaseNode {
             tzString = libString.getJavaString(tz);
         }
 
-        if (tz == nil()) {
+        if (Nil.is(tz)) {
             // $TZ is not set, use the system timezone
             return new TimeZoneAndName(getSystemTimeZone());
         } else if (libString.isRubyString(tz)) {

--- a/src/main/java/org/truffleruby/core/time/GetTimeZoneNode.java
+++ b/src/main/java/org/truffleruby/core/time/GetTimeZoneNode.java
@@ -79,7 +79,7 @@ public abstract class GetTimeZoneNode extends RubyBaseNode {
             tzString = libString.getJavaString(tz);
         }
 
-        if (tz == nil) {
+        if (tz == nil()) {
             // $TZ is not set, use the system timezone
             return new TimeZoneAndName(getSystemTimeZone());
         } else if (libString.isRubyString(tz)) {

--- a/src/main/java/org/truffleruby/core/time/RubyTime.java
+++ b/src/main/java/org/truffleruby/core/time/RubyTime.java
@@ -43,7 +43,7 @@ public class RubyTime extends RubyDynamicObject {
             boolean relativeOffset,
             boolean isUtc) {
         super(rubyClass, shape);
-        assert zone instanceof RubyString || zone == Nil.INSTANCE;
+        assert zone instanceof RubyString || zone == Nil.get();
         this.dateTime = dateTime;
         this.offset = offset;
         this.zone = zone;

--- a/src/main/java/org/truffleruby/core/time/RubyTime.java
+++ b/src/main/java/org/truffleruby/core/time/RubyTime.java
@@ -43,7 +43,7 @@ public class RubyTime extends RubyDynamicObject {
             boolean relativeOffset,
             boolean isUtc) {
         super(rubyClass, shape);
-        assert zone instanceof RubyString || zone == Nil.get();
+        assert zone instanceof RubyString || Nil.is(zone);
         this.dateTime = dateTime;
         this.offset = offset;
         this.zone = zone;

--- a/src/main/java/org/truffleruby/core/time/TimeNodes.java
+++ b/src/main/java/org/truffleruby/core/time/TimeNodes.java
@@ -517,7 +517,7 @@ public abstract class TimeNodes {
                 zone = GetTimeZoneNode.UTC;
                 relativeOffset = false;
                 zoneToStore = language.coreStrings.UTC.createInstance(getContext());
-            } else if (utcoffset == nil()) {
+            } else if (Nil.is(utcoffset)) {
                 if (makeStringNode == null) {
                     CompilerDirectives.transferToInterpreterAndInvalidate();
                     makeStringNode = insert(StringNodes.MakeStringNode.create());

--- a/src/main/java/org/truffleruby/core/time/TimeNodes.java
+++ b/src/main/java/org/truffleruby/core/time/TimeNodes.java
@@ -66,7 +66,7 @@ public abstract class TimeNodes {
 
         @Specialization
         protected RubyTime allocate(RubyClass rubyClass) {
-            final RubyTime instance = new RubyTime(rubyClass, getLanguage().timeShape, ZERO, nil, 0, false, false);
+            final RubyTime instance = new RubyTime(rubyClass, getLanguage().timeShape, ZERO, nil(), 0, false, false);
             AllocationTracing.trace(instance, this);
             return instance;
         }
@@ -113,7 +113,7 @@ public abstract class TimeNodes {
 
             time.isUtc = false;
             time.relativeOffset = true;
-            time.zone = nil;
+            time.zone = nil();
             time.dateTime = dateTime;
 
             return time;
@@ -181,7 +181,7 @@ public abstract class TimeNodes {
             final TimeZoneAndName zoneAndName = getTimeZoneNode.executeGetTimeZone();
             final ZonedDateTime dt = now(zoneAndName.getZone());
             final RubyString zone = getShortZoneName(makeStringNode, dt, zoneAndName);
-            final RubyTime instance = new RubyTime(timeClass, getLanguage().timeShape, dt, zone, nil, false, false);
+            final RubyTime instance = new RubyTime(timeClass, getLanguage().timeShape, dt, zone, nil(), false, false);
             AllocationTracing.trace(instance, this);
             return instance;
 
@@ -207,7 +207,7 @@ public abstract class TimeNodes {
             final RubyString zone = getShortZoneName(makeStringNode, dateTime, zoneAndName);
 
             final Shape shape = getLanguage().timeShape;
-            final RubyTime instance = new RubyTime(timeClass, shape, dateTime, zone, nil, false, false);
+            final RubyTime instance = new RubyTime(timeClass, shape, dateTime, zone, nil(), false, false);
             AllocationTracing.trace(instance, this);
             return instance;
         }
@@ -510,14 +510,14 @@ public abstract class TimeNodes {
 
             final ZoneId zone;
             final boolean relativeOffset;
-            Object zoneToStore = nil;
+            Object zoneToStore = nil();
             TimeZoneAndName envZone = null;
 
             if (isutc) {
                 zone = GetTimeZoneNode.UTC;
                 relativeOffset = false;
                 zoneToStore = language.coreStrings.UTC.createInstance(getContext());
-            } else if (utcoffset == nil) {
+            } else if (utcoffset == nil()) {
                 if (makeStringNode == null) {
                     CompilerDirectives.transferToInterpreterAndInvalidate();
                     makeStringNode = insert(StringNodes.MakeStringNode.create());
@@ -530,7 +530,7 @@ public abstract class TimeNodes {
                 final int offset = ((Number) utcoffset).intValue();
                 zone = getZoneOffset(offset);
                 relativeOffset = true;
-                zoneToStore = nil;
+                zoneToStore = nil();
             } else {
                 throw new UnsupportedOperationException(
                         StringUtils.format("%s %s %s %s", isdst, isutc, utcoffset, utcoffset.getClass()));

--- a/src/main/java/org/truffleruby/debug/DebugHelpers.java
+++ b/src/main/java/org/truffleruby/debug/DebugHelpers.java
@@ -62,7 +62,7 @@ public abstract class DebugHelpers {
                 declarationContext,
                 null,
                 RubyArguments.getSelf(currentFrame),
-                Nil.INSTANCE,
+                Nil.get(),
                 EmptyArgumentsDescriptor.INSTANCE,
                 RubyNode.EMPTY_ARGUMENTS);
 

--- a/src/main/java/org/truffleruby/debug/TruffleDebugNodes.java
+++ b/src/main/java/org/truffleruby/debug/TruffleDebugNodes.java
@@ -123,7 +123,7 @@ public abstract class TruffleDebugNodes {
             }
 
             System.err.println(javaString);
-            return nil;
+            return nil();
         }
 
     }
@@ -181,7 +181,7 @@ public abstract class TruffleDebugNodes {
         @Specialization
         protected Object remove(RubyHandle handle) {
             ((EventBinding<?>) handle.object).dispose();
-            return nil;
+            return nil();
         }
 
     }
@@ -207,7 +207,7 @@ public abstract class TruffleDebugNodes {
         @Specialization
         protected Object printBacktrace() {
             getContext().getDefaultBacktraceFormatter().printBacktraceOnEnvStderr(this);
-            return nil;
+            return nil();
         }
 
     }
@@ -242,12 +242,12 @@ public abstract class TruffleDebugNodes {
                 @Cached ToCallTargetNode toCallTargetNode) {
             final RootCallTarget callTarget = toCallTargetNode.execute(executable);
             ast(callTarget.getRootNode());
-            return nil;
+            return nil();
         }
 
         private Object ast(Node node) {
             if (node == null) {
-                return nil;
+                return nil();
             }
 
             final List<Object> array = new ArrayList<>();
@@ -270,7 +270,7 @@ public abstract class TruffleDebugNodes {
                 @Cached ToCallTargetNode toCallTargetNode) {
             final RootCallTarget callTarget = toCallTargetNode.execute(executable);
             NodeUtil.printCompactTree(System.err, callTarget.getRootNode());
-            return nil;
+            return nil();
         }
     }
 
@@ -373,7 +373,7 @@ public abstract class TruffleDebugNodes {
         protected Object logWarning(Object value,
                 @Cached ToJavaStringNode toJavaStringNode) {
             warning(toJavaStringNode.executeToJavaString(value));
-            return nil;
+            return nil();
         }
 
         @TruffleBoundary
@@ -390,7 +390,7 @@ public abstract class TruffleDebugNodes {
         protected Object logInfo(Object value,
                 @Cached ToJavaStringNode toJavaStringNode) {
             info(toJavaStringNode.executeToJavaString(value));
-            return nil;
+            return nil();
         }
 
         @TruffleBoundary
@@ -407,7 +407,7 @@ public abstract class TruffleDebugNodes {
         protected Object logConfig(Object value,
                 @Cached ToJavaStringNode toJavaStringNode) {
             config(toJavaStringNode.executeToJavaString(value));
-            return nil;
+            return nil();
         }
 
         @TruffleBoundary
@@ -425,7 +425,7 @@ public abstract class TruffleDebugNodes {
         protected Object throwJavaException(Object message,
                 @CachedLibrary(limit = "LIBSTRING_CACHE") RubyStringLibrary strings) {
             callingMethod(strings.getJavaString(message));
-            return nil;
+            return nil();
         }
 
         // These two named methods makes it easy to test that the backtrace for a Java exception is what we expect
@@ -471,7 +471,7 @@ public abstract class TruffleDebugNodes {
         @Specialization
         protected Object doAssert(boolean condition) {
             assert condition;
-            return nil;
+            return nil();
         }
     }
 
@@ -480,7 +480,7 @@ public abstract class TruffleDebugNodes {
         @Specialization
         protected Object doAssert(boolean condition) {
             assert condition;
-            return nil;
+            return nil();
         }
     }
 
@@ -1142,7 +1142,7 @@ public abstract class TruffleDebugNodes {
         @Specialization
         protected Object drainFinalizationQueue() {
             getContext().getFinalizationService().drainFinalizationQueue(getContext());
-            return nil;
+            return nil();
         }
 
     }
@@ -1211,7 +1211,7 @@ public abstract class TruffleDebugNodes {
                             .createBinding(getContext(), getLanguage(), frame, sourceSection);
                     frameBindings.add(binding);
                 } else {
-                    frameBindings.add(nil);
+                    frameBindings.add(nil());
                 }
             }
             Collections.reverse(frameBindings);

--- a/src/main/java/org/truffleruby/extra/AtomicReferenceNodes.java
+++ b/src/main/java/org/truffleruby/extra/AtomicReferenceNodes.java
@@ -34,7 +34,8 @@ public abstract class AtomicReferenceNodes {
         @Specialization
         protected RubyAtomicReference allocate(RubyClass rubyClass) {
             final Shape shape = getLanguage().atomicReferenceShape;
-            final RubyAtomicReference instance = new RubyAtomicReference(rubyClass, shape, new AtomicReference<>(nil));
+            final RubyAtomicReference instance = new RubyAtomicReference(rubyClass, shape,
+                    new AtomicReference<>(nil()));
             AllocationTracing.trace(instance, this);
             return instance;
         }

--- a/src/main/java/org/truffleruby/extra/TruffleGraalNodes.java
+++ b/src/main/java/org/truffleruby/extra/TruffleGraalNodes.java
@@ -112,8 +112,8 @@ public abstract class TruffleGraalNodes {
                             null,
                             RubyArguments.getMethod(proc.declarationFrame),
                             null,
-                            nil,
-                            nil,
+                            nil(),
+                            nil(),
                             EmptyArgumentsDescriptor.INSTANCE,
                             EMPTY_ARGUMENTS);
 
@@ -168,7 +168,7 @@ public abstract class TruffleGraalNodes {
                 compiledBoundary();
             }
 
-            return nil;
+            return nil();
         }
 
         @TruffleBoundary
@@ -185,7 +185,7 @@ public abstract class TruffleGraalNodes {
         protected Object bailout(Object message,
                 @CachedLibrary(limit = "LIBSTRING_CACHE") RubyStringLibrary strings) {
             CompilerDirectives.bailout(strings.getJavaString(message));
-            return nil;
+            return nil();
         }
     }
 
@@ -196,31 +196,31 @@ public abstract class TruffleGraalNodes {
         @Specialization
         protected Object blackhole(boolean value) {
             CompilerDirectives.blackhole(value);
-            return nil;
+            return nil();
         }
 
         @Specialization
         protected Object blackhole(int value) {
             CompilerDirectives.blackhole(value);
-            return nil;
+            return nil();
         }
 
         @Specialization
         protected Object blackhole(long value) {
             CompilerDirectives.blackhole(value);
-            return nil;
+            return nil();
         }
 
         @Specialization
         protected Object blackhole(double value) {
             CompilerDirectives.blackhole(value);
-            return nil;
+            return nil();
         }
 
         @Specialization
         protected Object blackhole(Object value) {
             CompilerDirectives.blackhole(value);
-            return nil;
+            return nil();
         }
 
     }

--- a/src/main/java/org/truffleruby/extra/TruffleRubyNodes.java
+++ b/src/main/java/org/truffleruby/extra/TruffleRubyNodes.java
@@ -47,7 +47,7 @@ public abstract class TruffleRubyNodes {
                 @Cached StringNodes.MakeStringNode makeStringNode) {
             String value = getProperty("org.graalvm.home");
             if (value == null) {
-                return nil;
+                return nil();
             } else {
                 return makeStringNode.executeMake(value, Encodings.UTF_8, CodeRange.CR_UNKNOWN);
             }
@@ -101,7 +101,7 @@ public abstract class TruffleRubyNodes {
         @Specialization
         protected Object fullMemoryBarrier() {
             VarHandle.fullFence();
-            return nil;
+            return nil();
         }
     }
 

--- a/src/main/java/org/truffleruby/extra/ffi/PointerNodes.java
+++ b/src/main/java/org/truffleruby/extra/ffi/PointerNodes.java
@@ -251,7 +251,7 @@ public abstract class PointerNodes {
             final Pointer ptr = new Pointer(to);
             checkNull(ptr);
             ptr.writeBytes(0, new Pointer(from), 0, size);
-            return nil;
+            return nil();
         }
 
     }
@@ -327,12 +327,12 @@ public abstract class PointerNodes {
             final Pointer ptr = new Pointer(address);
             if (zeroProfile.profile(length == 0)) {
                 // No need to check the pointer address if we read nothing
-                return nil;
+                return nil();
             } else {
                 checkNull(ptr);
                 final byte[] bytes = array.bytes;
                 ptr.readBytes(0, bytes, arrayOffset, length);
-                return nil;
+                return nil();
             }
         }
 
@@ -552,7 +552,7 @@ public abstract class PointerNodes {
             checkNull(ptr);
             byte byteValue = (byte) value;
             ptr.writeByte(0, byteValue);
-            return nil;
+            return nil();
         }
 
     }
@@ -567,7 +567,7 @@ public abstract class PointerNodes {
             checkNull(ptr);
             byte byteValue = (byte) value;
             ptr.writeByte(0, byteValue);
-            return nil;
+            return nil();
         }
 
         @Specialization(guards = { "value > MAX_VALUE", "value < 256" })
@@ -576,7 +576,7 @@ public abstract class PointerNodes {
             checkNull(ptr);
             byte signed = (byte) value; // Same as value - 2^8
             ptr.writeByte(0, signed);
-            return nil;
+            return nil();
         }
 
     }
@@ -591,7 +591,7 @@ public abstract class PointerNodes {
             checkNull(ptr);
             short shortValue = (short) value;
             ptr.writeShort(0, shortValue);
-            return nil;
+            return nil();
         }
 
     }
@@ -606,7 +606,7 @@ public abstract class PointerNodes {
             checkNull(ptr);
             short shortValue = (short) value;
             ptr.writeShort(0, shortValue);
-            return nil;
+            return nil();
         }
 
         @Specialization(guards = { "value > MAX_VALUE", "value < 65536" })
@@ -615,7 +615,7 @@ public abstract class PointerNodes {
             checkNull(ptr);
             short signed = (short) value; // Same as value - 2^16
             ptr.writeShort(0, signed);
-            return nil;
+            return nil();
         }
 
     }
@@ -628,7 +628,7 @@ public abstract class PointerNodes {
             final Pointer ptr = new Pointer(address);
             checkNull(ptr);
             ptr.writeInt(0, value);
-            return nil;
+            return nil();
         }
 
     }
@@ -644,7 +644,7 @@ public abstract class PointerNodes {
             final Pointer ptr = new Pointer(address);
             checkNull(ptr);
             ptr.writeInt(0, value);
-            return nil;
+            return nil();
         }
 
         @Specialization(guards = { "value > MAX_VALUE", "value < MAX_UNSIGNED_INT_PLUS_ONE" })
@@ -653,7 +653,7 @@ public abstract class PointerNodes {
             checkNull(ptr);
             int signed = (int) value; // Same as value - 2^32
             ptr.writeInt(0, signed);
-            return nil;
+            return nil();
         }
 
     }
@@ -666,7 +666,7 @@ public abstract class PointerNodes {
             final Pointer ptr = new Pointer(address);
             checkNull(ptr);
             ptr.writeLong(0, value);
-            return nil;
+            return nil();
         }
 
     }
@@ -679,7 +679,7 @@ public abstract class PointerNodes {
             final Pointer ptr = new Pointer(address);
             checkNull(ptr);
             ptr.writeLong(0, value);
-            return nil;
+            return nil();
         }
 
         @Specialization
@@ -687,7 +687,7 @@ public abstract class PointerNodes {
             final Pointer ptr = new Pointer(address);
             checkNull(ptr);
             writeUnsignedLong(ptr, 0, value);
-            return nil;
+            return nil();
         }
 
         @TruffleBoundary
@@ -709,7 +709,7 @@ public abstract class PointerNodes {
             final Pointer ptr = new Pointer(address);
             checkNull(ptr);
             ptr.writeFloat(0, (float) value);
-            return nil;
+            return nil();
         }
 
     }
@@ -722,7 +722,7 @@ public abstract class PointerNodes {
             final Pointer ptr = new Pointer(address);
             checkNull(ptr);
             ptr.writeDouble(0, value);
-            return nil;
+            return nil();
         }
 
     }
@@ -735,7 +735,7 @@ public abstract class PointerNodes {
             final Pointer ptr = new Pointer(address);
             checkNull(ptr);
             ptr.writePointer(0, value);
-            return nil;
+            return nil();
         }
 
     }

--- a/src/main/java/org/truffleruby/interop/InteropNodes.java
+++ b/src/main/java/org/truffleruby/interop/InteropNodes.java
@@ -225,7 +225,7 @@ public abstract class InteropNodes {
                 throw new RaiseException(getContext(), coreExceptions().ioError(e, this));
             }
 
-            return nil;
+            return nil();
         }
 
     }
@@ -726,7 +726,7 @@ public abstract class InteropNodes {
                 throw translateInteropException.execute(e);
             }
 
-            return Nil.INSTANCE;
+            return Nil.get();
         }
     }
 
@@ -1302,7 +1302,7 @@ public abstract class InteropNodes {
         protected Nil toNative(Object receiver,
                 @CachedLibrary("receiver") InteropLibrary receivers) {
             receivers.toNative(receiver);
-            return Nil.INSTANCE;
+            return Nil.get();
         }
 
     }
@@ -1460,7 +1460,7 @@ public abstract class InteropNodes {
                 throw translateInteropException.execute(e);
             }
 
-            return Nil.INSTANCE;
+            return Nil.get();
         }
     }
 
@@ -1658,14 +1658,14 @@ public abstract class InteropNodes {
                 @CachedLibrary("receiver") InteropLibrary receivers,
                 @Cached FromJavaStringNode fromJavaStringNode) {
             if (!receivers.hasLanguage(receiver)) {
-                return nil;
+                return nil();
             }
 
             final Class<? extends TruffleLanguage<?>> language;
             try {
                 language = receivers.getLanguage(receiver);
             } catch (UnsupportedMessageException e) {
-                return nil;
+                return nil();
             }
 
             final String name = languageClassToLanguageName(language);
@@ -2158,7 +2158,7 @@ public abstract class InteropNodes {
                 @Cached TranslateInteropExceptionNode translateInteropException) {
             try {
                 interop.removeHashEntry(receiver, key);
-                return nil;
+                return nil();
             } catch (InteropException e) {
                 throw translateInteropException.execute(e);
             }
@@ -2253,7 +2253,7 @@ public abstract class InteropNodes {
                     throw translateInteropException.execute(e);
                 }
             } else {
-                return nil;
+                return nil();
             }
         }
     }

--- a/src/main/java/org/truffleruby/interop/PolyglotNodes.java
+++ b/src/main/java/org/truffleruby/interop/PolyglotNodes.java
@@ -277,7 +277,7 @@ public abstract class PolyglotNodes {
         @Specialization
         protected Object close(RubyInnerContext rubyInnerContext) {
             rubyInnerContext.innerContext.close();
-            return nil;
+            return nil();
         }
     }
 
@@ -286,7 +286,7 @@ public abstract class PolyglotNodes {
         @Specialization
         protected Object closeExited(RubyInnerContext rubyInnerContext) {
             rubyInnerContext.innerContext.closeCancelled(this, "force terminate");
-            return nil;
+            return nil();
         }
     }
 

--- a/src/main/java/org/truffleruby/language/DataNode.java
+++ b/src/main/java/org/truffleruby/language/DataNode.java
@@ -50,7 +50,7 @@ public class DataNode extends RubyContextSourceNode {
 
         coreLibrary().objectClass.fields.setConstant(getContext(), null, "DATA", data);
 
-        return nil;
+        return nil();
     }
 
     @TruffleBoundary

--- a/src/main/java/org/truffleruby/language/EmitWarningsNode.java
+++ b/src/main/java/org/truffleruby/language/EmitWarningsNode.java
@@ -35,7 +35,7 @@ public class EmitWarningsNode extends RubyContextSourceNode {
     public Object execute(VirtualFrame frame) {
         final RubyContext context = getContext();
         printWarnings(context);
-        return nil;
+        return nil();
     }
 
     public void printWarnings(RubyContext context) {

--- a/src/main/java/org/truffleruby/language/Nil.java
+++ b/src/main/java/org/truffleruby/language/Nil.java
@@ -26,7 +26,11 @@ import static org.truffleruby.cext.ValueWrapperManager.NIL_HANDLE;
 @ExportLibrary(InteropLibrary.class)
 public final class Nil extends ImmutableRubyObject implements TruffleObject {
 
-    public static final Nil INSTANCE = new Nil();
+    private static final Nil INSTANCE = new Nil();
+
+    public static Nil get() {
+        return INSTANCE;
+    }
 
     private Nil() {
         this.valueWrapper = new ValueWrapper(this, NIL_HANDLE, null);

--- a/src/main/java/org/truffleruby/language/Nil.java
+++ b/src/main/java/org/truffleruby/language/Nil.java
@@ -10,7 +10,10 @@
 package org.truffleruby.language;
 
 import com.oracle.truffle.api.library.CachedLibrary;
+import com.oracle.truffle.api.nodes.Node;
+import com.oracle.truffle.api.source.SourceSection;
 import org.truffleruby.RubyContext;
+import org.truffleruby.RubyLanguage;
 import org.truffleruby.cext.ValueWrapper;
 import org.truffleruby.core.klass.RubyClass;
 
@@ -18,7 +21,11 @@ import com.oracle.truffle.api.interop.InteropLibrary;
 import com.oracle.truffle.api.interop.TruffleObject;
 import com.oracle.truffle.api.library.ExportLibrary;
 import com.oracle.truffle.api.library.ExportMessage;
+import org.truffleruby.core.string.StringUtils;
+import org.truffleruby.language.backtrace.BacktraceFormatter;
 import org.truffleruby.language.objects.ObjectIDOperations;
+
+import java.util.ArrayList;
 
 import static org.truffleruby.cext.ValueWrapperManager.NIL_HANDLE;
 
@@ -26,18 +33,38 @@ import static org.truffleruby.cext.ValueWrapperManager.NIL_HANDLE;
 @ExportLibrary(InteropLibrary.class)
 public final class Nil extends ImmutableRubyObject implements TruffleObject {
 
+    public static final boolean TRACE = true;
+
     private static final Nil INSTANCE = new Nil();
 
     public static Nil get() {
-        return INSTANCE;
+        return get(null, "implicit nil");
+    }
+
+    public static Nil get(Node node, String event) {
+        if (TRACE) {
+            final Nil nil = new Nil();
+            nil.trace(node, event);
+            return nil;
+        } else {
+            return INSTANCE;
+        }
     }
 
     public static boolean is(Object object) {
-        return object == INSTANCE;
+        if (TRACE) {
+            return object instanceof Nil;
+        } else {
+            return object == INSTANCE;
+        }
     }
 
     public static boolean isNot(Object object) {
-        return object != INSTANCE;
+        if (TRACE) {
+            return !(object instanceof Nil);
+        } else {
+            return object != INSTANCE;
+        }
     }
 
     private Nil() {
@@ -73,5 +100,49 @@ public final class Nil extends ImmutableRubyObject implements TruffleObject {
         return true;
     }
     // endregion
+
+    private static class TraceEntry {
+
+        private final TraceEntry previous;
+        private final Node node;
+        private final String event;
+
+        public TraceEntry(TraceEntry previous, Node node, String event) {
+            this.previous = previous;
+            this.node = node;
+            this.event = event;
+        }
+
+    }
+
+    private TraceEntry trace = null;
+
+    public void trace(Node node, String event) {
+        if (TRACE) {
+            trace = new TraceEntry(trace, node, event);
+        }
+    }
+
+    public String[] getTrace(RubyLanguage language) {
+        final ArrayList<String> lines = new ArrayList<>();
+
+        for (TraceEntry entry = trace; entry != null; entry = entry.previous) {
+            if (entry.node == null) {
+                lines.add(entry.event);
+            } else {
+                final SourceSection sourceSection = entry.node.getEncapsulatingSourceSection();
+                if (BacktraceFormatter.isUserSourceSection(language, sourceSection)) {
+                    final String source = RubyLanguage.fileLine(sourceSection);
+                    final String method = entry.node.getRootNode().getName();
+                    lines.add(entry.event + " from " + source + " in " + method);
+                } else if (entry.previous == null) {
+                    // Source of nil may be in the core library, but we still want to show it
+                    lines.add(entry.event);
+                }
+            }
+        }
+
+        return lines.toArray(StringUtils.EMPTY_STRING_ARRAY);
+    }
 
 }

--- a/src/main/java/org/truffleruby/language/Nil.java
+++ b/src/main/java/org/truffleruby/language/Nil.java
@@ -32,6 +32,14 @@ public final class Nil extends ImmutableRubyObject implements TruffleObject {
         return INSTANCE;
     }
 
+    public static boolean is(Object object) {
+        return object == INSTANCE;
+    }
+
+    public static boolean isNot(Object object) {
+        return object != INSTANCE;
+    }
+
     private Nil() {
         this.valueWrapper = new ValueWrapper(this, NIL_HANDLE, null);
         this.objectId = ObjectIDOperations.NIL;

--- a/src/main/java/org/truffleruby/language/NoImplicitCastsToLong.java
+++ b/src/main/java/org/truffleruby/language/NoImplicitCastsToLong.java
@@ -21,7 +21,7 @@ public abstract class NoImplicitCastsToLong {
 
     @TypeCheck(Nil.class)
     public static boolean isNil(Object value) {
-        return value == Nil.get();
+        return Nil.is(value);
     }
 
     @TypeCast(Nil.class)

--- a/src/main/java/org/truffleruby/language/NoImplicitCastsToLong.java
+++ b/src/main/java/org/truffleruby/language/NoImplicitCastsToLong.java
@@ -21,12 +21,12 @@ public abstract class NoImplicitCastsToLong {
 
     @TypeCheck(Nil.class)
     public static boolean isNil(Object value) {
-        return value == Nil.INSTANCE;
+        return value == Nil.get();
     }
 
     @TypeCast(Nil.class)
     public static Nil asNil(Object value) {
-        return Nil.INSTANCE;
+        return Nil.get();
     }
 
     @TypeCheck(NotProvided.class)

--- a/src/main/java/org/truffleruby/language/RubyBaseNode.java
+++ b/src/main/java/org/truffleruby/language/RubyBaseNode.java
@@ -48,7 +48,7 @@ public abstract class RubyBaseNode extends Node {
         return getLanguage().singleContext;
     }
 
-    public static Nil nil() {
+    public Nil nil() {
         return Nil.get();
     }
 
@@ -56,7 +56,7 @@ public abstract class RubyBaseNode extends Node {
         return Nil.is(value) ? null : value;
     }
 
-    public static Object nullToNil(Object value) {
+    public Object nullToNil(Object value) {
         return value == null ? nil() : value;
     }
 

--- a/src/main/java/org/truffleruby/language/RubyBaseNode.java
+++ b/src/main/java/org/truffleruby/language/RubyBaseNode.java
@@ -53,7 +53,7 @@ public abstract class RubyBaseNode extends Node {
     }
 
     public static Object nilToNull(Object value) {
-        return value == nil() ? null : value;
+        return Nil.is(value) ? null : value;
     }
 
     public static Object nullToNil(Object value) {

--- a/src/main/java/org/truffleruby/language/RubyBaseNode.java
+++ b/src/main/java/org/truffleruby/language/RubyBaseNode.java
@@ -49,7 +49,11 @@ public abstract class RubyBaseNode extends Node {
     }
 
     public Nil nil() {
-        return Nil.get();
+        return Nil.get(this, "implicit nil");
+    }
+
+    public Nil nil(String event) {
+        return Nil.get(this, event);
     }
 
     public static Object nilToNull(Object value) {

--- a/src/main/java/org/truffleruby/language/RubyBaseNode.java
+++ b/src/main/java/org/truffleruby/language/RubyBaseNode.java
@@ -40,8 +40,6 @@ public abstract class RubyBaseNode extends Node {
 
     public static final Object[] EMPTY_ARGUMENTS = ArrayUtils.EMPTY_ARRAY;
 
-    public static final Nil nil = Nil.INSTANCE;
-
     public static final int MAX_EXPLODE_SIZE = 16;
 
     public static final int LIBSTRING_CACHE = 3;
@@ -50,12 +48,16 @@ public abstract class RubyBaseNode extends Node {
         return getLanguage().singleContext;
     }
 
+    public static Nil nil() {
+        return Nil.get();
+    }
+
     public static Object nilToNull(Object value) {
-        return value == nil ? null : value;
+        return value == nil() ? null : value;
     }
 
     public static Object nullToNil(Object value) {
-        return value == null ? nil : value;
+        return value == null ? nil() : value;
     }
 
     /** Variants for {@link com.oracle.truffle.api.library.Library}. The node argument should typically be

--- a/src/main/java/org/truffleruby/language/RubyGuards.java
+++ b/src/main/java/org/truffleruby/language/RubyGuards.java
@@ -173,7 +173,7 @@ public abstract class RubyGuards {
     }
 
     public static boolean isNil(Object object) {
-        return object == Nil.get();
+        return Nil.is(object);
     }
 
     // Internal types

--- a/src/main/java/org/truffleruby/language/RubyGuards.java
+++ b/src/main/java/org/truffleruby/language/RubyGuards.java
@@ -173,7 +173,7 @@ public abstract class RubyGuards {
     }
 
     public static boolean isNil(Object object) {
-        return object == Nil.INSTANCE;
+        return object == Nil.get();
     }
 
     // Internal types

--- a/src/main/java/org/truffleruby/language/RubyParsingRequestNode.java
+++ b/src/main/java/org/truffleruby/language/RubyParsingRequestNode.java
@@ -81,7 +81,7 @@ public class RubyParsingRequestNode extends RubyBaseRootNode implements Internal
                     method,
                     null,
                     context.getCoreLibrary().mainObject,
-                    Nil.INSTANCE,
+                    Nil.get(),
                     EmptyArgumentsDescriptor.INSTANCE,
                     frame.getArguments()));
 

--- a/src/main/java/org/truffleruby/language/RubyTypes.java
+++ b/src/main/java/org/truffleruby/language/RubyTypes.java
@@ -30,7 +30,7 @@ public abstract class RubyTypes {
 
     @TypeCheck(Nil.class)
     public static boolean isNil(Object value) {
-        return value == Nil.get();
+        return Nil.is(value);
     }
 
     @TypeCast(Nil.class)

--- a/src/main/java/org/truffleruby/language/RubyTypes.java
+++ b/src/main/java/org/truffleruby/language/RubyTypes.java
@@ -30,12 +30,12 @@ public abstract class RubyTypes {
 
     @TypeCheck(Nil.class)
     public static boolean isNil(Object value) {
-        return value == Nil.INSTANCE;
+        return value == Nil.get();
     }
 
     @TypeCast(Nil.class)
     public static Nil asNil(Object value) {
-        return Nil.INSTANCE;
+        return Nil.get();
     }
 
     @TypeCheck(NotProvided.class)

--- a/src/main/java/org/truffleruby/language/SetTopLevelBindingNode.java
+++ b/src/main/java/org/truffleruby/language/SetTopLevelBindingNode.java
@@ -23,7 +23,7 @@ public class SetTopLevelBindingNode extends RubyContextSourceNode {
     public Object execute(VirtualFrame frame) {
         final MaterializedFrame mainScriptFrame = frame.materialize();
         updateTopLevelBindingFrame(mainScriptFrame);
-        return nil;
+        return nil();
     }
 
     @TruffleBoundary

--- a/src/main/java/org/truffleruby/language/TruffleBootNodes.java
+++ b/src/main/java/org/truffleruby/language/TruffleBootNodes.java
@@ -71,7 +71,7 @@ public abstract class TruffleBootNodes {
         protected Object rubyHome() {
             final String home = getLanguage().getRubyHome();
             if (home == null) {
-                return nil;
+                return nil();
             } else {
                 return makeStringNode.executeMake(home, Encodings.UTF_8, CodeRange.CR_UNKNOWN);
             }
@@ -84,7 +84,7 @@ public abstract class TruffleBootNodes {
 
         @Specialization
         protected Object forceContext() {
-            return nil;
+            return nil();
         }
     }
 
@@ -279,7 +279,7 @@ public abstract class TruffleBootNodes {
             });
 
             if (source == null) {
-                return nil;
+                return nil();
             }
 
             return makeStringNode
@@ -303,7 +303,7 @@ public abstract class TruffleBootNodes {
             if (emitWarningsNode != null) {
                 emitWarningsNode.printWarnings(context);
             }
-            return nil;
+            return nil();
         }
 
     }
@@ -323,7 +323,7 @@ public abstract class TruffleBootNodes {
                 throw new RaiseException(
                         getContext(),
                         coreExceptions()
-                                .nameError("option not defined: " + optionNameString, nil, optionNameString, this));
+                                .nameError("option not defined: " + optionNameString, nil(), optionNameString, this));
             }
 
             Object value = getContext().getOptions().fromDescriptor(descriptor);
@@ -371,7 +371,7 @@ public abstract class TruffleBootNodes {
         @Specialization
         protected Object printTimeMetric(RubySymbol name) {
             Metrics.printTime(name.getString());
-            return nil;
+            return nil();
         }
 
     }

--- a/src/main/java/org/truffleruby/language/WarnNode.java
+++ b/src/main/java/org/truffleruby/language/WarnNode.java
@@ -36,7 +36,7 @@ public class WarnNode extends RubyBaseNode {
 
     public boolean shouldWarn() {
         final Object verbosity = readVerboseNode.execute();
-        return verbosity != nil();
+        return Nil.isNot(verbosity);
     }
 
     public final boolean shouldWarnForDeprecation() {

--- a/src/main/java/org/truffleruby/language/WarnNode.java
+++ b/src/main/java/org/truffleruby/language/WarnNode.java
@@ -36,7 +36,7 @@ public class WarnNode extends RubyBaseNode {
 
     public boolean shouldWarn() {
         final Object verbosity = readVerboseNode.execute();
-        return verbosity != nil;
+        return verbosity != nil();
     }
 
     public final boolean shouldWarnForDeprecation() {

--- a/src/main/java/org/truffleruby/language/arguments/CheckNoKeywordArgumentsNode.java
+++ b/src/main/java/org/truffleruby/language/arguments/CheckNoKeywordArgumentsNode.java
@@ -34,6 +34,6 @@ public class CheckNoKeywordArgumentsNode extends RubyContextSourceNode {
             throw new RaiseException(getContext(), coreExceptions().argumentError("no keywords accepted", this));
         }
 
-        return nil;
+        return nil();
     }
 }

--- a/src/main/java/org/truffleruby/language/arguments/ReadPostArgumentNode.java
+++ b/src/main/java/org/truffleruby/language/arguments/ReadPostArgumentNode.java
@@ -36,7 +36,7 @@ public class ReadPostArgumentNode extends RubyContextSourceNode {
             return RubyArguments.getArgument(frame, effectiveIndex);
         } else {
             // CheckArityNode will prevent this case for methods & lambdas, but it is still possible for procs.
-            return nil;
+            return nil();
         }
     }
 

--- a/src/main/java/org/truffleruby/language/arguments/ReadPreArgumentNode.java
+++ b/src/main/java/org/truffleruby/language/arguments/ReadPreArgumentNode.java
@@ -51,7 +51,7 @@ public class ReadPreArgumentNode extends RubyContextSourceNode {
                 return NotProvided.INSTANCE;
 
             case NIL:
-                return nil;
+                return nil();
 
             default:
                 throw Utils.unsupportedOperation("unknown missing argument behaviour");

--- a/src/main/java/org/truffleruby/language/arguments/RubyArguments.java
+++ b/src/main/java/org/truffleruby/language/arguments/RubyArguments.java
@@ -70,7 +70,7 @@ public final class RubyArguments {
         assert RubyGuards.assertIsValidRubyValue(rubyArgs[ArgumentIndicies.SELF.ordinal()]);
 
         final Object block = rubyArgs[ArgumentIndicies.BLOCK.ordinal()];
-        assert block instanceof RubyProc || block == Nil.get() : block;
+        assert block instanceof RubyProc || Nil.is(block) : block;
 
         Object descriptor = rubyArgs[ArgumentIndicies.DESCRIPTOR.ordinal()];
         assert descriptor instanceof ArgumentsDescriptor : descriptor;
@@ -264,20 +264,20 @@ public final class RubyArguments {
     public static Object getBlock(Object[] args) {
         final Object block = args[ArgumentIndicies.BLOCK.ordinal()];
         /* We put into the frame arguments either a Nil or RubyProc, so that's all we'll get out at this point. */
-        assert block instanceof Nil || block instanceof RubyProc : StringUtils.toString(block);
+        assert Nil.is(block) || block instanceof RubyProc : StringUtils.toString(block);
         return block;
     }
 
     public static void setBlock(Object[] args, Object block) {
         // We put into the frame arguments either a Nil or RubyProc.
-        assert block instanceof Nil || block instanceof RubyProc : StringUtils.toString(block);
+        assert Nil.is(block) || block instanceof RubyProc : StringUtils.toString(block);
         args[ArgumentIndicies.BLOCK.ordinal()] = block;
     }
 
     public static Object getBlock(Frame frame) {
         final Object block = frame.getArguments()[ArgumentIndicies.BLOCK.ordinal()];
         /* We put into the frame arguments either a Nil or RubyProc, so that's all we'll get out at this point. */
-        assert block instanceof Nil || block instanceof RubyProc : StringUtils.toString(block);
+        assert Nil.is(block) || block instanceof RubyProc : StringUtils.toString(block);
         return block;
     }
 

--- a/src/main/java/org/truffleruby/language/arguments/RubyArguments.java
+++ b/src/main/java/org/truffleruby/language/arguments/RubyArguments.java
@@ -70,7 +70,7 @@ public final class RubyArguments {
         assert RubyGuards.assertIsValidRubyValue(rubyArgs[ArgumentIndicies.SELF.ordinal()]);
 
         final Object block = rubyArgs[ArgumentIndicies.BLOCK.ordinal()];
-        assert block instanceof RubyProc || block == Nil.INSTANCE : block;
+        assert block instanceof RubyProc || block == Nil.get() : block;
 
         Object descriptor = rubyArgs[ArgumentIndicies.DESCRIPTOR.ordinal()];
         assert descriptor instanceof ArgumentsDescriptor : descriptor;

--- a/src/main/java/org/truffleruby/language/arguments/SaveMethodBlockNode.java
+++ b/src/main/java/org/truffleruby/language/arguments/SaveMethodBlockNode.java
@@ -24,7 +24,7 @@ public class SaveMethodBlockNode extends RubyContextSourceNode {
     @Override
     public Object execute(VirtualFrame frame) {
         frame.setObject(slot, RubyArguments.getBlock(frame));
-        return nil;
+        return nil();
     }
 
 }

--- a/src/main/java/org/truffleruby/language/backtrace/Backtrace.java
+++ b/src/main/java/org/truffleruby/language/backtrace/Backtrace.java
@@ -275,7 +275,7 @@ public class Backtrace {
         // Omitting more locations than available should return nil.
         if (stackTraceLength == 0) {
             return omitted > totalUnderlyingElements
-                    ? Nil.INSTANCE
+                    ? Nil.get()
                     : ArrayHelpers.createEmptyArray(context, language);
         }
 

--- a/src/main/java/org/truffleruby/language/constants/ReadConstantNode.java
+++ b/src/main/java/org/truffleruby/language/constants/ReadConstantNode.java
@@ -15,6 +15,7 @@ import org.truffleruby.core.module.ModuleOperations;
 import org.truffleruby.core.module.RubyModule;
 import org.truffleruby.core.string.FrozenStrings;
 import org.truffleruby.language.LexicalScope;
+import org.truffleruby.language.Nil;
 import org.truffleruby.language.RubyConstant;
 import org.truffleruby.language.RubyContextSourceNode;
 import org.truffleruby.language.RubyNode;
@@ -78,7 +79,7 @@ public class ReadConstantNode extends RubyContextSourceNode {
 
     /** Whether the module part of this constant read is undefined, without attempting to evaluate it. */
     public boolean isModuleTriviallyUndefined(VirtualFrame frame, RubyLanguage language, RubyContext context) {
-        return moduleNode.isDefined(frame, language, context) == nil();
+        return Nil.is(moduleNode.isDefined(frame, language, context));
     }
 
     @Override

--- a/src/main/java/org/truffleruby/language/constants/ReadConstantNode.java
+++ b/src/main/java/org/truffleruby/language/constants/ReadConstantNode.java
@@ -78,20 +78,20 @@ public class ReadConstantNode extends RubyContextSourceNode {
 
     /** Whether the module part of this constant read is undefined, without attempting to evaluate it. */
     public boolean isModuleTriviallyUndefined(VirtualFrame frame, RubyLanguage language, RubyContext context) {
-        return moduleNode.isDefined(frame, language, context) == nil;
+        return moduleNode.isDefined(frame, language, context) == nil();
     }
 
     @Override
     public Object isDefined(VirtualFrame frame, RubyLanguage language, RubyContext context) {
         if (isModuleTriviallyUndefined(frame, language, context)) {
-            return nil;
+            return nil();
         }
         try {
             final RubyModule module = checkModule(moduleNode.execute(frame));
             final RubyConstant constant = getConstantIfDefined(module);
-            return constant == null ? nil : FrozenStrings.CONSTANT;
+            return constant == null ? nil() : FrozenStrings.CONSTANT;
         } catch (RaiseException e) {
-            return nil; // MRI swallows all exceptions in defined? (https://bugs.ruby-lang.org/issues/5786)
+            return nil(); // MRI swallows all exceptions in defined? (https://bugs.ruby-lang.org/issues/5786)
         }
     }
 

--- a/src/main/java/org/truffleruby/language/constants/ReadConstantWithDynamicScopeNode.java
+++ b/src/main/java/org/truffleruby/language/constants/ReadConstantWithDynamicScopeNode.java
@@ -52,7 +52,7 @@ public class ReadConstantWithDynamicScopeNode extends RubyContextSourceNode {
         } catch (RaiseException e) {
             if (e.getException().getLogicalClass() == coreLibrary().nameErrorClass) {
                 // private constant
-                return nil;
+                return nil();
             }
             throw e;
         }
@@ -60,7 +60,7 @@ public class ReadConstantWithDynamicScopeNode extends RubyContextSourceNode {
         if (ModuleOperations.isConstantDefined(constant)) {
             return FrozenStrings.CONSTANT;
         } else {
-            return nil;
+            return nil();
         }
     }
 

--- a/src/main/java/org/truffleruby/language/constants/ReadConstantWithLexicalScopeNode.java
+++ b/src/main/java/org/truffleruby/language/constants/ReadConstantWithLexicalScopeNode.java
@@ -50,7 +50,7 @@ public class ReadConstantWithLexicalScopeNode extends RubyContextSourceNode {
         } catch (RaiseException e) {
             if (e.getException().getLogicalClass() == coreLibrary().nameErrorClass) {
                 // private constant
-                return nil;
+                return nil();
             }
             throw e;
         }
@@ -58,7 +58,7 @@ public class ReadConstantWithLexicalScopeNode extends RubyContextSourceNode {
         if (ModuleOperations.isConstantDefined(constant)) {
             return FrozenStrings.CONSTANT;
         } else {
-            return nil;
+            return nil();
         }
     }
 

--- a/src/main/java/org/truffleruby/language/control/DynamicReturnNode.java
+++ b/src/main/java/org/truffleruby/language/control/DynamicReturnNode.java
@@ -9,6 +9,7 @@
  */
 package org.truffleruby.language.control;
 
+import org.truffleruby.language.Nil;
 import org.truffleruby.language.RubyContextSourceNode;
 import org.truffleruby.language.RubyNode;
 
@@ -27,7 +28,13 @@ public class DynamicReturnNode extends RubyContextSourceNode {
 
     @Override
     public Object execute(VirtualFrame frame) {
-        throw new DynamicReturnException(returnID, value.execute(frame));
+        final Object returned = value.execute(frame);
+
+        if (Nil.is(returned)) {
+            ((Nil) returned).trace(this, "returned");
+        }
+
+        throw new DynamicReturnException(returnID, returned);
     }
 
     @Override

--- a/src/main/java/org/truffleruby/language/control/IfNode.java
+++ b/src/main/java/org/truffleruby/language/control/IfNode.java
@@ -38,7 +38,7 @@ public class IfNode extends RubyContextSourceNode {
         if (conditionProfile.profile(condition.execute(frame))) {
             return thenBody.execute(frame);
         } else {
-            return nil;
+            return nil();
         }
     }
 

--- a/src/main/java/org/truffleruby/language/control/LocalReturnNode.java
+++ b/src/main/java/org/truffleruby/language/control/LocalReturnNode.java
@@ -9,6 +9,7 @@
  */
 package org.truffleruby.language.control;
 
+import org.truffleruby.language.Nil;
 import org.truffleruby.language.RubyContextSourceNode;
 import org.truffleruby.language.RubyNode;
 
@@ -24,7 +25,13 @@ public class LocalReturnNode extends RubyContextSourceNode {
 
     @Override
     public Object execute(VirtualFrame frame) {
-        throw new LocalReturnException(value.execute(frame));
+        final Object returned = value.execute(frame);
+
+        if (Nil.is(returned)) {
+            ((Nil) returned).trace(this, "returned");
+        }
+
+        throw new LocalReturnException(returned);
     }
 
     @Override
@@ -36,4 +43,5 @@ public class LocalReturnNode extends RubyContextSourceNode {
     public RubyNode simplifyAsTailExpression() {
         return value;
     }
+
 }

--- a/src/main/java/org/truffleruby/language/control/UnlessNode.java
+++ b/src/main/java/org/truffleruby/language/control/UnlessNode.java
@@ -39,7 +39,7 @@ public class UnlessNode extends RubyContextSourceNode {
         if (!conditionProfile.profile(condition.execute(frame))) {
             return thenBody.execute(frame);
         } else {
-            return nil;
+            return nil();
         }
     }
 

--- a/src/main/java/org/truffleruby/language/control/WhileNode.java
+++ b/src/main/java/org/truffleruby/language/control/WhileNode.java
@@ -34,7 +34,7 @@ public final class WhileNode extends RubyContextSourceNode {
     @Override
     public Object execute(VirtualFrame frame) {
         loopNode.execute(frame);
-        return nil;
+        return nil();
     }
 
     private abstract static class WhileRepeatingBaseNode extends RubyBaseNode implements RepeatingNode {

--- a/src/main/java/org/truffleruby/language/dispatch/DispatchNode.java
+++ b/src/main/java/org/truffleruby/language/dispatch/DispatchNode.java
@@ -112,7 +112,7 @@ public class DispatchNode extends FrameAndVariablesSendingNode {
     public Object call(Object receiver, String method) {
         final Object[] rubyArgs = RubyArguments.allocate(0);
         RubyArguments.setSelf(rubyArgs, receiver);
-        RubyArguments.setBlock(rubyArgs, nil);
+        RubyArguments.setBlock(rubyArgs, nil());
         RubyArguments.setDescriptor(rubyArgs, EmptyArgumentsDescriptor.INSTANCE);
         return dispatch(null, receiver, method, rubyArgs);
     }
@@ -120,7 +120,7 @@ public class DispatchNode extends FrameAndVariablesSendingNode {
     public Object call(Object receiver, String method, Object arg1) {
         final Object[] rubyArgs = RubyArguments.allocate(1);
         RubyArguments.setSelf(rubyArgs, receiver);
-        RubyArguments.setBlock(rubyArgs, nil);
+        RubyArguments.setBlock(rubyArgs, nil());
         RubyArguments.setDescriptor(rubyArgs, EmptyArgumentsDescriptor.INSTANCE);
         RubyArguments.setArgument(rubyArgs, 0, arg1);
         return dispatch(null, receiver, method, rubyArgs);
@@ -129,7 +129,7 @@ public class DispatchNode extends FrameAndVariablesSendingNode {
     public Object call(Object receiver, String method, Object arg1, Object arg2) {
         final Object[] rubyArgs = RubyArguments.allocate(2);
         RubyArguments.setSelf(rubyArgs, receiver);
-        RubyArguments.setBlock(rubyArgs, nil);
+        RubyArguments.setBlock(rubyArgs, nil());
         RubyArguments.setDescriptor(rubyArgs, EmptyArgumentsDescriptor.INSTANCE);
         RubyArguments.setArgument(rubyArgs, 0, arg1);
         RubyArguments.setArgument(rubyArgs, 1, arg2);
@@ -139,7 +139,7 @@ public class DispatchNode extends FrameAndVariablesSendingNode {
     public Object call(Object receiver, String method, Object arg1, Object arg2, Object arg3) {
         final Object[] rubyArgs = RubyArguments.allocate(3);
         RubyArguments.setSelf(rubyArgs, receiver);
-        RubyArguments.setBlock(rubyArgs, nil);
+        RubyArguments.setBlock(rubyArgs, nil());
         RubyArguments.setDescriptor(rubyArgs, EmptyArgumentsDescriptor.INSTANCE);
         RubyArguments.setArgument(rubyArgs, 0, arg1);
         RubyArguments.setArgument(rubyArgs, 1, arg2);
@@ -150,7 +150,7 @@ public class DispatchNode extends FrameAndVariablesSendingNode {
     public Object call(Object receiver, String method, Object[] arguments) {
         final Object[] rubyArgs = RubyArguments.allocate(arguments.length);
         RubyArguments.setSelf(rubyArgs, receiver);
-        RubyArguments.setBlock(rubyArgs, nil);
+        RubyArguments.setBlock(rubyArgs, nil());
         RubyArguments.setDescriptor(rubyArgs, EmptyArgumentsDescriptor.INSTANCE);
         RubyArguments.setArguments(rubyArgs, arguments);
         return dispatch(null, receiver, method, rubyArgs);
@@ -159,7 +159,7 @@ public class DispatchNode extends FrameAndVariablesSendingNode {
     public Object callWithKeywords(Object receiver, String method, Object arg1, RubyHash keywords) {
         final Object[] rubyArgs = RubyArguments.allocate(2);
         RubyArguments.setSelf(rubyArgs, receiver);
-        RubyArguments.setBlock(rubyArgs, nil);
+        RubyArguments.setBlock(rubyArgs, nil());
         RubyArguments.setDescriptor(rubyArgs, KeywordArgumentsDescriptorManager.EMPTY);
         RubyArguments.setArgument(rubyArgs, 0, arg1);
         RubyArguments.setArgument(rubyArgs, 1, keywords);
@@ -222,7 +222,7 @@ public class DispatchNode extends FrameAndVariablesSendingNode {
     public Object callWithFrame(Frame frame, Object receiver, String method) {
         final Object[] rubyArgs = RubyArguments.allocate(0);
         RubyArguments.setSelf(rubyArgs, receiver);
-        RubyArguments.setBlock(rubyArgs, nil);
+        RubyArguments.setBlock(rubyArgs, nil());
         RubyArguments.setDescriptor(rubyArgs, EmptyArgumentsDescriptor.INSTANCE);
         return dispatch(frame, receiver, method, rubyArgs);
     }
@@ -230,7 +230,7 @@ public class DispatchNode extends FrameAndVariablesSendingNode {
     public Object callWithFrame(Frame frame, Object receiver, String method, Object arg1) {
         final Object[] rubyArgs = RubyArguments.allocate(1);
         RubyArguments.setSelf(rubyArgs, receiver);
-        RubyArguments.setBlock(rubyArgs, nil);
+        RubyArguments.setBlock(rubyArgs, nil());
         RubyArguments.setDescriptor(rubyArgs, EmptyArgumentsDescriptor.INSTANCE);
         RubyArguments.setArgument(rubyArgs, 0, arg1);
         return dispatch(frame, receiver, method, rubyArgs);
@@ -239,7 +239,7 @@ public class DispatchNode extends FrameAndVariablesSendingNode {
     public Object callWithFrame(Frame frame, Object receiver, String method, Object arg1, Object arg2) {
         final Object[] rubyArgs = RubyArguments.allocate(2);
         RubyArguments.setSelf(rubyArgs, receiver);
-        RubyArguments.setBlock(rubyArgs, nil);
+        RubyArguments.setBlock(rubyArgs, nil());
         RubyArguments.setDescriptor(rubyArgs, EmptyArgumentsDescriptor.INSTANCE);
         RubyArguments.setArgument(rubyArgs, 0, arg1);
         RubyArguments.setArgument(rubyArgs, 1, arg2);
@@ -249,7 +249,7 @@ public class DispatchNode extends FrameAndVariablesSendingNode {
     public Object callWithFrame(Frame frame, Object receiver, String method, Object arg1, Object arg2, Object arg3) {
         final Object[] rubyArgs = RubyArguments.allocate(3);
         RubyArguments.setSelf(rubyArgs, receiver);
-        RubyArguments.setBlock(rubyArgs, nil);
+        RubyArguments.setBlock(rubyArgs, nil());
         RubyArguments.setDescriptor(rubyArgs, EmptyArgumentsDescriptor.INSTANCE);
         RubyArguments.setArgument(rubyArgs, 0, arg1);
         RubyArguments.setArgument(rubyArgs, 1, arg2);
@@ -260,7 +260,7 @@ public class DispatchNode extends FrameAndVariablesSendingNode {
     public Object callWithFrame(Frame frame, Object receiver, String method, Object[] arguments) {
         final Object[] rubyArgs = RubyArguments.allocate(arguments.length);
         RubyArguments.setSelf(rubyArgs, receiver);
-        RubyArguments.setBlock(rubyArgs, nil);
+        RubyArguments.setBlock(rubyArgs, nil());
         RubyArguments.setDescriptor(rubyArgs, EmptyArgumentsDescriptor.INSTANCE);
         RubyArguments.setArguments(rubyArgs, arguments);
         return dispatch(frame, receiver, method, rubyArgs);

--- a/src/main/java/org/truffleruby/language/dispatch/RubyCallNode.java
+++ b/src/main/java/org/truffleruby/language/dispatch/RubyCallNode.java
@@ -87,8 +87,8 @@ public class RubyCallNode extends LiteralCallNode implements AssignableNode {
     @Override
     public Object execute(VirtualFrame frame) {
         final Object receiverObject = receiver.execute(frame);
-        if (isSafeNavigation && nilProfile.profile(receiverObject == nil)) {
-            return nil;
+        if (isSafeNavigation && nilProfile.profile(receiverObject == nil())) {
+            return nil();
         }
         Object[] rubyArgs = RubyArguments.allocate(arguments.length);
         RubyArguments.setSelf(rubyArgs, receiverObject);
@@ -115,7 +115,7 @@ public class RubyCallNode extends LiteralCallNode implements AssignableNode {
                 ((NilLiteralNode) getLastArgumentNode()).isImplicit()) : getLastArgumentNode();
 
         final Object receiverObject = receiver.execute(frame);
-        if (isSafeNavigation && nilProfile.profile(receiverObject == nil)) {
+        if (isSafeNavigation && nilProfile.profile(receiverObject == nil())) {
             return;
         }
         Object[] rubyArgs = RubyArguments.allocate(arguments.length);
@@ -126,7 +126,7 @@ public class RubyCallNode extends LiteralCallNode implements AssignableNode {
             rubyArgs = splatArgs(receiverObject, rubyArgs);
         }
 
-        assert RubyArguments.getLastArgument(rubyArgs) == nil;
+        assert RubyArguments.getLastArgument(rubyArgs) == nil();
         RubyArguments.setLastArgument(rubyArgs, value);
 
         RubyArguments.setBlock(rubyArgs, executeBlock(frame));
@@ -175,7 +175,7 @@ public class RubyCallNode extends LiteralCallNode implements AssignableNode {
         if (block != null) {
             return block.execute(frame);
         } else {
-            return nil;
+            return nil();
         }
     }
 
@@ -255,14 +255,14 @@ public class RubyCallNode extends LiteralCallNode implements AssignableNode {
 
         @ExplodeLoop
         public Object isDefined(VirtualFrame frame, RubyContext context) {
-            if (receiverDefinedProfile.profile(receiver.isDefined(frame, getLanguage(), context) == nil)) {
-                return nil;
+            if (receiverDefinedProfile.profile(receiver.isDefined(frame, getLanguage(), context) == nil())) {
+                return nil();
             }
 
             for (RubyNode argument : arguments) {
-                if (argument.isDefined(frame, getLanguage(), context) == nil) {
+                if (argument.isDefined(frame, getLanguage(), context) == nil()) {
                     argumentNotDefinedProfile.enter();
-                    return nil;
+                    return nil();
                 }
             }
 
@@ -274,7 +274,7 @@ public class RubyCallNode extends LiteralCallNode implements AssignableNode {
                 receiverObject = receiver.execute(frame);
             } catch (Exception e) {
                 receiverExceptionProfile.enter();
-                return nil;
+                return nil();
             }
 
             final InternalMethod method = lookupMethodNode.execute(frame, receiverObject, methodName, dispatchConfig);
@@ -283,7 +283,7 @@ public class RubyCallNode extends LiteralCallNode implements AssignableNode {
                 final Object r = respondToMissing.call(receiverObject, "respond_to_missing?", methodNameSymbol, false);
 
                 if (r != DispatchNode.MISSING && !respondToMissingCast.execute(r)) {
-                    return nil;
+                    return nil();
                 }
             }
 

--- a/src/main/java/org/truffleruby/language/dispatch/RubyCallNode.java
+++ b/src/main/java/org/truffleruby/language/dispatch/RubyCallNode.java
@@ -19,6 +19,7 @@ import org.truffleruby.core.cast.BooleanCastNodeGen;
 import org.truffleruby.core.inlined.LambdaToProcNode;
 import org.truffleruby.core.string.FrozenStrings;
 import org.truffleruby.core.symbol.RubySymbol;
+import org.truffleruby.language.Nil;
 import org.truffleruby.language.RubyBaseNode;
 import org.truffleruby.language.RubyGuards;
 import org.truffleruby.language.RubyNode;
@@ -87,7 +88,7 @@ public class RubyCallNode extends LiteralCallNode implements AssignableNode {
     @Override
     public Object execute(VirtualFrame frame) {
         final Object receiverObject = receiver.execute(frame);
-        if (isSafeNavigation && nilProfile.profile(receiverObject == nil())) {
+        if (isSafeNavigation && nilProfile.profile(Nil.is(receiverObject))) {
             return nil();
         }
         Object[] rubyArgs = RubyArguments.allocate(arguments.length);
@@ -115,7 +116,7 @@ public class RubyCallNode extends LiteralCallNode implements AssignableNode {
                 ((NilLiteralNode) getLastArgumentNode()).isImplicit()) : getLastArgumentNode();
 
         final Object receiverObject = receiver.execute(frame);
-        if (isSafeNavigation && nilProfile.profile(receiverObject == nil())) {
+        if (isSafeNavigation && nilProfile.profile(Nil.is(receiverObject))) {
             return;
         }
         Object[] rubyArgs = RubyArguments.allocate(arguments.length);
@@ -126,7 +127,7 @@ public class RubyCallNode extends LiteralCallNode implements AssignableNode {
             rubyArgs = splatArgs(receiverObject, rubyArgs);
         }
 
-        assert RubyArguments.getLastArgument(rubyArgs) == nil();
+        assert Nil.is(RubyArguments.getLastArgument(rubyArgs));
         RubyArguments.setLastArgument(rubyArgs, value);
 
         RubyArguments.setBlock(rubyArgs, executeBlock(frame));
@@ -255,12 +256,12 @@ public class RubyCallNode extends LiteralCallNode implements AssignableNode {
 
         @ExplodeLoop
         public Object isDefined(VirtualFrame frame, RubyContext context) {
-            if (receiverDefinedProfile.profile(receiver.isDefined(frame, getLanguage(), context) == nil())) {
+            if (receiverDefinedProfile.profile(Nil.is(receiver.isDefined(frame, getLanguage(), context)))) {
                 return nil();
             }
 
             for (RubyNode argument : arguments) {
-                if (argument.isDefined(frame, getLanguage(), context) == nil()) {
+                if (Nil.is(argument.isDefined(frame, getLanguage(), context))) {
                     argumentNotDefinedProfile.enter();
                     return nil();
                 }

--- a/src/main/java/org/truffleruby/language/exceptions/EnsureNode.java
+++ b/src/main/java/org/truffleruby/language/exceptions/EnsureNode.java
@@ -48,7 +48,7 @@ public class EnsureNode extends RubyContextSourceNode {
     /** The reason this is so complicated is to avoid duplication of the ensurePart so it is PE'd only once, no matter
      * which execution paths are taken (GR-25608). */
     public Object executeCommon(VirtualFrame frame, boolean executeVoid) {
-        Object value = nil;
+        Object value = nil();
         AbstractTruffleException guestException = null;
         Throwable javaException = null;
 

--- a/src/main/java/org/truffleruby/language/globals/AliasGlobalVarNode.java
+++ b/src/main/java/org/truffleruby/language/globals/AliasGlobalVarNode.java
@@ -26,7 +26,7 @@ public class AliasGlobalVarNode extends RubyContextSourceNode {
     @Override
     public Object execute(VirtualFrame frame) {
         getContext().getCoreLibrary().globalVariables.alias(oldName, newName);
-        return nil;
+        return nil();
     }
 
 }

--- a/src/main/java/org/truffleruby/language/globals/GlobalVariableStorage.java
+++ b/src/main/java/org/truffleruby/language/globals/GlobalVariableStorage.java
@@ -50,7 +50,7 @@ public final class GlobalVariableStorage {
 
     public Object getValue() {
         Object currentValue = value;
-        return currentValue == UNSET_VALUE ? Nil.INSTANCE : currentValue;
+        return currentValue == UNSET_VALUE ? Nil.get() : currentValue;
     }
 
     public boolean isDefined() {

--- a/src/main/java/org/truffleruby/language/globals/IsDefinedGlobalVariableNode.java
+++ b/src/main/java/org/truffleruby/language/globals/IsDefinedGlobalVariableNode.java
@@ -40,7 +40,7 @@ public abstract class IsDefinedGlobalVariableNode extends RubyBaseNode {
         if (storage.isDefined()) {
             return FrozenStrings.GLOBAL_VARIABLE;
         } else {
-            return nil;
+            return nil();
         }
     }
 

--- a/src/main/java/org/truffleruby/language/globals/ReadMatchReferenceNodes.java
+++ b/src/main/java/org/truffleruby/language/globals/ReadMatchReferenceNodes.java
@@ -39,8 +39,8 @@ public abstract class ReadMatchReferenceNodes extends RubyContextSourceNode {
         public Object execute(VirtualFrame frame) {
             final Object match = readMatchNode.execute(frame);
 
-            if (matchNilProfile.profile(match == nil)) {
-                return nil;
+            if (matchNilProfile.profile(match == nil())) {
+                return nil();
             }
 
             return callGetIndex(frame, match, index);
@@ -56,8 +56,8 @@ public abstract class ReadMatchReferenceNodes extends RubyContextSourceNode {
 
         @Override
         public Object isDefined(VirtualFrame frame, RubyLanguage language, RubyContext context) {
-            if (execute(frame) == nil) {
-                return nil;
+            if (execute(frame) == nil()) {
+                return nil();
             } else {
                 return FrozenStrings.GLOBAL_VARIABLE;
             }
@@ -88,7 +88,7 @@ public abstract class ReadMatchReferenceNodes extends RubyContextSourceNode {
         public Object execute(VirtualFrame frame) {
             final Object matchResult = matchDataNode.execute(frame);
             Object match = readMatchNode.execute(frame);
-            if (matchNilProfile.profile(match == nil)) {
+            if (matchNilProfile.profile(match == nil())) {
                 setNamedForNil(frame);
             } else {
                 setNamedForNonNil(frame);

--- a/src/main/java/org/truffleruby/language/globals/ReadMatchReferenceNodes.java
+++ b/src/main/java/org/truffleruby/language/globals/ReadMatchReferenceNodes.java
@@ -12,6 +12,7 @@ package org.truffleruby.language.globals;
 import org.truffleruby.RubyContext;
 import org.truffleruby.RubyLanguage;
 import org.truffleruby.core.string.FrozenStrings;
+import org.truffleruby.language.Nil;
 import org.truffleruby.language.RubyContextSourceNode;
 import org.truffleruby.language.RubyNode;
 import org.truffleruby.language.dispatch.DispatchNode;
@@ -39,7 +40,7 @@ public abstract class ReadMatchReferenceNodes extends RubyContextSourceNode {
         public Object execute(VirtualFrame frame) {
             final Object match = readMatchNode.execute(frame);
 
-            if (matchNilProfile.profile(match == nil())) {
+            if (matchNilProfile.profile(Nil.is(match))) {
                 return nil();
             }
 
@@ -56,7 +57,7 @@ public abstract class ReadMatchReferenceNodes extends RubyContextSourceNode {
 
         @Override
         public Object isDefined(VirtualFrame frame, RubyLanguage language, RubyContext context) {
-            if (execute(frame) == nil()) {
+            if (Nil.is(execute(frame))) {
                 return nil();
             } else {
                 return FrozenStrings.GLOBAL_VARIABLE;
@@ -88,7 +89,7 @@ public abstract class ReadMatchReferenceNodes extends RubyContextSourceNode {
         public Object execute(VirtualFrame frame) {
             final Object matchResult = matchDataNode.execute(frame);
             Object match = readMatchNode.execute(frame);
-            if (matchNilProfile.profile(match == nil())) {
+            if (matchNilProfile.profile(Nil.is(match))) {
                 setNamedForNil(frame);
             } else {
                 setNamedForNonNil(frame);

--- a/src/main/java/org/truffleruby/language/literal/NilLiteralNode.java
+++ b/src/main/java/org/truffleruby/language/literal/NilLiteralNode.java
@@ -29,7 +29,7 @@ public class NilLiteralNode extends RubyContextSourceNode {
 
     @Override
     public Object execute(VirtualFrame frame) {
-        return nil;
+        return nil();
     }
 
     @Override

--- a/src/main/java/org/truffleruby/language/literal/NilLiteralNode.java
+++ b/src/main/java/org/truffleruby/language/literal/NilLiteralNode.java
@@ -29,7 +29,11 @@ public class NilLiteralNode extends RubyContextSourceNode {
 
     @Override
     public Object execute(VirtualFrame frame) {
-        return nil();
+        if (isImplicit) {
+            return nil();
+        } else {
+            return nil("nil literal");
+        }
     }
 
     @Override

--- a/src/main/java/org/truffleruby/language/loader/CodeLoader.java
+++ b/src/main/java/org/truffleruby/language/loader/CodeLoader.java
@@ -143,7 +143,7 @@ public class CodeLoader {
                 method,
                 null,
                 self,
-                Nil.INSTANCE,
+                Nil.get(),
                 EmptyArgumentsDescriptor.INSTANCE,
                 arguments);
     }

--- a/src/main/java/org/truffleruby/language/loader/FeatureLoader.java
+++ b/src/main/java/org/truffleruby/language/loader/FeatureLoader.java
@@ -61,8 +61,6 @@ import com.oracle.truffle.api.profiles.ConditionProfile;
 import com.oracle.truffle.api.source.Source;
 import com.oracle.truffle.api.source.SourceSection;
 
-import static org.truffleruby.language.RubyBaseNode.nil;
-
 public class FeatureLoader {
 
     private final RubyContext context;
@@ -451,7 +449,7 @@ public class FeatureLoader {
                 final Object initFunction = findFunctionInLibrary(library, "rb_tr_init", rubyLibPath);
 
                 final InteropLibrary interop = InteropLibrary.getFactory().getUncached();
-                language.getCurrentThread().getCurrentFiber().extensionCallStack.push(false, nil, nil);
+                language.getCurrentThread().getCurrentFiber().extensionCallStack.push(false, Nil.get(), Nil.get());
                 try {
                     // rb_tr_init(Truffle::CExt)
                     interop.execute(initFunction, truffleCExt);
@@ -516,7 +514,7 @@ public class FeatureLoader {
 
     private Object getEmbeddedABIVersion(String expandedPath, Object library) {
         if (!InteropLibrary.getFactory().getUncached(library).isMemberReadable(library, "rb_tr_abi_version")) {
-            return Nil.INSTANCE;
+            return Nil.get();
         }
 
         final Object abiVersionFunction = findFunctionInLibrary(library, "rb_tr_abi_version", expandedPath);

--- a/src/main/java/org/truffleruby/language/loader/RequireNode.java
+++ b/src/main/java/org/truffleruby/language/loader/RequireNode.java
@@ -283,7 +283,7 @@ public abstract class RequireNode extends RubyBaseNode {
 
         requireMetric("before-execute-" + feature);
         ValueWrapperManager.allocateNewBlock(getContext(), getLanguage());
-        getLanguage().getCurrentThread().getCurrentFiber().extensionCallStack.push(false, nil, nil);
+        getLanguage().getCurrentThread().getCurrentFiber().extensionCallStack.push(false, nil(), nil());
         try {
             InteropNodes
                     .execute(

--- a/src/main/java/org/truffleruby/language/locals/ReadLocalNode.java
+++ b/src/main/java/org/truffleruby/language/locals/ReadLocalNode.java
@@ -46,10 +46,10 @@ public abstract class ReadLocalNode extends RubyContextSourceNode {
                 return FrozenStrings.LOCAL_VARIABLE;
 
             case FRAME_LOCAL_GLOBAL:
-                if (readFrameSlot(frame) != nil) {
+                if (readFrameSlot(frame) != nil()) {
                     return FrozenStrings.GLOBAL_VARIABLE;
                 } else {
-                    return nil;
+                    return nil();
                 }
 
             default:

--- a/src/main/java/org/truffleruby/language/locals/ReadLocalNode.java
+++ b/src/main/java/org/truffleruby/language/locals/ReadLocalNode.java
@@ -13,6 +13,7 @@ import org.truffleruby.RubyContext;
 import org.truffleruby.RubyLanguage;
 import org.truffleruby.core.string.FrozenStrings;
 import org.truffleruby.debug.SingleMemberDescriptor;
+import org.truffleruby.language.Nil;
 import org.truffleruby.language.RubyContextSourceNode;
 import org.truffleruby.language.RubyNode;
 import org.truffleruby.utils.Utils;
@@ -46,7 +47,7 @@ public abstract class ReadLocalNode extends RubyContextSourceNode {
                 return FrozenStrings.LOCAL_VARIABLE;
 
             case FRAME_LOCAL_GLOBAL:
-                if (readFrameSlot(frame) != nil()) {
+                if (Nil.isNot(readFrameSlot(frame))) {
                     return FrozenStrings.GLOBAL_VARIABLE;
                 } else {
                     return nil();

--- a/src/main/java/org/truffleruby/language/locals/WriteFrameSlotNode.java
+++ b/src/main/java/org/truffleruby/language/locals/WriteFrameSlotNode.java
@@ -12,6 +12,7 @@ package org.truffleruby.language.locals;
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import org.truffleruby.core.array.AssignableNode;
+import org.truffleruby.language.Nil;
 import org.truffleruby.language.RubyBaseNode;
 import org.truffleruby.language.RubyGuards;
 
@@ -65,6 +66,10 @@ public abstract class WriteFrameSlotNode extends RubyBaseNode implements Assigna
         /* No-op if kind is already Object. */
         final FrameDescriptor descriptor = getFrameDescriptor(frame);
         descriptor.setSlotKind(frameSlot, FrameSlotKind.Object);
+
+        if (Nil.is(value)) {
+            ((Nil) value).trace(this, "stored in local");
+        }
 
         frame.setObject(frameSlot, value);
     }

--- a/src/main/java/org/truffleruby/language/methods/CallForeignMethodNode.java
+++ b/src/main/java/org/truffleruby/language/methods/CallForeignMethodNode.java
@@ -51,10 +51,10 @@ public abstract class CallForeignMethodNode extends RubyBaseNode {
             @Cached TranslateExceptionNode translateException,
             @Cached ConditionProfile hasBlock,
             @Cached BranchProfile errorProfile) {
-        assert block instanceof Nil || block instanceof RubyProc : block;
+        assert Nil.is(block) || block instanceof RubyProc : block;
 
         Object[] newArguments = arguments;
-        if (hasBlock.profile(block != nil())) {
+        if (hasBlock.profile(Nil.isNot(block))) {
             newArguments = ArrayUtils.append(arguments, block);
         }
 

--- a/src/main/java/org/truffleruby/language/methods/CallForeignMethodNode.java
+++ b/src/main/java/org/truffleruby/language/methods/CallForeignMethodNode.java
@@ -54,7 +54,7 @@ public abstract class CallForeignMethodNode extends RubyBaseNode {
         assert block instanceof Nil || block instanceof RubyProc : block;
 
         Object[] newArguments = arguments;
-        if (hasBlock.profile(block != nil)) {
+        if (hasBlock.profile(block != nil())) {
             newArguments = ArrayUtils.append(arguments, block);
         }
 

--- a/src/main/java/org/truffleruby/language/methods/GetMethodObjectNode.java
+++ b/src/main/java/org/truffleruby/language/methods/GetMethodObjectNode.java
@@ -101,7 +101,7 @@ public abstract class GetMethodObjectNode extends RubyBaseNode {
         final RubyRootNode newRootNode = new RubyRootNode(
                 getLanguage(),
                 info.getSourceSection(),
-                new FrameDescriptor(nil),
+                new FrameDescriptor(nil()),
                 info,
                 newBody,
                 Split.HEURISTIC,

--- a/src/main/java/org/truffleruby/language/methods/InternalMethod.java
+++ b/src/main/java/org/truffleruby/language/methods/InternalMethod.java
@@ -29,8 +29,6 @@ import org.truffleruby.language.objects.ObjectGraphNode;
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.RootCallTarget;
 
-import static org.truffleruby.language.RubyBaseNode.nil;
-
 /** A Ruby method: either a method in a module, a literal module/class body or some meta-information for eval'd code.
  * Blocks capture the method in which they are defined. */
 public class InternalMethod implements ObjectGraphNode {
@@ -81,7 +79,7 @@ public class InternalMethod implements ObjectGraphNode {
                 proc,
                 callTarget,
                 null,
-                nil);
+                Nil.get());
     }
 
     public InternalMethod(
@@ -106,7 +104,7 @@ public class InternalMethod implements ObjectGraphNode {
                 null,
                 callTarget,
                 null,
-                Nil.INSTANCE);
+                Nil.get());
     }
 
     /** Constructor for new methods, computing builtIn from the context */

--- a/src/main/java/org/truffleruby/language/methods/InternalMethod.java
+++ b/src/main/java/org/truffleruby/language/methods/InternalMethod.java
@@ -162,7 +162,7 @@ public class InternalMethod implements ObjectGraphNode {
         assert lexicalScope != null;
         assert !sharedMethodInfo.isBlock() : sharedMethodInfo;
         assert callTarget == null || RubyRootNode.of(callTarget).getSharedMethodInfo() == sharedMethodInfo;
-        assert capturedBlock instanceof Nil || capturedBlock instanceof RubyProc : capturedBlock;
+        assert Nil.is(capturedBlock) || capturedBlock instanceof RubyProc : capturedBlock;
         this.sharedMethodInfo = sharedMethodInfo;
         this.lexicalScope = lexicalScope;
         this.declarationContext = declarationContext;

--- a/src/main/java/org/truffleruby/language/methods/LiteralMethodDefinitionNode.java
+++ b/src/main/java/org/truffleruby/language/methods/LiteralMethodDefinitionNode.java
@@ -83,7 +83,7 @@ public class LiteralMethodDefinitionNode extends RubyContextSourceNode {
                 null,
                 null,
                 callTargetSupplier,
-                Nil.INSTANCE);
+                Nil.get());
 
         if (isDefSingleton) {
             module.addMethodIgnoreNameVisibility(getContext(), method, visibility, this);

--- a/src/main/java/org/truffleruby/language/methods/ModuleBodyDefinitionNode.java
+++ b/src/main/java/org/truffleruby/language/methods/ModuleBodyDefinitionNode.java
@@ -54,7 +54,7 @@ public class ModuleBodyDefinitionNode extends RubyBaseNode {
         if (captureBlock) {
             capturedBlock = RubyArguments.getBlock(frame);
         } else {
-            capturedBlock = nil;
+            capturedBlock = nil();
         }
 
         final LexicalScope parentLexicalScope = RubyArguments.getMethod(frame).getLexicalScope();

--- a/src/main/java/org/truffleruby/language/objects/ReadInstanceVariableNode.java
+++ b/src/main/java/org/truffleruby/language/objects/ReadInstanceVariableNode.java
@@ -42,9 +42,9 @@ public class ReadInstanceVariableNode extends RubyContextSourceNode {
         if (objectProfile.profile(receiverObject instanceof RubyDynamicObject)) {
             final DynamicObjectLibrary objectLibrary = getObjectLibrary();
             final RubyDynamicObject dynamicObject = (RubyDynamicObject) receiverObject;
-            return objectLibrary.getOrDefault(dynamicObject, name, nil);
+            return objectLibrary.getOrDefault(dynamicObject, name, nil());
         } else {
-            return nil;
+            return nil();
         }
     }
 
@@ -58,7 +58,7 @@ public class ReadInstanceVariableNode extends RubyContextSourceNode {
             if (objectLibrary.containsKey(dynamicObject, name)) {
                 return FrozenStrings.INSTANCE_VARIABLE;
             } else {
-                return nil;
+                return nil();
             }
         } else {
             return false;

--- a/src/main/java/org/truffleruby/language/objects/RunModuleDefinitionNode.java
+++ b/src/main/java/org/truffleruby/language/objects/RunModuleDefinitionNode.java
@@ -43,7 +43,7 @@ public class RunModuleDefinitionNode extends RubyContextSourceNode {
                 definition,
                 null,
                 module,
-                nil,
+                nil(),
                 EmptyArgumentsDescriptor.INSTANCE,
                 EMPTY_ARGUMENTS));
     }

--- a/src/main/java/org/truffleruby/language/objects/classvariables/ReadClassVariableNode.java
+++ b/src/main/java/org/truffleruby/language/objects/classvariables/ReadClassVariableNode.java
@@ -65,7 +65,7 @@ public class ReadClassVariableNode extends RubyContextSourceNode {
         final Object value = lookupClassVariableNode.execute(module, name);
 
         if (value == null) {
-            return nil;
+            return nil();
         } else {
             return FrozenStrings.CLASS_VARIABLE;
         }

--- a/src/main/java/org/truffleruby/language/supercall/SuperCallNode.java
+++ b/src/main/java/org/truffleruby/language/supercall/SuperCallNode.java
@@ -80,7 +80,7 @@ public class SuperCallNode extends LiteralCallNode {
         final InternalMethod superMethod = executeLookupSuperMethod(frame, self);
 
         if (superMethod == null) {
-            return nil;
+            return nil();
         } else {
             return FrozenStrings.SUPER;
         }

--- a/src/main/java/org/truffleruby/language/supercall/ZSuperOutsideMethodNode.java
+++ b/src/main/java/org/truffleruby/language/supercall/ZSuperOutsideMethodNode.java
@@ -48,7 +48,7 @@ public class ZSuperOutsideMethodNode extends RubyContextSourceNode {
         final InternalMethod superMethod = lookupSuperMethodNode.executeLookupSuperMethod(frame, self);
 
         if (superMethod == null) {
-            return nil;
+            return nil();
         } else {
             return FrozenStrings.SUPER;
         }

--- a/src/main/java/org/truffleruby/language/threadlocal/SpecialVariableStorage.java
+++ b/src/main/java/org/truffleruby/language/threadlocal/SpecialVariableStorage.java
@@ -71,7 +71,7 @@ public final class SpecialVariableStorage implements TruffleObject {
 
     public Object getLastMatch(ConditionProfile unsetProfile, ConditionProfile sameThreadProfile) {
         if (unsetProfile.profile(lastMatch == null)) {
-            return Nil.INSTANCE;
+            return Nil.get();
         } else {
             return lastMatch.get(sameThreadProfile);
         }
@@ -87,7 +87,7 @@ public final class SpecialVariableStorage implements TruffleObject {
 
     public Object getLastLine(ConditionProfile unsetProfile, ConditionProfile sameThreadProfilew) {
         if (unsetProfile.profile(lastLine == null)) {
-            return Nil.INSTANCE;
+            return Nil.get();
         } else {
             return lastLine.get(sameThreadProfilew);
         }

--- a/src/main/java/org/truffleruby/language/threadlocal/ThreadAndFrameLocalStorage.java
+++ b/src/main/java/org/truffleruby/language/threadlocal/ThreadAndFrameLocalStorage.java
@@ -27,7 +27,7 @@ public class ThreadAndFrameLocalStorage {
     public ThreadAndFrameLocalStorage(RubyContext context) {
         // Cannot store a Thread id while pre-initializing
         originalThreadId = context.isPreInitializing() ? 0 : Thread.currentThread().getId();
-        originalThreadValue = Nil.INSTANCE;
+        originalThreadValue = Nil.get();
     }
 
     public Object get(ConditionProfile sameThreadProfile) {
@@ -47,7 +47,7 @@ public class ThreadAndFrameLocalStorage {
                 if (otherThreadValues != null) {
                     return otherThreadValues;
                 } else {
-                    otherThreadValues = ThreadLocal.withInitial(() -> Nil.INSTANCE);
+                    otherThreadValues = ThreadLocal.withInitial(() -> Nil.get());
                     return otherThreadValues;
                 }
             }

--- a/src/main/java/org/truffleruby/language/threadlocal/ThreadLocalGlobals.java
+++ b/src/main/java/org/truffleruby/language/threadlocal/ThreadLocalGlobals.java
@@ -11,10 +11,9 @@ package org.truffleruby.language.threadlocal;
 
 import com.oracle.truffle.api.exception.AbstractTruffleException;
 import org.truffleruby.core.exception.RubyException;
+import org.truffleruby.language.Nil;
 import org.truffleruby.language.control.RaiseException;
 import org.truffleruby.language.control.TerminationException;
-
-import static org.truffleruby.language.RubyBaseNode.nil;
 
 public class ThreadLocalGlobals {
 
@@ -22,8 +21,8 @@ public class ThreadLocalGlobals {
     public Object processStatus; // $?
 
     public ThreadLocalGlobals() {
-        this.lastException = nil;
-        this.processStatus = nil;
+        this.lastException = Nil.get();
+        this.processStatus = Nil.get();
     }
 
     public Object getLastException() {
@@ -33,7 +32,8 @@ public class ThreadLocalGlobals {
     public void setLastException(Object exception) {
         assert !(exception instanceof TerminationException) : "$? should never be a TerminationException: " + exception;
         assert !(exception instanceof RaiseException) : "$? should never be a RaiseException: " + exception;
-        assert exception == nil || exception instanceof RubyException || exception instanceof AbstractTruffleException;
+        assert exception == Nil.get() || exception instanceof RubyException ||
+                exception instanceof AbstractTruffleException;
         this.lastException = exception;
     }
 }

--- a/src/main/java/org/truffleruby/language/threadlocal/ThreadLocalGlobals.java
+++ b/src/main/java/org/truffleruby/language/threadlocal/ThreadLocalGlobals.java
@@ -32,8 +32,7 @@ public class ThreadLocalGlobals {
     public void setLastException(Object exception) {
         assert !(exception instanceof TerminationException) : "$? should never be a TerminationException: " + exception;
         assert !(exception instanceof RaiseException) : "$? should never be a RaiseException: " + exception;
-        assert exception == Nil.get() || exception instanceof RubyException ||
-                exception instanceof AbstractTruffleException;
+        assert Nil.is(exception) || exception instanceof RubyException || exception instanceof AbstractTruffleException;
         this.lastException = exception;
     }
 }

--- a/src/main/java/org/truffleruby/language/yield/CallBlockNode.java
+++ b/src/main/java/org/truffleruby/language/yield/CallBlockNode.java
@@ -42,12 +42,12 @@ public abstract class CallBlockNode extends RubyBaseNode {
 
     public final Object yield(RubyProc block, ArgumentsDescriptor descriptor, Object[] args,
             LiteralCallNode literalCallNode) {
-        return executeCallBlock(block.declarationContext, block, ProcOperations.getSelf(block), nil, descriptor, args,
+        return executeCallBlock(block.declarationContext, block, ProcOperations.getSelf(block), nil(), descriptor, args,
                 literalCallNode);
     }
 
     public final Object yield(RubyProc block, Object... args) {
-        return executeCallBlock(block.declarationContext, block, ProcOperations.getSelf(block), nil,
+        return executeCallBlock(block.declarationContext, block, ProcOperations.getSelf(block), nil(),
                 EmptyArgumentsDescriptor.INSTANCE, args, null);
     }
 

--- a/src/main/java/org/truffleruby/language/yield/YieldExpressionNode.java
+++ b/src/main/java/org/truffleruby/language/yield/YieldExpressionNode.java
@@ -69,7 +69,7 @@ public class YieldExpressionNode extends LiteralCallNode {
         }
 
         final Object maybeBlock = readBlock(frame);
-        if (maybeBlock == nil) {
+        if (maybeBlock == nil()) {
             noCapturedBlock.enter();
             throw new RaiseException(getContext(), coreExceptions().noBlockToYieldTo(this));
         }
@@ -98,7 +98,7 @@ public class YieldExpressionNode extends LiteralCallNode {
     private Object readBlock(VirtualFrame frame) {
         Object block = readBlockNode.execute(frame);
 
-        if (block == nil) {
+        if (block == nil()) {
             useCapturedBlock.enter();
             block = RubyArguments.getMethod(frame).getCapturedBlock();
         }
@@ -117,8 +117,8 @@ public class YieldExpressionNode extends LiteralCallNode {
     @Override
     public Object isDefined(VirtualFrame frame, RubyLanguage language, RubyContext context) {
         Object block = readBlock(frame);
-        if (block == nil) {
-            return nil;
+        if (block == nil()) {
+            return nil();
         } else {
             return FrozenStrings.YIELD;
         }

--- a/src/main/java/org/truffleruby/language/yield/YieldExpressionNode.java
+++ b/src/main/java/org/truffleruby/language/yield/YieldExpressionNode.java
@@ -15,6 +15,7 @@ import org.truffleruby.core.array.ArrayToObjectArrayNode;
 import org.truffleruby.core.array.ArrayToObjectArrayNodeGen;
 import org.truffleruby.core.proc.RubyProc;
 import org.truffleruby.core.string.FrozenStrings;
+import org.truffleruby.language.Nil;
 import org.truffleruby.language.RubyNode;
 import org.truffleruby.language.WarnNode;
 import org.truffleruby.language.arguments.ArgumentsDescriptor;
@@ -69,7 +70,7 @@ public class YieldExpressionNode extends LiteralCallNode {
         }
 
         final Object maybeBlock = readBlock(frame);
-        if (maybeBlock == nil()) {
+        if (Nil.is(maybeBlock)) {
             noCapturedBlock.enter();
             throw new RaiseException(getContext(), coreExceptions().noBlockToYieldTo(this));
         }
@@ -98,7 +99,7 @@ public class YieldExpressionNode extends LiteralCallNode {
     private Object readBlock(VirtualFrame frame) {
         Object block = readBlockNode.execute(frame);
 
-        if (block == nil()) {
+        if (Nil.is(block)) {
             useCapturedBlock.enter();
             block = RubyArguments.getMethod(frame).getCapturedBlock();
         }
@@ -117,7 +118,7 @@ public class YieldExpressionNode extends LiteralCallNode {
     @Override
     public Object isDefined(VirtualFrame frame, RubyLanguage language, RubyContext context) {
         Object block = readBlock(frame);
-        if (block == nil()) {
+        if (Nil.is(block)) {
             return nil();
         } else {
             return FrozenStrings.YIELD;

--- a/src/main/java/org/truffleruby/parser/BodyTranslator.java
+++ b/src/main/java/org/truffleruby/parser/BodyTranslator.java
@@ -735,7 +735,7 @@ public class BodyTranslator extends Translator {
             }
 
             if (blockTranslated instanceof ObjectLiteralNode &&
-                    ((ObjectLiteralNode) blockTranslated).getObject() == Nil.get()) {
+                    Nil.is(((ObjectLiteralNode) blockTranslated).getObject())) {
                 blockTranslated = null;
             }
         } else {

--- a/src/main/java/org/truffleruby/parser/BodyTranslator.java
+++ b/src/main/java/org/truffleruby/parser/BodyTranslator.java
@@ -735,7 +735,7 @@ public class BodyTranslator extends Translator {
             }
 
             if (blockTranslated instanceof ObjectLiteralNode &&
-                    ((ObjectLiteralNode) blockTranslated).getObject() == Nil.INSTANCE) {
+                    ((ObjectLiteralNode) blockTranslated).getObject() == Nil.get()) {
                 blockTranslated = null;
             }
         } else {

--- a/src/main/java/org/truffleruby/parser/TranslatorEnvironment.java
+++ b/src/main/java/org/truffleruby/parser/TranslatorEnvironment.java
@@ -150,7 +150,7 @@ public class TranslatorEnvironment {
                     "A descriptor should either be a method and have special variables, or be a block and have no special variables");
         }
 
-        var builder = FrameDescriptor.newBuilder().defaultValue(Nil.INSTANCE);
+        var builder = FrameDescriptor.newBuilder().defaultValue(Nil.get());
 
         if (parentDescriptor != null) {
             builder.info(parentDescriptor);

--- a/src/main/java/org/truffleruby/stdlib/CoverageNodes.java
+++ b/src/main/java/org/truffleruby/stdlib/CoverageNodes.java
@@ -34,7 +34,7 @@ public abstract class CoverageNodes {
         @Specialization
         protected Object enable() {
             getLanguage().coverageManager.enable();
-            return nil;
+            return nil();
         }
 
     }
@@ -45,7 +45,7 @@ public abstract class CoverageNodes {
         @Specialization
         protected Object disable() {
             getLanguage().coverageManager.disable();
-            return nil;
+            return nil();
         }
 
     }
@@ -73,7 +73,7 @@ public abstract class CoverageNodes {
 
                 for (int n = 0; n < countsArray.length; n++) {
                     if (countsArray[n] == CoverageManager.NO_CODE) {
-                        countsStore[n] = nil;
+                        countsStore[n] = nil();
                     } else {
                         countsStore[n] = countsArray[n];
                     }

--- a/src/main/java/org/truffleruby/stdlib/ObjSpaceNodes.java
+++ b/src/main/java/org/truffleruby/stdlib/ObjSpaceNodes.java
@@ -95,7 +95,7 @@ public abstract class ObjSpaceNodes {
 
         @Fallback
         protected Object adjacentObjectsPrimitive(Object object) {
-            return nil;
+            return nil();
         }
     }
 
@@ -116,7 +116,7 @@ public abstract class ObjSpaceNodes {
         @Specialization
         protected Object traceAllocationsStart() {
             getContext().getObjectSpaceManager().traceAllocationsStart(getLanguage());
-            return nil;
+            return nil();
         }
     }
 
@@ -126,7 +126,7 @@ public abstract class ObjSpaceNodes {
         @Specialization
         protected Object traceAllocationsStop() {
             getContext().getObjectSpaceManager().traceAllocationsStop(getLanguage());
-            return nil;
+            return nil();
         }
     }
 
@@ -136,7 +136,7 @@ public abstract class ObjSpaceNodes {
         @Specialization
         protected Object traceAllocationsClear() {
             getContext().getObjectSpaceManager().traceAllocationsClear();
-            return nil;
+            return nil();
         }
     }
 
@@ -148,11 +148,11 @@ public abstract class ObjSpaceNodes {
                 @Cached MakeStringNode makeStringNode) {
             AllocationTrace trace = getAllocationTrace(getContext(), object);
             if (trace == null) {
-                return nil;
+                return nil();
             } else {
                 final String className = trace.className;
                 if (className.isEmpty()) {
-                    return nil;
+                    return nil();
                 } else {
                     return makeStringNode.executeMake(className, Encodings.UTF_8, CodeRange.CR_UNKNOWN);
                 }
@@ -161,7 +161,7 @@ public abstract class ObjSpaceNodes {
 
         @Fallback
         protected Object allocationInfoImmutable(Object object) {
-            return nil;
+            return nil();
         }
     }
 
@@ -172,7 +172,7 @@ public abstract class ObjSpaceNodes {
         protected Object allocationInfo(RubyDynamicObject object) {
             AllocationTrace trace = getAllocationTrace(getContext(), object);
             if (trace == null) {
-                return nil;
+                return nil();
             } else {
                 return trace.gcGeneration;
             }
@@ -180,7 +180,7 @@ public abstract class ObjSpaceNodes {
 
         @Fallback
         protected Object allocationGenerationImmutable(Object object) {
-            return nil;
+            return nil();
         }
     }
 
@@ -191,11 +191,11 @@ public abstract class ObjSpaceNodes {
         protected Object allocationInfo(RubyDynamicObject object) {
             AllocationTrace trace = getAllocationTrace(getContext(), object);
             if (trace == null) {
-                return nil;
+                return nil();
             } else {
                 final String allocatingMethod = trace.allocatingMethod;
                 if (allocatingMethod.startsWith("<")) { // <top (required)> or <main> are hidden in MRI
-                    return nil;
+                    return nil();
                 } else if (allocatingMethod.equals("__allocate__")) { // The allocator function is hidden in MRI
                     return getLanguage().coreSymbols.NEW;
                 } else {
@@ -206,7 +206,7 @@ public abstract class ObjSpaceNodes {
 
         @Fallback
         protected Object allocationMethodIdImmutable(Object object) {
-            return nil;
+            return nil();
         }
     }
 
@@ -218,7 +218,7 @@ public abstract class ObjSpaceNodes {
                 @Cached MakeStringNode makeStringNode) {
             AllocationTrace trace = getAllocationTrace(getContext(), object);
             if (trace == null) {
-                return nil;
+                return nil();
             } else {
                 final String sourcePath = getLanguage().getSourcePath(trace.allocatingSourceSection.getSource());
                 return makeStringNode.executeMake(sourcePath, Encodings.UTF_8, CodeRange.CR_UNKNOWN);
@@ -227,7 +227,7 @@ public abstract class ObjSpaceNodes {
 
         @Fallback
         protected Object allocationSourcefileImmutable(Object object) {
-            return nil;
+            return nil();
         }
     }
 
@@ -238,7 +238,7 @@ public abstract class ObjSpaceNodes {
         protected Object allocationInfo(RubyDynamicObject object) {
             AllocationTrace trace = getAllocationTrace(getContext(), object);
             if (trace == null) {
-                return nil;
+                return nil();
             } else {
                 return trace.allocatingSourceSection.getStartLine();
             }
@@ -246,7 +246,7 @@ public abstract class ObjSpaceNodes {
 
         @Fallback
         protected Object allocationSourcelineImmutable(Object object) {
-            return nil;
+            return nil();
         }
     }
 

--- a/src/main/java/org/truffleruby/stdlib/readline/ReadlineHistoryNodes.java
+++ b/src/main/java/org/truffleruby/stdlib/readline/ReadlineHistoryNodes.java
@@ -101,7 +101,7 @@ public abstract class ReadlineHistoryNodes {
             final ConsoleHolder consoleHolder = getContext().getConsoleHolder();
 
             if (consoleHolder.getHistory().isEmpty()) {
-                return nil;
+                return nil();
             }
 
             final String lastLine = consoleHolder.getHistory().removeLast().line();
@@ -124,7 +124,7 @@ public abstract class ReadlineHistoryNodes {
             final ConsoleHolder consoleHolder = getContext().getConsoleHolder();
 
             if (consoleHolder.getHistory().isEmpty()) {
-                return nil;
+                return nil();
             }
 
             final String lastLine = consoleHolder.getHistory().removeFirst().line();
@@ -158,7 +158,7 @@ public abstract class ReadlineHistoryNodes {
             } catch (IOException e) {
                 throw new RaiseException(getContext(), coreExceptions().ioError(e, this));
             }
-            return nil;
+            return nil();
         }
 
     }
@@ -240,7 +240,7 @@ public abstract class ReadlineHistoryNodes {
 
             try {
                 consoleHolder.getHistory().set(normalizedIndex, line);
-                return nil;
+                return nil();
             } catch (IndexOutOfBoundsException e) {
                 throw new RaiseException(getContext(), coreExceptions().indexErrorInvalidIndex(this));
             }

--- a/src/main/java/org/truffleruby/stdlib/readline/ReadlineNodes.java
+++ b/src/main/java/org/truffleruby/stdlib/readline/ReadlineNodes.java
@@ -163,7 +163,7 @@ public abstract class ReadlineNodes {
 
             final String value = result.get();
             if (value == null) { // EOF
-                return nil;
+                return nil();
             } else {
                 if (addToHistory) {
                     readline.getHistory().add(value);

--- a/src/main/ruby/truffleruby/core/truffle/exception_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/exception_operations.rb
@@ -156,6 +156,15 @@ module Truffle
         end
         append_causes(result, exception, {}.compare_by_identity, reverse, highlight)
       end
+      if exception.is_a?(NameError) && exception.receiver.nil?
+        trace = Primitive.nil_trace(exception)
+        unless trace.empty?
+          result << "nil trace:\n"
+          trace.reverse.each do |line|
+            result << "\t" << line << "\n"
+          end
+        end
+      end
       result
     end
 


### PR DESCRIPTION
This PR sketches out an option for allowing users to trace where `nil` values have come from. For example:

```ruby
def read_from_hash(hash, key)
  hash[key]
end

def foo(hash)
  read_from_hash(hash, :baz)
end

hash = {foo: 14, bar: 2}

# We'll get a NME here - should say nil came from the hash's default value
# in #read_from_hash and was returned to here via foo
p foo(hash) * 2

# demo-hash.rb:13:in `<main>': undefined method `*' for nil:NilClass (NoMethodError)
# nil trace:
#         default hash value
#         returned from demo-hash.rb:2 in Object#read_from_hash
#         returned from demo-hash.rb:6 in Object#foo
```

This has an overhead when disabled of 2% in the interpreter and nothing in peak, and an overhead when tracing of 24% in the interpreter and 6% in peak. Enough to always run locally and when running test suites.

It works by allowing multiple instances of `nil`. When tracing, a log is created for control flow involving the `nil` instances. The log is a linked list of references to events and the nodes where they happened, so allocation has a simple always-fast-path, and as all tracing code is visible to PE, `nils` and their traces that don't escape are optimised away.

I'd need to turn the option into a proper option, add some more trace events, fix the failing PE tests (some complex things that were PE constant before aren't now, haven't investigated), and write some more elaborate demos to check it's actually useful for bug fixing.

Review by commit - the first two are large refactorings. 54cd3883038355dee6cc6a40b0fa7e06deb8f87a is the actual work.

Rubinius had `nil` tracing, but I think their ideas was only to record the original source of the nil, not where it went since, and I'm not sure how much was actually implemented.

* https://medium.com/metalanguage/nil-is-not-null-and-other-tales-febf6730f216
* https://twitter.com/rubinius/status/685534200213061632
* https://github.com/rubinius/rubinius/commit/da81b5daf4bf4633944caef8b898762eabada5ea