### PR TITLE
Remove duplicated Dir#ensure_open call

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,13 +35,27 @@ You can use `tool/hooks/lint-check.sh` as a git hook to run `jt lint fast` autom
 
 ## ChangeLog
 
-When opening a Pull Request, please add a ChangeLog entry with the format:
+When opening a Pull Request, if the change is visible or meaningful to users (they are the intended readers of the ChangeLog),
+please add a ChangeLog entry with this format:
 
 ```
 * Description (#GitHub issue number if any, @author).
 ```
 
 See the [the ChangeLog](CHANGELOG.md) for examples.
+
+This is the meaning of the sections in the ChangeLog:
+* New features: a big new feature or a new method provided by TruffleRuby which does not exist in CRuby (e.g. a new interop method).
+* Compatibility: any change which helps compatibility with CRuby, whether it is a new method or behavior closer to CRuby.
+* Bug fixes: only for fixes where the bug "silently" caused incorrect behavior.
+  For example, if it raised an exception before, the wrong behavior was pretty clear, so it should be under `Compatibility` not `Bug fixes`.
+  On the other hand, if e.g. `1 + 2` returned `4` that should be under `Bug fixes`.
+* Performance: something which improves performance (whether interpreter, warmup or peak).
+* Memory Footprint: something which improves memory footprint.
+* Changes: this means incompatible changes that users may need to adapt to.
+
+Always keep an empty line around the various sections, like it is done for entries in older releases.
+The idea is only add lines, never remove lines (important since this file uses union merge).
 
 GitHub might show on the Pull Request:
 ```

--- a/src/main/ruby/truffleruby/core/truffle/dir_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/dir_operations.rb
@@ -60,7 +60,6 @@ module Truffle
     end
 
     def self.readdir_name(dir)
-      dir.__send__(:ensure_open)
       dirptr = Primitive.object_ivar_get(dir, :@ptr)
       entry = Truffle::POSIX.truffleposix_readdir_name(dirptr)
       Errno.handle unless entry


### PR DESCRIPTION
The `Dir#ensure_open` method was called twice when calling `Dir#read`. Redundant to https://github.com/oracle/truffleruby/blob/7da015fbb94d880d19e1aca03d0343f7c1d570c9/src/main/ruby/truffleruby/core/truffle/dir_operations.rb#L63 (its own direct call).