### PR TITLE
Read to separator fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Bug fixes:
 * Fix `StringIO#write` to transcode strings with encodings that don't match the `StringIO`'s `external_encoding`. (#2839, @flavorjones)
 * Fix processing of proc rest arguments located at the beginning if there are no actual arguments (#2921, @andrykonchin).
 * Fix `Monitor#exit` to raise `ThreadError` when monitor not owned by the current thread (#2922, @andrykonchin).
+* Fix `IO` line reading calls when using a multi-byte delimiter (`IO#{each,gets,readline,readlines,etc.}) (#2961, @vinistock, @nirvdrum).
 
 Compatibility:
 

--- a/spec/ruby/core/io/gets_spec.rb
+++ b/spec/ruby/core/io/gets_spec.rb
@@ -113,6 +113,33 @@ describe "IO#gets" do
         $..should == @count += 1
       end
     end
+
+    describe "that consists of multiple bytes" do
+      it "should match the separator even if the buffer is filled over successive reads" do
+        IO.pipe do |read, write|
+
+          # Write part of the string with the separator split between two write calls. We want
+          # the read to intertwine such that when the read starts the full data isn't yet
+          # available in the buffer.
+          write.write("Aquí está la línea tres\r\n")
+
+          t = Thread.new do
+            # Continue reading until the separator is encountered or the pipe is closed.
+            read.gets("\r\n\r\n")
+          end
+
+          # Write the other half of the separator, which should cause the `gets` call to now
+          # match. Explicitly close the pipe for good measure so a bug in `gets` doesn't block forever.
+          Thread.pass until t.stop?
+
+          write.write("\r\nelse\r\n\r\n")
+          write.close
+
+          t.value.bytes.should == "Aquí está la línea tres\r\n\r\n".bytes
+          read.read(8).bytes.should == "else\r\n\r\n".bytes
+        end
+      end
+    end
   end
 
   describe "when passed chomp" do

--- a/src/main/java/org/truffleruby/core/string/StringNodes.java
+++ b/src/main/java/org/truffleruby/core/string/StringNodes.java
@@ -98,7 +98,6 @@ import org.truffleruby.annotations.CoreMethod;
 import org.truffleruby.builtins.CoreMethodArrayArgumentsNode;
 import org.truffleruby.builtins.CoreMethodNode;
 import org.truffleruby.annotations.CoreModule;
-import org.truffleruby.builtins.NonStandard;
 import org.truffleruby.annotations.Primitive;
 import org.truffleruby.builtins.PrimitiveArrayArgumentsNode;
 import org.truffleruby.builtins.PrimitiveNode;
@@ -4328,9 +4327,8 @@ public abstract class StringNodes {
 
     }
 
-    @NonStandard
-    @CoreMethod(names = "from_bytearray", onSingleton = true, required = 4, lowerFixnum = { 2, 3 })
-    public abstract static class StringFromByteArrayPrimitiveNode extends CoreMethodArrayArgumentsNode {
+    @Primitive(name = "string_from_bytearray", lowerFixnum = { 1, 2 })
+    public abstract static class StringFromByteArrayPrimitiveNode extends PrimitiveArrayArgumentsNode {
 
         @Specialization
         protected RubyString stringFromByteArray(

--- a/src/main/java/org/truffleruby/core/support/ByteArrayNodes.java
+++ b/src/main/java/org/truffleruby/core/support/ByteArrayNodes.java
@@ -15,7 +15,9 @@ import com.oracle.truffle.api.strings.AbstractTruffleString;
 import com.oracle.truffle.api.strings.TruffleString;
 import org.truffleruby.annotations.CoreMethod;
 import org.truffleruby.annotations.CoreModule;
+import org.truffleruby.annotations.Primitive;
 import org.truffleruby.builtins.CoreMethodArrayArgumentsNode;
+import org.truffleruby.builtins.PrimitiveArrayArgumentsNode;
 import org.truffleruby.core.encoding.TStringUtils;
 import org.truffleruby.core.klass.RubyClass;
 import org.truffleruby.core.string.RubyString;
@@ -151,8 +153,8 @@ public abstract class ByteArrayNodes {
 
     }
 
-    @CoreMethod(names = "locate", required = 3, lowerFixnum = { 2, 3 })
-    public abstract static class LocateNode extends CoreMethodArrayArgumentsNode {
+    @Primitive(name = "bytearray_locate", lowerFixnum = { 2, 3 })
+    public abstract static class LocateNode extends PrimitiveArrayArgumentsNode {
 
         @Specialization(
                 guards = "isSingleBytePattern(patternTString, patternEncoding)", limit = "1")

--- a/src/main/ruby/truffleruby/core/io.rb
+++ b/src/main/ruby/truffleruby/core/io.rb
@@ -1135,6 +1135,8 @@ class IO
     # method A, D
     def read_to_separator
       str = +''
+      last_scan_end = 0
+      separator_byte_size = @separator.bytesize
 
       until @buffer.exhausted?
         available = @buffer.fill_from @io, @skip
@@ -1143,20 +1145,83 @@ class IO
         if count = @buffer.find(@separator)
           s = @buffer.shift(count)
 
-          unless str.empty?
-            s.prepend(str)
-            str.clear
+          # We need to be careful matching against multi-byte separators since the
+          # `str` value is being built up progressively.
+          #
+          # If the separator is only a single byte wide and we found it in the buffer
+          # then `count` must be the correct position because there's no way for a single
+          # byte read to be split up; it doesn't matter what `str` contains.
+          #
+          # If the separator is multiple bytes, then we look at `str`. If it's empty,
+          # then the buffer trivially must contain the separator. If not, however, we
+          # must scan the entire `str` after appending the buffer to see if the separator
+          # pattern appears earlier than the position detected by `count`.
+          if str.empty? || separator_byte_size == 1
+            unless str.empty?
+              s.prepend(str)
+              str.clear
+            end
+
+            s = IO.read_encode(@io, s)
+
+            s.chomp!(@separator) if @chomp
+            $. = @io.__send__(:increment_lineno)
+            @buffer.discard @skip if @skip
+
+            yield s
+
+            next
+          else
+            str << s
           end
-
-          s = IO.read_encode(@io, s)
-
-          s.chomp!(@separator) if @chomp
-          $. = @io.__send__(:increment_lineno)
-          @buffer.discard @skip if @skip
-
-          yield s
         else
           str << @buffer.shift
+        end
+
+        if separator_byte_size > 1 && last_scan_end < str.bytesize
+          # Since the separator could be split over multiple passes of this loop,
+          # it's possible for the separator to never appear completely in `@buffer`,
+          # but may appear in `str` after successive passes. If we found an unambiguous
+          # match in the buffer, we wouldn't be in this branch. Since we are, we need
+          # to check if the separator appears in the total read string.
+          #
+          # Rather than scan the entirety of `str` every time, we track how far we've
+          # previously scanned. Since the separator bytes can span reads, we need to
+          # step back `@separator.bytesize - 1` bytes to ensure we don't skip over the
+          # separator bytes. It's `@separator.bytesize - 1` because if the entire
+          # separator was already in `str` we would have found it on a previous pass of
+          # the loop. Since we also need to subtract one to account for zero-based offsets,
+          # we can include that in our offset and just substract the separator byte size.
+          # On the very first scan we don't need to account for any partial scans of the
+          # separator.
+
+          search_offset = last_scan_end - separator_byte_size
+          search_offset = 0 if search_offset < 0
+
+          found_byte_index = Primitive.string_byte_index(str, @separator.b, Encoding::BINARY, search_offset)
+
+          if found_byte_index
+            offset = found_byte_index + @separator.bytesize
+
+            # If we've read more bytes than we need to satisfy the current request, we
+            # need to put the remainder back into the buffer so that subsequent reads
+            # will have the correct bytes.
+            if offset < str.bytesize
+              @buffer.put_back(str.byteslice(offset, str.bytesize - offset))
+            end
+
+            res = IO.read_encode(@io, str.byteslice(0, offset))
+            res.chomp!(@separator) if @chomp
+            $. = @io.__send__(:increment_lineno)
+            @buffer.discard @skip if @skip
+
+            str.clear
+            last_scan_end = 0
+
+            yield res
+          else
+            last_scan_end = str.bytesize
+          end
         end
       end
 

--- a/src/main/ruby/truffleruby/core/io.rb
+++ b/src/main/ruby/truffleruby/core/io.rb
@@ -202,7 +202,7 @@ class IO
     # Returns the number of bytes to fetch from the buffer up-to-
     # and-including +pattern+. Returns +nil+ if pattern is not found.
     def find(pattern, discard = nil)
-      if count = @storage.locate(pattern, @start, @used)
+      if count = Primitive.bytearray_locate(@storage, pattern, @start, @used)
         count - @start
       end
     end

--- a/src/main/ruby/truffleruby/core/io.rb
+++ b/src/main/ruby/truffleruby/core/io.rb
@@ -225,7 +225,7 @@ class IO
         total = size
         total = count if count and count < total
 
-        str = String.from_bytearray @storage, @start, total, encoding
+        str = Primitive.string_from_bytearray(@storage, @start, total, encoding)
         @start += total
 
         str


### PR DESCRIPTION
This PR fixes `IO::EachReader#read_to_separator` and `IO::EachReader#read_to_separator_with_limit` with multi-byte delimiters. If the delimiter appears in the IO object being read from but it split over multiple reads, the old search logic would fail to find the delimiter. Confusingly, if the delimiter appeared in full later in the IO object, that second occurrence's byte position would be returned.

I feel quite confident about the `IO::EachReader#read_to_separator` fix. This original issue was detected when working on getting the [ruby-lsp](https://github.com/Shopify/ruby-lsp) test suite passing on TruffleRuby. That test suite uses a pipe to communicate with a subprocess running the Ruby LSP server. With this PR in place those tests now pass. The new `gets` spec was based on the observed problem with that test suite. Our first attempt was insufficient because it failed to re-insert any bytes past the delimiter back into the read buffer. The test accounts for this situation.

I'm less confident about the `IO::EachReader#read_to_separator_with_limit` changes. I based them on the changes for `read_to_separator` and wrote a new `gets` spec that initially failed, but now passes. However, I don't have any real life code using this call so I can't test against that. Unfortunately, the logic is a bit more involved than simply finding the delimiter or reading the first N bytes because Ruby will read beyond N bytes to ensure only complete codepoints are returned.

Beyond that, I switched some internal calls over to primitives. And I did a minor code clean up of `IO::EachReader`. I think that code in general could benefit from a more comprehensive pass. I've left that for future work. I was aiming to keep this PR as bug fixes only. Each commit is logically standalone so we can selectively apply what's needed for now.

Fixes #2938: IO reads with a delimiter broken for multi-byte delimiters.

/cc @vinistock