### PR TITLE
[Compatibility] Enable tests for Module#used_refinements

### DIFF
--- a/spec/truffleruby.next-specs
+++ b/spec/truffleruby.next-specs
@@ -25,3 +25,5 @@ spec/ruby/core/string/byterindex_spec.rb
 spec/ruby/core/queue/deq_spec.rb
 spec/ruby/core/queue/pop_spec.rb
 spec/ruby/core/queue/shift_spec.rb
+
+spec/ruby/core/module/used_refinements_spec.rb

--- a/src/main/java/org/truffleruby/core/module/ModuleNodes.java
+++ b/src/main/java/org/truffleruby/core/module/ModuleNodes.java
@@ -2333,7 +2333,7 @@ public abstract class ModuleNodes {
         protected RubyArray usedRefinements() {
             final Frame frame = getContext().getCallStack().getCallerFrame(FrameAccess.READ_ONLY);
             final DeclarationContext declarationContext = RubyArguments.getDeclarationContext(frame);
-            final Set<RubyModule> refinements = new HashSet<>();
+            final List<RubyModule> refinements = new ArrayList<>();
             for (RubyModule[] refinementModules : declarationContext.getRefinements().values()) {
                 for (RubyModule refinementModule : refinementModules) {
                     refinements.add(refinementModule);

--- a/test/mri/tests/ruby/test_refinement.rb
+++ b/test/mri/tests/ruby/test_refinement.rb
@@ -1791,6 +1791,8 @@ class TestRefinement < Test::Unit::TestCase
       refine Object do
         def in_ref_a
         end
+
+        RefA.const_set(:REF, self)
       end
     end
 
@@ -1798,6 +1800,8 @@ class TestRefinement < Test::Unit::TestCase
       refine Object do
         def in_ref_b
         end
+
+        RefB.const_set(:REF, self)
       end
     end
 
@@ -1807,23 +1811,28 @@ class TestRefinement < Test::Unit::TestCase
       refine Object do
         def in_ref_c
         end
+
+        RefC.const_set(:REF, self)
       end
     end
 
     module Foo
       using RefB
       USED_MODS = Module.used_modules
+      USED_REFS = Module.used_refinements
     end
 
     module Bar
       using RefC
       USED_MODS = Module.used_modules
+      USED_REFS = Module.used_refinements
     end
 
     module Combined
       using RefA
       using RefB
       USED_MODS = Module.used_modules
+      USED_REFS = Module.used_refinements
     end
   end
 
@@ -1833,6 +1842,14 @@ class TestRefinement < Test::Unit::TestCase
     assert_equal [ref::RefB], ref::Foo::USED_MODS
     assert_equal [ref::RefC], ref::Bar::USED_MODS
     assert_equal [ref::RefB, ref::RefA], ref::Combined::USED_MODS
+  end
+
+  def test_used_refinements
+    ref = VisibleRefinements
+    assert_equal [], Module.used_refinements
+    assert_equal [ref::RefB::REF], ref::Foo::USED_REFS
+    assert_equal [ref::RefC::REF], ref::Bar::USED_REFS
+    assert_equal [ref::RefB::REF, ref::RefA::REF], ref::Combined::USED_REFS
   end
 
   def test_warn_setconst_in_refinmenet


### PR DESCRIPTION
Source: https://github.com/oracle/truffleruby/issues/3039

[already done, just need to untag specs/tests] Module.used_refinements has been added. [[Feature #14332](https://bugs.ruby-lang.org/issues/14332)]