### PR TITLE
[Compatibility] Fix encoding related error messages for CRuby 3.2

### DIFF
--- a/spec/ruby/core/string/index_spec.rb
+++ b/spec/ruby/core/string/index_spec.rb
@@ -167,6 +167,13 @@ describe "String#index with String" do
   it "handles a substring in a subset encoding" do
     'été'.index('t'.force_encoding(Encoding::US_ASCII)).should == 1
   end
+
+  it "raises an Encoding::CompatibilityError if the encodings are incompatible" do
+    str = 'abc'.force_encoding("ISO-2022-JP")
+    pattern = 'b'.force_encoding("EUC-JP")
+
+    -> { str.index(pattern) }.should raise_error(Encoding::CompatibilityError, "incompatible character encodings: ISO-2022-JP and EUC-JP")
+  end
 end
 
 describe "String#index with Regexp" do
@@ -316,6 +323,6 @@ describe "String#index with Regexp" do
     re = Regexp.new "れ".encode(Encoding::EUC_JP)
     -> do
       "あれ".index re
-    end.should raise_error(Encoding::CompatibilityError)
+    end.should raise_error(Encoding::CompatibilityError, "incompatible character encodings: UTF-8 and EUC-JP")
   end
 end

--- a/spec/ruby/core/string/rindex_spec.rb
+++ b/spec/ruby/core/string/rindex_spec.rb
@@ -204,6 +204,13 @@ describe "String#rindex with String" do
   it "handles a substring in a subset encoding" do
     'été'.rindex('t'.force_encoding(Encoding::US_ASCII)).should == 1
   end
+
+  it "raises an Encoding::CompatibilityError if the encodings are incompatible" do
+    str = 'abc'.force_encoding("ISO-2022-JP")
+    pattern = 'b'.force_encoding("EUC-JP")
+
+    -> { str.rindex(pattern) }.should raise_error(Encoding::CompatibilityError, "incompatible character encodings: ISO-2022-JP and EUC-JP")
+  end
 end
 
 describe "String#rindex with Regexp" do
@@ -373,6 +380,6 @@ describe "String#rindex with Regexp" do
     re = Regexp.new "れ".encode(Encoding::EUC_JP)
     -> do
       "あれ".rindex re
-    end.should raise_error(Encoding::CompatibilityError)
+    end.should raise_error(Encoding::CompatibilityError, "incompatible encoding regexp match (EUC-JP regexp with UTF-8 string)")
   end
 end

--- a/spec/ruby/core/string/upto_spec.rb
+++ b/spec/ruby/core/string/upto_spec.rb
@@ -80,6 +80,12 @@ describe "String#upto" do
     a.should == ["Σ", "Τ", "Υ", "Φ", "Χ", "Ψ", "Ω"]
   end
 
+  it "raises Encoding::CompatibilityError when incompatible characters are given" do
+    char1 = 'a'.force_encoding("EUC-JP")
+    char2 = 'b'.force_encoding("ISO-2022-JP")
+    -> { char1.upto(char2) {} }.should raise_error(Encoding::CompatibilityError, "incompatible character encodings: EUC-JP and ISO-2022-JP")
+  end
+
   describe "on sequence of numbers" do
     it "calls the block as Integer#upto"  do
       "8".upto("11").to_a.should == 8.upto(11).map(&:to_s)

--- a/spec/tags/core/string/byteindex_tags.txt
+++ b/spec/tags/core/string/byteindex_tags.txt
@@ -1,1 +1,0 @@
-fails:String#byteindex with multibyte codepoints raises an Encoding::CompatibilityError if the encodings are incompatible

--- a/spec/tags/core/string/byterindex_tags.txt
+++ b/spec/tags/core/string/byterindex_tags.txt
@@ -1,1 +1,0 @@
-fails:String#byterindex with object with multibyte codepoints raises an Encoding::CompatibilityError if the encodings are incompatible

--- a/src/main/ruby/truffleruby/core/string.rb
+++ b/src/main/ruby/truffleruby/core/string.rb
@@ -617,6 +617,8 @@ class String
       end
     else
       unless stop.size < size
+        Primitive.encoding_ensure_compatible(self.encoding, stop.encoding)
+
         after_stop = exclusive ? stop : stop.succ
         current = self
 
@@ -1115,7 +1117,7 @@ class String
     byte_finish = Primitive.character_index_to_byte_index(self, finish)
 
     if Primitive.is_a?(sub, Regexp)
-      Primitive.encoding_ensure_compatible self, sub
+      Primitive.regexp_check_encoding(sub, self)
 
       match_data = Truffle::RegexpOperations.search_region(sub, self, 0, byte_finish, false, true)
       Primitive.regexp_last_match_set(Primitive.caller_special_variables, match_data)
@@ -1159,7 +1161,7 @@ class String
     end
 
     if is_regex_pattern
-      Primitive.encoding_ensure_compatible(self, str)
+      Primitive.regexp_check_encoding(str, self)
 
       match = Truffle::RegexpOperations.match_from(str, self, start)
       Primitive.regexp_last_match_set(Primitive.caller_special_variables, match)
@@ -1186,7 +1188,7 @@ class String
     end
 
     if Primitive.is_a?(str, Regexp)
-      Primitive.encoding_ensure_compatible(self, str)
+      Primitive.regexp_check_encoding(str, self)
 
       match = Truffle::RegexpOperations.search_region(str, self, 0, finish, false, true)
       Primitive.regexp_last_match_set(Primitive.caller_special_variables, match)


### PR DESCRIPTION
Fixing an incorrect error message when an encoding error happens during `String#byteindex` and `String#byterindex`.

Incorrect: `Encoding::CompatibilityError (incompatible character encodings: UTF-8 and EUC-JP)`
Correct: `Encoding::CompatibilityError (incompatible encoding regexp match (EUC-JP regexp with UTF-8 string))`

---

Related CRuby issue: https://bugs.ruby-lang.org/issues/19763