### PR TITLE
[Compatibility] Implement Module#undefined_instance_methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Compatibility:
 * Add `Module#refinements` (#3039, @itarato).
 * Add `Refinement#refined_class` (#3039, @itarato).
 * Add `rb_hash_new_capa` function (#3039, @itarato).
+* Add `Module#undefined_instance_methods` (#3039, @itarato).
 
 Performance:
 

--- a/spec/tags/truffle/methods_tags.txt
+++ b/spec/tags/truffle/methods_tags.txt
@@ -115,3 +115,4 @@ fails:Public methods on UnboundMethod should include protected?
 fails:Public methods on UnboundMethod should include public?
 fails:Public methods on String should not include bytesplice
 fails:Public methods on Module should not include refinements
+fails:Public methods on Module should not include undefined_instance_methods

--- a/spec/truffleruby.next-specs
+++ b/spec/truffleruby.next-specs
@@ -34,3 +34,4 @@ spec/ruby/core/module/refinements_spec.rb
 spec/ruby/core/refinement/refined_class_spec.rb
 spec/ruby/core/module/used_refinements_spec.rb
 spec/ruby/optional/capi/hash_spec.rb
+spec/ruby/core/module/undefined_instance_methods_spec.rb

--- a/src/main/java/org/truffleruby/core/module/ModuleNodes.java
+++ b/src/main/java/org/truffleruby/core/module/ModuleNodes.java
@@ -2355,4 +2355,22 @@ public abstract class ModuleNodes {
             return rubyClass.isSingleton;
         }
     }
+
+    @CoreMethod(names = "undefined_instance_methods")
+    public abstract static class UndefinedInstanceMethodsNode extends CoreMethodArrayArgumentsNode {
+
+        @Specialization
+        @TruffleBoundary
+        protected RubyArray undefinedInstanceMethods(RubyModule module) {
+            List<RubySymbol> methodNames = new ArrayList<>();
+
+            for (InternalMethod methodEntry : module.fields.getMethods()) {
+                if (methodEntry != null && methodEntry.isUndefined()) {
+                    methodNames.add(getLanguage().getSymbol(methodEntry.getName()));
+                }
+            }
+
+            return createArray(methodNames.toArray());
+        }
+    }
 }

--- a/test/mri/tests/ruby/test_module.rb
+++ b/test/mri/tests/ruby/test_module.rb
@@ -955,6 +955,15 @@ class TestModule < Test::Unit::TestCase
     assert_equal([:bClass1], BClass.public_instance_methods(false))
   end
 
+  def test_undefined_instance_methods
+    assert_equal([],  AClass.undefined_instance_methods)
+    assert_equal([], BClass.undefined_instance_methods)
+    c = Class.new(AClass) {undef aClass}
+    assert_equal([:aClass], c.undefined_instance_methods)
+    c = Class.new(c)
+    assert_equal([], c.undefined_instance_methods)
+  end
+
   def test_s_public
     o = (c = Class.new(AClass)).new
     assert_raise(NoMethodError, /private method/) {o.aClass1}


### PR DESCRIPTION
Source: https://github.com/oracle/truffleruby/issues/3039

Module#undefined_instance_methods has been added. [[Feature #12655](https://bugs.ruby-lang.org/issues/12655)]