### PR TITLE
Fix `Marshal.dump` error message for anonymous classes

### DIFF
--- a/spec/ruby/core/marshal/dump_spec.rb
+++ b/spec/ruby/core/marshal/dump_spec.rb
@@ -222,7 +222,7 @@ describe "Marshal.dump" do
     end
 
     it "raises TypeError with an anonymous Module" do
-      -> { Marshal.dump(Module.new) }.should raise_error(TypeError)
+      -> { Marshal.dump(Module.new) }.should raise_error(TypeError, /can't dump anonymous module/)
     end
   end
 


### PR DESCRIPTION
Working through removing TruffleRuby test exclusions in the IRB test suite with @st0012 we ran into a case where the `Marshal.dump` message on anonymous classes didn't match what MRI is doing. Matching the message is trivial, so we've opened up a PR to make them align.