### PR TITLE
FFI: Allow type retrieval of attached functions and global variables

### DIFF
--- a/lib/truffle/truffle/ffi_backend/function.rb
+++ b/lib/truffle/truffle/ffi_backend/function.rb
@@ -137,6 +137,10 @@ module FFI
       @native_wrapper = nil
     end
 
+    private def type
+      @function_info
+    end
+
     private def convert_ruby_to_native(type, value, enums)
       if Primitive.is_a?(type, FFI::Type::Mapped)
         type.to_native(value, nil)
@@ -207,6 +211,8 @@ module FFI
   end
 
   class VariadicInvoker
+    attr_reader :return_type
+
     def initialize(function, args_types, return_type, options)
       @function = function
       @return_type = return_type

--- a/lib/truffle/truffle/ffi_backend/type.rb
+++ b/lib/truffle/truffle/ffi_backend/type.rb
@@ -112,6 +112,7 @@ module FFI
 
     class Mapped < Type
       attr_reader :native_type
+      attr_reader :converter
       alias_method :type, :native_type
 
       def initialize(converter)


### PR DESCRIPTION
This is the corresponding change to revealed type information introduced in https://github.com/ffi/ffi/pull/1023 .
https://github.com/ffi/ffi/pull/1023/commits/e987ab50366a4b08617a20568eabdaa1fb761317

It allows to retrieve the signature of functions and details about the types and global variables as requested in https://github.com/ffi/ffi/pull/975 .