### PR TITLE
[3.2 compatibility] Return nil for beginless ranges where the end is not numeric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Compatibility:
 * Add `Process.argv0` method (@andrykonchin).
 * Add support for array pattern matching. This is opt-in via `--pattern-matching` since pattern matching is not fully supported yet. (#2683, @razetime).
 * Fix `Array#[]` with `ArithmeticSequence` argument when step is negative (@itarato).
+* Fix `Range#size` and return `nil` for beginningless Range when end isn't Numeric (@rwstauner).
 
 Performance:
 

--- a/spec/ruby/core/range/size_spec.rb
+++ b/spec/ruby/core/range/size_spec.rb
@@ -44,12 +44,12 @@ describe "Range#size" do
   end
 
   ruby_version_is "3.2" do
-    it 'returns Float::INFINITY for all beginless ranges if the start is numeric' do
+    it 'returns Float::INFINITY for all beginless ranges if the end is numeric' do
       (..1).size.should == Float::INFINITY
       (...0.5).size.should == Float::INFINITY
     end
 
-    it 'returns nil for all beginless ranges if the start is numeric' do
+    it 'returns nil for all beginless ranges if the end is not numeric' do
       (...'o').size.should == nil
     end
 

--- a/spec/tags/core/range/size_tags.txt
+++ b/spec/tags/core/range/size_tags.txt
@@ -1,0 +1,1 @@
+fails:Range#size returns Float::INFINITY for all beginless ranges

--- a/spec/truffleruby.next-specs
+++ b/spec/truffleruby.next-specs
@@ -13,3 +13,4 @@ spec/ruby/core/array/slice_spec.rb
 spec/ruby/core/array/element_reference_spec.rb
 
 spec/ruby/core/hash/shift_spec.rb
+spec/ruby/core/range/size_spec.rb

--- a/src/main/ruby/truffleruby/core/range.rb
+++ b/src/main/ruby/truffleruby/core/range.rb
@@ -509,7 +509,9 @@ class Range
   end
 
   def size
-    return Float::INFINITY if Primitive.nil? self.begin
+    if Primitive.nil? self.begin
+      return Primitive.is_a?(self.end, Numeric) ? Float::INFINITY : nil
+    end
     return nil unless Primitive.is_a?(self.begin, Numeric)
     return Float::INFINITY if Primitive.nil? self.end
 


### PR DESCRIPTION
- Make descriptions match code for beginless range size specs
- Return nil for beginless ranges where the end is not numeric

This is for ruby 3.2 (TODO: change merge target)

I changed the spec descriptions to match the code... let me know if you think something isn't right about that.