### PR TITLE
[Bug] Fix singleton class lookup bug when singleton class is replaced on the instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ New features:
 Bug fixes:
 
 * Fix `Dir.glob` returning blank string entry with leading `**/` in glob and `base:` argument (@rwstauner).
+* Fix class lookup after an object's class has been replaced by `IO#reopen` (@itarato, @eregon).
 
 Compatibility:
 

--- a/spec/ruby/core/kernel/singleton_class_spec.rb
+++ b/spec/ruby/core/kernel/singleton_class_spec.rb
@@ -1,3 +1,4 @@
+# truffleruby_primitives: true
 require_relative '../../spec_helper'
 
 describe "Kernel#singleton_class" do
@@ -41,5 +42,33 @@ describe "Kernel#singleton_class" do
     obj = Object.new
     obj.freeze
     obj.singleton_class.frozen?.should be_true
+  end
+
+  context "for an IO object with a replaced singleton class" do
+    it "looks up singleton methods from the fresh singleton class after an object instance got a new one" do
+      proxy = -> (io) { io.foo }
+      if RUBY_ENGINE == 'truffleruby'
+        # We need an inline cache with only this object seen, the best way to do that is to use a Primitive
+        sclass = -> (io) { Primitive.singleton_class(io) }
+      else
+        sclass = -> (io) { io.singleton_class }
+      end
+
+      io = File.new(__FILE__)
+      io.define_singleton_method(:foo) { "old" }
+      sclass1 = sclass.call(io)
+      proxy.call(io).should == "old"
+
+      # IO#reopen is the only method which can replace an object's singleton class
+      io2 = File.new(__FILE__)
+      io.reopen(io2)
+      io.define_singleton_method(:foo) { "new" }
+      sclass2 = sclass.call(io)
+      sclass2.should_not.equal?(sclass1)
+      proxy.call(io).should == "new"
+    ensure
+      io2.close
+      io.close
+    end
   end
 end

--- a/src/main/java/org/truffleruby/core/VMPrimitiveNodes.java
+++ b/src/main/java/org/truffleruby/core/VMPrimitiveNodes.java
@@ -68,11 +68,11 @@ import org.truffleruby.core.numeric.RubyBignum;
 import org.truffleruby.core.proc.ProcOperations;
 import org.truffleruby.core.proc.RubyProc;
 import org.truffleruby.core.string.RubyString;
+import org.truffleruby.core.support.RubyIO;
 import org.truffleruby.core.symbol.RubySymbol;
 import org.truffleruby.core.thread.RubyThread;
 import org.truffleruby.extra.ffi.Pointer;
 import org.truffleruby.interop.TranslateInteropExceptionNode;
-import org.truffleruby.language.RubyDynamicObject;
 import org.truffleruby.language.RubyGuards;
 import org.truffleruby.language.SafepointAction;
 import org.truffleruby.language.arguments.ArgumentsDescriptor;
@@ -423,9 +423,10 @@ public abstract class VMPrimitiveNodes {
     @Primitive(name = "vm_set_class")
     public abstract static class VMSetClassNode extends PrimitiveArrayArgumentsNode {
 
+        /** Only support it on IO for IO#reopen since this is the only case which needs it */
         @TruffleBoundary
         @Specialization
-        protected RubyDynamicObject setClass(RubyDynamicObject object, RubyClass newClass) {
+        protected RubyIO setClass(RubyIO object, RubyClass newClass) {
             SharedObjects.propagate(getLanguage(), object, newClass);
             synchronized (object) {
                 object.setMetaClass(newClass);

--- a/src/main/java/org/truffleruby/core/support/TypeNodes.java
+++ b/src/main/java/org/truffleruby/core/support/TypeNodes.java
@@ -49,6 +49,7 @@ import org.truffleruby.language.objects.IsANode;
 import org.truffleruby.language.objects.IsFrozenNode;
 import org.truffleruby.language.objects.LogicalClassNode;
 import org.truffleruby.language.objects.MetaClassNode;
+import org.truffleruby.language.objects.SingletonClassNode;
 import org.truffleruby.language.objects.WriteObjectFieldNode;
 
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
@@ -100,6 +101,15 @@ public abstract class TypeNodes {
         protected RubyClass metaClass(Object object,
                 @Cached MetaClassNode metaClassNode) {
             return metaClassNode.execute(this, object);
+        }
+    }
+
+    @Primitive(name = "singleton_class")
+    public abstract static class SingletonClassPrimitiveNode extends PrimitiveArrayArgumentsNode {
+        @Specialization
+        protected RubyClass singletonClass(Object object,
+                @Cached SingletonClassNode singletonClassNode) {
+            return singletonClassNode.executeSingletonClass(object);
         }
     }
 

--- a/src/main/java/org/truffleruby/language/RubyGuards.java
+++ b/src/main/java/org/truffleruby/language/RubyGuards.java
@@ -33,6 +33,7 @@ import org.truffleruby.core.regexp.RubyMatchData;
 import org.truffleruby.core.regexp.RubyRegexp;
 import org.truffleruby.core.string.ImmutableRubyString;
 import org.truffleruby.core.string.RubyString;
+import org.truffleruby.core.support.RubyIO;
 import org.truffleruby.core.symbol.RubySymbol;
 import org.truffleruby.interop.ToJavaStringNode;
 import org.truffleruby.language.arguments.ArgumentsDescriptor;
@@ -135,6 +136,11 @@ public abstract class RubyGuards {
 
     public static boolean isRubyModule(Object value) {
         return value instanceof RubyModule;
+    }
+
+    @Idempotent
+    public static boolean isRubyIO(Object value) {
+        return value instanceof RubyIO;
     }
 
     public static boolean isRubyRegexp(Object value) {

--- a/src/main/java/org/truffleruby/language/objects/MetaClassNode.java
+++ b/src/main/java/org/truffleruby/language/objects/MetaClassNode.java
@@ -42,7 +42,11 @@ public abstract class MetaClassNode extends RubyBaseNode {
     public abstract RubyClass execute(Node node, Object value);
 
     @Specialization(
-            guards = { "isSingleContext()", "object == cachedObject", "metaClass.isSingleton" },
+            guards = {
+                    "isSingleContext()",
+                    "object == cachedObject",
+                    "metaClass.isSingleton",
+                    "!isRubyIO(cachedObject)" },
             limit = "1")
     protected static RubyClass singleton(Node node, RubyDynamicObject object,
             @Cached("object") RubyDynamicObject cachedObject,

--- a/src/main/java/org/truffleruby/language/objects/SingletonClassNode.java
+++ b/src/main/java/org/truffleruby/language/objects/SingletonClassNode.java
@@ -10,6 +10,7 @@
 package org.truffleruby.language.objects;
 
 import com.oracle.truffle.api.dsl.GenerateUncached;
+import com.oracle.truffle.api.dsl.NeverDefault;
 import org.truffleruby.RubyContext;
 import org.truffleruby.core.klass.ClassNodes;
 import org.truffleruby.core.klass.RubyClass;
@@ -35,6 +36,7 @@ public abstract class SingletonClassNode extends RubySourceNode {
         return SingletonClassNodeGen.getUncached();
     }
 
+    @NeverDefault
     public static SingletonClassNode create() {
         return SingletonClassNodeGen.create(null);
     }
@@ -58,7 +60,11 @@ public abstract class SingletonClassNode extends RubySourceNode {
 
     @Specialization(
             // no need to guard on the context, the RubyDynamicObject is context-specific
-            guards = { "isSingleContext()", "object == cachedObject", "!isRubyClass(cachedObject)" },
+            guards = {
+                    "isSingleContext()",
+                    "object == cachedObject",
+                    "!isRubyClass(cachedObject)",
+                    "!isRubyIO(cachedObject)" },
             limit = "1")
     protected RubyClass singletonClassInstanceCached(RubyDynamicObject object,
             @Cached("object") RubyDynamicObject cachedObject,


### PR DESCRIPTION
`IO#reopen` is one of those few examples (maybe the only one) where the caller object's singleton class is replaced:

https://github.com/oracle/truffleruby/blob/master/src/main/ruby/truffleruby/core/io.rb#L1901

This means, methods defined only on an IO object's singleton class won't be available after calling `#reopen` on it.

However, currently in TruffleRuby fetching the singleton class for an object is cached against the object - which makes an assumption that the same object must have the same singleton class during its lifetime. As the beginning states, this is not the case for IO objects currently.

An example where this occurs on production: ActiveSupport's test runner contains an IO capture mechanism: https://github.com/rails/rails/blob/0e99d0893b0e98c626a3c7d8972eea22d29c9d25/activesupport/lib/active_support/testing/stream.rb#L23-L38 This effectively erases `STDOUT`'s singleton class. Any extension on `STDOUT`'s singleton class, eg with [this public gem](https://github.com/Shopify/cli-ui/blob/f6294ff1864dc3279fa7ca08ec79d17b338fe1f5/lib/cli/ui/stdout_router.rb#L402-L410) could cause a lookup of the old singleton class function.

The actual break on production was a bit more nuanced:
- the linked gem re-aliased the `IO#write` method with a new proxy method, both on the singleton class (to enhance the functionality of `STDOUT.write`).
- a test was leveraging `ActiveSupport`'s `#capture` mechanism, which deleted the singleton class
- a follow up `STDOUT.write` was - due to the bug - directed to the old metaclass' `.write` method, which failed to call the old alias.

To sum up the bug's effect, after replacing a singleton class:
- singleton methods and aliases can be "mixed up" causing method-not-find
- new singleton methods/aliases not being found
