### PR TITLE
[WIP] [Memory footprint] Memoize FeatureLoader.load_feature_path results to avoid massive string allocations

### DIFF
--- a/src/main/ruby/truffleruby/core/truffle/feature_loader.rb
+++ b/src/main/ruby/truffleruby/core/truffle/feature_loader.rb
@@ -41,12 +41,15 @@ module Truffle
     # nil if there is no relative path in $LOAD_PATH, a copy of the cwd to check if the cwd changed otherwise.
     @working_directory_copy = nil
 
+    @loaded_feature_path_cache = {}
+
     def self.clear_cache
       @loaded_features_index.clear
       @loaded_features_version = -1
       @expanded_load_path.clear
       @load_path_version = -1
       @working_directory_copy = nil
+      @loaded_feature_path_cache = {}
     end
 
     class FeatureEntry
@@ -171,7 +174,7 @@ module Truffle
                                if expanded
                                  nil
                                else
-                                 loaded_feature_path(loaded_feature, feature, get_expanded_load_path)
+                                 cached_loaded_feature_path(loaded_feature, feature)
                                end
                              end
               if feature_path
@@ -193,6 +196,11 @@ module Truffle
 
         false
       end
+    end
+
+    def self.cached_loaded_feature_path(loaded_feature, feature)
+      cache_key = "#{loaded_feature}::#{feature}"
+      @loaded_feature_path_cache[cache_key] ||= loaded_feature_path(loaded_feature, feature, get_expanded_load_path)
     end
 
     # MRI: loaded_feature_path


### PR DESCRIPTION
Running a small test on a mid-class Rails project we've noticed a suspicious top allocation:

```ruby
jt --use jvm-ce ruby --memtracer --memtracer.TraceCalls -S bin/rails test test/..._test.rb
```

 Name                                                |      Self Count |     Total Count | Location
-----------------------------------------------------|-----------------|-----------------|---------
 block in Truffle::FeatureLoader.loaded_feature_path | 11304309  60.3% | 11304309  60.3% | ../../../../truffle/truffleruby/src/main/ruby/truffleruby/core/truffle/feature_loader.rb~203-204:7082-7202

This was happening during the bootstrap phase when gems/files/scripts were loading. This was called ~3.2k times:

```
 Truffle::FeatureLoader.loaded_feature_path   |          3261 100.0% |          3261 100.0% |             0   0.0% | ../../../../truffle/truffleruby/src/main/ruby/truffleruby/core/truffle/feature_loader.rb~201-206:6970-7220
```

... where mostly it re-queried the same features. Adding memoization reduced the allocation count to 19% of the original version:

Name                                                |      Self Count |     Total Count | Location
----------------------------------------------------|-----------------|-----------------|---------
block in Truffle::FeatureLoader.loaded_feature_path |  2181095  22.6% |  2181095  22.6% | ../../../../truffle/truffleruby/src/main/ruby/truffleruby/core/truffle/feature_loader.rb~210-211:7306-7466

(Note: this was the top allocation item in both before/after runs.)

Caveat: there is a small extra allocation added to the caching method (when generating the cache key), however this is still significantly less than before:

```
Truffle::FeatureLoader.cached_loaded_feature_path | 13044 0.1% | 2870600  27.8% | ../../../../truffle/truffleruby/src/main/ruby/truffleruby/core/truffle/feature_loader.rb~201-204:6873-7111
```

### Implementation notes:

There is a second memoized function added (instead of memoizing in-place) due to the use of an argument (`load_path`) which would have been hard to test if it's an internal variable (and memoization only works if we internalize that). Hence we have an aid-function to do the caching, so the original function can still be tested as is.

### Risks

As mentioned above - in order to cache the result of the path lookup, the source needed to be fixed (so it's not a variable for the function). However in real life it might be subject to change - since the origin on the path collection (`$-I`) is mutable. This means that updating `$-I` on purpose could make the caching irrelevant.