### PR TITLE
Introduce accessor method cache to OpenStruct

### DIFF
--- a/lib/mri/ostruct.rb
+++ b/lib/mri/ostruct.rb
@@ -108,7 +108,7 @@
 #
 class OpenStruct
   VERSION = "0.3.1"
-  MIXINS = {}
+  ATTRIBUTE_ACCESSOR_MIXINS = {}
 
   #
   # Creates a new OpenStruct object.  By default, the resulting OpenStruct
@@ -279,30 +279,16 @@ class OpenStruct
   def []=(name, value)
     name = name.to_sym
     unless is_method_protected!(name)
-      mixin = MIXINS[name]
+      mixin = ATTRIBUTE_ACCESSOR_MIXINS[name]
       unless mixin
         mixin = Module.new do
           define_method name, -> { name }
           define_method "#{name}=".to_sym, -> (x) { @table[name] = x }
         end
-        MIXINS[name] = mixin
+        ATTRIBUTE_ACCESSOR_MIXINS[name] = mixin
       end
       extend mixin
     end
-    # unless is_method_protected!(name)
-    #   accessors = ACCESSORS[name]
-    #   unless accessors
-    #     accessors = {
-    #       name => -> { name },
-    #       "#{name}=".to_sym => -> (x) { @table[name] = x }
-    #     }
-    #     ACCESSORS[name] = accessors
-    #   end
-    #   accessors.each do |key, value|
-    #     define_singleton_method key, value
-    #   end
-    # end
-
     @table[name] = value
   end
   alias_method :set_ostruct_member_value!, :[]=

--- a/lib/mri/ostruct.rb
+++ b/lib/mri/ostruct.rb
@@ -108,6 +108,7 @@
 #
 class OpenStruct
   VERSION = "0.3.1"
+  MIXINS = {}
 
   #
   # Creates a new OpenStruct object.  By default, the resulting OpenStruct
@@ -277,7 +278,31 @@ class OpenStruct
   #
   def []=(name, value)
     name = name.to_sym
-    new_ostruct_member!(name)
+    unless is_method_protected!(name)
+      mixin = MIXINS[name]
+      unless mixin
+        mixin = Module.new do
+          define_method name, -> { name }
+          define_method "#{name}=".to_sym, -> (x) { @table[name] = x }
+        end
+        MIXINS[name] = mixin
+      end
+      extend mixin
+    end
+    # unless is_method_protected!(name)
+    #   accessors = ACCESSORS[name]
+    #   unless accessors
+    #     accessors = {
+    #       name => -> { name },
+    #       "#{name}=".to_sym => -> (x) { @table[name] = x }
+    #     }
+    #     ACCESSORS[name] = accessors
+    #   end
+    #   accessors.each do |key, value|
+    #     define_singleton_method key, value
+    #   end
+    # end
+
     @table[name] = value
   end
   alias_method :set_ostruct_member_value!, :[]=

--- a/lib/mri/ostruct.rb
+++ b/lib/mri/ostruct.rb
@@ -323,7 +323,8 @@ class OpenStruct
   def delete_field(name)
     sym = name.to_sym
     begin
-      singleton_class.remove_method(sym, "#{sym}=")
+      singleton_class.undef_method(sym) #.remove_method(sym, "#{sym}=")
+      singleton_class.undef_method("#{sym}=")
     rescue NameError
     end
     @table.delete(sym) do

--- a/lib/mri/ostruct.rb
+++ b/lib/mri/ostruct.rb
@@ -270,7 +270,7 @@ class OpenStruct
       unless mixin
         mixin = Module.new do
           define_method name, -> { @table[name] }
-          define_method"#{name}=".to_sym, -> (x) {@table[name] = x}
+          define_method :"#{name}=", -> (x) { @table[name] = x }
         end
         ATTRIBUTE_ACCESSOR_MIXINS[name] = mixin
       end

--- a/lib/mri/ostruct.rb
+++ b/lib/mri/ostruct.rb
@@ -205,19 +205,6 @@ class OpenStruct
   #
   alias_method :marshal_load, :update_to_values! # :nodoc:
 
-  #
-  # Used internally to defined properties on the
-  # OpenStruct. It does this by using the metaprogramming function
-  # define_singleton_method for both the getter method and the setter method.
-  #
-  def new_ostruct_member!(name) # :nodoc:
-    unless @table.key?(name) || is_method_protected!(name)
-      define_singleton_method!(name) { @table[name] }
-      define_singleton_method!("#{name}=") {|x| @table[name] = x}
-    end
-  end
-  private :new_ostruct_member!
-
   private def is_method_protected!(name) # :nodoc:
     if !respond_to?(name, true)
       false
@@ -278,12 +265,12 @@ class OpenStruct
   #
   def []=(name, value)
     name = name.to_sym
-    unless is_method_protected!(name)
+    unless @table.key?(name) || is_method_protected!(name)
       mixin = ATTRIBUTE_ACCESSOR_MIXINS[name]
       unless mixin
         mixin = Module.new do
-          define_method name, -> { name }
-          define_method "#{name}=".to_sym, -> (x) { @table[name] = x }
+          define_method name, -> { @table[name] }
+          define_method"#{name}=".to_sym, -> (x) {@table[name] = x}
         end
         ATTRIBUTE_ACCESSOR_MIXINS[name] = mixin
       end

--- a/src/main/java/org/truffleruby/core/klass/ClassLike.java
+++ b/src/main/java/org/truffleruby/core/klass/ClassLike.java
@@ -1,0 +1,7 @@
+package org.truffleruby.core.klass;
+
+public interface ClassLike {
+
+    RubyClass reify();
+
+}

--- a/src/main/java/org/truffleruby/core/klass/ConcreteClass.java
+++ b/src/main/java/org/truffleruby/core/klass/ConcreteClass.java
@@ -1,0 +1,16 @@
+package org.truffleruby.core.klass;
+
+public class ConcreteClass implements ClassLike {
+
+    private final RubyClass concreteClass;
+
+    public ConcreteClass(RubyClass concreteClass) {
+        this.concreteClass = concreteClass;
+    }
+
+    @Override
+    public RubyClass reify() {
+        return concreteClass;
+    }
+
+}

--- a/src/main/java/org/truffleruby/core/klass/WithSingletonClass.java
+++ b/src/main/java/org/truffleruby/core/klass/WithSingletonClass.java
@@ -1,0 +1,16 @@
+package org.truffleruby.core.klass;
+
+public class WithSingletonClass implements ClassLike {
+
+    private final ClassLike underlying;
+
+    public WithSingletonClass(ClassLike underlying) {
+        this.underlying = underlying;
+    }
+
+    @Override
+    public RubyClass reify() {
+        throw new UnsupportedOperationException();
+    }
+
+}

--- a/src/main/java/org/truffleruby/language/RubyDynamicObject.java
+++ b/src/main/java/org/truffleruby/language/RubyDynamicObject.java
@@ -20,6 +20,8 @@ import org.truffleruby.core.cast.IntegerCastNode;
 import org.truffleruby.core.cast.LongCastNode;
 import org.truffleruby.core.cast.ToLongNode;
 import org.truffleruby.core.kernel.KernelNodes;
+import org.truffleruby.core.klass.ClassLike;
+import org.truffleruby.core.klass.ConcreteClass;
 import org.truffleruby.core.klass.RubyClass;
 import org.truffleruby.core.range.RubyObjectRange;
 import org.truffleruby.core.string.RubyString;
@@ -65,30 +67,30 @@ public abstract class RubyDynamicObject extends DynamicObject {
 
     private static final int FROZEN = 1;
 
-    private RubyClass metaClass;
+    private ClassLike metaClass;
 
     public RubyDynamicObject(RubyClass metaClass, Shape shape) {
         super(shape);
         assert metaClass != null;
-        this.metaClass = metaClass;
+        this.metaClass = new ConcreteClass(metaClass);
     }
 
     protected RubyDynamicObject(Shape classShape, String constructorOnlyForClassClass) {
         super(classShape);
-        this.metaClass = (RubyClass) this;
+        this.metaClass = new ConcreteClass((RubyClass) this);
     }
 
     public final RubyClass getMetaClass() {
-        return metaClass;
+        return metaClass.reify();
     }
 
     public void setMetaClass(RubyClass metaClass) {
         SharedObjects.assertPropagateSharing(this, metaClass);
-        this.metaClass = metaClass;
+        this.metaClass = new ConcreteClass(metaClass);
     }
 
     public final RubyClass getLogicalClass() {
-        return metaClass.nonSingletonClass;
+        return getMetaClass().nonSingletonClass;
     }
 
     @Override

--- a/src/main/java/org/truffleruby/language/objects/SingletonClassNode.java
+++ b/src/main/java/org/truffleruby/language/objects/SingletonClassNode.java
@@ -13,6 +13,7 @@ import com.oracle.truffle.api.dsl.GenerateUncached;
 import org.truffleruby.RubyContext;
 import org.truffleruby.core.klass.ClassNodes;
 import org.truffleruby.core.klass.RubyClass;
+import org.truffleruby.core.klass.WithSingletonClass;
 import org.truffleruby.language.ImmutableRubyObject;
 import org.truffleruby.language.Nil;
 import org.truffleruby.language.RubyDynamicObject;
@@ -135,7 +136,8 @@ public abstract class SingletonClassNode extends RubySourceNode {
             }
 
             SharedObjects.propagate(context.getLanguageSlow(), object, singletonClass);
-            object.setMetaClass(singletonClass);
+
+            object.setClassLike(new WithSingletonClass(object.getClassLike()));
 
             return singletonClass;
         }


### PR DESCRIPTION
`define_method` when used with a block, generates a new call target every time. This is because the captured environment for the block needs to be injected into the method.

This PR rewrites the implementation of `ostruct` to instead of using `define_method` every time, instead to cache the generated accessor methods as mixin modules within the class. This removes the constant re-generations of methods and more importantly, call targets, that currently occurs when using `ostruct`.

This is accomplished by creating a hash of property names and corresponding modules that contain a getter and setter method for that property, and including these generated methods upon subsequent member definitions. This means no new call targets are generated when the application is stable.

For example this code:

```ruby
require 'ostruct'

puts RUBY_DESCRIPTION

def foo(o)
  o.bar
end

loop do
  o = OpenStruct.new
  o.bar = 14
  foo(o)
end

```

Used to generate a new pair of call targets for every iteration. After this PR, it does not.

This further allows users of the objects to have stable call target caches (the lookup of the call target is still megamorphic - due to singleton classes - we're fixing this as well.)

In this graph, we can see that the accessor was a megamorphic call before, as the call targets were fresh each time. After this PR, in the second graph, the call target is stable (as we already said, the call target lookup is not, that's a separate issue, we're fixing.)

Before:
<img width="762" alt="image" src="https://user-images.githubusercontent.com/19317416/183457500-56a7b027-a679-4c76-b181-71a982bcdb06.png">

After:
<img width="783" alt="image" src="https://user-images.githubusercontent.com/19317416/183457690-a9c1d979-0841-4e8b-89bf-06fcff686e4b.png">

`1245` is the read from the hash table.

[before.pdf](https://github.com/oracle/truffleruby/files/9283123/test-ostruct.pdf)
[after.pdf](https://github.com/oracle/truffleruby/files/9283130/after.pdf)



