### PR TITLE
Fix type coercion protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Bug fixes:
 * Fix processing of proc rest arguments located at the beginning if there are no actual arguments (#2921, @andrykonchin).
 * Fix `Monitor#exit` to raise `ThreadError` when monitor not owned by the current thread (#2922, @andrykonchin).
 * Fix `MatchData#[]` to support negative `length` argument (#2929, @andrykonchin).
+* Fix the exception type raised when type coercion raises a `NoMethodError` (#2903, @paracycle, @nirvdrum).
 
 Compatibility:
 

--- a/spec/ruby/core/array/plus_spec.rb
+++ b/spec/ruby/core/array/plus_spec.rb
@@ -14,10 +14,23 @@ describe "Array#+" do
     (ary + ary).should == [1, 2, 3, 1, 2, 3]
   end
 
-  it "tries to convert the passed argument to an Array using #to_ary" do
-    obj = mock('["x", "y"]')
-    obj.should_receive(:to_ary).and_return(["x", "y"])
-    ([1, 2, 3] + obj).should == [1, 2, 3, "x", "y"]
+  describe "converts the passed argument to an Array using #to_ary" do
+    it "successfully concatenates the resulting array from the #to_ary call" do
+      obj = mock('["x", "y"]')
+      obj.should_receive(:to_ary).and_return(["x", "y"])
+      ([1, 2, 3] + obj).should == [1, 2, 3, "x", "y"]
+    end
+
+    it "raises a Typeerror if the given argument can't be converted to an array" do
+      -> { [1, 2, 3] + nil }.should raise_error(TypeError)
+      -> { [1, 2, 3] + "abc" }.should raise_error(TypeError)
+    end
+
+    it "raises a NoMethodError if the given argument raises a NoMethodError during type coercion to an Array" do
+      obj = mock("hello")
+      obj.should_receive(:to_ary).and_raise(NoMethodError)
+      -> { [1, 2, 3] + obj }.should raise_error(NoMethodError)
+    end
   end
 
   it "properly handles recursive arrays" do

--- a/spec/ruby/core/kernel/method_spec.rb
+++ b/spec/ruby/core/kernel/method_spec.rb
@@ -29,7 +29,7 @@ describe "Kernel#method" do
     m.call.should == :defined
   end
 
-  it "can be called even if we only repond_to_missing? method, true" do
+  it "can be called even if we only respond_to_missing? method, true" do
     m = KernelSpecs::RespondViaMissing.new.method(:handled_privately)
     m.should be_an_instance_of(Method)
     m.call(1, 2, 3).should == "Done handled_privately([1, 2, 3])"
@@ -57,5 +57,24 @@ describe "Kernel#method" do
     end
     m = cls.new.method(:bar)
     m.call.should == :bar
+  end
+
+  describe "converts the given name to a String using #to_str" do
+    it "calls #to_str to convert the given name to a String" do
+      name = mock("method-name")
+      name.should_receive(:to_str).and_return("hash")
+      Object.method(name).should == Object.method(:hash)
+    end
+
+    it "raises a TypeError if the given name can't be converted to a String" do
+      -> { Object.method(nil) }.should raise_error(TypeError)
+      -> { Object.method([])  }.should raise_error(TypeError)
+    end
+
+    it "raises a NoMethodError if the given argument raises a NoMethodError during type coercion to a String" do
+      name = mock("method-name")
+      name.should_receive(:to_str).and_raise(NoMethodError)
+      -> { Object.method(name) }.should raise_error(NoMethodError)
+    end
   end
 end

--- a/spec/ruby/core/math/cos_spec.rb
+++ b/spec/ruby/core/math/cos_spec.rb
@@ -15,7 +15,6 @@ describe "Math.cos" do
     Math.cos(2*Math::PI).should be_close(1.0, TOLERANCE)
   end
 
-
   it "raises a TypeError unless the argument is Numeric and has #to_f" do
     -> { Math.cos("test") }.should raise_error(TypeError)
   end
@@ -24,14 +23,23 @@ describe "Math.cos" do
     Math.cos(nan_value).nan?.should be_true
   end
 
-  it "raises a TypeError if the argument is nil" do
-    -> { Math.cos(nil) }.should raise_error(TypeError)
-  end
+  describe "coerces its argument with #to_f" do
+    it "coerces its argument with #to_f" do
+      f = mock_numeric('8.2')
+      f.should_receive(:to_f).and_return(8.2)
+      Math.cos(f).should == Math.cos(8.2)
+    end
 
-  it "coerces its argument with #to_f" do
-    f = mock_numeric('8.2')
-    f.should_receive(:to_f).and_return(8.2)
-    Math.cos(f).should == Math.cos(8.2)
+    it "raises a TypeError if the given argument can't be converted to a Float" do
+      -> { Math.cos(nil) }.should raise_error(TypeError)
+      -> { Math.cos(:abc) }.should raise_error(TypeError)
+    end
+
+    it "raises a NoMethodError if the given argument raises a NoMethodError during type coercion to a Float" do
+      object = mock_numeric('mock-float')
+      object.should_receive(:to_f).and_raise(NoMethodError)
+      -> { Math.cos(object) }.should raise_error(NoMethodError)
+    end
   end
 end
 

--- a/spec/ruby/core/module/alias_method_spec.rb
+++ b/spec/ruby/core/module/alias_method_spec.rb
@@ -81,6 +81,12 @@ describe "Module#alias_method" do
     -> { @class.make_alias mock('x'), :public_one }.should raise_error(TypeError)
   end
 
+  it "raises a NoMethodError if the given name raises a NoMethodError during type coercion using to_str" do
+    obj = mock("mock-name")
+    obj.should_receive(:to_str).and_raise(NoMethodError)
+    -> { @class.make_alias obj, :public_one }.should raise_error(NoMethodError)
+  end
+
   it "is a public method" do
     Module.should have_public_instance_method(:alias_method, false)
   end

--- a/spec/ruby/core/module/const_defined_spec.rb
+++ b/spec/ruby/core/module/const_defined_spec.rb
@@ -80,10 +80,23 @@ describe "Module#const_defined?" do
     ConstantSpecs::ClassA.const_defined?(:CS_CONSTX).should == false
   end
 
-  it "calls #to_str to convert the given name to a String" do
-    name = mock("ClassA")
-    name.should_receive(:to_str).and_return("ClassA")
-    ConstantSpecs.const_defined?(name).should == true
+  describe "converts the given name to a String using #to_str" do
+    it "calls #to_str to convert the given name to a String" do
+      name = mock("ClassA")
+      name.should_receive(:to_str).and_return("ClassA")
+      ConstantSpecs.const_defined?(name).should == true
+    end
+
+    it "raises a TypeError if the given name can't be converted to a String" do
+      -> { ConstantSpecs.const_defined?(nil) }.should raise_error(TypeError)
+      -> { ConstantSpecs.const_defined?([])  }.should raise_error(TypeError)
+    end
+
+    it "raises a NoMethodError if the given argument raises a NoMethodError during type coercion to a String" do
+      name = mock("classA")
+      name.should_receive(:to_str).and_raise(NoMethodError)
+      -> { ConstantSpecs.const_defined?(name) }.should raise_error(NoMethodError)
+    end
   end
 
   it "special cases Object and checks it's included Modules" do

--- a/spec/ruby/core/queue/initialize_spec.rb
+++ b/spec/ruby/core/queue/initialize_spec.rb
@@ -22,16 +22,29 @@ describe "Queue#initialize" do
       q.should.empty?
     end
 
-    it "uses #to_a on the provided Enumerable" do
-      enumerable = MockObject.new('mock-enumerable')
-      enumerable.should_receive(:to_a).and_return([1, 2, 3])
-      q = Queue.new(enumerable)
-      q.size.should == 3
-      q.should_not.empty?
-      q.pop.should == 1
-      q.pop.should == 2
-      q.pop.should == 3
-      q.should.empty?
+    describe "converts the given argument to an Array using #to_a" do
+      it "uses #to_a on the provided Enumerable" do
+        enumerable = MockObject.new('mock-enumerable')
+        enumerable.should_receive(:to_a).and_return([1, 2, 3])
+        q = Queue.new(enumerable)
+        q.size.should == 3
+        q.should_not.empty?
+        q.pop.should == 1
+        q.pop.should == 2
+        q.pop.should == 3
+        q.should.empty?
+      end
+
+      it "raises a TypeError if the given argument can't be converted to an Array" do
+        -> { Queue.new(42) }.should raise_error(TypeError)
+        -> { Queue.new(:abc) }.should raise_error(TypeError)
+      end
+
+      it "raises a NoMethodError if the given argument raises a NoMethodError during type coercion to an Array" do
+        enumerable = MockObject.new('mock-enumerable')
+        enumerable.should_receive(:to_a).and_raise(NoMethodError)
+        -> { Queue.new(enumerable) }.should raise_error(NoMethodError)
+      end
     end
 
     it "raises TypeError if the provided Enumerable does not respond to #to_a" do

--- a/spec/ruby/core/string/append_spec.rb
+++ b/spec/ruby/core/string/append_spec.rb
@@ -5,6 +5,7 @@ require_relative 'shared/concat'
 describe "String#<<" do
   it_behaves_like :string_concat, :<<
   it_behaves_like :string_concat_encoding, :<<
+  it_behaves_like :string_concat_type_coercion, :<<
 
   it "raises an ArgumentError when given the incorrect number of arguments" do
     -> { "hello".send(:<<) }.should raise_error(ArgumentError)

--- a/spec/ruby/core/string/concat_spec.rb
+++ b/spec/ruby/core/string/concat_spec.rb
@@ -5,6 +5,7 @@ require_relative 'shared/concat'
 describe "String#concat" do
   it_behaves_like :string_concat, :concat
   it_behaves_like :string_concat_encoding, :concat
+  it_behaves_like :string_concat_type_coercion, :concat
 
   it "takes multiple arguments" do
     str = "hello "

--- a/spec/ruby/core/string/plus_spec.rb
+++ b/spec/ruby/core/string/plus_spec.rb
@@ -3,6 +3,9 @@ require_relative 'fixtures/classes'
 require_relative 'shared/concat'
 
 describe "String#+" do
+  it_behaves_like :string_concat_encoding, :+
+  it_behaves_like :string_concat_type_coercion, :+
+
   it "returns a new string containing the given string concatenated to self" do
     ("" + "").should == ""
     ("" + "Hello").should == "Hello"
@@ -31,6 +34,4 @@ describe "String#+" do
     ("hello" + StringSpecs::MyString.new("foo")).should be_an_instance_of(String)
     ("hello" + StringSpecs::MyString.new("")).should be_an_instance_of(String)
   end
-
-  it_behaves_like :string_concat_encoding, :+
 end

--- a/spec/ruby/core/string/shared/concat.rb
+++ b/spec/ruby/core/string/shared/concat.rb
@@ -5,18 +5,6 @@ describe :string_concat, shared: true do
     str.should == "hello world"
   end
 
-  it "converts the given argument to a String using to_str" do
-    obj = mock('world!')
-    obj.should_receive(:to_str).and_return("world!")
-    a = 'hello '.send(@method, obj)
-    a.should == 'hello world!'
-  end
-
-  it "raises a TypeError if the given argument can't be converted to a String" do
-    -> { 'hello '.send(@method, [])        }.should raise_error(TypeError)
-    -> { 'hello '.send(@method, mock('x')) }.should raise_error(TypeError)
-  end
-
   it "raises a FrozenError when self is frozen" do
     a = "hello"
     a.freeze
@@ -146,5 +134,25 @@ describe :string_concat_encoding, shared: true do
     it "uses BINARY encoding" do
       "abc".encode("BINARY").send(@method, "123".encode("US-ASCII")).encoding.should == Encoding::BINARY
     end
+  end
+end
+
+describe :string_concat_type_coercion, shared: true do
+  it "converts the given argument to a String using to_str" do
+    obj = mock('world!')
+    obj.should_receive(:to_str).and_return("world!")
+    a = 'hello '.send(@method, obj)
+    a.should == 'hello world!'
+  end
+
+  it "raises a TypeError if the given argument can't be converted to a String" do
+    -> { 'hello '.send(@method, [])        }.should raise_error(TypeError)
+    -> { 'hello '.send(@method, mock('x')) }.should raise_error(TypeError)
+  end
+
+  it "raises a NoMethodError if the given argument raises a NoMethodError during type coercion to a String" do
+    obj = mock('world!')
+    obj.should_receive(:to_str).and_raise(NoMethodError)
+    -> { 'hello '.send(@method, obj) }.should raise_error(NoMethodError)
   end
 end

--- a/spec/tags/core/module/const_defined_tags.txt
+++ b/spec/tags/core/module/const_defined_tags.txt
@@ -1,0 +1,1 @@
+fails:Module#const_defined? converts the given name to a String using #to_str raises a NoMethodError if the given argument raises a NoMethodError during type coercion to a String

--- a/spec/truffle/always_inlined_spec.rb
+++ b/spec/truffle/always_inlined_spec.rb
@@ -44,12 +44,6 @@ describe "Always-inlined core methods" do
       }.should raise_error(ArgumentError) { |e| e.backtrace_locations[0].label.should == 'binding' }
     end
 
-    it "for #eval" do
-      -> {
-        eval(Object.new)
-      }.should raise_error(TypeError) { |e| e.backtrace_locations[0].label.should == 'eval' }
-    end
-
     it "for #local_variables" do
       -> {
         local_variables(:wrong)
@@ -233,6 +227,26 @@ describe "Always-inlined core methods" do
         e.backtrace_locations[1].label.should.start_with?('block (4 levels)')
         e.backtrace_locations[1].lineno.should == line + 2
       }
+    end
+
+    it "for #eval" do
+      -> {
+        eval(Object.new)
+      }.should raise_error(TypeError) { |e|
+        e.backtrace_locations[0].label.should == 'convert_type'
+      }
+    end
+
+    it "for Module#class_eval with Object" do
+      -> {
+        Module.new.class_eval(Object.new)
+      }.should raise_error(TypeError) { |e| e.backtrace_locations[0].label.should == 'convert_type' }
+    end
+
+    it "for Module#module_eval with Object" do
+      -> {
+        Module.new.module_eval(Object.new)
+      }.should raise_error(TypeError) { |e| e.backtrace_locations[0].label.should == 'convert_type' }
     end
 
     guard -> { RUBY_ENGINE != "ruby" } do

--- a/src/main/java/org/truffleruby/core/cast/ToAryNode.java
+++ b/src/main/java/org/truffleruby/core/cast/ToAryNode.java
@@ -12,13 +12,11 @@ package org.truffleruby.core.cast;
 import com.oracle.truffle.api.dsl.NeverDefault;
 import org.truffleruby.core.array.RubyArray;
 import org.truffleruby.language.RubyBaseNodeWithExecute;
-import org.truffleruby.language.control.RaiseException;
-import org.truffleruby.language.dispatch.DispatchNode;
 
 import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.NodeChild;
 import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.profiles.BranchProfile;
+import org.truffleruby.language.dispatch.DispatchNode;
 
 @NodeChild(value = "childNode", type = RubyBaseNodeWithExecute.class)
 public abstract class ToAryNode extends RubyBaseNodeWithExecute {
@@ -43,30 +41,13 @@ public abstract class ToAryNode extends RubyBaseNodeWithExecute {
 
     @Specialization(guards = "!isRubyArray(object)")
     protected RubyArray coerceObject(Object object,
-            @Cached BranchProfile errorProfile,
             @Cached DispatchNode toAryNode) {
-        final Object coerced;
-        try {
-            coerced = toAryNode.call(object, "to_ary");
-        } catch (RaiseException e) {
-            errorProfile.enter();
-            if (e.getException().getLogicalClass() == coreLibrary().noMethodErrorClass) {
-                throw new RaiseException(
-                        getContext(),
-                        coreExceptions().typeErrorNoImplicitConversion(object, "Array", this));
-            } else {
-                throw e;
-            }
-        }
-
-        if (coerced instanceof RubyArray) {
-            return (RubyArray) coerced;
-        } else {
-            errorProfile.enter();
-            throw new RaiseException(
-                    getContext(),
-                    coreExceptions().typeErrorBadCoercion(object, "Array", "to_ary", coerced, this));
-        }
+        return (RubyArray) toAryNode.call(
+                coreLibrary().truffleTypeModule,
+                "rb_convert_type",
+                object,
+                coreLibrary().arrayClass,
+                coreSymbols().TO_ARY);
     }
 
     @Override

--- a/src/main/java/org/truffleruby/core/cast/ToStrNode.java
+++ b/src/main/java/org/truffleruby/core/cast/ToStrNode.java
@@ -15,14 +15,11 @@ import com.oracle.truffle.api.dsl.NeverDefault;
 import org.truffleruby.core.string.RubyString;
 import org.truffleruby.core.string.ImmutableRubyString;
 import org.truffleruby.language.RubyBaseNodeWithExecute;
-import org.truffleruby.language.control.RaiseException;
 import org.truffleruby.language.dispatch.DispatchNode;
 
 import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.NodeChild;
 import com.oracle.truffle.api.dsl.Specialization;
-import com.oracle.truffle.api.profiles.BranchProfile;
-import org.truffleruby.language.library.RubyStringLibrary;
 
 @GenerateUncached
 @NodeChild(value = "childNode", type = RubyBaseNodeWithExecute.class)
@@ -53,31 +50,13 @@ public abstract class ToStrNode extends RubyBaseNodeWithExecute {
 
     @Specialization(guards = "isNotRubyString(object)")
     protected Object coerceObject(Object object,
-            @Cached BranchProfile errorProfile,
-            @Cached DispatchNode toStrNode,
-            @Cached RubyStringLibrary libString) {
-        final Object coerced;
-        try {
-            coerced = toStrNode.call(object, "to_str");
-        } catch (RaiseException e) {
-            errorProfile.enter();
-            if (e.getException().getLogicalClass() == coreLibrary().noMethodErrorClass) {
-                throw new RaiseException(
-                        getContext(),
-                        coreExceptions().typeErrorNoImplicitConversion(object, "String", this));
-            } else {
-                throw e;
-            }
-        }
-
-        if (libString.isRubyString(coerced)) {
-            return coerced;
-        } else {
-            errorProfile.enter();
-            throw new RaiseException(
-                    getContext(),
-                    coreExceptions().typeErrorBadCoercion(object, "String", "to_str", coerced, this));
-        }
+            @Cached DispatchNode toStrNode) {
+        return toStrNode.call(
+                coreLibrary().truffleTypeModule,
+                "rb_convert_type",
+                object,
+                coreLibrary().stringClass,
+                coreSymbols().TO_STR);
     }
 
     @Override

--- a/src/main/java/org/truffleruby/core/inlined/AlwaysInlinedMethodNode.java
+++ b/src/main/java/org/truffleruby/core/inlined/AlwaysInlinedMethodNode.java
@@ -26,8 +26,8 @@ import org.truffleruby.language.control.RaiseException;
  * {@link #needCallerFrame(Frame, RootCallTarget)} that the caller frame is not null before using it (if it needs it),
  * in order to provide a useful exception in that case.
  * <p>
- * Such a method will not appear in backtraces. However, Ruby exceptions emitted from this node will be resent through a
- * CallTarget to get the proper backtrace. This should be tested in spec/truffle/always_inlined_spec.rb.
+ * Such a method will not appear in backtraces. However, Ruby exceptions emitted from this node will be re-sent through
+ * a CallTarget to get the proper backtrace. This should be tested in spec/truffle/always_inlined_spec.rb.
  * <p>
  * Such a core method should not emit significantly more Graal nodes than a non-inlined call, as Truffle cannot decide
  * to not inline it, and that could lead to too big methods to compile. */


### PR DESCRIPTION
This PR fixes some differences in behavior between our type coercion nodes and our `Truffle::Type` class in Ruby. The nodes now delegate to `Truffle::Type`, which improves compatibility and reduces the amount of Java code needed. It fixes the Sorbet test issue that @paracycle and I previously ran into (#2903).

Only the `to_str` fixes impact the Sorbet test suite, but since the cast nodes all follow the same pattern, I've updated nearly all of them. `ToProcNode` needs special consideration to handle refinements, so I left it as is for now. I've some specs for each node I've adjusted, but there are a lot of core library methods that attempt to coerce values, but for which there are no specs.

If possible, I'd love to get this backported for the TruffleRuby 23.0.0 release. I can split into a smaller PR to just apply the `to_str` fix, if that's helpful.