### PR TITLE
[Compatibility] Add timeout argument to Thread::SizedQueue#pop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Compatibility:
 * Add `String#byteindex` and `String#byterindex` (#3039, @itarato).
 * Add implementations of `rb_proc_call_with_block`, `rb_proc_call_kw`, `rb_proc_call_with_block_kw` and `rb_funcall_with_block_kw` (#3068, @andrykonchin).
 * Add optional `timeout` argument to `Thread::Queue#pop` (#3039, @itarato).
+* Add optional `timeout` argument to `Thread::SizedsQueue#pop` (#3039, @itarato).
 
 Performance:
 

--- a/lib/truffle/thread.rb
+++ b/lib/truffle/thread.rb
@@ -35,7 +35,18 @@ class Thread
       Primitive.queue_pop(
         self,
         Primitive.as_boolean(non_block),
-        Truffle::QueueOperations.validate_and_prepare_timeout(non_block, timeout))
+        Truffle::QueueOperations.validate_and_prepare_timeout_in_milliseconds(non_block, timeout))
+    end
+    alias_method :shift, :pop
+    alias_method :deq, :pop
+  end
+
+  class SizedQueue
+    def pop(non_block = false, timeout: nil)
+      Primitive.sized_queue_pop(
+        self,
+        Primitive.as_boolean(non_block),
+        Truffle::QueueOperations.validate_and_prepare_timeout_in_milliseconds(non_block, timeout))
     end
     alias_method :shift, :pop
     alias_method :deq, :pop

--- a/spec/ruby/core/sizedqueue/deq_spec.rb
+++ b/spec/ruby/core/sizedqueue/deq_spec.rb
@@ -1,6 +1,13 @@
 require_relative '../../spec_helper'
 require_relative '../../shared/queue/deque'
+require_relative '../../shared/types/rb_num2dbl_fails'
 
 describe "SizedQueue#deq" do
   it_behaves_like :queue_deq, :deq, -> { SizedQueue.new(10) }
+end
+
+describe "SizedQueue operations with timeout" do
+  ruby_version_is "3.2" do
+    it_behaves_like :rb_num2dbl_fails, nil, -> v { q = SizedQueue.new(10); q.push(1); q.deq(timeout: v) }
+  end
 end

--- a/spec/ruby/core/sizedqueue/pop_spec.rb
+++ b/spec/ruby/core/sizedqueue/pop_spec.rb
@@ -1,6 +1,13 @@
 require_relative '../../spec_helper'
 require_relative '../../shared/queue/deque'
+require_relative '../../shared/types/rb_num2dbl_fails'
 
 describe "SizedQueue#pop" do
   it_behaves_like :queue_deq, :pop, -> { SizedQueue.new(10) }
+end
+
+describe "SizedQueue operations with timeout" do
+  ruby_version_is "3.2" do
+    it_behaves_like :rb_num2dbl_fails, nil, -> v { q = SizedQueue.new(10); q.push(1); q.pop(timeout: v) }
+  end
 end

--- a/spec/ruby/core/sizedqueue/shift_spec.rb
+++ b/spec/ruby/core/sizedqueue/shift_spec.rb
@@ -1,6 +1,13 @@
 require_relative '../../spec_helper'
 require_relative '../../shared/queue/deque'
+require_relative '../../shared/types/rb_num2dbl_fails'
 
 describe "SizedQueue#shift" do
   it_behaves_like :queue_deq, :shift, -> { SizedQueue.new(10) }
+end
+
+describe "SizedQueue operations with timeout" do
+  ruby_version_is "3.2" do
+    it_behaves_like :rb_num2dbl_fails, nil, -> v { q = SizedQueue.new(10); q.push(1); q.shift(timeout: v) }
+  end
 end

--- a/spec/ruby/shared/queue/deque.rb
+++ b/spec/ruby/shared/queue/deque.rb
@@ -123,6 +123,12 @@ describe :queue_deq, shared: true do
           "can't set a timeout if non_block is enabled",
         )
       end
+
+      it "returns nil for a closed empty queue" do
+        q = @object.call
+        q.close
+        q.send(@method, timeout: 0).should == nil
+      end
     end
   end
 

--- a/spec/truffleruby.next-specs
+++ b/spec/truffleruby.next-specs
@@ -25,3 +25,7 @@ spec/ruby/core/string/byterindex_spec.rb
 spec/ruby/core/queue/deq_spec.rb
 spec/ruby/core/queue/pop_spec.rb
 spec/ruby/core/queue/shift_spec.rb
+
+spec/ruby/core/sizedqueue/deq_spec.rb
+spec/ruby/core/sizedqueue/pop_spec.rb
+spec/ruby/core/sizedqueue/shift_spec.rb

--- a/src/main/.checkstyle_checks.xml
+++ b/src/main/.checkstyle_checks.xml
@@ -150,6 +150,10 @@
       <property name="message" value="Use ConcurrentOperations.getOrCompute() instead of ConcurrentHashMap.computeIfAbsent() which does not scale"/>
     </module>
     <module name="RegexpSinglelineJava">
+      <property name="format" value="\b(?!\w*[Ll]atch)\w+\.await\(.*\)"/>
+      <property name="message" value="Use ConcurrentOperations.awaitAndCheckInterrupt() instead"/>
+    </module>
+    <module name="RegexpSinglelineJava">
       <property name="format" value="@NodeChildren"/>
       <property name="message" value="Do not use @NodeChildren, use multiple @Child annotations directly"/>
     </module>

--- a/src/main/java/org/truffleruby/core/queue/SizedQueue.java
+++ b/src/main/java/org/truffleruby/core/queue/SizedQueue.java
@@ -148,8 +148,7 @@ public class SizedQueue {
                 final boolean signalled = ConcurrentOperations.awaitAndCheckInterrupt(canTake, timeoutMilliseconds,
                         TimeUnit.MILLISECONDS);
 
-                if (!signalled) {
-                    // Timed out.
+                if (!signalled) { // timed out
                     return null;
                 }
 

--- a/src/main/java/org/truffleruby/core/queue/UnsizedQueue.java
+++ b/src/main/java/org/truffleruby/core/queue/UnsizedQueue.java
@@ -114,7 +114,7 @@ public class UnsizedQueue {
                 final boolean signalled = ConcurrentOperations.awaitAndCheckInterrupt(canTake, timeoutMilliseconds,
                         TimeUnit.MILLISECONDS);
 
-                if (!signalled) {
+                if (!signalled) { // timed out
                     return null;
                 }
 

--- a/src/main/java/org/truffleruby/core/thread/ThreadManager.java
+++ b/src/main/java/org/truffleruby/core/thread/ThreadManager.java
@@ -568,7 +568,7 @@ public class ThreadManager {
      * given action should throw an {@link InterruptedException} when {@link Thread#interrupt()} is called. Otherwise,
      * the {@link SafepointManager} will not be able to interrupt this action. See
      * {@link ThreadNodes.ThreadRunBlockingSystemCallNode} for blocking native calls. If the action throws an
-     * {@link InterruptedException}, it will be retried until it returns a non-null value.
+     * {@link InterruptedException}, it will be retried.
      *
      * @param action must not touch any Ruby state
      * @return the return value from {@code action} */

--- a/src/main/ruby/truffleruby/core/truffle/queue_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/queue_operations.rb
@@ -10,17 +10,11 @@
 
 module Truffle
   module QueueOperations
-    def self.validate_and_prepare_timeout(non_block, timeout)
-      if non_block
-        raise ArgumentError, "can't set a timeout if non_block is enabled" unless Primitive.nil?(timeout)
-      else
-        unless Primitive.nil?(timeout)
-          # Convert seconds to milliseconds.
-          return (Truffle::Type.rb_num2dbl(timeout) * 1000).to_i
-        end
-      end
+    def self.validate_and_prepare_timeout_in_milliseconds(non_block, timeout_seconds_or_nil)
+      return timeout_seconds_or_nil if Primitive.nil?(timeout_seconds_or_nil)
+      raise ArgumentError, "can't set a timeout if non_block is enabled" if non_block
 
-      timeout
+      (Truffle::Type.rb_num2dbl(timeout_seconds_or_nil) * 1000).to_i
     end
   end
 end

--- a/src/main/ruby/truffleruby/core/truffle/queue_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/queue_operations.rb
@@ -11,7 +11,7 @@
 module Truffle
   module QueueOperations
     def self.validate_and_prepare_timeout_in_milliseconds(non_block, timeout_seconds_or_nil)
-      return timeout_seconds_or_nil if Primitive.nil?(timeout_seconds_or_nil)
+      return nil if Primitive.nil?(timeout_seconds_or_nil)
       raise ArgumentError, "can't set a timeout if non_block is enabled" if non_block
 
       (Truffle::Type.rb_num2dbl(timeout_seconds_or_nil) * 1000).to_i


### PR DESCRIPTION
Source: https://github.com/oracle/truffleruby/issues/3039

Thread::SizedQueue#pop(timeout: sec) is added. [[Feature #18774](https://bugs.ruby-lang.org/issues/18774)]