### PR TITLE
Fix Dir.glob returning a blank string entry in some cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ New features:
 
 Bug fixes:
 
+* Fix `Dir.glob` returning blank string entry with leading `**/` in glob and `base:` argument (@rwstauner).
 
 Compatibility:
 

--- a/spec/ruby/core/dir/glob_spec.rb
+++ b/spec/ruby/core/dir/glob_spec.rb
@@ -186,16 +186,18 @@ describe "Dir.glob" do
     Dir.glob('**/**', base: "dir").should == ["filename_ordering"]
 
     expected = %w[
-      directory
-      directory/structure
-      directory/structure/bar
-      directory/structure/baz
-      directory/structure/file_one
-      directory/structure/file_one.ext
-      directory/structure/foo
+      nested
+      nested/directory
+      nested/directory/structure
+      nested/directory/structure/bar
+      nested/directory/structure/baz
+      nested/directory/structure/file_one
+      nested/directory/structure/file_one.ext
+      nested/directory/structure/foo
+      nondotfile
     ].sort
 
-    Dir.glob('**/**', base: "deeply/nested").sort.should == expected
+    Dir.glob('**/**', base: "deeply").sort.should == expected
   end
 
   it "handles **/ with base keyword argument" do
@@ -207,17 +209,59 @@ describe "Dir.glob" do
     Dir.glob('**/', base: "deeply/nested").sort.should == expected
   end
 
+  it "handles **/nondotfile with base keyword argument" do
+    expected = %w[
+      deeply/nondotfile
+      nondotfile
+      subdir_one/nondotfile
+      subdir_two/nondotfile
+    ]
+    Dir.glob('**/nondotfile', base: ".").sort.should == expected
+  end
+
+  it "handles **/nondotfile with base keyword argument and FNM_DOTMATCH" do
+    expected = %w[
+      .dotsubdir/nondotfile
+      deeply/nondotfile
+      nested/.dotsubir/nondotfile
+      nondotfile
+      subdir_one/nondotfile
+      subdir_two/nondotfile
+    ]
+    Dir.glob('**/nondotfile', File::FNM_DOTMATCH, base: ".").sort.should == expected
+  end
+
+  it "handles **/.dotfile with base keyword argument" do
+    expected = %w[
+      .dotfile
+      deeply/.dotfile
+      subdir_one/.dotfile
+    ]
+    Dir.glob('**/.dotfile', base: ".").sort.should == expected
+  end
+
+  it "handles **/.dotfile with base keyword argument and FNM_DOTMATCH" do
+    expected = %w[
+      .dotfile
+      .dotsubdir/.dotfile
+      deeply/.dotfile
+      nested/.dotsubir/.dotfile
+      subdir_one/.dotfile
+    ]
+    Dir.glob('**/.dotfile', File::FNM_DOTMATCH, base: ".").sort.should == expected
+  end
+
+  it "handles **/.* with base keyword argument" do
+    expected = %w[
+      .dotfile.ext
+      directory/structure/.ext
+    ].sort
+
+    Dir.glob('**/.*', base: "deeply/nested").sort.should == expected
+  end
+
   # 2.7 and 3.0 include a "." entry for every dir: ["directory/.", "directory/structure/.", ...]
-  guard_not -> { ruby_version_is ''...'3.1' } do
-    it "handles **/.* with base keyword argument" do
-      expected = %w[
-        .dotfile.ext
-        directory/structure/.ext
-      ].sort
-
-      Dir.glob('**/.*', base: "deeply/nested").sort.should == expected
-    end
-
+  ruby_version_is '3.1' do
     it "handles **/.* with base keyword argument and FNM_DOTMATCH" do
       expected = %w[
         .

--- a/spec/ruby/core/dir/glob_spec.rb
+++ b/spec/ruby/core/dir/glob_spec.rb
@@ -182,6 +182,90 @@ describe "Dir.glob" do
     Dir.glob('**/**/**').should_not.empty?
   end
 
+  it "handles **/** with base keyword argument" do
+    Dir.glob('**/**', base: "dir").should == ["filename_ordering"]
+
+    expected = %w[
+      directory
+      directory/structure
+      directory/structure/bar
+      directory/structure/baz
+      directory/structure/file_one
+      directory/structure/file_one.ext
+      directory/structure/foo
+    ].sort
+
+    Dir.glob('**/**', base: "deeply/nested").sort.should == expected
+  end
+
+  it "handles **/ with base keyword argument" do
+    expected = %w[
+      /
+      directory/
+      directory/structure/
+    ]
+    Dir.glob('**/', base: "deeply/nested").sort.should == expected
+  end
+
+  # 2.7 and 3.0 include a "." entry for every dir: ["directory/.", "directory/structure/.", ...]
+  guard_not -> { ruby_version_is ''...'3.1' } do
+    it "handles **/.* with base keyword argument" do
+      expected = %w[
+        .dotfile.ext
+        directory/structure/.ext
+      ].sort
+
+      Dir.glob('**/.*', base: "deeply/nested").sort.should == expected
+    end
+
+    it "handles **/.* with base keyword argument and FNM_DOTMATCH" do
+      expected = %w[
+        .
+        .dotfile.ext
+        directory/structure/.ext
+      ].sort
+
+      Dir.glob('**/.*', File::FNM_DOTMATCH, base: "deeply/nested").sort.should == expected
+    end
+
+    it "handles **/** with base keyword argument and FNM_DOTMATCH" do
+      expected = %w[
+        .
+        .dotfile.ext
+        directory
+        directory/structure
+        directory/structure/.ext
+        directory/structure/bar
+        directory/structure/baz
+        directory/structure/file_one
+        directory/structure/file_one.ext
+        directory/structure/foo
+      ].sort
+
+      Dir.glob('**/**', File::FNM_DOTMATCH, base: "deeply/nested").sort.should == expected
+    end
+  end
+
+  it "handles **/*pattern* with base keyword argument and FNM_DOTMATCH" do
+    expected = %w[
+      .dotfile.ext
+      directory/structure/file_one
+      directory/structure/file_one.ext
+    ]
+
+    Dir.glob('**/*file*', File::FNM_DOTMATCH, base: "deeply/nested").sort.should == expected
+  end
+
+  it "handles **/glob with base keyword argument and FNM_EXTGLOB" do
+    expected = %w[
+      directory/structure/bar
+      directory/structure/file_one
+      directory/structure/file_one.ext
+    ]
+
+    Dir.glob('**/*{file,bar}*', File::FNM_EXTGLOB, base: "deeply/nested").sort.should == expected
+  end
+
   it "handles simple filename patterns" do
     Dir.glob('.dotfile').should == ['.dotfile']
   end


### PR DESCRIPTION
When the first part of the glob is `**`
and the base keyword argument is provided
we end up including an empty string as the first entry:

```
$ ls -a ~/tmp/one
.     ..    .no   1.txt
$ ~/.rubies/truffleruby-graalvm-22.3.1/bin/ruby -ve 'puts Dir.glob("**/**", base: "#{ENV["HOME"]}/tmp/one").inspect'
truffleruby 22.3.1, like ruby 3.0.3, GraalVM CE Native [aarch64-darwin]
["", "1.txt"]
$ ruby -ve 'puts Dir.glob("**/**", base: "#{ENV["HOME"]}/tmp/one").inspect'
ruby 3.1.3p185 (2022-11-24 revision 1a6b16756e) [arm64-darwin21]
["1.txt"]
```

When the glob starts with `**/` we use `StartRecursiveDirectories`.
It doesn't look like we ever set a `@separator` explicitly on it.
We call `process_entry` with `''` _if_ a base dir was set.

I don't have much context on the history of this to understand why or if this was useful in the past
but  i can see the file has been reworked a few times, it's possible it just isn't needed any more.
 
There was no test exercising this scenario (leading `**` with `base` arg) so i added one.

Anyone with historical knowledge of this component think this makes sense?
Do we need more testing of any sort here?