### PR TITLE
Update arg to ruby-install in docs

### DIFF
--- a/doc/user/ruby-managers.md
+++ b/doc/user/ruby-managers.md
@@ -105,7 +105,7 @@ Follow the [installation instructions](https://github.com/postmodern/ruby-instal
 Then install the latest TruffleRuby standalone release with:
 
 ```bash
-ruby-install --latest
+ruby-install --update
 ruby-install truffleruby
 ```
 


### PR DESCRIPTION
ruby-install says
> *** DEPRECATION: -L,--latest is deprecated. Please use -U,--update instead.