### PR TITLE
On jt graph, keep the graph file around

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,7 +100,8 @@ doc/user/README.md
 # Ignore .rb files at the root, it's temporary files to debug some issue
 /*.rb
 
-# Ignore Seafoam generated illustrations
+# Ignore graphs and Seafoam generated illustrations
+/*.bgv
 /*.pdf
 /*.svg
 

--- a/tool/jt.rb
+++ b/tool/jt.rb
@@ -2171,6 +2171,9 @@ module Commands
         graph = graphs.last
         raise "Could not find graph in #{dumps}" unless graph
 
+        FileUtils.cp graph, 'graph.bgv'
+        graph = 'graph.bgv'
+
         list = run_gem_test_pack_gem_or_install('seafoam', SEAFOAM_VERSION, '--json', graph, 'list', capture: :out, no_print_cmd: true)
         decoded = JSON.parse(list)
         graph_names = decoded.map { |entry| entry.fetch('graph_name_components').last }


### PR DESCRIPTION
Easier to then continue investigations or send to someone else.