### PR TITLE
Update Coverage for Ruby 3.2 interface changes.

### DIFF
--- a/lib/truffle/coverage.rb
+++ b/lib/truffle/coverage.rb
@@ -13,7 +13,6 @@ module Coverage
   def self.supported?(mode)
     mode == :lines
   end
-  
   def self.start(*arguments, **options)
     # Arguments/options are ignored.
     Truffle::Coverage.enable

--- a/lib/truffle/coverage.rb
+++ b/lib/truffle/coverage.rb
@@ -13,6 +13,7 @@ module Coverage
   def self.supported?(mode)
     mode == :lines
   end
+
   def self.start(*arguments, **options)
     # Arguments/options are ignored.
     Truffle::Coverage.enable

--- a/lib/truffle/coverage.rb
+++ b/lib/truffle/coverage.rb
@@ -10,7 +10,12 @@
 
 module Coverage
 
-  def self.start
+  def self.supported?(mode)
+    mode == :lines
+  end
+  
+  def self.start(*arguments, **options)
+    # Arguments/options are ignored.
     Truffle::Coverage.enable
   end
 


### PR DESCRIPTION
Fixes <https://github.com/oracle/truffleruby/issues/3149>.
Related <https://github.com/oracle/truffleruby/issues/1636>.

Tests for this should be in ruby spec itself.