### PR TITLE
Convert string arg to Pathname in relative_path_from

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Compatibility:
 * Fix `Array#[]` with `ArithmeticSequence` argument when step is negative (#3039, @itarato).
 * Fix `Range#size` and return `nil` for beginningless Range when end isn't Numeric (#3039, @rwstauner).
 * Alias `String#-@` to `String#dedup` (#3039, @itarato).
+* Fix `Pathname#relative_path_from` to convert string arguments to Pathname objects (@rwstauner).
 
 Performance:
 

--- a/lib/truffle/pathname.rb
+++ b/lib/truffle/pathname.rb
@@ -763,6 +763,7 @@ class Pathname
   # This method has existed since 1.8.1.
   #
   def relative_path_from(base_directory)
+    base_directory = Pathname.new(base_directory) unless Primitive.is_a?(base_directory, Pathname)
     dest_directory = self.cleanpath.to_s
     base_directory = base_directory.cleanpath.to_s
     dest_prefix = dest_directory

--- a/spec/ruby/library/pathname/relative_path_from_spec.rb
+++ b/spec/ruby/library/pathname/relative_path_from_spec.rb
@@ -48,4 +48,8 @@ describe "Pathname#relative_path_from" do
     relative_path_str('..', '..').should == '.'
     relative_path_str('..', '.').should == '..'
   end
+
+  it 'converts string argument to Pathname' do
+    Pathname.new('/usr/bin/ls').relative_path_from('/usr').to_s.should == 'bin/ls'
+  end
 end


### PR DESCRIPTION
It is not documented but CRuby does it:
https://github.com/ruby/ruby/blob/381475f02e6b44ae729f9403637b30c445b622e5/ext/pathname/lib/pathname.rb#L512
