### PR TITLE
Implement `UnboundMethod#original_name`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ Compatibility:
 * Fix `Enumerable` methods `each_cons` and `each_slice` to return receiver (#2733, @horakivo)
 * `Module` methods `#private`, `#public`, `#protected`, `#module_function` now returns their arguments like in CRuby 3.1 (#2733, @horakivo)
 * `Kernel#exit!`, killing Fibers and internal errors do not run code in `ensure` clauses anymore, the same as CRuby (@eregon).
+* Implement `UnboundMethod#original_name` (@paracycle, @nirvdrum).
 
 Performance:
 

--- a/spec/tags/core/unboundmethod/original_name_tags.txt
+++ b/spec/tags/core/unboundmethod/original_name_tags.txt
@@ -1,3 +1,0 @@
-fails:UnboundMethod#original_name returns the name of the method
-fails:UnboundMethod#original_name returns the original name
-fails:UnboundMethod#original_name returns the original name even when aliased twice

--- a/src/main/java/org/truffleruby/core/MainNodes.java
+++ b/src/main/java/org/truffleruby/core/MainNodes.java
@@ -73,7 +73,7 @@ public abstract class MainNodes {
 
         @TruffleBoundary
         private boolean isCalledFromTopLevel(InternalMethod callerMethod) {
-            final String name = callerMethod.getSharedMethodInfo().getBacktraceName();
+            final String name = callerMethod.getSharedMethodInfo().getOriginalName();
             return name.equals("<main>") || name.startsWith("<top ");
         }
     }

--- a/src/main/java/org/truffleruby/core/MainNodes.java
+++ b/src/main/java/org/truffleruby/core/MainNodes.java
@@ -73,7 +73,7 @@ public abstract class MainNodes {
 
         @TruffleBoundary
         private boolean isCalledFromTopLevel(InternalMethod callerMethod) {
-            final String name = callerMethod.getSharedMethodInfo().getOriginalName();
+            final String name = callerMethod.getOriginalName();
             return name.equals("<main>") || name.startsWith("<top ");
         }
     }

--- a/src/main/java/org/truffleruby/core/method/UnboundMethodNodes.java
+++ b/src/main/java/org/truffleruby/core/method/UnboundMethodNodes.java
@@ -19,6 +19,7 @@ import org.truffleruby.annotations.Primitive;
 import org.truffleruby.builtins.PrimitiveArrayArgumentsNode;
 import org.truffleruby.core.Hashing;
 import org.truffleruby.core.array.RubyArray;
+import org.truffleruby.core.cast.ToSymbolNode;
 import org.truffleruby.core.encoding.Encodings;
 import org.truffleruby.core.klass.RubyClass;
 import org.truffleruby.core.module.MethodLookupResult;
@@ -143,6 +144,19 @@ public abstract class UnboundMethodNodes {
         @Specialization
         protected RubyModule origin(RubyUnboundMethod unboundMethod) {
             return unboundMethod.origin;
+        }
+
+    }
+
+    @CoreMethod(names = "original_name")
+    public abstract static class OriginalNameNode extends CoreMethodArrayArgumentsNode {
+
+        @Specialization
+        protected RubySymbol originalName(RubyUnboundMethod unboundMethod,
+                @Cached ToSymbolNode toSymbolNode) {
+            String originalName = unboundMethod.method.getSharedMethodInfo().getBacktraceName();
+
+            return toSymbolNode.execute(originalName);
         }
 
     }

--- a/src/main/java/org/truffleruby/core/method/UnboundMethodNodes.java
+++ b/src/main/java/org/truffleruby/core/method/UnboundMethodNodes.java
@@ -153,7 +153,7 @@ public abstract class UnboundMethodNodes {
         @Specialization
         protected RubySymbol originalName(RubyUnboundMethod unboundMethod,
                 @Cached ToSymbolNode toSymbolNode) {
-            String originalName = unboundMethod.method.getSharedMethodInfo().getBacktraceName();
+            String originalName = unboundMethod.method.getSharedMethodInfo().getOriginalName();
 
             return toSymbolNode.execute(originalName);
         }

--- a/src/main/java/org/truffleruby/core/method/UnboundMethodNodes.java
+++ b/src/main/java/org/truffleruby/core/method/UnboundMethodNodes.java
@@ -137,9 +137,8 @@ public abstract class UnboundMethodNodes {
 
     }
 
-    // TODO: We should have an additional method for this but we need to access it for #inspect.
-    @CoreMethod(names = "origin", visibility = Visibility.PRIVATE)
-    public abstract static class OriginNode extends CoreMethodArrayArgumentsNode {
+    @Primitive(name = "unbound_method_origin")
+    public abstract static class OriginNode extends PrimitiveArrayArgumentsNode {
 
         @Specialization
         protected RubyModule origin(RubyUnboundMethod unboundMethod) {

--- a/src/main/java/org/truffleruby/core/method/UnboundMethodNodes.java
+++ b/src/main/java/org/truffleruby/core/method/UnboundMethodNodes.java
@@ -153,11 +153,9 @@ public abstract class UnboundMethodNodes {
         @Specialization
         protected RubySymbol originalName(RubyUnboundMethod unboundMethod,
                 @Cached ToSymbolNode toSymbolNode) {
-            String originalName = unboundMethod.method.getSharedMethodInfo().getOriginalName();
-
+            String originalName = unboundMethod.method.getOriginalName();
             return toSymbolNode.execute(originalName);
         }
-
     }
 
     @CoreMethod(names = "owner")

--- a/src/main/java/org/truffleruby/core/proc/ProcNodes.java
+++ b/src/main/java/org/truffleruby/core/proc/ProcNodes.java
@@ -286,7 +286,7 @@ public abstract class ProcNodes {
         @Specialization
         protected Object symbolToProcSymbol(RubyProc proc) {
             if (proc.arity == SymbolNodes.ToProcNode.ARITY) {
-                return getSymbol(proc.getSharedMethodInfo().getBacktraceName());
+                return getSymbol(proc.getSharedMethodInfo().getOriginalName());
             } else {
                 return nil;
             }

--- a/src/main/java/org/truffleruby/language/backtrace/Backtrace.java
+++ b/src/main/java/org/truffleruby/language/backtrace/Backtrace.java
@@ -151,7 +151,7 @@ public class Backtrace {
         RootNode root = e.getTarget().getRootNode();
         String label = root instanceof RubyRootNode
                 // Ruby backtraces do not include the class name for MRI compatibility.
-                ? ((RubyRootNode) root).getSharedMethodInfo().getBacktraceName()
+                ? ((RubyRootNode) root).getSharedMethodInfo().getOriginalName()
                 : root.getName();
         return label == null ? "<unknown>" : label;
     }

--- a/src/main/java/org/truffleruby/language/methods/InternalMethod.java
+++ b/src/main/java/org/truffleruby/language/methods/InternalMethod.java
@@ -194,6 +194,10 @@ public final class InternalMethod implements ObjectGraphNode {
         return name;
     }
 
+    public String getOriginalName() {
+        return sharedMethodInfo.getOriginalName();
+    }
+
     public Visibility getVisibility() {
         return visibility;
     }

--- a/src/main/java/org/truffleruby/language/methods/SharedMethodInfo.java
+++ b/src/main/java/org/truffleruby/language/methods/SharedMethodInfo.java
@@ -24,8 +24,10 @@ import com.oracle.truffle.api.source.SourceSection;
 import org.truffleruby.parser.OpenModule;
 import org.truffleruby.parser.ParserContext;
 
-/** {@link InternalMethod} objects are copied as properties such as visibility are changed. {@link SharedMethodInfo}
- * stores the state that does not change, such as where the method was defined. */
+/** SharedMethodInfo represents static information from the parser for either a method definition or a block like its
+ * name, SourceSection, etc. Such information is always "original" since it comes from the source as opposed to
+ * "aliased" (e.g. the aliased name of a method). In contrast, {@link InternalMethod} are runtime objects containing
+ * properties that change for a method. */
 public final class SharedMethodInfo {
 
     private final SourceSection sourceSection;
@@ -150,6 +152,7 @@ public final class SharedMethodInfo {
         }
     }
 
+    /** See {@link #originalName} */
     public String getOriginalName() {
         return originalName;
     }

--- a/src/main/java/org/truffleruby/language/methods/SharedMethodInfo.java
+++ b/src/main/java/org/truffleruby/language/methods/SharedMethodInfo.java
@@ -34,7 +34,7 @@ public final class SharedMethodInfo {
     private final Arity arity;
     /** The original name of the method. Does not change when aliased. Looks like "block in foo" or "block (2 levels) in
      * foo" for blocks. This is the name shown in backtraces: "from FILE:LINE:in `NAME'". */
-    private final String backtraceName;
+    private final String originalName;
     /** The "static" name of this method at parse time, such as "M::C#foo", "M::C.foo", "<module:Inner>", "block (2
      * levels) in M::C.foo" or "block (2 levels) in <module:Inner>". This name is used for tools. */
     private final String parseName;
@@ -48,16 +48,16 @@ public final class SharedMethodInfo {
             SourceSection sourceSection,
             LexicalScope staticLexicalScope,
             Arity arity,
-            String backtraceName,
+            String originalName,
             int blockDepth,
             String parseName,
             String notes,
             ArgumentDescriptor[] argumentDescriptors) {
-        assert blockDepth == 0 || backtraceName.startsWith("block ") : backtraceName;
+        assert blockDepth == 0 || originalName.startsWith("block ") : originalName;
         this.sourceSection = sourceSection;
         this.staticLexicalScope = staticLexicalScope;
         this.arity = arity;
-        this.backtraceName = backtraceName;
+        this.originalName = originalName;
         this.blockDepth = blockDepth;
         this.parseName = parseName;
         this.notes = notes;
@@ -93,7 +93,7 @@ public final class SharedMethodInfo {
                 sourceSection,
                 staticLexicalScope,
                 newArity,
-                backtraceName,
+                originalName,
                 blockDepth,
                 parseName,
                 notes,
@@ -131,7 +131,7 @@ public final class SharedMethodInfo {
 
     @TruffleBoundary
     public boolean isModuleBody() {
-        boolean isModuleBody = isModuleBody(getBacktraceName());
+        boolean isModuleBody = isModuleBody(getOriginalName());
         assert !(isModuleBody && isBlock()) : this;
         return isModuleBody;
     }
@@ -150,19 +150,19 @@ public final class SharedMethodInfo {
         }
     }
 
-    public String getBacktraceName() {
-        return backtraceName;
+    public String getOriginalName() {
+        return originalName;
     }
 
     /** Returns the method name on its own. Can start with "<" like "<module:Inner>" for module bodies. */
     public String getMethodName() {
-        return blockDepth == 0 ? backtraceName : notes;
+        return blockDepth == 0 ? originalName : notes;
     }
 
     /** More efficient than {@link #getMethodName()} when we know blockDepth == 0 */
     public String getMethodNameForNotBlock() {
         assert blockDepth == 0;
-        return backtraceName;
+        return originalName;
     }
 
     public String getParseName() {

--- a/src/main/java/org/truffleruby/parser/BodyTranslator.java
+++ b/src/main/java/org/truffleruby/parser/BodyTranslator.java
@@ -1079,7 +1079,7 @@ public class BodyTranslator extends Translator {
                 environment.getReturnID());
 
         return new ModuleBodyDefinition(
-                environment.getSharedMethodInfo().getBacktraceName(),
+                environment.getSharedMethodInfo().getOriginalName(),
                 environment.getSharedMethodInfo(),
                 rootNode.getCallTarget(),
                 environment.getStaticLexicalScopeOrNull());
@@ -2006,14 +2006,14 @@ public class BodyTranslator extends Translator {
         final int blockDepth = environment.getBlockDepth() + 1;
 
         // "block in foo"
-        String backtraceName = SharedMethodInfo.getBlockName(blockDepth, methodName);
+        String originalName = SharedMethodInfo.getBlockName(blockDepth, methodName);
         // "block (2 levels) in M::C.foo"
         String parseName = SharedMethodInfo.getBlockName(blockDepth, methodParent.getSharedMethodInfo().getParseName());
         final SharedMethodInfo sharedMethodInfo = new SharedMethodInfo(
                 sourceSection.toSourceSection(source),
                 environment.getStaticLexicalScopeOrNull(),
                 argsNode.getArity(),
-                backtraceName,
+                originalName,
                 blockDepth,
                 parseName,
                 methodName,

--- a/src/main/ruby/truffleruby/core/unbound_method.rb
+++ b/src/main/ruby/truffleruby/core/unbound_method.rb
@@ -10,7 +10,7 @@
 
 class UnboundMethod
   def inspect
-    Truffle::MethodOperations.inspect_method(self, origin, owner)
+    Truffle::MethodOperations.inspect_method(self, Primitive.unbound_method_origin(self), owner)
   end
   alias_method :to_s, :inspect
 


### PR DESCRIPTION
While working with @paracycle on getting the Sorbet test suite passing on TruffleRuby, we ran into a problem with `UnboundMethod#original_name` not being defined. While we were in there, we cleaned up some related code, introducing a new primitive and renaming a field to better reflect its meaning.