### PR TITLE
[Compatibility] Adding IO#timeout

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -382,6 +382,10 @@ Style/UnlessElse:
   Description: Checks for unless expressions with else clauses.
   Enabled: true
 
+Style/WhileUntilDo:
+  Description: Checks for uses of do in multi-line while/until statements.
+  Enabled: true
+
 # Supports --auto-correct
 Layout/SpaceBeforeBlockBraces:
   Enabled: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Compatibility:
 * Add `rb_syserr_new` function (@rwstauner).
 * Add `Enumerator#product` (#3039, @itarato).
 * Add `Module#const_added` (#3039,  @itarato).
+* Adding `IO#timeout` and `IO#timeout=` (#3039, @itarato).
 
 Performance:
 

--- a/spec/ruby/core/io/timeout_spec.rb
+++ b/spec/ruby/core/io/timeout_spec.rb
@@ -1,0 +1,210 @@
+# -*- encoding: utf-8 -*-
+require_relative '../../spec_helper'
+
+ruby_version_is "3.2" do
+  describe "IO#timeout=" do
+    before :each do
+      @rpipe, @wpipe = IO.pipe
+    end
+
+    after :each do
+      @rpipe.close
+      @wpipe.close
+    end
+
+    it "can be set and read on File instances" do
+      fname = tmp("io_timeout_attribute.txt")
+      touch(fname)
+      file = File.open(fname, "a+")
+
+      file.timeout.should == nil
+
+      file.timeout = 1.23
+      file.timeout.should == 1.23
+    ensure
+      file.close
+      rm_r fname
+    end
+
+    it "can be set and read on IO instances" do
+      @rpipe.timeout.should == nil
+      @wpipe.timeout.should == nil
+
+      @rpipe.timeout = 1.23
+      @wpipe.timeout = 4.56
+
+      @rpipe.timeout.should == 1.23
+      @wpipe.timeout.should == 4.56
+    end
+
+    it "raises TypeError when incorrect value is provided for timeout" do
+      -> { @rpipe.timeout = -1 }.should raise_error(ArgumentError, 'time interval must not be negative')
+      -> { @rpipe.timeout = "1" }.should raise_error(TypeError, 'can\'t convert String into time interval')
+    end
+
+    it "accepts objects for interval that have the :divmod method defined" do
+      s = "abc"
+      s.define_singleton_method(:divmod) { |_| [0, 0.001] }
+
+      @rpipe.timeout = s
+      @rpipe.timeout.should == s
+    end
+  end
+
+  describe "IO#timeout" do
+    before :each do
+      @rpipe, @wpipe = IO.pipe
+      # There is no strict long term standard for pipe limits (2**16 bytes currently). This is an attempt to set a safe
+      # enough size to test a full pipe.
+      @more_than_pipe_limit = 1 << 18
+    end
+
+    after :each do
+      @rpipe.close
+      @wpipe.close
+    end
+
+    it "raises TypeError when incorrect value is observed for timeout at the time of use" do
+      klass = Class.new do
+        attr_accessor(:v)
+        def divmod(_); [v, 0]; end
+      end
+
+      o = klass.new
+      o.v = 1
+
+      @rpipe.timeout = o
+
+      o.v = -1
+      -> { @rpipe.read(1) }.should raise_error(ArgumentError, 'time interval must not be negative')
+    end
+
+    it "raises IO::TimeoutError when timeout is exceeded for .read" do
+      @rpipe.timeout = 0.001
+      -> { @rpipe.read.should }.should raise_error(IO::TimeoutError)
+    end
+
+    it "raises IO::TimeoutError when timeout is exceeded for .read(n)" do
+      @rpipe.timeout = 0.001
+      -> { @rpipe.read(3) }.should raise_error(IO::TimeoutError)
+    end
+
+    it "raises IO::TimeoutError when timeout is exceeded for .gets" do
+      @rpipe.timeout = 0.001
+      -> { @rpipe.gets }.should raise_error(IO::TimeoutError)
+    end
+
+    it "attempts to read first before checking the timeout" do
+      @wpipe.write("abc")
+      @wpipe.close
+
+      @rpipe.timeout = 0
+      @rpipe.read(3).should == "abc"
+    end
+
+    it "waits for a read and completes" do
+      @rpipe.timeout = 1
+      read_result = nil
+
+      can_write = false
+
+      t = Thread.new do
+        can_write = true
+        read_result = @rpipe.read(3)
+      end
+
+      Thread.pass until can_write
+
+      @wpipe.write("abc")
+      @wpipe.close
+
+      t.join
+
+      read_result.should == "abc"
+    end
+
+    it "raises IO::TimeoutError when timeout is exceeded for .write" do
+      @wpipe.timeout = 0.001
+      -> { @wpipe.write("x" * @more_than_pipe_limit) }.should raise_error(IO::TimeoutError)
+    end
+
+    it "raises IO::TimeoutError when timeout is exceeded for .puts" do
+      @wpipe.timeout = 0.001
+      -> { @wpipe.puts("x" * @more_than_pipe_limit) }.should raise_error(IO::TimeoutError)
+    end
+
+    it "waits for a write and completes" do
+      @wpipe.timeout = 1
+      write_result = nil
+
+      begin
+        @wpipe.puts("x" * @more_than_pipe_limit)
+      rescue IO::TimeoutError
+        # Writer is now full. Raise can be ignored.
+      end
+
+      can_read = false
+
+      t = Thread.new do
+        can_read = true
+        write_result = @wpipe.write("abc")
+      end
+
+      Thread.pass until can_read
+
+      # Reading a page worth of bytes to trigger a buffer release in the pipe.
+      @rpipe.read(4096)
+
+      t.join
+
+      write_result.should == 3
+    end
+
+    it "attempts to write first before checking the timeout" do
+      @wpipe.timeout = 0
+      @wpipe.write("abc").should == 3
+    end
+
+    it "times out with .read when there is no EOF" do
+      @wpipe.write("hello")
+      @rpipe.timeout = 0.001
+
+      -> { @rpipe.read }.should raise_error(IO::TimeoutError)
+    end
+
+    it "returns content with .read when there is EOF" do
+      @wpipe.write("hello")
+      @wpipe.close
+
+      @rpipe.timeout = 0.001
+
+      @rpipe.read.should == "hello"
+    end
+
+    it "times out with .read(N) when there is not enough bytes" do
+      @wpipe.write("hello")
+      @rpipe.timeout = 0.001
+
+      @rpipe.read(2).should == "he"
+      -> { @rpipe.read(5) }.should raise_error(IO::TimeoutError)
+    end
+
+    it "returns partial content with .read(N) when there is not enough bytes but there is EOF" do
+      @wpipe.write("hello")
+      @rpipe.timeout = 0.001
+
+      @rpipe.read(2).should == "he"
+
+      @wpipe.close
+      @rpipe.read(5).should == "llo"
+    end
+
+    it "blocks after timeout has been nullified" do
+      require "timeout"
+      @rpipe.timeout = 0.001
+      @rpipe.timeout = nil
+
+      -> { Timeout.timeout(0.01) { @rpipe.read } }.should raise_error(Timeout::Error)
+    end
+  end
+end

--- a/spec/tags/truffle/methods_tags.txt
+++ b/spec/tags/truffle/methods_tags.txt
@@ -116,3 +116,5 @@ fails:Public methods on UnboundMethod should include public?
 fails:Public methods on String should not include bytesplice
 fails:Public methods on Module should not include refinements
 fails:Public methods on Module should not include undefined_instance_methods
+fails:Public methods on IO should not include timeout
+fails:Public methods on IO should not include timeout=

--- a/src/main/ruby/truffleruby/core/io.rb
+++ b/src/main/ruby/truffleruby/core/io.rb
@@ -38,6 +38,8 @@ class IO
 
   include Enumerable
 
+  class TimeoutError < IOError; end
+
   module WaitReadable; end
   module WaitWritable; end
 
@@ -1646,6 +1648,21 @@ class IO
   def printf(fmt, *args)
     fmt = StringValue(fmt)
     write sprintf(fmt, *args)
+  end
+
+  attr_reader(:timeout)
+
+  def timeout=(new_timeout)
+    if Primitive.nil?(new_timeout)
+      self.nonblock = false
+    else
+      self.nonblock = true
+
+      # For validation.
+      Truffle::KernelOperations.convert_duration_to_milliseconds(new_timeout)
+    end
+
+    @timeout = new_timeout
   end
 
   def read(length = nil, buffer = nil)

--- a/src/main/ruby/truffleruby/core/posix.rb
+++ b/src/main/ruby/truffleruby/core/posix.rb
@@ -401,10 +401,10 @@ module Truffle::POSIX
   # by IO#sysread
 
   def self.read_string_native(io, length)
-    fd = io.fileno
     buffer = Primitive.io_thread_buffer_allocate(length)
     begin
-      bytes_read = Truffle::POSIX.read(fd, buffer, length)
+      bytes_read = execute_posix_read(io, buffer, length)
+
       if bytes_read < 0
         bytes_read, errno = bytes_read, Errno.errno
       elsif bytes_read == 0 # EOF
@@ -425,11 +425,58 @@ module Truffle::POSIX
     end
   end
 
-  def self.read_to_buffer_native(io, length)
+  def self.execute_posix_read(io, buffer, length)
+    return Truffle::POSIX.read(io.fileno, buffer, length) unless io.timeout
+    execute_posix_read_with_timeout(io, buffer, length)
+  end
+
+  def self.execute_posix_read_with_timeout(io, buffer, length)
     fd = io.fileno
+    timeout_milliseconds = Truffle::KernelOperations.convert_duration_to_milliseconds(io.timeout)
+    deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC, :millisecond) + timeout_milliseconds
+
+    while true
+      bytes_read = Truffle::POSIX.read(fd, buffer, length)
+      return bytes_read if bytes_read >= 0
+      return bytes_read unless Errno.errno == Errno::EAGAIN::Errno
+
+      current_timeout = deadline - Process.clock_gettime(Process::CLOCK_MONOTONIC, :millisecond)
+      raise IO::TimeoutError if current_timeout <= 0
+
+      poll_result = Truffle::IOOperations.poll_milliseconds(io, Truffle::IOOperations::POLLIN, current_timeout)
+      raise IO::TimeoutError if poll_result == 0
+      Errno.handle_errno(Errno.errno) if poll_result == -1
+    end
+  end
+
+  def self.execute_posix_write(io, buffer, length)
+    return Truffle::POSIX.write(io.fileno, buffer, length) unless io.timeout
+    execute_posix_write_with_timeout(io, buffer, length)
+  end
+
+  def self.execute_posix_write_with_timeout(io, buffer, length)
+    fd = io.fileno
+    timeout_milliseconds = Truffle::KernelOperations.convert_duration_to_milliseconds(io.timeout)
+    deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC, :millisecond) + timeout_milliseconds
+
+    while true
+      bytes_written = Truffle::POSIX.write(fd, buffer, length)
+      return bytes_written if bytes_written >= 0
+      return bytes_written unless Errno.errno == Errno::EAGAIN::Errno
+
+      current_timeout = deadline - Process.clock_gettime(Process::CLOCK_MONOTONIC, :millisecond)
+      raise IO::TimeoutError if current_timeout <= 0
+
+      poll_result = Truffle::IOOperations.poll_milliseconds(io, Truffle::IOOperations::POLLOUT, current_timeout)
+      raise IO::TimeoutError if poll_result == 0
+      Errno.handle_errno(Errno.errno) if poll_result == -1
+    end
+  end
+
+  def self.read_to_buffer_native(io, length)
     buffer = Primitive.io_thread_buffer_allocate(length)
     begin
-      bytes_read = Truffle::POSIX.read(fd, buffer, length)
+      bytes_read = execute_posix_read(io, buffer, length)
       if bytes_read < 0
         bytes_read, errno = bytes_read, Errno.errno
       elsif bytes_read == 0 # EOF
@@ -495,7 +542,7 @@ module Truffle::POSIX
 
       written = 0
       while written < length
-        ret = Truffle::POSIX.write(fd, buffer + written, length - written)
+        ret = execute_posix_write(io, buffer + written, length - written)
         if ret < 0
           errno = Errno.errno
           if errno == EAGAIN_ERRNO
@@ -540,12 +587,11 @@ module Truffle::POSIX
   # #write_string_nonblock_polylgot) is called by IO#write_nonblock
 
   def self.write_string_nonblock_native(io, string)
-    fd = io.fileno
     length = string.bytesize
     buffer = Primitive.io_thread_buffer_allocate(length)
     begin
       buffer.write_bytes string
-      written = Truffle::POSIX.write(fd, buffer, length)
+      written = execute_posix_write(io, buffer, length)
 
       if written < 0
         errno = Errno.errno

--- a/src/main/ruby/truffleruby/core/truffle/kernel_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/kernel_operations.rb
@@ -30,6 +30,17 @@ module Truffle
       ((a + b) * 1_000_000_000)
     end
 
+    def self.convert_duration_to_milliseconds(duration)
+      unless duration.respond_to?(:divmod)
+        raise TypeError, "can't convert #{Primitive.class(duration)} into time interval"
+      end
+
+      whole_seconds, fragments = duration.divmod(1)
+      raise ArgumentError, 'time interval must not be negative' if whole_seconds < 0
+
+      ((whole_seconds + fragments) * 1000).to_i
+    end
+
     def self.define_hooked_variable(name, getter, setter, defined = proc { 'global-variable' })
       define_hooked_variable_with_is_defined(name, getter, setter, defined)
     end


### PR DESCRIPTION
Source: https://github.com/oracle/truffleruby/issues/3039

Introduce IO#timeout= and IO#timeout which can cause
IO::TimeoutError to be raised if a blocking operation exceeds the
specified timeout. [[Feature #18630](https://bugs.ruby-lang.org/issues/18630)]

```ruby
STDIN.timeout = 1
STDIN.read # => Blocking operation timed out! (IO::TimeoutError)
```

### Caveat

This PR does not contain updating the error type for `TCPSocket` `#open` and `#new`. It seems we don't have the whole timeout logic implemented for that yet. I rather have them implemented in a separate PR to keep it clean.