### PR TITLE
ci: add GitHub token permissions for workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@
 # Most of the CI is defined in ci.jsonnet.
 name: CI
 on: [push, pull_request]
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: lint


### PR DESCRIPTION
This PR adds minimum token permissions for the GITHUB_TOKEN.

GitHub recommends defining minimum GITHUB_TOKEN permissions for securing GitHub Actions workflows 
- https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/  
- https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
- The Open Source Security Foundation (OpenSSF) [Scorecards](https://github.com/ossf/scorecard) treats not setting token permissions as a high-risk issue 

Signed-off-by: Varun Sharma <varunsh@stepsecurity.io>

### Before this change
`GITHUB_TOKEN` has `write` permissions for multiple scopes which are not needed. 
e.g. https://github.com/oracle/truffleruby/runs/7521413259?check_suite_focus=true#step:1:16

### After this change
`GITHUB_TOKEN` will have minimum permissions needed