### PR TITLE
Better foreign exception handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Bug fixes:
 * Update `Process` methods to use `module_function` (@bjfish).
 * Fix `File::Stat`'s `#executable?` and `#executable_real?` predicates that unconditionally returned `true` for a superuser (#2690, @andrykonchin).
 * The `strip` option `--keep-section=.llvmbc` is not supported on macOS (#2697, @eregon).
+* Disallow the marshaling of polyglot exceptions since we can't properly reconstruct them (@nirvdrum).
 
 Compatibility:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Compatibility:
 * Fix `IO.pipe` - allow overriding `IO.new` that is used to create new pipes (#2692, @andykonchin).
 * Fix exception message when there are missing or extra keyword arguments - it contains all the missing/extra keywords now (#1522, @andrykonchin).
 * Always terminate native strings with enough `\0` bytes (#2704, @eregon).
+* Support `#dup` and `#clone` on foreign strings (@eregon).
 
 Performance:
 

--- a/spec/truffle/interop/polyglot/foreign_exception_spec.rb
+++ b/spec/truffle/interop/polyglot/foreign_exception_spec.rb
@@ -90,6 +90,12 @@ describe "Polyglot::ForeignException" do
     end
   end
 
+  it 'cannot be marshaled' do
+    -> {
+      Marshal.dump(@foreign)
+    }.should raise_error(TypeError)
+  end
+
   describe "when reaching the top-level" do
     it "is printed like a Ruby exception" do
       out = ruby_exe('raise Truffle::Debug.foreign_exception "main"', args: "2>&1", exit_status: 1, escape: false)

--- a/spec/truffle/interop/polyglot/foreign_string_spec.rb
+++ b/spec/truffle/interop/polyglot/foreign_string_spec.rb
@@ -14,6 +14,7 @@ describe "Polyglot::ForeignString" do
     @java_string = Truffle::Interop.as_string("abc")
     @truffle_string = Truffle::Interop.as_truffle_string("abc")
     @foreign_string = Truffle::Debug.foreign_string("abc")
+    @all = [@java_character, @java_string, @truffle_string, @foreign_string]
   end
 
   it "are of the expected Java class" do
@@ -97,6 +98,33 @@ describe "Polyglot::ForeignString" do
     @java_string.should == "abc"
     @truffle_string.should == "abc"
     @foreign_string.should == "abc"
+  end
+
+  it "supports #+@ and then mutation" do
+    @all.each do |foreign_string|
+      copy = +foreign_string
+      copy << "."
+      copy.should == "#{foreign_string}."
+    end
+  end
+
+  it "supports #dup and then mutation" do
+    @all.each do |foreign_string|
+      copy = foreign_string.dup
+      copy << "."
+      copy.should == "#{foreign_string}."
+    end
+  end
+
+  it "supports #clone and then mutation" do
+    @all.each do |foreign_string|
+      foreign_string.clone.should.frozen?
+      foreign_string.clone(freeze: true).should.frozen?
+
+      copy = foreign_string.clone(freeze: false)
+      copy << "."
+      copy.should == "#{foreign_string}."
+    end
   end
 
   it "has all Ruby String methods" do

--- a/src/main/ruby/truffleruby/core/truffle/polyglot.rb
+++ b/src/main/ruby/truffleruby/core/truffle/polyglot.rb
@@ -317,7 +317,7 @@ module Polyglot
       raise TypeError, "Foreign exception cannot be dumped: #{inspect}"
     end
 
-    def marshal_load(...)
+    def marshal_load(array)
       raise TypeError, 'Foreign exception cannot be restored'
     end
   end

--- a/src/main/ruby/truffleruby/core/truffle/polyglot.rb
+++ b/src/main/ruby/truffleruby/core/truffle/polyglot.rb
@@ -533,6 +533,14 @@ module Polyglot
 
   class ForeignObject < Object
     include ObjectTrait
+
+    class << self
+      undef_method :new
+    end
+
+    def self.__allocate__
+      raise TypeError, "allocator undefined for #{self}"
+    end
   end
 
   class ForeignException < Exception # rubocop:disable Lint/InheritException

--- a/src/main/ruby/truffleruby/core/truffle/polyglot.rb
+++ b/src/main/ruby/truffleruby/core/truffle/polyglot.rb
@@ -312,6 +312,14 @@ module Polyglot
     def backtrace
       backtrace_locations&.map(&:to_s)
     end
+
+    def marshal_dump
+      raise TypeError, "TruffleRuby foreign exceptions cannot be dumped: #{message}"
+    end
+
+    def marshal_load(...)
+      raise TypeError, 'TruffleRuby foreign exceptions cannot be restored'
+    end
   end
 
   module ExecutableTrait

--- a/src/main/ruby/truffleruby/core/truffle/polyglot.rb
+++ b/src/main/ruby/truffleruby/core/truffle/polyglot.rb
@@ -314,11 +314,11 @@ module Polyglot
     end
 
     def marshal_dump
-      raise TypeError, "TruffleRuby foreign exceptions cannot be dumped: #{message}"
+      raise TypeError, "Foreign exception cannot be dumped: #{inspect}"
     end
 
     def marshal_load(...)
-      raise TypeError, 'TruffleRuby foreign exceptions cannot be restored'
+      raise TypeError, 'Foreign exception cannot be restored'
     end
   end
 

--- a/src/main/ruby/truffleruby/core/truffle/polyglot.rb
+++ b/src/main/ruby/truffleruby/core/truffle/polyglot.rb
@@ -546,6 +546,14 @@ module Polyglot
   class ForeignException < Exception # rubocop:disable Lint/InheritException
     include ObjectTrait
     include ExceptionTrait
+
+    class << self
+      undef_method :new
+    end
+
+    def self.__allocate__
+      raise TypeError, "allocator undefined for #{self}"
+    end
   end
   # endregion
 end

--- a/src/main/ruby/truffleruby/core/truffle/polyglot_methods.rb
+++ b/src/main/ruby/truffleruby/core/truffle/polyglot_methods.rb
@@ -128,6 +128,10 @@ module Polyglot
       to_s.clear(...)
     end
 
+    def clone(...)
+      to_s.clone(...)
+    end
+
     def codepoints(...)
       to_s.codepoints(...)
     end
@@ -178,6 +182,10 @@ module Polyglot
 
     def dump(...)
       to_s.dump(...)
+    end
+
+    def dup(...)
+      to_s.dup(...)
     end
 
     def each_byte(...)

--- a/tool/generate-polyglot-methods.rb
+++ b/tool/generate-polyglot-methods.rb
@@ -17,11 +17,13 @@ module Polyglot
   module StringTrait
 RUBY
 
-string_methods = String.public_instance_methods(false).sort
+string_methods = String.public_instance_methods(false)
 # Already implemented
 string_methods -= %i[to_s to_str freeze frozen?]
+# Kernel methods which we want to handle by converting to a Ruby String first
+string_methods += %i[clone dup]
 
-string_methods.each do |name|
+string_methods.sort.each do |name|
   code << <<-RUBY
     def #{name}(...)
       to_s.#{name}(...)


### PR DESCRIPTION
I've run into problems running the [html_tokenizer](https://github.com/EiNSTeiN-/html_tokenizer) tests with TruffleRuby. At the heart of it, we haven't implemented `rb_enc_strlen` yet, so we get an exception from Sulong. This bubbles up as a `Polyglot::ForeignException`. minitest attempts to [marshal exceptions](https://github.com/minitest/minitest/blob/9c5f10084663fbee0ed57b9da11396b3643b609e/lib/minitest/test.rb#L204-L209), which didn't work for us because `Polyglot::ForeignException` is not a `RubyException`, so we had no specializations that matched. Ultimately, we can't restore the data anyway, so now we raise a `TypeError` on marshal, like other exceptions that can't be marshaled do. minitest's fallback behavior then [duplicates the exception message](https://github.com/minitest/minitest/blob/9c5f10084663fbee0ed57b9da11396b3643b609e/lib/minitest/test.rb#L213), which in this case is a `j.l.String`. We didn't have a specialization for duplicating a Java String. Now, we convert that to a Ruby string when the message is read from Ruby.

With these two changes in place, I can see individual minitest test failures rather than the entire process blowing up because of the missing specializations.