### PR TITLE
Added Truffle::System.allocated_bytes_of_current_thread

### DIFF
--- a/mx.truffleruby/suite.py
+++ b/mx.truffleruby/suite.py
@@ -201,6 +201,7 @@ suite = {
             "requires": [
                 "java.logging",
                 "java.management",
+                "jdk.management",
                 "jdk.unsupported", # sun.misc.Signal
             ],
             "dependencies": [

--- a/src/main/java/org/truffleruby/core/TruffleSystemNodes.java
+++ b/src/main/java/org/truffleruby/core/TruffleSystemNodes.java
@@ -282,6 +282,7 @@ public abstract class TruffleSystemNodes {
         @TruffleBoundary
         @Specialization
         protected static long allocatedBytes() {
+            // a race here should be unproblematic, and setThreadAllocatedMemoryEnabled idempotent
             if (bean == null) {
                 bean = (ThreadMXBean) ManagementFactory.getThreadMXBean();
                 bean.setThreadAllocatedMemoryEnabled(true);

--- a/src/main/java/org/truffleruby/core/TruffleSystemNodes.java
+++ b/src/main/java/org/truffleruby/core/TruffleSystemNodes.java
@@ -39,11 +39,13 @@
 package org.truffleruby.core;
 
 import java.io.IOException;
+import java.lang.management.ManagementFactory;
 import java.nio.file.NoSuchFileException;
 import java.util.Set;
 import java.util.logging.Level;
 
 import com.oracle.truffle.api.strings.TruffleString;
+import com.sun.management.ThreadMXBean;
 import org.truffleruby.RubyLanguage;
 import org.truffleruby.builtins.CoreMethod;
 import org.truffleruby.builtins.CoreMethodArrayArgumentsNode;
@@ -273,4 +275,19 @@ public abstract class TruffleSystemNodes {
 
     }
 
+    @CoreMethod(names = "allocated_bytes_of_current_thread", onSingleton = true)
+    public abstract static class AllocatedBytesNode extends CoreMethodArrayArgumentsNode {
+        private static ThreadMXBean bean;
+
+        @TruffleBoundary
+        @Specialization
+        protected static long allocatedBytes() {
+            if (bean == null) {
+                bean = (ThreadMXBean) ManagementFactory.getThreadMXBean();
+                bean.setThreadAllocatedMemoryEnabled(true);
+            }
+
+            return bean.getCurrentThreadAllocatedBytes();
+        }
+    }
 }


### PR DESCRIPTION
This adds `Truffle::System.allocated_bytes_of_current_thread` to expose HotSpot+SVM's `ThreadMXBean.getCurrentThreadAllocatedBytes()`.

Note, it includes `jdk.management` as new dependency to suite.py.