### PR TITLE
Reverse Array#shuffle implementation to match output of CRuby

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ Bug fixes:
 
 Compatibility:
 
-- Fix `Hash#shift` when Hash is empty but has initial default value or initial default proc (@itarato).
+* Fix `Hash#shift` when Hash is empty but has initial default value or initial default proc (@itarato).
+* Make `Array#shuffle` produce the same results as CRuby (@rwstauner).
 
 Performance:
 

--- a/spec/ruby/core/array/shuffle_spec.rb
+++ b/spec/ruby/core/array/shuffle_spec.rb
@@ -93,4 +93,14 @@ describe "Array#shuffle!" do
     -> { ArraySpecs.frozen_array.shuffle! }.should raise_error(FrozenError)
     -> { ArraySpecs.empty_frozen_array.shuffle! }.should raise_error(FrozenError)
   end
+
+  it "matches CRuby with random:" do
+    %w[a b c].shuffle(random: Random.new(1)).should == %w[a c b]
+    (0..10).to_a.shuffle(random: Random.new(10)).should == [2, 6, 8, 5, 7, 10, 3, 1, 0, 4, 9]
+  end
+
+  it "matches CRuby with srand" do
+    srand(123)
+    %w[a b c d e f g h i j k].shuffle.should == %w[a e f h i j d b g k c]
+  end
 end

--- a/src/main/ruby/truffleruby/core/array.rb
+++ b/src/main/ruby/truffleruby/core/array.rb
@@ -1240,9 +1240,11 @@ class Array
       random_generator = options[:random] if options[:random].respond_to?(:rand)
     end
 
-    size.times do |i|
-      r = i + random_generator.rand(size - i).to_int
-      raise RangeError, "random number too big #{r - i}" if r < 0 || r >= size
+    # Start at the end and work toward the beginning for compatibility with CRuby.
+    (size - 1).downto(0) do |i|
+      r = random_generator.rand(i + 1).to_int
+      raise RangeError, "random number too small #{r}" if r < 0
+      raise RangeError, "random number too big #{r}" if r > i
       swap(i, r)
     end
     self


### PR DESCRIPTION
The [ci-queue gem](https://github.com/Shopify/ci-queue) has a [test suite](https://github.com/Shopify/ci-queue/blob/aa16b8798b23cffe2b657a555e48b3de928ca634/test/integration/rspec_redis_test.rb#L38) that expects [`Array#shuffle`](https://github.com/Shopify/ci-queue/blob/aa16b8798b23cffe2b657a555e48b3de928ca634/lib/ci/queue.rb#L35) to return a specific order when given a specific seed.

On CRuby this order has been consistent for several versions.
JRuby also produces the same result.
TruffleRuby produces a different result.

While it isn't strictly necessary to match this behavior, It would ease adoption.

```
$ chruby | while read version; do (chruby $version 2>&-; printf '%5s'; ruby -ve 'puts %w[a b c].shuffle(random: Random.new(1)).join(" ")' 2>&-); done
     ruby 2.6.3p62 (2019-04-16 revision 67580) [-darwin21]
a c b
     ruby 2.6.5p114 (2019-10-01 revision 67812) [-darwin22]
a c b
     ruby 2.7.3p183 (2021-04-05 revision 6847ee089d) [arm64-darwin21]
a c b
     ruby 2.7.5p203 (2021-11-24 revision f69aeb8314) [arm64-darwin21]
a c b
     ruby 3.0.2p107 (2021-07-07 revision 0db68f0233) [arm64-darwin21]
a c b
     ruby 3.0.6p216 (2023-03-30 revision 23a532679b) [arm64-darwin22]
a c b
     ruby 3.1.0p0 (2021-12-25 revision fb4df44d16) [arm64-darwin21]
a c b
     ruby 3.1.1p18 (2022-02-18 revision 53f5fc4236) [arm64-darwin21]
a c b
     ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [arm64-darwin21]
a c b
     ruby 3.1.3p185 (2022-11-24 revision 1a6b16756e) [arm64-darwin21]
a c b
     ruby 3.2.0 (2022-12-25 revision a528908271) [arm64-darwin21.5.0]
a c b
     ruby 3.2.1 (2023-02-08 revision 31819e82c8) [arm64-darwin22]
a c b
     ruby 3.2.2 (2023-03-30 revision e51014f9c0) [arm64-darwin22]
a c b
     jruby 9.4.2.0 (3.1.0) 2023-03-08 90d2913fda OpenJDK 64-Bit Server VM 19.0.2 on 19.0.2 +jit [arm64-darwin]
a c b
     truffleruby 23.1.0-dev-1883f8ad, like ruby 3.1.3, GraalVM CE Native [aarch64-darwin]
b c a
     truffleruby 22.3.1, like ruby 3.0.3, GraalVM CE Native [aarch64-darwin]
b c a
```

This more closely matches the CRuby implementation: https://github.com/ruby/ruby/blob/381475f02e6b44ae729f9403637b30c445b622e5/array.c#L6655-L6667
https://github.com/ruby/ruby/blob/381475f02e6b44ae729f9403637b30c445b622e5/random.c#L1183-L1188

I added some additional specs to ensure we maintain that compatibility.