### PR TITLE
Process#spawn should call #to_io on non-IO file descriptor objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Compatibility:
 * Fix argument implicit convertion in `IO#pos=` and `IO#seek` methods (#2787, @andrykonchin).
 * Warn about unknown directive passed to `Array#pack` in verbose mode (#2791, @andrykonchin).
 * Added constants `IO::SEEK_DATE` and `IO::SEEK_HOLE` (#2792, @andrykonchin).
+* `Process#spawn` should call `#to_io` on non-IO file descriptor objects (#2809, @jcouball).
 
 Performance:
 

--- a/spec/ruby/core/process/spawn_spec.rb
+++ b/spec/ruby/core/process/spawn_spec.rb
@@ -477,49 +477,13 @@ describe "Process.spawn" do
 
   # redirection
 
-  context "redirects STDOUT to the IO returned by obj.to_io if out: obj" do
-    # When an instance of @wrapped_io_class is passed as a value for Process#spawn
-    # redirection (e.g. as the value for out: or err:), Process#spawn is
-    # expected to call #to_io to get the wrapped IO object.
-    #
-    @wrapped_io_class = Class.new do
-      def initialize(io)
-        @io = io
-        @to_io_called = false
-      end
-
-      def to_io
-        @to_io_called = true
-        @io
-      end
-
-      def to_io_called?
-        @to_io_called
-      end
-    end
-
-    it 'should not raise an error' do
-      out = @wrapped_io_class.new(STDOUT)
-      # Since 'exit' is a shell builtin, the quotes around 0 are necessary to
-      # force spawn to use a shell
-      -> { Process.wait Process.spawn('exit "0"', out: out) }.should_not raise_error
-    end
-
-    it 'should call #to_io to get the wrapped IO object' do
-      out = @wrapped_io_class.new(STDOUT)
-      # Since 'exit' is a shell builtin, the quotes around 0 are necessary to
-      # force spawn to use a shell
-      Process.wait Process.spawn('exit "0"', out: out)
-      out.to_io_called?.should == true
-    end
-
-    it 'should redirect stdout of the subprocess to the wrapped IO object' do
-      File.open(@name, 'w') do |file|
-        -> do
-          out = @wrapped_io_class.new(file)
-          Process.wait Process.spawn('echo "Hello World"', out: out)
-        end.should output_to_fd("Hello World\n", file)
-      end
+  it 'redirects to the wrapped IO using wrapped_io.to_io if out: wrapped_io' do
+    File.open(@name, 'w') do |file|
+      -> do
+        wrapped_io = mock('wrapped IO')
+        wrapped_io.should_receive(:to_io).and_return(file)
+        Process.wait Process.spawn('echo "Hello World"', out: wrapped_io)
+      end.should output_to_fd("Hello World\n", file)
     end
   end
 

--- a/src/main/ruby/truffleruby/core/truffle/process_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/process_operations.rb
@@ -377,7 +377,11 @@ module Truffle
             open_file_for_child(obj[0], convert_file_mode(obj[1]), obj[2])
           end
         else
-          raise ArgumentError, "wrong exec redirect: #{obj.inspect}"
+          if obj.respond_to?(:to_io)
+            obj.to_io.fileno
+          else
+            raise ArgumentError, "wrong exec redirect: #{obj.inspect}"
+          end
         end
       end
 


### PR DESCRIPTION
When an object is passed as the value to a `Process#spawn` redirection option AND that object isn't a Symbol, Array, Integer, or an IO object AND that object responds to `#to_io`, then `Process#spawn` should call `#to_io` on that object to get the file descriptor.

In TruffleRuby 22.3.0 and head, `Process#spawn` raises an error in this situation without calling the object's `#to_io` method.

The MRI implementation has done this since 2.0.0 and JRuby has done this since 9.4.0.0. I have created the project [jcouball/convert_to_fd_test](https://github.com/jcouball/convert_to_fd_test) to illustrate this. The project contains [RSpec tests](https://github.com/jcouball/convert_to_fd_test/blob/main/spec/test_spec.rb) that test this scenario and uses Github Actions to run these tests on different versions of MRI, JRuby, and TruffleRuby. The results of running these tests on different Rubies can be found [here](https://github.com/jcouball/convert_to_fd_test/actions/runs/3716621445).

I am not able to run the spec in Windows and an hoping those are exercised via the CI build.