### PR TITLE
Fix `Struct#inspect` in anonymous classes/modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ Compatibility:
 * Fix `Enumerable` methods `each_cons` and `each_slice` to return receiver (#2733, @horakivo)
 * `Module` methods `#private`, `#public`, `#protected`, `#module_function` now returns their arguments like in CRuby 3.1 (#2733, @horakivo)
 * `Kernel#exit!`, killing Fibers and internal errors do not run code in `ensure` clauses anymore, the same as CRuby (@eregon).
+* Modify `Struct#{inspect,to_s}` to match MRI when the struct is nested inside of an anonymous class or module (@st0012, @nirvdrum).
 
 Performance:
 

--- a/spec/ruby/core/struct/inspect_spec.rb
+++ b/spec/ruby/core/struct/inspect_spec.rb
@@ -3,10 +3,5 @@ require_relative 'fixtures/classes'
 require_relative 'shared/inspect'
 
 describe "Struct#inspect" do
-  it "returns a string representation showing members and values" do
-    car = StructClasses::Car.new('Ford', 'Ranger')
-    car.inspect.should == '#<struct StructClasses::Car make="Ford", model="Ranger", year=nil>'
-  end
-
   it_behaves_like :struct_inspect, :inspect
 end

--- a/spec/ruby/core/struct/shared/inspect.rb
+++ b/spec/ruby/core/struct/shared/inspect.rb
@@ -9,12 +9,12 @@ describe :struct_inspect, shared: true do
   end
 
   it "returns a string representation without the class name for structs nested in anonymous classes" do
-    obj = Object.new
-    obj.singleton_class.class_eval <<~DOC
+    c = Class.new
+    c.class_eval <<~DOC
       class Foo < Struct.new(:a); end
     DOC
 
-    obj.singleton_class::Foo.new("").send(@method).should == '#<struct a="">'
+    c::Foo.new("").send(@method).should == '#<struct a="">'
   end
 
   it "returns a string representation without the class name for structs nested in anonymous modules" do

--- a/spec/ruby/core/struct/shared/inspect.rb
+++ b/spec/ruby/core/struct/shared/inspect.rb
@@ -1,4 +1,9 @@
 describe :struct_inspect, shared: true do
+  it "returns a string representation showing members and values" do
+    car = StructClasses::Car.new('Ford', 'Ranger')
+    car.send(@method).should == '#<struct StructClasses::Car make="Ford", model="Ranger", year=nil>'
+  end
+
   it "returns a string representation without the class name for anonymous structs" do
     Struct.new(:a).new("").send(@method).should == '#<struct a="">'
   end

--- a/spec/ruby/core/struct/shared/inspect.rb
+++ b/spec/ruby/core/struct/shared/inspect.rb
@@ -2,4 +2,22 @@ describe :struct_inspect, shared: true do
   it "returns a string representation without the class name for anonymous structs" do
     Struct.new(:a).new("").send(@method).should == '#<struct a="">'
   end
+
+  it "returns a string representation without the class name for structs nested in anonymous classes" do
+    obj = Object.new
+    obj.singleton_class.class_eval <<~DOC
+      class Foo < Struct.new(:a); end
+    DOC
+
+    obj.singleton_class::Foo.new("").send(@method).should == '#<struct a="">'
+  end
+
+  it "returns a string representation without the class name for structs nested in anonymous modules" do
+    m = Module.new
+    m.module_eval <<~DOC
+      class Foo < Struct.new(:a); end
+    DOC
+
+    m::Foo.new("").send(@method).should == '#<struct a="">'
+  end
 end

--- a/src/main/ruby/truffleruby/core/struct.rb
+++ b/src/main/ruby/truffleruby/core/struct.rb
@@ -147,7 +147,7 @@ class Struct
 
       name = self.class.name
 
-      if Primitive.nil?(name) || name.empty?
+      if Primitive.nil?(name) || name.empty? || name[0] == '#'
         return "#<struct #{values.join(', ')}>"
       else
         return "#<struct #{self.class.name} #{values.join(', ')}>"


### PR DESCRIPTION
In MRI, `Struct#{inspect,to_s}` omits the parent class or module name if they don't have an explicit name. This was discovered while looking into IRB spec inclusions on TruffleRuby with @st0012.

This behavior was [introduced in MRI in 2009](https://github.com/ruby/ruby/commit/31f4a829421d2c5ecc21f42d14f5b38ac9e846de), but without a spec we overlooked it. We've implemented the check the same way MRI does, by seeing if the first character in the class name is `'#'`. While I don't think the inspect string should matter that much in general, there are [IRB specs](https://github.com/ruby/irb/blob/aa1a9090d7ba4080ec658d0240a91b85709b87ea/test/irb/test_context.rb#L119-L150) that compare the output and due to the mismatch, skip entirely on TruffleRuby.
