### PR TITLE
Run jt idea when bootstrapping in Spin

### DIFF
--- a/.spin/bin/bootstrap
+++ b/.spin/bin/bootstrap
@@ -17,5 +17,6 @@ jt install jvmci
 jt install eclipse
 jt mx sforceimports
 jt build
+jt idea
 jt ruby --version
 popd


### PR DESCRIPTION
So that we can connect IntelliJ remotely.