### PR TITLE
added Integer.try_convert, Ruby 3.1 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ Compatibility:
 * Modify `Struct#{inspect,to_s}` to match MRI when the struct is nested inside of an anonymous class or module (@st0012, @nirvdrum).
 * `Fiber.current` and `Fiber#transfer` are available without `require 'fiber'` like in CRuby 3.1 (#2733, @eregon).
 * Add `freeze` keyword argument to `Marshal.load` (#2733, @andrykonchin).
+* Add `Integer.try_convert` (#2733, @moste00, @eregon).
 
 Performance:
 

--- a/spec/ruby/core/array/try_convert_spec.rb
+++ b/spec/ruby/core/array/try_convert_spec.rb
@@ -39,7 +39,7 @@ describe "Array.try_convert" do
   it "sends #to_ary to the argument and raises TypeError if it's not a kind of Array" do
     obj = mock("to_ary")
     obj.should_receive(:to_ary).and_return(Object.new)
-    -> { Array.try_convert obj }.should raise_error(TypeError)
+    -> { Array.try_convert obj }.should raise_error(TypeError, "can't convert MockObject to Array (MockObject#to_ary gives Object)")
   end
 
   it "does not rescue exceptions raised by #to_ary" do

--- a/spec/ruby/core/hash/try_convert_spec.rb
+++ b/spec/ruby/core/hash/try_convert_spec.rb
@@ -39,7 +39,7 @@ describe "Hash.try_convert" do
   it "sends #to_hash to the argument and raises TypeError if it's not a kind of Hash" do
     obj = mock("to_hash")
     obj.should_receive(:to_hash).and_return(Object.new)
-    -> { Hash.try_convert obj }.should raise_error(TypeError)
+    -> { Hash.try_convert obj }.should raise_error(TypeError, "can't convert MockObject to Hash (MockObject#to_hash gives Object)")
   end
 
   it "does not rescue exceptions raised by #to_hash" do

--- a/spec/ruby/core/integer/try_convert_spec.rb
+++ b/spec/ruby/core/integer/try_convert_spec.rb
@@ -28,7 +28,28 @@ ruby_version_is "3.1" do
     it "sends #to_int to the argument and raises TypeError if it's not a kind of Integer" do
       obj = mock("to_int")
       obj.should_receive(:to_int).and_return(Object.new)
-      -> { Integer.try_convert obj }.should raise_error(TypeError)
+      -> {
+        Integer.try_convert obj
+      }.should raise_error(TypeError, "can't convert MockObject to Integer (MockObject#to_int gives Object)")
+    end
+
+    it "responds with a different error message when it raises a TypeError, depending on the type of the non-Integer object :to_int returns" do
+      obj = mock("to_int")
+      obj.should_receive(:to_int).and_return("A String")
+      -> {
+        Integer.try_convert obj
+      }.should raise_error(TypeError, "can't convert MockObject to Integer (MockObject#to_int gives String)")
+    end
+
+    it "responds with a different error message when it raises a TypeError, depending on the type of the argument object :to_int was called on " do
+      class DifferentMockObject
+        def to_int
+          Object.new
+        end
+      end
+      -> {
+        Integer.try_convert DifferentMockObject.new
+      }.should raise_error(TypeError, "can't convert DifferentMockObject to Integer (DifferentMockObject#to_int gives Object)")
     end
 
     it "does not rescue exceptions raised by #to_int" do

--- a/spec/ruby/core/integer/try_convert_spec.rb
+++ b/spec/ruby/core/integer/try_convert_spec.rb
@@ -41,17 +41,6 @@ ruby_version_is "3.1" do
       }.should raise_error(TypeError, "can't convert MockObject to Integer (MockObject#to_int gives String)")
     end
 
-    it "responds with a different error message when it raises a TypeError, depending on the type of the argument object :to_int was called on " do
-      class DifferentMockObject
-        def to_int
-          Object.new
-        end
-      end
-      -> {
-        Integer.try_convert DifferentMockObject.new
-      }.should raise_error(TypeError, "can't convert DifferentMockObject to Integer (DifferentMockObject#to_int gives Object)")
-    end
-
     it "does not rescue exceptions raised by #to_int" do
       obj = mock("to_int")
       obj.should_receive(:to_int).and_raise(RuntimeError)

--- a/spec/ruby/core/io/try_convert_spec.rb
+++ b/spec/ruby/core/io/try_convert_spec.rb
@@ -38,7 +38,7 @@ describe "IO.try_convert" do
   it "raises a TypeError if the object does not return an IO from #to_io" do
     obj = mock("io")
     obj.should_receive(:to_io).and_return("io")
-    -> { IO.try_convert(obj) }.should raise_error(TypeError)
+    -> { IO.try_convert(obj) }.should raise_error(TypeError, "can't convert MockObject to IO (MockObject#to_io gives String)")
   end
 
   it "propagates an exception raised by #to_io" do

--- a/spec/ruby/core/regexp/try_convert_spec.rb
+++ b/spec/ruby/core/regexp/try_convert_spec.rb
@@ -18,4 +18,10 @@ describe "Regexp.try_convert" do
     rex.should_receive(:to_regexp).and_return(/(p(a)t[e]rn)/)
     Regexp.try_convert(rex).should == /(p(a)t[e]rn)/
   end
+
+  it "raises a TypeError if the object does not return an Regexp from #to_regexp" do
+    obj = mock("regexp")
+    obj.should_receive(:to_regexp).and_return("string")
+    -> { Regexp.try_convert(obj) }.should raise_error(TypeError, "can't convert MockObject to Regexp (MockObject#to_regexp gives String)")
+  end
 end

--- a/spec/ruby/core/string/try_convert_spec.rb
+++ b/spec/ruby/core/string/try_convert_spec.rb
@@ -39,7 +39,7 @@ describe "String.try_convert" do
   it "sends #to_str to the argument and raises TypeError if it's not a kind of String" do
     obj = mock("to_str")
     obj.should_receive(:to_str).and_return(Object.new)
-    -> { String.try_convert obj }.should raise_error(TypeError)
+    -> { String.try_convert obj }.should raise_error(TypeError, "can't convert MockObject to String (MockObject#to_str gives Object)")
   end
 
   it "does not rescue exceptions raised by #to_str" do

--- a/spec/tags/core/integer/try_convert_tags.txt
+++ b/spec/tags/core/integer/try_convert_tags.txt
@@ -1,6 +1,0 @@
-fails:Integer.try_convert returns the argument if it's an Integer
-fails:Integer.try_convert returns nil when the argument does not respond to #to_int
-fails:Integer.try_convert sends #to_int to the argument and returns the result if it's nil
-fails:Integer.try_convert sends #to_int to the argument and returns the result if it's an Integer
-fails:Integer.try_convert sends #to_int to the argument and raises TypeError if it's not a kind of Integer
-fails:Integer.try_convert does not rescue exceptions raised by #to_int

--- a/src/main/ruby/truffleruby/core/integer.rb
+++ b/src/main/ruby/truffleruby/core/integer.rb
@@ -333,16 +333,7 @@ class Integer < Numeric
   end
 
   def self.try_convert(obj)
-    unless obj.respond_to?(:to_int)
-      return nil
-    end
-
-    result = obj.to_int
-    if Primitive.nil?(result) or Primitive.object_kind_of?(result, Integer)
-      return result
-    end
-
-    Truffle::Type.conversion_mismatch_into(obj, Integer, :to_int, result)
+    Truffle::Type.try_convert(obj, Integer, :to_int)
   end
 
   def self.sqrt(n)

--- a/src/main/ruby/truffleruby/core/integer.rb
+++ b/src/main/ruby/truffleruby/core/integer.rb
@@ -332,6 +332,19 @@ class Integer < Numeric
     self == 0
   end
 
+  def self.try_convert(obj)
+    unless obj.respond_to?(:to_int)
+      return nil
+    end
+
+    result = obj.to_int
+    if Primitive.nil?(result) or Primitive.object_kind_of?(result, Integer)
+      return result
+    end
+
+    Truffle::Type.conversion_mismatch_into(obj, Integer, :to_int, result)
+  end
+
   def self.sqrt(n)
     n = Primitive.rb_to_int(n)
     raise Math::DomainError if n.negative?

--- a/src/main/ruby/truffleruby/core/type.rb
+++ b/src/main/ruby/truffleruby/core/type.rb
@@ -187,6 +187,12 @@ module Truffle
       raise TypeError, "can't convert #{oc} to #{cls} (#{oc}##{meth} gives #{Primitive.object_class(res)})"
     end
 
+    # Same as conversion mismatch, with a tiny difference in error message ("into" instead of "to")
+    def self.conversion_mismatch_into(obj, cls, meth, res)
+      oc = Primitive.object_class(obj)
+      raise TypeError, "can't convert #{oc} into #{cls} (#{oc}##{meth} gives #{Primitive.object_class(res)})"
+    end
+
     def self.fits_into_int?(val)
       Integer === val && Primitive.integer_fits_into_int(val)
     end

--- a/src/main/ruby/truffleruby/core/type.rb
+++ b/src/main/ruby/truffleruby/core/type.rb
@@ -187,12 +187,6 @@ module Truffle
       raise TypeError, "can't convert #{oc} to #{cls} (#{oc}##{meth} gives #{Primitive.object_class(res)})"
     end
 
-    # Same as conversion mismatch, with a tiny difference in error message ("into" instead of "to")
-    def self.conversion_mismatch_into(obj, cls, meth, res)
-      oc = Primitive.object_class(obj)
-      raise TypeError, "can't convert #{oc} into #{cls} (#{oc}##{meth} gives #{Primitive.object_class(res)})"
-    end
-
     def self.fits_into_int?(val)
       Integer === val && Primitive.integer_fits_into_int(val)
     end
@@ -373,7 +367,7 @@ module Truffle
       if Primitive.nil?(ret) || Primitive.object_kind_of?(ret, cls)
         ret
       else
-        raise TypeError, "Coercion error: obj.#{meth} did NOT return a #{cls} (was #{Primitive.object_class(ret)})"
+        conversion_mismatch(obj, cls, meth, ret)
       end
     end
 


### PR DESCRIPTION
Fixed an issue listed in https://github.com/oracle/truffleruby/issues/2733, namely the addition of a method try_convert to the class Integer, spec is in spec/ruby/core/integer/try_convert_spec.rb.  