### PR TITLE
[Compatibility] Add Enumerator#product

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Compatibility:
 * Add `Module#refinements` (#3039, @itarato).
 * Add `Refinement#refined_class` (#3039, @itarato).
 * Add `rb_hash_new_capa` function (#3039, @itarato).
+* Add `Enumerator#product` (#3039, @itarato).
 
 Performance:
 

--- a/spec/truffleruby.next-specs
+++ b/spec/truffleruby.next-specs
@@ -34,3 +34,5 @@ spec/ruby/core/module/refinements_spec.rb
 spec/ruby/core/refinement/refined_class_spec.rb
 spec/ruby/core/module/used_refinements_spec.rb
 spec/ruby/optional/capi/hash_spec.rb
+
+spec/ruby/core/enumerator/product_spec.rb

--- a/src/main/ruby/truffleruby/core/truffle/kernel_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/kernel_operations.rb
@@ -242,6 +242,13 @@ module Truffle
       KERNEL_FROZEN.bind(value).call
     end
 
+    def self.validate_no_kwargs(kwargs)
+      return if (kwargs_size = kwargs.size) == 0
+
+      raise ArgumentError, "unknown keyword: #{kwargs.keys.first.inspect}" if kwargs_size == 1
+      raise ArgumentError, "unknown keywords: #{kwargs.keys.map(&:inspect).join(', ')}"
+    end
+
     # To get the class even if the value's class does not include `Kernel`, use `Primitive.class`.
   end
 end


### PR DESCRIPTION
Source: https://github.com/oracle/truffleruby/issues/3039

Enumerator.product has been added. Enumerator::Product is the implementation. [[Feature #18685](https://bugs.ruby-lang.org/issues/18685)]