### PR TITLE
Fix String#split

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Bug fixes:
 * Fix `File::Stat`'s `#executable?` and `#executable_real?` predicates that unconditionally returned `true` for a superuser (#2690, @andrykonchin).
 * The `strip` option `--keep-section=.llvmbc` is not supported on macOS (#2697, @eregon).
 * Disallow the marshaling of polyglot exceptions since we can't properly reconstruct them (@nirvdrum).
+* Fix `String#split` missing a value in its return array when called with a pattern of `" "` and a _limit_ value > 0 on a string with trailing whitespace where the limit hasn't been met (@nirvdrum).
 
 Compatibility:
 

--- a/spec/ruby/core/string/split_spec.rb
+++ b/spec/ruby/core/string/split_spec.rb
@@ -34,6 +34,29 @@ describe "String#split with String" do
     ",".split(",", 0).should == []
   end
 
+  it "does not suppress trailing empty fields when a positive limit is given" do
+    " 1 2 ".split(" ", 2).should == ["1", "2 "]
+    " 1 2 ".split(" ", 3).should == ["1", "2", ""]
+    " 1 2 ".split(" ", 4).should == ["1", "2", ""]
+    " 1 あ ".split(" ", 2).should == ["1", "あ "]
+    " 1 あ ".split(" ", 3).should == ["1", "あ", ""]
+    " 1 あ ".split(" ", 4).should == ["1", "あ", ""]
+
+    "1,2,".split(',', 2).should == ["1", "2,"]
+    "1,2,".split(',', 3).should == ["1", "2", ""]
+    "1,2,".split(',', 4).should == ["1", "2", ""]
+    "1,あ,".split(',', 2).should == ["1", "あ,"]
+    "1,あ,".split(',', 3).should == ["1", "あ", ""]
+    "1,あ,".split(',', 4).should == ["1", "あ", ""]
+
+    "1 2 ".split(/ /, 2).should == ["1", "2 "]
+    "1 2 ".split(/ /, 3).should == ["1", "2", ""]
+    "1 2 ".split(/ /, 4).should == ["1", "2", ""]
+    "1 あ ".split(/ /, 2).should == ["1", "あ "]
+    "1 あ ".split(/ /, 3).should == ["1", "あ", ""]
+    "1 あ ".split(/ /, 4).should == ["1", "あ", ""]
+  end
+
   it "returns an array with one entry if limit is 1: the original string" do
     "hai".split("hai", 1).should == ["hai"]
     "x.y.z".split(".", 1).should == ["x.y.z"]

--- a/spec/ruby/core/string/split_spec.rb
+++ b/spec/ruby/core/string/split_spec.rb
@@ -29,9 +29,12 @@ describe "String#split with String" do
     "1,2,,3,4,,".split(',').should == ["1", "2", "", "3", "4"]
     "1,2,,3,4,,".split(',', 0).should == ["1", "2", "", "3", "4"]
     "  a  b  c\nd  ".split("  ").should == ["", "a", "b", "c\nd"]
+    "  a  あ  c\nd  ".split("  ").should == ["", "a", "あ", "c\nd"]
     "hai".split("hai").should == []
     ",".split(",").should == []
     ",".split(",", 0).should == []
+    "あ".split("あ").should == []
+    "あ".split("あ", 0).should == []
   end
 
   it "does not suppress trailing empty fields when a positive limit is given" do

--- a/src/main/java/org/truffleruby/core/string/StringNodes.java
+++ b/src/main/java/org/truffleruby/core/string/StringNodes.java
@@ -3173,8 +3173,7 @@ public abstract class StringNodes {
                             findingSubstringEnd = false;
 
                             final RubyString substring = createSubString(substringNode, tstring, encoding,
-                                    substringStart,
-                                    i - substringStart);
+                                    substringStart, i - substringStart);
                             ret = addSubstring(
                                     ret,
                                     storeIndex++,
@@ -3245,12 +3244,12 @@ public abstract class StringNodes {
             var iterator = createCodePointIteratorNode.execute(tstring, tencoding, ErrorHandling.RETURN_NEGATIVE);
 
             boolean skip = true;
-            int e = 0, b = 0, n = 0;
+            int e = 0, b = 0, iterations = 0;
             try {
                 while (loopProfile.inject(iterator.hasNext())) {
                     int c = nextNode.execute(iterator);
                     int p = iterator.getByteIndex();
-                    n++;
+                    iterations++;
 
                     if (skip) {
                         if (StringSupport.isAsciiSpace(c)) {
@@ -3283,7 +3282,7 @@ public abstract class StringNodes {
                     }
                 }
             } finally {
-                profileAndReportLoopCount(loopProfile, n);
+                profileAndReportLoopCount(loopProfile, iterations);
             }
 
             if (trailingSubstringProfile.profile(len > 0 && (limitPositive || len > b || limit < 0))) {

--- a/src/main/java/org/truffleruby/core/string/StringNodes.java
+++ b/src/main/java/org/truffleruby/core/string/StringNodes.java
@@ -3140,6 +3140,7 @@ public abstract class StringNodes {
         @Child GetByteCodeRangeNode codeRangeNode = GetByteCodeRangeNode.create();
 
         private static final int SUBSTRING_CREATED = -1;
+        private static final int DEFAULT_SPLIT_VALUES_SIZE = 10;
 
         @Specialization(guards = "is7Bit(tstring, encoding, codeRangeNode)")
         protected Object stringAwkSplitAsciiOnly(Object string, int limit, Object block,
@@ -3154,7 +3155,8 @@ public abstract class StringNodes {
                 @Cached LoopConditionProfile loopProfile,
                 @Bind("strings.getTString(string)") AbstractTruffleString tstring,
                 @Bind("strings.getEncoding(string)") RubyEncoding encoding) {
-            Object[] ret = new Object[10];
+            int retSize = limit > 0 && limit < DEFAULT_SPLIT_VALUES_SIZE ? limit : DEFAULT_SPLIT_VALUES_SIZE;
+            Object[] ret = new Object[retSize];
             int storeIndex = 0;
 
             int byteLength = tstring.byteLength(encoding.tencoding);
@@ -3230,7 +3232,8 @@ public abstract class StringNodes {
                 @Cached LoopConditionProfile loopProfile,
                 @Bind("strings.getTString(string)") AbstractTruffleString tstring,
                 @Bind("strings.getEncoding(string)") RubyEncoding encoding) {
-            Object[] ret = new Object[10];
+            int retSize = limit > 0 && limit < DEFAULT_SPLIT_VALUES_SIZE ? limit : DEFAULT_SPLIT_VALUES_SIZE;
+            Object[] ret = new Object[retSize];
             int storeIndex = 0;
 
             final boolean limitPositive = limit > 0;

--- a/src/main/java/org/truffleruby/core/string/StringNodes.java
+++ b/src/main/java/org/truffleruby/core/string/StringNodes.java
@@ -3140,7 +3140,7 @@ public abstract class StringNodes {
         private static final int SUBSTRING_CREATED = -1;
 
         @Specialization(guards = "is7Bit(tstring, encoding, codeRangeNode)")
-        protected Object stringAwkSplitSingleByte(Object string, int limit, Object block,
+        protected Object stringAwkSplitAsciiOnly(Object string, int limit, Object block,
                 @Cached RubyStringLibrary strings,
                 @Cached ConditionProfile executeBlockProfile,
                 @Cached ConditionProfile growArrayProfile,
@@ -3159,6 +3159,7 @@ public abstract class StringNodes {
 
             int substringStart = 0;
             boolean findingSubstringEnd = false;
+
             for (int i = 0; i < byteLength; i++) {
                 if (StringSupport.isAsciiSpace(readByteNode.execute(tstring, i, encoding.tencoding))) {
                     if (findingSubstringEnd) {
@@ -3193,7 +3194,7 @@ public abstract class StringNodes {
                 ret = addSubstring(ret, storeIndex++, substring, block, executeBlockProfile, growArrayProfile);
             }
 
-            if (trailingEmptyStringProfile.profile(limit < 0 &&
+            if (trailingEmptyStringProfile.profile((limit < 0 || storeIndex < limit) &&
                     StringSupport.isAsciiSpace(readByteNode.execute(tstring, byteLength - 1, encoding.tencoding)))) {
                 final RubyString substring = createSubString(substringNode, tstring, encoding, byteLength - 1, 0);
                 ret = addSubstring(ret, storeIndex++, substring, block, executeBlockProfile, growArrayProfile);


### PR DESCRIPTION
This PR fixes an issue I ran into running Bundler. For a particular gem source using compact gem indices, I ended up down a path that looked similar to `name, _, checksum = str.split(" ", 3)`, where `str` was of the form `"<gem_name> <gem_versions> "`. The bug only appears in a fairly niche case. The string must be ASCII-only, the split limit must be > 0, the separator pattern must be `" "`,  and there must be trailing whitespace in the string. Using the example above, `checksum == ""` on MRI, but `checksum == nil` on TruffleRuby.

While I was at it, I added missing loop profiles and reduced the size of the resulting array if a `limit > 0` is provided, with an upper-threshold as a safety measure. It might be worth caching on the limit size, but I've left that for future work.