### PR TITLE
If a call target supplier is fulfilled, just use it

### DIFF
--- a/src/main/java/org/truffleruby/builtins/CoreMethodNodeManager.java
+++ b/src/main/java/org/truffleruby/builtins/CoreMethodNodeManager.java
@@ -16,7 +16,7 @@ import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.TruffleSafepoint;
 import org.truffleruby.RubyContext;
 import org.truffleruby.RubyLanguage;
-import org.truffleruby.collections.CachedSupplier;
+import org.truffleruby.language.methods.CachedLazyCallTargetSupplier;
 import org.truffleruby.core.CoreLibrary;
 import org.truffleruby.core.DummyNode;
 import org.truffleruby.core.array.ArrayUtils;
@@ -253,7 +253,7 @@ public class CoreMethodNodeManager {
                     arity);
 
             final RootCallTarget callTarget;
-            final CachedSupplier<RootCallTarget> callTargetSupplier;
+            final CachedLazyCallTargetSupplier callTargetSupplier;
             final NodeFactory<? extends RubyBaseNode> alwaysInlinedNodeFactory;
             if (alwaysInlined) {
                 callTarget = callTargetFactory.apply(sharedMethodInfo);
@@ -262,10 +262,8 @@ public class CoreMethodNodeManager {
             } else {
                 if (context.getLanguageSlow().options.LAZY_CALLTARGETS) {
                     callTarget = null;
-                    callTargetSupplier = new CachedSupplier<>(() -> {
-                        CompilerDirectives.transferToInterpreterAndInvalidate();
-                        return callTargetFactory.apply(sharedMethodInfo);
-                    });
+                    callTargetSupplier = new CachedLazyCallTargetSupplier(
+                            () -> callTargetFactory.apply(sharedMethodInfo));
                 } else {
                     callTarget = callTargetFactory.apply(sharedMethodInfo);
                     callTargetSupplier = null;

--- a/src/main/java/org/truffleruby/builtins/CoreMethodNodeManager.java
+++ b/src/main/java/org/truffleruby/builtins/CoreMethodNodeManager.java
@@ -262,7 +262,10 @@ public class CoreMethodNodeManager {
             } else {
                 if (context.getLanguageSlow().options.LAZY_CALLTARGETS) {
                     callTarget = null;
-                    callTargetSupplier = new CachedSupplier<>(() -> callTargetFactory.apply(sharedMethodInfo));
+                    callTargetSupplier = new CachedSupplier<>(() -> {
+                        CompilerDirectives.transferToInterpreterAndInvalidate();
+                        return callTargetFactory.apply(sharedMethodInfo);
+                    });
                 } else {
                     callTarget = callTargetFactory.apply(sharedMethodInfo);
                     callTargetSupplier = null;

--- a/src/main/java/org/truffleruby/collections/CachedSupplier.java
+++ b/src/main/java/org/truffleruby/collections/CachedSupplier.java
@@ -22,7 +22,7 @@ public class CachedSupplier<T> implements Supplier<T> {
 
     @Override
     public T get() {
-        if (value != null) {
+        if (isAvailable()) {
             return value;
         }
         synchronized (this) {
@@ -33,4 +33,9 @@ public class CachedSupplier<T> implements Supplier<T> {
             return value;
         }
     }
+
+    public boolean isAvailable() {
+        return value != null;
+    }
+
 }

--- a/src/main/java/org/truffleruby/collections/CachedSupplier.java
+++ b/src/main/java/org/truffleruby/collections/CachedSupplier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Oracle and/or its affiliates. All rights reserved. This
+ * Copyright (c) 2020, 2022 Oracle and/or its affiliates. All rights reserved. This
  * code is released under a tri EPL/GPL/LGPL license. You can use it,
  * redistribute it and/or modify it under the terms of the:
  *
@@ -11,7 +11,7 @@ package org.truffleruby.collections;
 
 import java.util.function.Supplier;
 
-public class CachedSupplier<T> implements Supplier<T> {
+public class CachedSupplier<T> {
 
     private volatile T value = null;
     private Supplier<T> supplier;
@@ -20,7 +20,6 @@ public class CachedSupplier<T> implements Supplier<T> {
         this.supplier = supplier;
     }
 
-    @Override
     public T get() {
         if (isAvailable()) {
             return value;

--- a/src/main/java/org/truffleruby/language/methods/CachedLazyCallTargetSupplier.java
+++ b/src/main/java/org/truffleruby/language/methods/CachedLazyCallTargetSupplier.java
@@ -7,23 +7,27 @@
  * GNU General Public License version 2, or
  * GNU Lesser General Public License version 2.1.
  */
-package org.truffleruby.collections;
+package org.truffleruby.language.methods;
+
+import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.RootCallTarget;
 
 import java.util.function.Supplier;
 
-public class CachedSupplier<T> {
+public class CachedLazyCallTargetSupplier {
 
-    private volatile T value = null;
-    private Supplier<T> supplier;
+    private volatile RootCallTarget value = null;
+    private Supplier<RootCallTarget> supplier;
 
-    public CachedSupplier(Supplier<T> supplier) {
+    public CachedLazyCallTargetSupplier(Supplier<RootCallTarget> supplier) {
         this.supplier = supplier;
     }
 
-    public T get() {
+    public RootCallTarget get() {
         if (isAvailable()) {
             return value;
         }
+        CompilerDirectives.transferToInterpreterAndInvalidate();
         synchronized (this) {
             if (value == null) {
                 value = supplier.get();

--- a/src/main/java/org/truffleruby/language/methods/CachedLazyCallTargetSupplier.java
+++ b/src/main/java/org/truffleruby/language/methods/CachedLazyCallTargetSupplier.java
@@ -26,6 +26,12 @@ public class CachedLazyCallTargetSupplier {
 
     public RootCallTarget get() {
         CompilerAsserts.neverPartOfCompilation("Only behind a transfer, must not PE the Supplier");
+
+        RootCallTarget alreadySet = this.callTarget;
+        if (alreadySet != null) {
+            return alreadySet;
+        }
+
         synchronized (this) {
             if (callTarget == null) {
                 callTarget = supplier.get();

--- a/src/main/java/org/truffleruby/language/methods/CachedLazyCallTargetSupplier.java
+++ b/src/main/java/org/truffleruby/language/methods/CachedLazyCallTargetSupplier.java
@@ -9,6 +9,7 @@
  */
 package org.truffleruby.language.methods;
 
+import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.RootCallTarget;
 
 import java.util.function.Supplier;
@@ -24,6 +25,7 @@ public class CachedLazyCallTargetSupplier {
     }
 
     public RootCallTarget get() {
+        CompilerAsserts.neverPartOfCompilation("Only behind a transfer, must not PE the Supplier");
         synchronized (this) {
             if (callTarget == null) {
                 callTarget = supplier.get();

--- a/src/main/java/org/truffleruby/language/methods/InternalMethod.java
+++ b/src/main/java/org/truffleruby/language/methods/InternalMethod.java
@@ -11,7 +11,6 @@ package org.truffleruby.language.methods;
 
 import java.util.Set;
 
-import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.api.dsl.NodeFactory;
 import org.truffleruby.RubyContext;
@@ -233,7 +232,6 @@ public class InternalMethod implements ObjectGraphNode {
 
     public RootCallTarget getCallTarget() {
         if (callTarget == null) {
-            CompilerDirectives.transferToInterpreterAndInvalidate();
             callTarget = callTargetSupplier.get();
             assert RubyRootNode.of(callTarget).getSharedMethodInfo() == sharedMethodInfo;
         }

--- a/src/main/java/org/truffleruby/language/methods/InternalMethod.java
+++ b/src/main/java/org/truffleruby/language/methods/InternalMethod.java
@@ -171,6 +171,13 @@ public class InternalMethod implements ObjectGraphNode {
         this.proc = proc;
         this.callTarget = callTarget;
         this.callTargetSupplier = callTargetSupplier;
+
+        /* If the call target supplier has already been run, then don't wait until the first time the InternalMethod is
+         * asked for the call target, because this would be a deoptimisation in getCallTarget. */
+
+        if (callTarget == null && callTargetSupplier != null && callTargetSupplier.isAvailable()) {
+            this.callTarget = callTargetSupplier.get();
+        }
     }
 
     public SharedMethodInfo getSharedMethodInfo() {

--- a/src/main/java/org/truffleruby/language/methods/InternalMethod.java
+++ b/src/main/java/org/truffleruby/language/methods/InternalMethod.java
@@ -14,7 +14,6 @@ import java.util.Set;
 import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.api.dsl.NodeFactory;
 import org.truffleruby.RubyContext;
-import org.truffleruby.collections.CachedSupplier;
 import org.truffleruby.core.klass.RubyClass;
 import org.truffleruby.core.module.RubyModule;
 import org.truffleruby.core.proc.RubyProc;
@@ -52,7 +51,7 @@ public class InternalMethod implements ObjectGraphNode {
     public final NodeFactory<? extends RubyBaseNode> alwaysInlinedNodeFactory;
     private final RubyProc proc; // only if method is created from a Proc
 
-    private final CachedSupplier<RootCallTarget> callTargetSupplier;
+    private final CachedLazyCallTargetSupplier callTargetSupplier;
     @CompilationFinal private RootCallTarget callTarget;
 
     public static InternalMethod fromProc(
@@ -116,7 +115,7 @@ public class InternalMethod implements ObjectGraphNode {
             NodeFactory<? extends RubyBaseNode> alwaysInlined,
             RubyProc proc,
             RootCallTarget callTarget,
-            CachedSupplier<RootCallTarget> callTargetSupplier) {
+            CachedLazyCallTargetSupplier callTargetSupplier) {
         this(
                 sharedMethodInfo,
                 lexicalScope,
@@ -150,7 +149,7 @@ public class InternalMethod implements ObjectGraphNode {
             DeclarationContext activeRefinements,
             RubyProc proc,
             RootCallTarget callTarget,
-            CachedSupplier<RootCallTarget> callTargetSupplier) {
+            CachedLazyCallTargetSupplier callTargetSupplier) {
         assert declaringModule != null;
         assert lexicalScope != null;
         assert !sharedMethodInfo.isBlock() : sharedMethodInfo;

--- a/src/main/java/org/truffleruby/language/methods/InternalMethod.java
+++ b/src/main/java/org/truffleruby/language/methods/InternalMethod.java
@@ -11,6 +11,7 @@ package org.truffleruby.language.methods;
 
 import java.util.Set;
 
+import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.api.dsl.NodeFactory;
 import org.truffleruby.RubyContext;
@@ -172,8 +173,8 @@ public class InternalMethod implements ObjectGraphNode {
 
         /* If the call target supplier has already been run, then don't wait until the first time the InternalMethod is
          * asked for the call target, because this would be a deoptimization in getCallTarget(). */
-        if (callTarget == null && callTargetSupplier != null && callTargetSupplier.isAvailable()) {
-            this.callTarget = callTargetSupplier.get();
+        if (callTarget == null && callTargetSupplier != null) {
+            this.callTarget = callTargetSupplier.getWhenAvailable();
         }
     }
 
@@ -231,6 +232,7 @@ public class InternalMethod implements ObjectGraphNode {
 
     public RootCallTarget getCallTarget() {
         if (callTarget == null) {
+            CompilerDirectives.transferToInterpreterAndInvalidate();
             callTarget = callTargetSupplier.get();
             assert RubyRootNode.of(callTarget).getSharedMethodInfo() == sharedMethodInfo;
         }

--- a/src/main/java/org/truffleruby/language/methods/InternalMethod.java
+++ b/src/main/java/org/truffleruby/language/methods/InternalMethod.java
@@ -173,8 +173,7 @@ public class InternalMethod implements ObjectGraphNode {
         this.callTargetSupplier = callTargetSupplier;
 
         /* If the call target supplier has already been run, then don't wait until the first time the InternalMethod is
-         * asked for the call target, because this would be a deoptimisation in getCallTarget. */
-
+         * asked for the call target, because this would be a deoptimization in getCallTarget(). */
         if (callTarget == null && callTargetSupplier != null && callTargetSupplier.isAvailable()) {
             this.callTarget = callTargetSupplier.get();
         }

--- a/src/main/java/org/truffleruby/language/methods/LiteralMethodDefinitionNode.java
+++ b/src/main/java/org/truffleruby/language/methods/LiteralMethodDefinitionNode.java
@@ -13,14 +13,12 @@ import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.instrumentation.InstrumentableNode;
 import com.oracle.truffle.api.instrumentation.StandardTags;
 import com.oracle.truffle.api.instrumentation.Tag;
-import org.truffleruby.collections.CachedSupplier;
 import org.truffleruby.core.module.RubyModule;
 import org.truffleruby.language.RubyContextSourceNode;
 import org.truffleruby.language.RubyNode;
 import org.truffleruby.language.Visibility;
 import org.truffleruby.language.arguments.RubyArguments;
 
-import com.oracle.truffle.api.RootCallTarget;
 import com.oracle.truffle.api.frame.VirtualFrame;
 
 import java.util.Set;
@@ -32,7 +30,7 @@ public class LiteralMethodDefinitionNode extends RubyContextSourceNode {
     private final String name;
     private final SharedMethodInfo sharedMethodInfo;
     private final boolean isDefSingleton;
-    private final CachedSupplier<RootCallTarget> callTargetSupplier;
+    private final CachedLazyCallTargetSupplier callTargetSupplier;
 
     @Child private RubyNode moduleNode;
 
@@ -41,7 +39,7 @@ public class LiteralMethodDefinitionNode extends RubyContextSourceNode {
             String name,
             SharedMethodInfo sharedMethodInfo,
             boolean isDefSingleton,
-            CachedSupplier<RootCallTarget> callTargetSupplier) {
+            CachedLazyCallTargetSupplier callTargetSupplier) {
         this.name = name;
         this.sharedMethodInfo = sharedMethodInfo;
         this.isDefSingleton = isDefSingleton;

--- a/src/main/java/org/truffleruby/parser/MethodTranslator.java
+++ b/src/main/java/org/truffleruby/parser/MethodTranslator.java
@@ -12,6 +12,7 @@ package org.truffleruby.parser;
 import java.util.Arrays;
 import java.util.function.Supplier;
 
+import com.oracle.truffle.api.CompilerDirectives;
 import org.truffleruby.RubyLanguage;
 import org.truffleruby.collections.CachedSupplier;
 import org.truffleruby.core.IsNilNode;
@@ -423,6 +424,7 @@ public class MethodTranslator extends BodyTranslator {
 
         if (shouldLazyTranslate) {
             return new CachedSupplier<>(() -> {
+                CompilerDirectives.transferToInterpreterAndInvalidate();
                 return translateMethodNode(sourceSection, defNode, bodyNode).getCallTarget();
             });
         } else {

--- a/src/main/java/org/truffleruby/parser/MethodTranslator.java
+++ b/src/main/java/org/truffleruby/parser/MethodTranslator.java
@@ -12,9 +12,8 @@ package org.truffleruby.parser;
 import java.util.Arrays;
 import java.util.function.Supplier;
 
-import com.oracle.truffle.api.CompilerDirectives;
 import org.truffleruby.RubyLanguage;
-import org.truffleruby.collections.CachedSupplier;
+import org.truffleruby.language.methods.CachedLazyCallTargetSupplier;
 import org.truffleruby.core.IsNilNode;
 import org.truffleruby.core.cast.SplatCastNode;
 import org.truffleruby.core.cast.SplatCastNode.NilBehavior;
@@ -419,17 +418,15 @@ public class MethodTranslator extends BodyTranslator {
                 argsNode.getArity());
     }
 
-    public CachedSupplier<RootCallTarget> buildMethodNodeCompiler(SourceIndexLength sourceSection,
+    public CachedLazyCallTargetSupplier buildMethodNodeCompiler(SourceIndexLength sourceSection,
             MethodDefParseNode defNode, ParseNode bodyNode) {
 
         if (shouldLazyTranslate) {
-            return new CachedSupplier<>(() -> {
-                CompilerDirectives.transferToInterpreterAndInvalidate();
-                return translateMethodNode(sourceSection, defNode, bodyNode).getCallTarget();
-            });
+            return new CachedLazyCallTargetSupplier(
+                    () -> translateMethodNode(sourceSection, defNode, bodyNode).getCallTarget());
         } else {
             final RubyMethodRootNode root = translateMethodNode(sourceSection, defNode, bodyNode);
-            return new CachedSupplier<>(() -> root.getCallTarget());
+            return new CachedLazyCallTargetSupplier(() -> root.getCallTarget());
         }
     }
 


### PR DESCRIPTION
Let's say we define methods on individual object instances, via a conventional `def o.method`.

```ruby
def foo(o)
  o.bar
end

loop do
  o = Object.new
  def o.bar
    14
  end
  foo(o)
end
```

Expected would be that this compiles and stabilises over time, but it runs in a de-opt loop.

```
% jt ruby --engine.TraceCompilation test.rb 
...
[engine] opt deopt  id=1543  Object#foo                                         |                                                                                                               |Timestamp 10190028224291|Src test.rb:1
[engine] opt deopt  id=1542  block in <main> <split-1542>                       |                                                                                                               |Timestamp 10190028276875|Src test.rb:5
[engine] opt deopt  id=1730  while loop at kernel.rb:406<OSR>                   |                                                                                                               |Timestamp 10190028288541|Src n/a
[engine] opt inval. id=1730  while loop at kernel.rb:406<OSR>                                                                                                                                   |Timestamp 10190028484958|Src n/a|Reason validRootAssumption OSR compilation got invalidated
[engine] opt done   id=1543  Object#foo                                         |Tier 1|Time     7(   3+4   )ms|AST   16|Inlined   0Y   1N|IR    226/   381|CodeSize    1548|Addr 0x11a29d210|Timestamp 10190031523916|Src test.rb:1
[engine] opt deopt  id=1543  Object#foo                                         |                                                                                                               |Timestamp 10190031561666|Src test.rb:1
[engine] opt done   id=1542  block in <main> <split-1542>                       |Tier 1|Time    11(   7+3   )ms|AST   39|Inlined   0Y   1N|IR    204/   383|CodeSize    1376|Addr 0x11a29e690|Timestamp 10190033179500|Src test.rb:5
[engine] opt done   id=1543  Object#foo                                         |Tier 1|Time     8(   4+4   )ms|AST   16|Inlined   0Y   1N|IR    226/   381|CodeSize    1548|Addr 0x11a29f910|Timestamp 10190039963083|Src test.rb:1
[engine] opt deopt  id=1543  Object#foo                                         |                                                                                                               |Timestamp 10190040011541|Src test.rb:1
[engine] opt done   id=1543  Object#foo                                         |Tier 1|Time     7(   3+4   )ms|AST   16|Inlined   0Y   1N|IR    226/   381|CodeSize    1548|Addr 0x11a2a0d90|Timestamp 10190046864791|Src test.rb:1
[engine] opt deopt  id=1543  Object#foo                                         |                                                                                                               |Timestamp 10190046903000|Src test.rb:1
[engine] opt done   id=1542  block in <main> <split-1542>                       |Tier 2|Time    14(   9+5   )ms|AST   39|Inlined   2Y   0N|IR    179/   286|CodeSize    1108|Addr 0x11a2a2210|Timestamp 10190047783500|Src test.rb:5
[engine] opt deopt  id=1543  Object#foo                                         |                                                                                                               |Timestamp 10190047857875|Src test.rb:1
[engine] opt deopt  id=1542  block in <main> <split-1542>                       |                                                                                                               |Timestamp 10190047886833|Src test.rb:5
[engine] opt done   id=1731  while loop at kernel.rb:406<OSR>                   |Tier 2|Time    21(  10+11  )ms|AST    9|Inlined   3Y   0N|IR    234/   784|CodeSize    3040|Addr 0x11a2a3490|Timestamp 10190049504875|Src n/a
[engine] opt deopt  id=1543  Object#foo                                         |                                                                                                               |Timestamp 10190049636500|Src test.rb:1
[engine] opt deopt  id=1542  block in <main> <split-1542>                       |                                                                                                               |Timestamp 10190049654500|Src test.rb:5
[engine] opt deopt  id=1731  while loop at kernel.rb:406<OSR>                   |                                                                                                               |Timestamp 10190049663458|Src n/a
[engine] opt inval. id=1731  while loop at kernel.rb:406<OSR>                                                                                                                                   |Timestamp 10190049989500|Src n/a|Reason validRootAssumption OSR compilation got invalidated
[engine] opt done   id=1543  Object#foo                                         |Tier 1|Time     9(   5+4   )ms|AST   16|Inlined   0Y   1N|IR    226/   381|CodeSize    1548|Addr 0x11a2a5c90|Timestamp 10190056611875|Src test.rb:1
[engine] opt deopt  id=1543  Object#foo                                         |                                                                                                               |Timestamp 10190056757458|Src test.rb:1
[engine] opt done   id=1542  block in <main> <split-1542>                       |Tier 1|Time    10(   7+3   )ms|AST   39|Inlined   0Y   1N|IR    204/   383|CodeSize    1376|Addr 0x11a2a7110|Timestamp 10190057990708|Src test.rb:5
[engine] opt done   id=1543  Object#foo                                         |Tier 1|Time     8(   4+4   )ms|AST   16|Inlined   0Y   1N|IR    226/   381|CodeSize    1548|Addr 0x11a2a8390|Timestamp 10190064513125|Src test.rb:1
[engine] opt deopt  id=1543  Object#foo                                         |                                                                                                               |Timestamp 10190064560833|Src test.rb:1
[engine] opt done   id=1543  Object#foo                                         |Tier 1|Time     7(   3+4   )ms|AST   16|Inlined   0Y   1N|IR    226/   381|CodeSize    1548|Addr 0x11a2a9810|Timestamp 10190071991583|Src test.rb:1
[engine] opt deopt  id=1543  Object#foo                                         |                                                                                                               |Timestamp 10190072141708|Src test.rb:1
[engine] opt done   id=1732  while loop at kernel.rb:406<OSR>                   |Tier 2|Time    23(  11+12  )ms|AST    9|Inlined   3Y   0N|IR    234/   784|CodeSize    3040|Addr 0x11a2aac90|Timestamp 10190073154541|Src n/a
[engine] opt deopt  id=1543  Object#foo                                         |                                                                                                               |Timestamp 10190073305291|Src test.rb:1
[engine] opt deopt  id=1542  block in <main> <split-1542>                       |                                                                                                               |Timestamp 10190073335458|Src test.rb:5
[engine] opt deopt  id=1732  while loop at kernel.rb:406<OSR>                   |                                                                                                               |Timestamp 10190073349208|Src n/a
[engine] opt done   id=1542  block in <main> <split-1542>                       |Tier 2|Time    16(  10+6   )ms|AST   39|Inlined   2Y   0N|IR    179/   286|CodeSize    1108|Addr 0x11a2ad490|Timestamp 10190074310875|Src test.rb:5
[engine] opt inval. id=1732  while loop at kernel.rb:406<OSR>                                                                                                                                   |Timestamp 10190074316375|Src n/a|Reason validRootAssumption OSR compilation got invalidated
[engine] opt deopt  id=1543  Object#foo                                         |                                                                                                               |Timestamp 10190074488500|Src test.rb:1
[engine] opt deopt  id=1542  block in <main> <split-1542>                       |                                                                                                               |Timestamp 10190074503958|Src test.rb:5
[engine] opt done   id=1543  Object#foo                                         |Tier 1|Time     7(   3+4   )ms|AST   16|Inlined   0Y   1N|IR    226/   381|CodeSize    1548|Addr 0x11a2ae710|Timestamp 10190081583000|Src test.rb:1
[engine] opt deopt  id=1543  Object#foo                                         |                                                                                                               |Timestamp 10190081626291|Src test.rb:1
[engine] opt done   id=1542  block in <main> <split-1542>                       |Tier 1|Time     8(   5+3   )ms|AST   39|Inlined   0Y   1N|IR    204/   383|CodeSize    1376|Addr 0x11a2afb90|Timestamp 10190083046000|Src test.rb:5
[engine] opt done   id=1543  Object#foo                                         |Tier 1|Time     9(   4+4   )ms|AST   16|Inlined   0Y   1N|IR    226/   381|CodeSize    1548|Addr 0x11a2b0e10|Timestamp 10190090500958|Src test.rb:1
...
```

We would expect that the inline cache becomes megamorphic, because it's a new singleton class each time, but it's worse than that and we get this de-opt loop rather than stabilising in a megamorphic configuration.

We dug into why this was.

```
[engine] transferToInterpreter at
  Object#foo(test.rb:1)
    block in <main>(test.rb:10) <split-7df553af>
    Kernel#loop(../graalvm/truffleruby/src/main/ruby/truffleruby/core/kernel.rb:407)
    <main>(test.rb:5)
    Truffle::Boot.main((core):1)
    block in <top (required)>(main_boot_source:1) <split-7a729f84>
    org.graalvm.polyglot.Value<RubyProc>.execute(Unknown)
  jdk.internal.vm.compiler/org.graalvm.compiler.truffle.runtime.hotspot.AbstractHotSpotTruffleRuntime.notifyTransferToInterpreter(AbstractHotSpotTruffleRuntime.java:566)
    org.graalvm.truffle/com.oracle.truffle.api.CompilerDirectives.transferToInterpreterAndInvalidate(CompilerDirectives.java:95)
    org.truffleruby.language.methods.InternalMethod.getCallTarget(InternalMethod.java:230)
    org.truffleruby.language.methods.CallInternalMethodNodeGen.execute(CallInternalMethodNodeGen.java:52)
    org.truffleruby.language.dispatch.DispatchNode.dispatchInternal(DispatchNode.java:318)
    org.truffleruby.language.dispatch.DispatchNode.dispatch(DispatchNode.java:285)
    org.truffleruby.language.dispatch.RubyCallNode.doCall(RubyCallNode.java:152)
    org.truffleruby.language.dispatch.RubyCallNode.execute(RubyCallNode.java:109)
    org.truffleruby.language.control.SequenceNode.execute(SequenceNode.java:37)
    org.truffleruby.language.RubyMethodRootNode.execute(RubyMethodRootNode.java:65)
    jdk.internal.vm.compiler/org.graalvm.compiler.truffle.runtime.OptimizedCallTarget.executeRootNode(OptimizedCallTarget.java:656)
    jdk.internal.vm.compiler/org.graalvm.compiler.truffle.runtime.OptimizedCallTarget.callInlined(OptimizedCallTarget.java:509)
    jdk.internal.vm.compiler/org.graalvm.compiler.truffle.runtime.OptimizedDirectCallNode.call(OptimizedDirectCallNode.java:68)
    org.truffleruby.language.methods.CallInternalMethodNode.callCached(CallInternalMethodNode.java:70)
    org.truffleruby.language.methods.CallInternalMethodNodeGen.execute(CallInternalMethodNodeGen.java:54)
    org.truffleruby.language.dispatch.DispatchNode.dispatchInternal(DispatchNode.java:318)
    org.truffleruby.language.dispatch.DispatchNode.dispatch(DispatchNode.java:285)
    org.truffleruby.language.dispatch.RubyCallNode.doCall(RubyCallNode.java:152)
    org.truffleruby.language.dispatch.RubyCallNode.execute(RubyCallNode.java:109)
    org.truffleruby.language.control.SequenceNode.execute(SequenceNode.java:37)
    ...
```

What's going on is that in `InternalMethod#getCallTarget` the call target for a given method is being lazily initialised each time.

```java
    public RootCallTarget getCallTarget() {
        if (callTarget == null) {
            CompilerDirectives.transferToInterpreterAndInvalidate();
            callTarget = callTargetSupplier.get();
            assert RubyRootNode.of(callTarget).getSharedMethodInfo() == sharedMethodInfo;
        }
        return callTarget;
    }
```

The code is indeed creating new `InternalMethod` objects each time. The call target they're created with is `null`, but the supplier is a `CachedCallTargetSupplier`, and the supplier has already run and is available in the cache.

This PR just directly uses an available call target. Removes the de-opt loop.

@MattAlp 