### PR TITLE
Renamed RubyProc field to avoid obvious confusion

### DIFF
--- a/src/main/java/org/truffleruby/RubyContext.java
+++ b/src/main/java/org/truffleruby/RubyContext.java
@@ -319,7 +319,7 @@ public class RubyContext {
                 .getConstant("TO_RUN_AT_INIT")
                 .getValue();
         for (Object proc : ArrayOperations.toIterable((RubyArray) toRunAtInit)) {
-            final Source source = ((RubyProc) proc).method
+            final Source source = ((RubyProc) proc).declaringMethod
                     .getSharedMethodInfo()
                     .getSourceSection()
                     .getSource();

--- a/src/main/java/org/truffleruby/core/proc/ProcNodes.java
+++ b/src/main/java/org/truffleruby/core/proc/ProcNodes.java
@@ -123,7 +123,7 @@ public abstract class ProcNodes {
                     block.callTarget,
                     block.declarationFrame,
                     block.declarationVariables,
-                    block.method,
+                    block.declaringMethod,
                     block.frameOnStackMarker,
                     block.declarationContext);
 
@@ -161,7 +161,7 @@ public abstract class ProcNodes {
                     proc.callTarget,
                     proc.declarationFrame,
                     proc.declarationVariables,
-                    proc.method,
+                    proc.declaringMethod,
                     proc.frameOnStackMarker,
                     proc.declarationContext);
 

--- a/src/main/java/org/truffleruby/core/proc/ProcOperations.java
+++ b/src/main/java/org/truffleruby/core/proc/ProcOperations.java
@@ -33,7 +33,7 @@ public abstract class ProcOperations {
         return RubyArguments.pack(
                 proc.declarationFrame,
                 null,
-                proc.method,
+                proc.declaringMethod,
                 proc.frameOnStackMarker,
                 getSelf(proc),
                 nil,
@@ -106,7 +106,7 @@ public abstract class ProcOperations {
                         block.callTargets,
                         block.declarationFrame,
                         block.declarationVariables,
-                        block.method,
+                        block.declaringMethod,
                         type == ProcType.PROC ? block.frameOnStackMarker : null,
                         block.declarationContext);
     }

--- a/src/main/java/org/truffleruby/core/proc/RubyProc.java
+++ b/src/main/java/org/truffleruby/core/proc/RubyProc.java
@@ -41,7 +41,7 @@ public class RubyProc extends RubyDynamicObject implements ObjectGraphNode {
     // Accessed for calling a RubyProc
     public final RootCallTarget callTarget;
     public final MaterializedFrame declarationFrame;
-    public final InternalMethod method;
+    public final InternalMethod declaringMethod;
     public final FrameOnStackMarker frameOnStackMarker;
     public final DeclarationContext declarationContext;
     // Not accessed for calling a RubyProc
@@ -63,7 +63,7 @@ public class RubyProc extends RubyDynamicObject implements ObjectGraphNode {
             RootCallTarget callTarget,
             MaterializedFrame declarationFrame,
             SpecialVariableStorage declarationVariables,
-            InternalMethod method,
+            InternalMethod declaringMethod,
             FrameOnStackMarker frameOnStackMarker,
             DeclarationContext declarationContext) {
         super(rubyClass, shape);
@@ -74,7 +74,7 @@ public class RubyProc extends RubyDynamicObject implements ObjectGraphNode {
         this.callTarget = callTarget;
         this.declarationFrame = declarationFrame;
         this.declarationVariables = declarationVariables;
-        this.method = method;
+        this.declaringMethod = declaringMethod;
         this.frameOnStackMarker = frameOnStackMarker;
         this.declarationContext = declarationContext;
     }
@@ -91,7 +91,7 @@ public class RubyProc extends RubyDynamicObject implements ObjectGraphNode {
                 callTarget,
                 declarationFrame,
                 declarationVariables,
-                method,
+                declaringMethod,
                 frameOnStackMarker,
                 declarationContext);
     }
@@ -99,7 +99,7 @@ public class RubyProc extends RubyDynamicObject implements ObjectGraphNode {
     @Override
     public void getAdjacentObjects(Set<Object> reachable) {
         ObjectGraph.getObjectsInFrame(declarationFrame, reachable);
-        ObjectGraph.addProperty(reachable, method);
+        ObjectGraph.addProperty(reachable, declaringMethod);
     }
 
     public boolean isLambda() {

--- a/src/main/java/org/truffleruby/extra/TruffleGraalNodes.java
+++ b/src/main/java/org/truffleruby/extra/TruffleGraalNodes.java
@@ -131,7 +131,7 @@ public abstract class TruffleGraalNodes {
                     newCallTarget,
                     newDeclarationFrame,
                     variables,
-                    proc.method,
+                    proc.declaringMethod,
                     proc.frameOnStackMarker,
                     proc.declarationContext);
 

--- a/src/main/java/org/truffleruby/language/methods/InternalMethod.java
+++ b/src/main/java/org/truffleruby/language/methods/InternalMethod.java
@@ -67,7 +67,7 @@ public final class InternalMethod implements ObjectGraphNode {
         return new InternalMethod(
                 context,
                 sharedMethodInfo,
-                proc.method.getLexicalScope(),
+                proc.declaringMethod.getLexicalScope(),
                 declarationContext,
                 name,
                 declaringModule,

--- a/src/main/java/org/truffleruby/language/yield/CallBlockNode.java
+++ b/src/main/java/org/truffleruby/language/yield/CallBlockNode.java
@@ -99,7 +99,7 @@ public abstract class CallBlockNode extends RubyBaseNode {
         return RubyArguments.pack(
                 block.declarationFrame,
                 null,
-                block.method,
+                block.declaringMethod,
                 declarationContext,
                 block.frameOnStackMarker,
                 self,


### PR DESCRIPTION
`RubyProc` contained a field `InternalMethod method` which we'd previously assumed was the `InternalMethod` that it invoked when executed. It turns out that `RubyProc` only has `CallTargets`, and this method field is actually the method that defined it. It would also be worth looking into why we need this field and if the stack frame provided to `RubyProc` contains all of the information that we need, but that is a separate issue.