### PR TITLE
Faster empty ivar accesses

### DIFF
--- a/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
+++ b/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
@@ -1129,7 +1129,14 @@ public abstract class KernelNodes {
 
         @Specialization(limit = "getDynamicObjectCacheLimit()")
         protected boolean any(RubyDynamicObject self,
-                @CachedLibrary("self") DynamicObjectLibrary objectLibrary) {
+                @CachedLibrary("self") DynamicObjectLibrary objectLibrary,
+                @Cached ConditionProfile noPropertiesProfile) {
+            var shape = objectLibrary.getShape(self);
+
+            if (noPropertiesProfile.profile(shape.getPropertyCount() == 0)) {
+                return false;
+            }
+
             Object[] keys = objectLibrary.getKeyArray(self);
 
             for (Object key : keys) {


### PR DESCRIPTION
While looking at Psych loading performance in #2089, I saw that `String#-@` was taking longer than I would have expected. Interning is an inherently slow operation, but I noticed we were spending a lot of time in `Primitive.any_instance_variable?` when these strings have no instance variables. This PR adds a quick exit for that primitive when the shape has no properties. Since the `object_ivars` primitive looks quite similar, I carried it forward as well. I don't know if there's a real use case for it at the moment, but `"abc".instance_variables.empty?` compiles well with this PR. Both changes benefit the interpreter as well by avoiding unnecessary array allocations.