### PR TITLE
[Bugfix] Fix method visibility in some corner cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Bug fixes:
 * Fix class lookup after an object's class has been replaced by `IO#reopen` (@itarato, @eregon).
 * Fix `Marshal.load` and raise `ArgumentError` when dump is broken and is too short (#3108, @andrykonchin).
 * Fix `super` method lookup for unbounded attached methods (#3131,  @itarato).
+* Fix added module visibility via `define_method` (#3134, @itarato)
 
 Compatibility:
 

--- a/spec/ruby/core/module/define_method_spec.rb
+++ b/spec/ruby/core/module/define_method_spec.rb
@@ -499,6 +499,36 @@ describe "Module#define_method" do
       Class.new { define_method :bar, m }
     }.should raise_error(TypeError, /can't bind singleton method to a different class/)
   end
+
+  it "defines the new method public when the definition frame self is different from the target" do
+    foo_class = Class.new do
+      private def bar
+        "public"
+      end
+    end
+
+    foo = foo_class.new
+    foo.singleton_class.define_method(:bar, foo.method(:bar))
+
+    foo.bar.should == "public"
+  end
+
+  it "defines the new method according to the scope when the definition context is the same" do
+    FooWithOneBar = Class.new do
+      def bar; end
+    end
+
+    foo = FooWithOneBar.new
+
+    class << foo
+      private
+      define_method(:bar, FooWithOneBar.new.method(:bar))
+    end
+
+    -> { foo.bar }.should raise_error(NoMethodError)
+
+    Object.class_eval { remove_const(:FooWithOneBar) }
+  end
 end
 
 describe "Module#define_method" do

--- a/src/main/java/org/truffleruby/core/module/ModuleNodes.java
+++ b/src/main/java/org/truffleruby/core/module/ModuleNodes.java
@@ -1340,7 +1340,7 @@ public abstract class ModuleNodes {
             final String name = nameToJavaStringNode.execute(RubyArguments.getArgument(rubyArgs, 0));
             final Object method = RubyArguments.getArgument(rubyArgs, 1);
 
-            return addMethod(module, name, (RubyMethod) method);
+            return addMethod(callerFrame.materialize(), module, name, (RubyMethod) method);
         }
 
         @Specialization(guards = { "isMethodParameterProvided(rubyArgs)", "isRubyProc(getArgument(rubyArgs, 1))" })
@@ -1394,8 +1394,10 @@ public abstract class ModuleNodes {
         }
 
         @TruffleBoundary
-        private RubySymbol addMethod(RubyModule module, String name, RubyMethod method) {
-            final InternalMethod internalMethod = method.method;
+        private RubySymbol addMethod(MaterializedFrame callerFrame, RubyModule module, String name, RubyMethod method) {
+            Visibility expectedVisibility = DeclarationContext.findVisibilityCheckSelfAndDefaultDefinee(module,
+                    callerFrame);
+            final InternalMethod internalMethod = method.method.withVisibility(expectedVisibility);
 
             if (!ModuleOperations.canBindMethodTo(internalMethod, module)) {
                 final RubyModule declaringModule = internalMethod.getDeclaringModule();


### PR DESCRIPTION
We've been seeing some inconsistencies between truffle/cruby on how added method visibility is derived: https://github.com/oracle/truffleruby/issues/3134

Related Ruby issue: https://bugs.ruby-lang.org/issues/19749

### Expectation

- if `define target == current callFrame self` -> use scope visibility
- use public visibility

This PR is fixing these cases:

### Redefine private method but outside of its context (should be public)

```ruby
class Foo10
	private

	def bar
		"public"
	end
end

foo10 = Foo10.new
foo10.define_singleton_method(:bar, foo10.method(:bar))

foo10.bar # No error in CRuby but fails in TruffleRuby
```

### Redefine public method in the same context as private (should be private)

```ruby
class Foo11
	def bar; end
end

foo11 = Foo11.new

class << foo11
	private
	
	define_method(:bar, Foo11.new.method(:bar))
end

foo11.bar # Fails in CRuby but no errors in TruffleRuby
```