### PR TITLE
fix: StringIO#write transcodes strings with a different encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Bug fixes:
 * Fix constants lookup when `BasicObject#instance_eval` method is called with a String (#2810, @andrykonchin).
 * Don't trigger the `method_added` event when changing a method's visibility or calling `module_function` (@paracycle, @nirvdrum).
 * Fix `rb_time_timespec_new` function to not call `Time.at` method directly (@andrykonchin).
+* Fix `StringIO#write` to transcode strings with encodings that don't match the `StringIO`'s `external_encoding`. (#2839, @flavorjones)
 
 Compatibility:
 

--- a/lib/truffle/stringio.rb
+++ b/lib/truffle/stringio.rb
@@ -280,7 +280,9 @@ class StringIO
     str = String(str)
     return 0 if str.empty?
 
-    str = Truffle::IOOperations.write_transcoding(str, external_encoding)
+    unless str.encoding == Encoding::BINARY # difference to IO
+      str = Truffle::IOOperations.write_transcoding(str, external_encoding)
+    end
 
     d = @__data__
     TruffleRuby.synchronized(d) do

--- a/lib/truffle/stringio.rb
+++ b/lib/truffle/stringio.rb
@@ -280,6 +280,13 @@ class StringIO
     str = String(str)
     return 0 if str.empty?
 
+    if external_encoding &&
+       external_encoding != str.encoding &&
+       external_encoding != Encoding::BINARY &&
+       str.encoding != Encoding::BINARY
+      str = str.encode(external_encoding)
+    end
+
     d = @__data__
     TruffleRuby.synchronized(d) do
       pos = d.pos

--- a/lib/truffle/stringio.rb
+++ b/lib/truffle/stringio.rb
@@ -280,12 +280,7 @@ class StringIO
     str = String(str)
     return 0 if str.empty?
 
-    if external_encoding &&
-       external_encoding != str.encoding &&
-       external_encoding != Encoding::BINARY &&
-       str.encoding != Encoding::BINARY
-      str = str.encode(external_encoding)
-    end
+    str = Truffle::IOOperations.write_transcoding(str, external_encoding)
 
     d = @__data__
     TruffleRuby.synchronized(d) do

--- a/lib/truffle/stringio.rb
+++ b/lib/truffle/stringio.rb
@@ -280,8 +280,12 @@ class StringIO
     str = String(str)
     return 0 if str.empty?
 
-    unless str.encoding == Encoding::BINARY # difference to IO
-      str = Truffle::IOOperations.write_transcoding(str, external_encoding)
+    # difference to IO, see https://github.com/ruby/stringio/blob/009896b973/ext/stringio/stringio.c#L1498-L1506
+    enc = external_encoding
+    unless enc == Encoding::BINARY or enc == Encoding::US_ASCII
+      unless !str.ascii_only? && (str.encoding == Encoding::BINARY || str.encoding == Encoding::US_ASCII)
+        str = Truffle::IOOperations.write_transcoding(str, enc)
+      end
     end
 
     d = @__data__

--- a/spec/ruby/core/io/shared/write.rb
+++ b/spec/ruby/core/io/shared/write.rb
@@ -120,6 +120,15 @@ describe :io_write_transcode, shared: true do
 
     result.bytes.should == expected
   end
+
+  it "transcodes the given string when the external encoding is set and the string encoding is BINARY" do
+    str = "été".b
+
+    File.open(@transcode_filename, "w", external_encoding: Encoding::UTF_16BE) do |file|
+      file.external_encoding.should == Encoding::UTF_16BE
+      -> { file.send(@method, str) }.should raise_error(Encoding::UndefinedConversionError)
+    end
+  end
 end
 
 describe :io_write_no_transcode, shared: true do

--- a/spec/ruby/core/io/shared/write.rb
+++ b/spec/ruby/core/io/shared/write.rb
@@ -107,20 +107,18 @@ describe :io_write_transcode, shared: true do
     rm_r @transcode_filename
   end
 
-  describe "transcoding when UTF-16 encoding is set" do
-    it "accepts a UTF-8-encoded string and transcodes it" do
-      utf8_str = "hello"
+  it "transcodes the given string when the external encoding is set and neither is BINARY" do
+    utf8_str = "hello"
 
-      File.open(@transcode_filename, "w", external_encoding: Encoding::UTF_16BE) do |file|
-        file.external_encoding.should == Encoding::UTF_16BE
-        file.send(@method, utf8_str)
-      end
-
-      result = File.binread(@transcode_filename)
-      expected = [0, 104, 0, 101, 0, 108, 0, 108, 0, 111] # double-width "hello"
-
-      result.bytes.should == expected
+    File.open(@transcode_filename, "w", external_encoding: Encoding::UTF_16BE) do |file|
+      file.external_encoding.should == Encoding::UTF_16BE
+      file.send(@method, utf8_str)
     end
+
+    result = File.binread(@transcode_filename)
+    expected = [0, 104, 0, 101, 0, 108, 0, 108, 0, 111] # UTF-16BE bytes for "hello"
+
+    result.bytes.should == expected
   end
 end
 
@@ -133,19 +131,17 @@ describe :io_write_no_transcode, shared: true do
     rm_r @transcode_filename
   end
 
-  describe "transcoding when UTF-16 encoding is set" do
-    it "accepts a UTF-8-encoded string and transcodes it" do
-      utf8_str = "hello"
+  it "does not transcode the given string even when the external encoding is set" do
+    utf8_str = "hello"
 
-      File.open(@transcode_filename, "w", external_encoding: Encoding::UTF_16BE) do |file|
-        file.external_encoding.should == Encoding::UTF_16BE
-        file.send(@method, utf8_str)
-      end
-
-      result = File.binread(@transcode_filename)
-      expected = [104, 101, 108, 108, 111] # not transcoded to UTF-16BE
-
-      result.bytes.should == expected
+    File.open(@transcode_filename, "w", external_encoding: Encoding::UTF_16BE) do |file|
+      file.external_encoding.should == Encoding::UTF_16BE
+      file.send(@method, utf8_str)
     end
+
+    result = File.binread(@transcode_filename)
+    expected = [104, 101, 108, 108, 111] # UTF-8 bytes for "hello", not transcoded to UTF-16BE
+
+    result.bytes.should == expected
   end
 end

--- a/spec/ruby/core/io/shared/write.rb
+++ b/spec/ruby/core/io/shared/write.rb
@@ -149,8 +149,6 @@ describe :io_write_no_transcode, shared: true do
     end
 
     result = File.binread(@transcode_filename)
-    expected = [104, 101, 108, 108, 111] # UTF-8 bytes for "hello", not transcoded to UTF-16BE
-
-    result.bytes.should == expected
+    result.bytes.should == utf8_str.bytes
   end
 end

--- a/spec/ruby/core/io/shared/write.rb
+++ b/spec/ruby/core/io/shared/write.rb
@@ -97,3 +97,55 @@ describe :io_write, shared: true do
     end
   end
 end
+
+describe :io_write_transcode, shared: true do
+  before :each do
+    @transcode_filename = tmp("io_write_transcode")
+  end
+
+  after :each do
+    rm_r @transcode_filename
+  end
+
+  describe "transcoding when UTF-16 encoding is set" do
+    it "accepts a UTF-8-encoded string and transcodes it" do
+      utf8_str = "hello"
+
+      File.open(@transcode_filename, "w", external_encoding: Encoding::UTF_16BE) do |file|
+        file.external_encoding.should == Encoding::UTF_16BE
+        file.send(@method, utf8_str)
+      end
+
+      result = File.binread(@transcode_filename)
+      expected = [0, 104, 0, 101, 0, 108, 0, 108, 0, 111] # double-width "hello"
+
+      result.bytes.should == expected
+    end
+  end
+end
+
+describe :io_write_no_transcode, shared: true do
+  before :each do
+    @transcode_filename = tmp("io_write_no_transcode")
+  end
+
+  after :each do
+    rm_r @transcode_filename
+  end
+
+  describe "transcoding when UTF-16 encoding is set" do
+    it "accepts a UTF-8-encoded string and transcodes it" do
+      utf8_str = "hello"
+
+      File.open(@transcode_filename, "w", external_encoding: Encoding::UTF_16BE) do |file|
+        file.external_encoding.should == Encoding::UTF_16BE
+        file.send(@method, utf8_str)
+      end
+
+      result = File.binread(@transcode_filename)
+      expected = [104, 101, 108, 108, 111] # not transcoded to UTF-16BE
+
+      result.bytes.should == expected
+    end
+  end
+end

--- a/spec/ruby/core/io/syswrite_spec.rb
+++ b/spec/ruby/core/io/syswrite_spec.rb
@@ -78,4 +78,5 @@ end
 
 describe "IO#syswrite" do
   it_behaves_like :io_write, :syswrite
+  it_behaves_like :io_write_no_transcode, :syswrite
 end

--- a/spec/ruby/core/io/write_nonblock_spec.rb
+++ b/spec/ruby/core/io/write_nonblock_spec.rb
@@ -50,6 +50,7 @@ platform_is_not :windows do
 
   describe "IO#write_nonblock" do
     it_behaves_like :io_write, :write_nonblock
+    it_behaves_like :io_write_no_transcode, :write_nonblock
   end
 end
 

--- a/spec/ruby/core/io/write_spec.rb
+++ b/spec/ruby/core/io/write_spec.rb
@@ -220,6 +220,7 @@ end
 
 describe "IO#write" do
   it_behaves_like :io_write, :write
+  it_behaves_like :io_write_transcode, :write
 
   it "accepts multiple arguments" do
     IO.pipe do |r, w|

--- a/spec/ruby/library/stringio/shared/write.rb
+++ b/spec/ruby/library/stringio/shared/write.rb
@@ -88,6 +88,25 @@ describe :stringio_write_string, shared: true do
     @io.write "fghi"
     @io.string.should == "12fghi"
   end
+
+  describe "transcoding" do
+    describe "when UTF-16 encoding is set" do
+      it "accepts a UTF-8-encoded string and transcodes it" do
+        io = StringIO.new.set_encoding(Encoding::UTF_16BE)
+        utf8_str = "hello"
+
+        io.send(@method, utf8_str)
+
+        result = io.string
+        expected = [
+          0, 104, 0, 101, 0, 108, 0, 108, 0, 111, # double-width "hello"
+        ]
+
+        io.external_encoding.should == Encoding::UTF_16BE
+        result.bytes.should == expected
+      end
+    end
+  end
 end
 
 describe :stringio_write_not_writable, shared: true do

--- a/spec/ruby/library/stringio/shared/write.rb
+++ b/spec/ruby/library/stringio/shared/write.rb
@@ -89,23 +89,17 @@ describe :stringio_write_string, shared: true do
     @io.string.should == "12fghi"
   end
 
-  describe "transcoding" do
-    describe "when UTF-16 encoding is set" do
-      it "accepts a UTF-8-encoded string and transcodes it" do
-        io = StringIO.new.set_encoding(Encoding::UTF_16BE)
-        utf8_str = "hello"
+  it "transcodes the given string when the external encoding is set and neither is BINARY" do
+    io = StringIO.new.set_encoding(Encoding::UTF_16BE)
+    utf8_str = "hello"
 
-        io.send(@method, utf8_str)
+    io.send(@method, utf8_str)
 
-        result = io.string
-        expected = [
-          0, 104, 0, 101, 0, 108, 0, 108, 0, 111, # double-width "hello"
-        ]
+    result = io.string
+    expected = [0, 104, 0, 101, 0, 108, 0, 108, 0, 111] # UTF-16BE bytes for "hello"
 
-        io.external_encoding.should == Encoding::UTF_16BE
-        result.bytes.should == expected
-      end
-    end
+    io.external_encoding.should == Encoding::UTF_16BE
+    result.bytes.should == expected
   end
 end
 

--- a/spec/ruby/library/stringio/shared/write.rb
+++ b/spec/ruby/library/stringio/shared/write.rb
@@ -90,16 +90,24 @@ describe :stringio_write_string, shared: true do
   end
 
   it "transcodes the given string when the external encoding is set and neither is BINARY" do
-    io = StringIO.new.set_encoding(Encoding::UTF_16BE)
     utf8_str = "hello"
+    io = StringIO.new.set_encoding(Encoding::UTF_16BE)
+    io.external_encoding.should == Encoding::UTF_16BE
 
     io.send(@method, utf8_str)
 
-    result = io.string
     expected = [0, 104, 0, 101, 0, 108, 0, 108, 0, 111] # UTF-16BE bytes for "hello"
+    io.string.bytes.should == expected
+  end
 
+  it "does not transcode the given string when the external encoding is set and the string encoding is BINARY" do
+    str = "été".b
+    io = StringIO.new.set_encoding(Encoding::UTF_16BE)
     io.external_encoding.should == Encoding::UTF_16BE
-    result.bytes.should == expected
+
+    io.send(@method, str)
+
+    io.string.bytes.should == str.bytes
   end
 end
 

--- a/spec/ruby/library/stringio/write_spec.rb
+++ b/spec/ruby/library/stringio/write_spec.rb
@@ -17,22 +17,3 @@ end
 describe "StringIO#write when in append mode" do
   it_behaves_like :stringio_write_append, :write
 end
-
-describe "StringIO#write transcoding" do
-  describe "when UTF-16 encoding is set" do
-    it "accepts a UTF-8-encoded string and transcodes it" do
-      io = StringIO.new.set_encoding(Encoding::UTF_16BE)
-      utf8_str = "hello"
-
-      io.write(utf8_str)
-
-      result = io.string
-      expected = [
-        0, 104, 0, 101, 0, 108, 0, 108, 0, 111, # double-width "hello"
-      ]
-
-      io.external_encoding.should == Encoding::UTF_16BE
-      result.bytes.should == expected
-    end
-  end
-end

--- a/spec/ruby/library/stringio/write_spec.rb
+++ b/spec/ruby/library/stringio/write_spec.rb
@@ -21,18 +21,17 @@ end
 describe "StringIO#write transcoding" do
   describe "when UTF-16 encoding is set" do
     it "accepts a UTF-8-encoded string and transcodes it" do
-      io = StringIO.new.set_encoding(Encoding::UTF_16)
+      io = StringIO.new.set_encoding(Encoding::UTF_16BE)
       utf8_str = "hello"
 
       io.write(utf8_str)
 
       result = io.string
       expected = [
-        254, 255, # BOM
         0, 104, 0, 101, 0, 108, 0, 108, 0, 111, # double-width "hello"
       ]
 
-      io.external_encoding.should == Encoding::UTF_16
+      io.external_encoding.should == Encoding::UTF_16BE
       result.bytes.should == expected
     end
   end

--- a/spec/ruby/library/stringio/write_spec.rb
+++ b/spec/ruby/library/stringio/write_spec.rb
@@ -17,3 +17,23 @@ end
 describe "StringIO#write when in append mode" do
   it_behaves_like :stringio_write_append, :write
 end
+
+describe "StringIO#write transcoding" do
+  describe "when UTF-16 encoding is set" do
+    it "accepts a UTF-8-encoded string and transcodes it" do
+      io = StringIO.new.set_encoding(Encoding::UTF_16)
+      utf8_str = "hello"
+
+      io.write(utf8_str)
+
+      result = io.string
+      expected = [
+        254, 255, # BOM
+        0, 104, 0, 101, 0, 108, 0, 108, 0, 111, # double-width "hello"
+      ]
+
+      io.external_encoding.should == Encoding::UTF_16
+      result.bytes.should == expected
+    end
+  end
+end

--- a/src/main/ruby/truffleruby/core/io.rb
+++ b/src/main/ruby/truffleruby/core/io.rb
@@ -2324,11 +2324,7 @@ class IO
 
       ensure_open_and_writable
 
-      if external_encoding && external_encoding != string.encoding && external_encoding != Encoding::BINARY
-        unless string.ascii_only? && external_encoding.ascii_compatible?
-          string = string.encode(external_encoding)
-        end
-      end
+      string = Truffle::IOOperations.write_transcoding(string, external_encoding)
 
       count = Truffle::POSIX.write_string self, string, true
       bytes_written += count

--- a/src/main/ruby/truffleruby/core/truffle/io_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/io_operations.rb
@@ -72,6 +72,15 @@ module Truffle
       nil
     end
 
+    def self.write_transcoding(string, external_encoding)
+      if external_encoding && external_encoding != string.encoding && external_encoding != Encoding::BINARY &&
+          !(string.ascii_only? && external_encoding.ascii_compatible?)
+        string.encode(external_encoding)
+      else
+        string
+      end
+    end
+
     def self.dup2_with_cloexec(old_fd, new_fd)
       if new_fd < 3
         # STDIO should not be made close-on-exec. `dup2` clears the close-on-exec bit for the destination FD.


### PR DESCRIPTION
This is a potential fix for #2839. I've based this approach on the [transcoding logic in `IO#write`](https://github.com/oracle/truffleruby/blob/master/src/main/ruby/truffleruby/core/io.rb#L2327-L2331).

I'm not sure I've placed the new test in the best place; or if this fix is the best option. This is my first PR to TR! Feedback welcome. :heart: 
