### PR TITLE
added keyword_init? to classes generated by Struct.new, Ruby 3.1 support

### DIFF
--- a/spec/ruby/core/struct/keyword_init_spec.rb
+++ b/spec/ruby/core/struct/keyword_init_spec.rb
@@ -17,5 +17,24 @@ ruby_version_is "3.1" do
       struct = Struct.new(:arg)
       struct.keyword_init?.should be_nil
     end
+
+    it "returns nil for a struct that does specify keyword_init to be nil" do
+      struct = Struct.new(:arg,keyword_init: nil)
+      struct.keyword_init?.should be_nil
+    end
+
+    it "returns true or false for truthy values in general, not just true" do
+      struct = Struct.new(:arg,keyword_init: 1)
+      struct.keyword_init?.should be_true
+
+      struct = Struct.new(:arg,keyword_init: "")
+      struct.keyword_init?.should be_true
+
+      struct = Struct.new(:arg,keyword_init: [])
+      struct.keyword_init?.should be_true
+
+      struct = Struct.new(:arg,keyword_init: {})
+      struct.keyword_init?.should be_true
+    end
   end
 end

--- a/spec/tags/core/struct/keyword_init_tags.txt
+++ b/spec/tags/core/struct/keyword_init_tags.txt
@@ -1,3 +1,0 @@
-fails:StructClass#keyword_init? returns true for a struct that accepts keyword arguments to initialize
-fails:StructClass#keyword_init? returns false for a struct that does not accept keyword arguments to initialize
-fails:StructClass#keyword_init? returns nil for a struct that did not explicitly specify keyword_init

--- a/src/main/ruby/truffleruby/core/struct.rb
+++ b/src/main/ruby/truffleruby/core/struct.rb
@@ -33,7 +33,7 @@ class Struct
     alias_method :subclass_new, :new
   end
 
-  def self.new(klass_name, *attrs, keyword_init: false, &block)
+  def self.new(klass_name, *attrs, keyword_init: nil, &block)
     if klass_name
       if Primitive.object_kind_of?(klass_name, Symbol) # Truffle: added to avoid exception and match MRI
         attrs.unshift klass_name
@@ -92,7 +92,15 @@ class Struct
 
       const_set :STRUCT_ATTRS, attrs
       const_set :KEYWORD_INIT, keyword_init
-    end
+
+      def self.keyword_init?
+        kw_init = self.const_get(:KEYWORD_INIT)
+        return nil if Primitive.nil?(kw_init)
+
+        Primitive.as_boolean(kw_init)
+      end
+
+      end
 
     const_set klass_name, klass if klass_name
 


### PR DESCRIPTION
As required by https://github.com/oracle/truffleruby/issues/2733, every class returned by Struct.new now has a keyword_init? method that returns nil if the optional argument to Struct.new of the same name was omitted, and returns true or false if that argument was provided and was truthy or falsey, respectively.

