### PR TITLE
[GSoC] Use a compact hash table for RubyHash instead of the buckets strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Compatibility:
 
 Performance:
 
+* Change the `Hash` representation from traditional buckets to a "compact hash table" for improved locality, performance and memory footprint (#3172, @moste00).
 * Optimize calls with `ruby2_keywords` forwarding by deciding it per call site instead of per callee thanks to [my fix in CRuby 3.2](https://bugs.ruby-lang.org/issues/18625) (@eregon).
 * Optimize feature loading when require is called with an absolute path to a .rb file (@rwstauner).
 

--- a/bench/micro/hash/buckets-lookup.rb
+++ b/bench/micro/hash/buckets-lookup.rb
@@ -1,0 +1,23 @@
+# truffleruby_primitives: true
+
+# Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved. This
+# code is released under a tri EPL/GPL/LGPL license. You can use it,
+# redistribute it and/or modify it under the terms of the:
+#
+# Eclipse Public License version 2.0, or
+# GNU General Public License version 2, or
+# GNU Lesser General Public License version 2.1.
+
+# Benchmarks looking up keys
+
+max = 400_000 # > 0.75*(524288 + 21) (cf. BucketsHashStore)
+hash = { a: 1, b: 2, c: 3, d: 4 } # big enough to start as a bucket hash
+max.times { |i|
+  hash[i] = i
+}
+
+benchmark 'core-hash-buckets-lookup' do
+  1000.times do |i|
+    Primitive.blackhole(hash[i])
+  end
+end

--- a/bench/micro/hash/each-buckets.rb
+++ b/bench/micro/hash/each-buckets.rb
@@ -13,6 +13,6 @@
 if RUBY_ENGINE == 'truffleruby'
   hash = { a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, g: 7, h: 8, i: 9, j: 10 }
   benchmark 'core-hash-each-buckets' do
-    hash.each { |k, v| Primitive.blackhole(v) }
+    hash.each { |k, v| Primitive.blackhole(k); Primitive.blackhole(v) }
   end
 end

--- a/spec/ruby/core/hash/delete_spec.rb
+++ b/spec/ruby/core/hash/delete_spec.rb
@@ -24,11 +24,25 @@ describe "Hash#delete" do
   it "allows removing a key while iterating" do
     h = { a: 1, b: 2 }
     visited = []
-    h.each_pair { |k,v|
+    h.each_pair { |k, v|
       visited << k
       h.delete(k)
     }
     visited.should == [:a, :b]
+    h.should == {}
+  end
+
+  it "allows removing a key while iterating for big hashes" do
+    h = { a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, g: 7, h: 8, i: 9, j: 10,
+          k: 11, l: 12, m: 13, n: 14, o: 15, p: 16, q: 17, r: 18, s: 19, t: 20,
+          u: 21, v: 22, w: 23, x: 24, y: 25, z: 26 }
+    visited = []
+    h.each_pair { |k, v|
+      visited << k
+      h.delete(k)
+    }
+    visited.should == [:a, :b, :c, :d, :e, :f, :g, :h, :i, :j, :k, :l, :m,
+                       :n, :o, :p, :q, :r, :s, :t, :u, :v, :w, :x, :y, :z]
     h.should == {}
   end
 
@@ -38,7 +52,7 @@ describe "Hash#delete" do
   end
 
   it "raises a FrozenError if called on a frozen instance" do
-    -> { HashSpecs.frozen_hash.delete("foo")  }.should raise_error(FrozenError)
+    -> { HashSpecs.frozen_hash.delete("foo") }.should raise_error(FrozenError)
     -> { HashSpecs.empty_frozen_hash.delete("foo") }.should raise_error(FrozenError)
   end
 end

--- a/spec/ruby/core/hash/rehash_spec.rb
+++ b/spec/ruby/core/hash/rehash_spec.rb
@@ -77,6 +77,36 @@ describe "Hash#rehash" do
     h.keys.should_not.include? [1]
   end
 
+  it "iterates keys in insertion order" do
+    key = Class.new do
+      attr_reader :name
+
+      def initialize(name)
+        @name = name
+      end
+
+      def hash
+        123
+      end
+    end
+
+    a, b, c, d = key.new('a'), key.new('b'), key.new('c'), key.new('d')
+    h = { a => 1, b => 2, c => 3, d => 4 }
+    h.size.should == 4
+
+    key.class_exec do
+      def eql?(other)
+        true
+      end
+    end
+
+    h.rehash
+    h.size.should == 1
+    k, v = h.first
+    k.name.should == 'a'
+    v.should == 4
+  end
+
   it "raises a FrozenError if called on a frozen instance" do
     -> { HashSpecs.frozen_hash.rehash  }.should raise_error(FrozenError)
     -> { HashSpecs.empty_frozen_hash.rehash }.should raise_error(FrozenError)

--- a/src/main/java/org/truffleruby/core/hash/CompareHashKeysNode.java
+++ b/src/main/java/org/truffleruby/core/hash/CompareHashKeysNode.java
@@ -9,6 +9,8 @@
  */
 package org.truffleruby.core.hash;
 
+import com.oracle.truffle.api.dsl.GenerateCached;
+import com.oracle.truffle.api.dsl.GenerateInline;
 import org.truffleruby.core.basicobject.ReferenceEqualNode;
 import org.truffleruby.core.kernel.KernelNodes.SameOrEqlNode;
 import org.truffleruby.language.RubyBaseNode;
@@ -18,14 +20,12 @@ import com.oracle.truffle.api.dsl.GenerateUncached;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.nodes.Node;
 
+@GenerateInline
+@GenerateCached(false)
 @GenerateUncached
 public abstract class CompareHashKeysNode extends RubyBaseNode {
 
-    public static CompareHashKeysNode getUncached() {
-        return CompareHashKeysNodeGen.getUncached();
-    }
-
-    public abstract boolean execute(boolean compareByIdentity, Object key, int hashed,
+    public abstract boolean execute(Node node, boolean compareByIdentity, Object key, int hashed,
             Object otherKey, int otherHashed);
 
     /** Checks if the two keys are the same object, which is used by both modes (by identity or not) of lookup. Enables
@@ -38,36 +38,35 @@ public abstract class CompareHashKeysNode extends RubyBaseNode {
     }
 
     @Specialization(guards = "compareByIdentity")
-    boolean refEquals(boolean compareByIdentity, Object key, int hashed, Object otherKey, int otherHashed,
+    static boolean refEquals(
+            Node node, boolean compareByIdentity, Object key, int hashed, Object otherKey, int otherHashed,
             @Cached ReferenceEqualNode refEqual) {
-        return refEqual.execute(this, key, otherKey);
+        return refEqual.execute(node, key, otherKey);
     }
 
     @Specialization(guards = "!compareByIdentity")
-    boolean same(boolean compareByIdentity, Object key, int hashed, Object otherKey, int otherHashed,
+    static boolean same(Node node, boolean compareByIdentity, Object key, int hashed, Object otherKey, int otherHashed,
             @Cached SameOrEqlNode same) {
-        return hashed == otherHashed && same.execute(key, otherKey);
+        return hashed == otherHashed && same.execute(node, key, otherKey);
     }
 
+    @GenerateInline
+    @GenerateCached(false)
     @GenerateUncached
     public abstract static class AssumingEqualHashes extends RubyBaseNode {
 
-        public static AssumingEqualHashes getUncached() {
-            return CompareHashKeysNodeGen.AssumingEqualHashesNodeGen.getUncached();
-        }
-
-        public abstract boolean execute(boolean compareByIdentity, Object key, Object otherKey);
+        public abstract boolean execute(Node node, boolean compareByIdentity, Object key, Object otherKey);
 
         @Specialization(guards = "compareByIdentity")
-        boolean refEquals(boolean compareByIdentity, Object key, Object otherKey,
+        static boolean refEquals(Node node, boolean compareByIdentity, Object key, Object otherKey,
                 @Cached ReferenceEqualNode refEqual) {
-            return refEqual.execute(this, key, otherKey);
+            return refEqual.execute(node, key, otherKey);
         }
 
         @Specialization(guards = "!compareByIdentity")
-        boolean same(boolean compareByIdentity, Object key, Object otherKey,
+        static boolean same(Node node, boolean compareByIdentity, Object key, Object otherKey,
                 @Cached SameOrEqlNode same) {
-            return same.execute(key, otherKey);
+            return same.execute(node, key, otherKey);
         }
     }
 }

--- a/src/main/java/org/truffleruby/core/hash/HashLiteralNode.java
+++ b/src/main/java/org/truffleruby/core/hash/HashLiteralNode.java
@@ -30,6 +30,10 @@ public abstract class HashLiteralNode extends RubyContextSourceNode {
         this.keyValues = keyValues;
     }
 
+    protected int getNumberOfEntries() {
+        return keyValues.length >> 1;
+    }
+
     public static HashLiteralNode create(RubyNode[] keyValues, RubyLanguage language) {
         if (keyValues.length == 0) {
             return new EmptyHashStore.EmptyHashLiteralNode();

--- a/src/main/java/org/truffleruby/core/hash/HashLiteralNode.java
+++ b/src/main/java/org/truffleruby/core/hash/HashLiteralNode.java
@@ -30,13 +30,13 @@ public abstract class HashLiteralNode extends RubyContextSourceNode {
         this.keyValues = keyValues;
     }
 
-    public static HashLiteralNode create(RubyNode[] keyValues, RubyLanguage rubyLanguage) {
+    public static HashLiteralNode create(RubyNode[] keyValues, RubyLanguage language) {
         if (keyValues.length == 0) {
             return new EmptyHashStore.EmptyHashLiteralNode();
         } else if (keyValues.length <= PackedHashStoreLibrary.MAX_ENTRIES * 2) {
             return PackedHashStoreLibraryFactory.SmallHashLiteralNodeGen.create(keyValues);
         } else {
-            return rubyLanguage.options.BIG_HASH_STRATEGY_IS_BUCKETS
+            return language.options.BIG_HASH_STRATEGY_IS_BUCKETS
                     ? new BucketsHashStore.BucketHashLiteralNode(keyValues)
                     : new CompactHashStore.CompactHashLiteralNode(keyValues);
         }

--- a/src/main/java/org/truffleruby/core/hash/HashLiteralNode.java
+++ b/src/main/java/org/truffleruby/core/hash/HashLiteralNode.java
@@ -9,12 +9,12 @@
  */
 package org.truffleruby.core.hash;
 
+import org.truffleruby.RubyLanguage;
 import org.truffleruby.core.hash.library.BucketsHashStore;
 import org.truffleruby.core.hash.library.CompactHashStore;
 import org.truffleruby.core.hash.library.EmptyHashStore;
 import org.truffleruby.core.hash.library.PackedHashStoreLibrary;
 import org.truffleruby.core.hash.library.PackedHashStoreLibraryFactory;
-import org.truffleruby.language.RubyBaseNode;
 import org.truffleruby.language.RubyContextSourceNode;
 import org.truffleruby.language.RubyNode;
 
@@ -30,24 +30,14 @@ public abstract class HashLiteralNode extends RubyContextSourceNode {
         this.keyValues = keyValues;
     }
 
-    public static final class BigHashConfiguredStrategy extends RubyBaseNode {
-        private BigHashConfiguredStrategy() {
-            isBuckets = getContext().getOptions().BIG_HASH_STRATEGY;
-        }
-
-        // dummy instance, so we can call getContext instance method, never used
-        private static final BigHashConfiguredStrategy bh = new BigHashConfiguredStrategy();
-        public static boolean isBuckets;
-    }
-
-    public static HashLiteralNode create(RubyNode[] keyValues) {
+    public static HashLiteralNode create(RubyNode[] keyValues, RubyLanguage rubyLanguage) {
         if (keyValues.length == 0) {
             return new EmptyHashStore.EmptyHashLiteralNode();
         } else if (keyValues.length <= PackedHashStoreLibrary.MAX_ENTRIES * 2) {
             return PackedHashStoreLibraryFactory.SmallHashLiteralNodeGen.create(keyValues);
         } else {
-            return BigHashConfiguredStrategy.isBuckets
-                    ? new BucketsHashStore.GenericHashLiteralNode(keyValues)
+            return rubyLanguage.options.BIG_HASH_STRATEGY_IS_BUCKETS
+                    ? new BucketsHashStore.BucketHashLiteralNode(keyValues)
                     : new CompactHashStore.CompactHashLiteralNode(keyValues);
         }
     }

--- a/src/main/java/org/truffleruby/core/hash/RubyHash.java
+++ b/src/main/java/org/truffleruby/core/hash/RubyHash.java
@@ -11,6 +11,20 @@ package org.truffleruby.core.hash;
 
 import java.util.Set;
 
+import org.truffleruby.RubyContext;
+import org.truffleruby.collections.PEBiFunction;
+import org.truffleruby.core.hash.library.BucketsHashStore;
+import org.truffleruby.core.hash.library.CompactHashStore;
+import org.truffleruby.core.hash.library.HashStoreLibrary;
+import org.truffleruby.core.klass.RubyClass;
+import org.truffleruby.interop.ForeignToRubyNode;
+import org.truffleruby.language.Nil;
+import org.truffleruby.language.RubyDynamicObject;
+import org.truffleruby.language.dispatch.DispatchNode;
+import org.truffleruby.language.objects.IsFrozenNode;
+import org.truffleruby.language.objects.ObjectGraph;
+import org.truffleruby.language.objects.ObjectGraphNode;
+
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.Bind;
 import com.oracle.truffle.api.dsl.Cached;
@@ -26,20 +40,7 @@ import com.oracle.truffle.api.library.ExportLibrary;
 import com.oracle.truffle.api.library.ExportMessage;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.object.Shape;
-
 import com.oracle.truffle.api.profiles.InlinedConditionProfile;
-import org.truffleruby.RubyContext;
-import org.truffleruby.collections.PEBiFunction;
-import org.truffleruby.core.hash.library.BucketsHashStore;
-import org.truffleruby.core.hash.library.HashStoreLibrary;
-import org.truffleruby.core.klass.RubyClass;
-import org.truffleruby.interop.ForeignToRubyNode;
-import org.truffleruby.language.Nil;
-import org.truffleruby.language.RubyDynamicObject;
-import org.truffleruby.language.dispatch.DispatchNode;
-import org.truffleruby.language.objects.IsFrozenNode;
-import org.truffleruby.language.objects.ObjectGraph;
-import org.truffleruby.language.objects.ObjectGraphNode;
 
 @ExportLibrary(InteropLibrary.class)
 @ImportStatic(HashGuards.class)
@@ -86,6 +87,8 @@ public final class RubyHash extends RubyDynamicObject implements ObjectGraphNode
     public void getAdjacentObjects(Set<Object> reachable) {
         if (store instanceof BucketsHashStore) {
             ((BucketsHashStore) store).getAdjacentObjects(reachable);
+        } else if (store instanceof CompactHashStore) {
+            ((CompactHashStore) store).getAdjacentObjects(reachable);
         } else {
             ObjectGraph.addProperty(reachable, store);
         }

--- a/src/main/java/org/truffleruby/core/hash/library/BucketsHashStore.java
+++ b/src/main/java/org/truffleruby/core/hash/library/BucketsHashStore.java
@@ -578,7 +578,7 @@ public final class BucketsHashStore {
 
         public BucketHashLiteralNode(RubyNode[] keyValues) {
             super(keyValues);
-            bucketsCount = growthCapacityGreaterThan(keyValues.length / 2);
+            bucketsCount = growthCapacityGreaterThan(getNumberOfEntries());
         }
 
         @ExplodeLoop

--- a/src/main/java/org/truffleruby/core/hash/library/BucketsHashStore.java
+++ b/src/main/java/org/truffleruby/core/hash/library/BucketsHashStore.java
@@ -558,7 +558,8 @@ public final class BucketsHashStore {
             Entry previousEntry = null;
 
             while (entry != null) {
-                if (compareHashKeysNode.execute(compareByIdentity, key, hashed, entry.getKey(), entry.getHashed())) {
+                if (compareHashKeysNode.execute(this, compareByIdentity, key, hashed, entry.getKey(),
+                        entry.getHashed())) {
                     return new HashLookupResult(hashed, index, previousEntry, entry);
                 }
 

--- a/src/main/java/org/truffleruby/core/hash/library/BucketsHashStore.java
+++ b/src/main/java/org/truffleruby/core/hash/library/BucketsHashStore.java
@@ -571,12 +571,12 @@ public final class BucketsHashStore {
 
     }
 
-    public static final class GenericHashLiteralNode extends HashLiteralNode {
+    public static final class BucketHashLiteralNode extends HashLiteralNode {
 
         @Child HashStoreLibrary hashes;
         private final int bucketsCount;
 
-        public GenericHashLiteralNode(RubyNode[] keyValues) {
+        public BucketHashLiteralNode(RubyNode[] keyValues) {
             super(keyValues);
             bucketsCount = growthCapacityGreaterThan(keyValues.length / 2);
         }
@@ -608,7 +608,7 @@ public final class BucketsHashStore {
 
         @Override
         public RubyNode cloneUninitialized() {
-            var copy = new GenericHashLiteralNode(cloneUninitialized(keyValues));
+            var copy = new BucketHashLiteralNode(cloneUninitialized(keyValues));
             return copy.copyFlags(this);
         }
 

--- a/src/main/java/org/truffleruby/core/hash/library/CompactHashStore.java
+++ b/src/main/java/org/truffleruby/core/hash/library/CompactHashStore.java
@@ -122,7 +122,7 @@ public final class CompactHashStore {
     // In hash entries, not array positions (in general, capacities and sizes are always in entries)
     public static final int DEFAULT_INITIAL_CAPACITY = 8;
 
-    public static final float THRESHOLD_LOAD_FACTOR_FOR_INDEX_REBUILD = 0.7f;
+    public static final float THRESHOLD_LOAD_FACTOR_FOR_INDEX_REBUILD = 0.75f;
 
     public CompactHashStore() {
         this(DEFAULT_INITIAL_CAPACITY);

--- a/src/main/java/org/truffleruby/core/hash/library/CompactHashStore.java
+++ b/src/main/java/org/truffleruby/core/hash/library/CompactHashStore.java
@@ -1,0 +1,666 @@
+/*
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates. All rights reserved. This
+ * code is released under a tri EPL/GPL/LGPL license. You can use it,
+ * redistribute it and/or modify it under the terms of the:
+ *
+ * Eclipse Public License version 2.0, or
+ * GNU General Public License version 2, or
+ * GNU Lesser General Public License version 2.1.
+ */
+package org.truffleruby.core.hash.library;
+
+import static com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
+import static com.oracle.truffle.api.CompilerDirectives.shouldNotReachHere;
+import static com.oracle.truffle.api.dsl.Cached.Exclusive;
+import static org.truffleruby.core.hash.library.HashStoreLibrary.EachEntryCallback;
+
+import java.util.Arrays;
+import java.util.Set;
+
+import org.truffleruby.RubyContext;
+import org.truffleruby.RubyLanguage;
+import org.truffleruby.collections.PEBiFunction;
+import org.truffleruby.core.array.ArrayHelpers;
+import org.truffleruby.core.array.RubyArray;
+import org.truffleruby.core.hash.CompareHashKeysNode;
+import org.truffleruby.core.hash.FreezeHashKeyIfNeededNode;
+import org.truffleruby.core.hash.HashLiteralNode;
+import org.truffleruby.core.hash.HashingNodes;
+import org.truffleruby.core.hash.RubyHash;
+import org.truffleruby.language.RubyBaseNode;
+import org.truffleruby.language.RubyNode;
+import org.truffleruby.language.objects.ObjectGraph;
+import org.truffleruby.language.objects.shared.PropagateSharingNode;
+
+import com.oracle.truffle.api.dsl.Bind;
+import com.oracle.truffle.api.dsl.Cached;
+import com.oracle.truffle.api.dsl.Cached.Shared;
+import com.oracle.truffle.api.dsl.GenerateUncached;
+import com.oracle.truffle.api.dsl.ImportStatic;
+import com.oracle.truffle.api.dsl.Specialization;
+import com.oracle.truffle.api.frame.Frame;
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.library.CachedLibrary;
+import com.oracle.truffle.api.library.ExportLibrary;
+import com.oracle.truffle.api.library.ExportMessage;
+import com.oracle.truffle.api.nodes.ExplodeLoop;
+import com.oracle.truffle.api.nodes.Node;
+import com.oracle.truffle.api.profiles.InlinedConditionProfile;
+import com.oracle.truffle.api.profiles.InlinedLoopConditionProfile;
+
+/* The Compact hash strategy from Hash Maps That Dont Hate You
+ * See https://blog.toit.io/hash-maps-that-dont-hate-you-1a96150b492a for more details (archived at
+ * https://archive.ph/wip/sucRY) */
+@ExportLibrary(value = HashStoreLibrary.class)
+@GenerateUncached
+public final class CompactHashStore {
+    //  ---------------------------------------------------------------------------------------------------------------
+    // Big Picture :
+    //  (1) A Compact Hash's big idea is storing all key-values in a contiguous array (the KV array) in insertion order
+    //      This enables us to do sequential iteration on all key-values in insertion order, which is what we want
+    //      But it doesn't allow constant-time lookups
+    //  -----------------------------------------------
+    //  (2) Thus, a Compact Hash also stores the position of every key in the KV array in another array called the index
+    //      That KV position is stored in the index array at a location that depends on the respective key's hash
+    //      Therefore, given a key we can always quickly find where it's in the KV array by :
+    //                                    -----------------------------------------------
+    //              1- Hashing it
+    //              2- Calculating the position of the hash from its value
+    //              3- Looking up the index array at that position,
+    //              4- Where we find the KV position
+    //              5- Then looking up the KV array by that position
+    //              6- Where we find the key and then the value right next to it
+    //                                    -----------------------------------------------
+    //      (step 3 is oversimplified a bit, the position calculated in (2) is where we store the hash itself in the
+    //       index array, the KV position is stored next to it. The reason we store the hash is that step 2 is lossy,
+    //       multiple not-equal hashes can map to the same position in the index array, that's a different sort of
+    //       "collision" in addition to the usual collision of equal hash values coming from different keys. Both kinds
+    //       of collisions actually result in the same outcome : contention on an index slot. So both are automatically
+    //       handled by the same collision-resolution strategy : open-addressing-with linear probing.)
+    //  -----------------------------------------------
+    //  (3) tl;dr: Compact Hashes give you both insertion-order iteration AND the usual const-time guarantees
+    //  ---------------------------------------------------------------------------------------------------------------
+
+    /* We view the index array as consisting of "Slots", each slot is 2 array positions. index[0] and index[1] is one
+     * slot, index[2] and index[3] is another,... The first position of a slot holds the hash of a key and the second
+     * holds an offsetted index into the KV store (index + 1) where the key is stored. The reason we store an offsetted
+     * index and not the index itself is so that 0 is not a valid index, thus we can use it as unused slot marker, and
+     * since all int[] arrays start out zeroed this means that new index arrays are marked unused "for free" */
+    private int[] index;
+    private Object[] kvStore;
+    // This tracks the next valid insertion position into kvStore, it starts at 0 and always increases by 2
+    // We can't use the size of the RubyHash for that, because deletion reduces its hash.size
+    // Whereas the insertion pos into kvStore can never decrease, we don't reuse empty slots
+    private int kvStoreInsertionPos;
+    // This tracks the number of occupied slots at which we should rebuild the index array
+    // For example, at a load factor of 0.75 and an index of total size 100 slot, that number is 75 slots
+    // (Technically, that's redundant information that is derived from the load factor and the index size,
+    //  but deriving it requires a float multiplication or division, and we want to check for it on every insertion, so
+    //  it's inefficient to keep calculating it every time its needed)
+    private int numSlotsForIndexRebuild;
+
+    // Each slot in the index array can be in one of 3 states, depending on the value of its second (offset) field :
+    // Offset >= 1 : Filled, the data in the hash field and the offset field is valid. Subtracting one from the offset
+    // will yield a valid index into the KV array.
+    // Offset == 0 : Unused, the data in the hash field and the offset field is NOT valid, and the slot was never filled
+    // with valid data.
+    // Offset == -1 : Deleted, the data in the hash field and the offset field is NOT valid, but the slot used to be
+    // occupied with valid data before.
+    private static final int INDEX_SLOT_UNUSED_MARKER = 0;
+    private static final int INDEX_SLOT_DELETED_MARKER = -1;
+
+    // returned by methods doing array search which doesn't find what they're looking for
+    protected static final int KEY_NOT_FOUND = -2;
+    private static final int HASH_NOT_FOUND = KEY_NOT_FOUND;
+
+    // a generic "not a valid array position" value to be used by all code doing array searches for things other than
+    // keys and hashes
+    private static final int INVALID_ARRAY_POSITION = Integer.MIN_VALUE;
+
+    // In hash entries, not array positions (in general, capacities and sizes are always in entries)
+    public static final int DEFAULT_INITIAL_CAPACITY = 8;
+
+    public static final float THRESHOLD_LOAD_FACTOR_FOR_INDEX_REBUILD = 0.7f;
+
+    public CompactHashStore() {
+        this(DEFAULT_INITIAL_CAPACITY);
+    }
+
+    // private non-allocating constructor for .copy(), not part of the interface
+    private CompactHashStore(int[] index, Object[] kvs, int kvStoreInsertionPos, int numSlotsForIndexRebuild) {
+        this.index = index;
+        this.kvStore = kvs;
+        this.kvStoreInsertionPos = kvStoreInsertionPos;
+        this.numSlotsForIndexRebuild = numSlotsForIndexRebuild;
+    }
+
+    public CompactHashStore(int capacity) {
+        assertConstructorPreconditions(capacity);
+
+        int kvCapacity = roundUpwardsToNearestPowerOf2(capacity);
+        // the index array needs to be a little sparse for good performance (i.e. low load factor)
+        // so to store 8 key-value entries an index of exactly 8 slots is too crowded
+        int indexCapacity = 2 * kvCapacity;
+
+        // All 0s by default, so all slots are marked empty for free
+        this.index = new int[2 * indexCapacity];
+        this.kvStore = new Object[2 * kvCapacity];
+        this.kvStoreInsertionPos = 0; // always increases by 2, never decreases
+        this.numSlotsForIndexRebuild = (int) (indexCapacity * THRESHOLD_LOAD_FACTOR_FOR_INDEX_REBUILD);
+    }
+
+    private static int roundUpwardsToNearestPowerOf2(int num) {
+        return Integer.highestOneBit(num - 1) << 1;
+    }
+
+    private static void assertConstructorPreconditions(int capacity) {
+        if (capacity < 1 || capacity > (1 << 28)) {
+            throw shouldNotReachHere();
+        }
+    }
+
+    @ExportMessage
+    protected boolean set(RubyHash hash, Object key, Object value, boolean byIdentity,
+            @Cached @Shared HashingNodes.ToHash hashFunction,
+            @Cached @Shared GetHashPosAndKvPosForKeyNode getHashPosAndKvPos,
+            @Cached FreezeHashKeyIfNeededNode freezeKey,
+            @Cached PropagateSharingNode propagateSharingForKey,
+            @Cached PropagateSharingNode propagateSharingForVal,
+            @Cached SetKvAtNode setKv,
+            @Bind("$node") Node node) {
+        var frozenKey = freezeKey.executeFreezeIfNeeded(key, byIdentity);
+        int keyHash = hashFunction.execute(frozenKey, byIdentity);
+        int keyKvPos = IntPair.second(
+                getHashPosAndKvPos.execute(frozenKey, keyHash, byIdentity, index, kvStore));
+
+        propagateSharingForKey.execute(node, hash, frozenKey);
+        propagateSharingForVal.execute(node, hash, value);
+
+        return setKv.execute(hash, this, keyKvPos, keyHash, frozenKey, value);
+    }
+
+    @ExportMessage
+    protected Object lookupOrDefault(Frame frame, RubyHash hash, Object key, PEBiFunction defaultNode,
+            @Cached @Shared GetHashPosAndKvPosForKeyNode getHashPosAndKvPos,
+            @Cached @Shared HashingNodes.ToHash hashFunction,
+            @Cached @Exclusive InlinedConditionProfile keyNotFound,
+            @Bind("$node") Node node) {
+        int keyHash = hashFunction.execute(key, hash.compareByIdentity);
+        int keyKvPos = IntPair.second(
+                getHashPosAndKvPos.execute(key, keyHash, hash.compareByIdentity, index, kvStore));
+
+        if (keyNotFound.profile(node, keyKvPos == KEY_NOT_FOUND)) {
+            return defaultNode.accept(frame, hash, key);
+        }
+        return kvStore[keyKvPos + 1];
+    }
+
+    @ExportMessage
+    protected Object delete(RubyHash hash, Object key,
+            @Cached @Shared GetHashPosAndKvPosForKeyNode getHashPosAndKvPos,
+            @Cached @Shared HashingNodes.ToHash hashFunction,
+            @Cached @Exclusive InlinedConditionProfile keyNotFound,
+            @Bind("$node") Node node) {
+        int keyHash = hashFunction.execute(key, hash.compareByIdentity);
+        long hashPosAndKeyKvPos = getHashPosAndKvPos.execute(key, keyHash, hash.compareByIdentity, index, kvStore);
+        int hashPos = IntPair.first(hashPosAndKeyKvPos);
+        int keyKvPos = IntPair.second(hashPosAndKeyKvPos);
+
+        if (keyNotFound.profile(node, keyKvPos == KEY_NOT_FOUND)) {
+            return null;
+        }
+
+        return deleteKvAndGetV(hash, hashPos, keyKvPos);
+    }
+
+    @ExportMessage
+    protected Object deleteLast(RubyHash hash, Object key,
+            @Cached @Shared HashingNodes.ToHash hashFunction,
+            @Cached @Shared GetHashPosForKeyAtKvPosNode getHashPos,
+            @Cached @Exclusive InlinedConditionProfile kvAllNulls,
+            @Cached @Exclusive InlinedConditionProfile keyGivenIsNotLastKey,
+            @Cached @Exclusive InlinedLoopConditionProfile nonNullKeyNotYetFound,
+            @Bind("$node") Node node) {
+        int lastKeyPos = firstNonNullKeyPosFromEnd(nonNullKeyNotYetFound, node);
+        if (kvAllNulls.profile(node, lastKeyPos == KEY_NOT_FOUND)) {
+            return null;
+        }
+        if (keyGivenIsNotLastKey.profile(node, key != kvStore[lastKeyPos])) {
+            return null;
+        }
+
+        int keyHash = hashFunction.execute(key, hash.compareByIdentity);
+        int hashPos = getHashPos.execute(keyHash, lastKeyPos, index);
+
+        return deleteKvAndGetV(hash, hashPos, lastKeyPos);
+    }
+
+    @ExportMessage
+    protected Object eachEntry(RubyHash hash, EachEntryCallback callback, Object state,
+            @Cached @Exclusive InlinedConditionProfile keyNotNull,
+            @Cached @Exclusive InlinedLoopConditionProfile tillArrayEnd,
+            @Bind("$node") Node node) {
+        for (int i = 0; tillArrayEnd.inject(node, i < kvStore.length); i += 2) {
+            if (keyNotNull.profile(node, kvStore[i] != null)) {
+                callback.accept(i / 2, kvStore[i], kvStore[i + 1], state);
+            }
+        }
+        return state;
+    }
+
+    @ExportMessage
+    protected Object eachEntrySafe(RubyHash hash, EachEntryCallback callback, Object state,
+            @CachedLibrary("this") HashStoreLibrary hashlib) {
+        return hashlib.eachEntry(this, hash, callback, state);
+    }
+
+    @ExportMessage
+    protected void replace(RubyHash hash, RubyHash dest,
+            @Cached @Exclusive PropagateSharingNode propagateSharing,
+            @Cached @Exclusive InlinedConditionProfile noReplaceNeeded,
+            @Bind("$node") Node node) {
+        if (noReplaceNeeded.profile(node, hash == dest)) {
+            return;
+        }
+
+        propagateSharing.execute(node, dest, hash);
+
+        CompactHashStore copy = this.copy();
+        dest.size = hash.size;
+        dest.store = copy;
+        dest.compareByIdentity = hash.compareByIdentity;
+        dest.defaultBlock = hash.defaultBlock;
+        dest.defaultValue = hash.defaultValue;
+    }
+
+    @ExportMessage
+    protected RubyArray shift(RubyHash hash,
+            @Cached @Shared HashingNodes.ToHash hashFunction,
+            @Cached @Shared GetHashPosForKeyAtKvPosNode getHashPos,
+            @CachedLibrary("this") HashStoreLibrary self,
+            @Cached @Exclusive InlinedConditionProfile noKvToShift,
+            @Cached @Exclusive InlinedLoopConditionProfile nonNullKeyNotYetFound,
+            @Cached @Exclusive InlinedConditionProfile nonNullKeyFound,
+            @Bind("$node") Node node) {
+        int lastKeyPos = firstNonNullKeyPosFromBeginning(nonNullKeyNotYetFound, nonNullKeyFound, node);
+        if (noKvToShift.profile(node, lastKeyPos == KEY_NOT_FOUND)) {
+            return null;
+        }
+        Object key = kvStore[lastKeyPos];
+        int keyHash = hashFunction.execute(key, hash.compareByIdentity);
+        int hashPos = getHashPos.execute(keyHash, lastKeyPos, index);
+        Object val = deleteKvAndGetV(hash, hashPos, lastKeyPos);
+
+        return ArrayHelpers.createArray(
+                RubyContext.get(self),
+                RubyLanguage.get(self),
+                new Object[]{ key, val });
+    }
+
+    @ExportMessage
+    protected void rehash(RubyHash hash,
+            @Cached @Shared HashingNodes.ToHash hashFunction,
+            @Cached @Exclusive InlinedConditionProfile slotUsed,
+            @Cached @Exclusive InlinedLoopConditionProfile indexSlotUnavailable,
+            @Cached @Exclusive InlinedLoopConditionProfile tillArrayEnd,
+            @Bind("$node") Node node) {
+        int[] oldIndex = index;
+        this.index = new int[oldIndex.length];
+
+        for (int i = 0; tillArrayEnd.inject(node, i < oldIndex.length); i += 2) {
+            int kvOffset = oldIndex[i + 1];
+
+            if (slotUsed.profile(node, kvOffset > INDEX_SLOT_UNUSED_MARKER)) {
+                Object key = kvStore[kvOffset - 1];
+                int newHash = hashFunction.execute(key, hash.compareByIdentity);
+
+                SetKvAtNode.insertIntoIndex(newHash, kvOffset, index, indexSlotUnavailable, node);
+            }
+        }
+    }
+
+    @ExportMessage
+    protected boolean verify(RubyHash hash) {
+        assert kvStoreInsertionPos > 0 && kvStoreInsertionPos < kvStore.length;
+        assert kvStoreInsertionPos % 2 == 0;
+        assert kvStoreInsertionPos >= hash.size; // because deletes only decrease hash.size
+
+        assert ((float) (2 * hash.size)) / index.length <= THRESHOLD_LOAD_FACTOR_FOR_INDEX_REBUILD;
+
+        assert (index.length & (index.length - 1)) == 0; //index.length is always a power of 2
+        return true;
+    }
+
+    private Object deleteKvAndGetV(RubyHash hash, int hashPos, int keyKvPos) {
+        Object deletedValue = kvStore[keyKvPos + 1];
+        index[hashPos + 1] = INDEX_SLOT_DELETED_MARKER;
+        // TODO: Instead of naively nulling out the key-value, which can produce long gaps of nulls in the kvStore,
+        //       See if we can annotate each gap with its length so that iteration code can "jump" over it
+        kvStore[keyKvPos] = null;
+        kvStore[keyKvPos + 1] = null;
+
+        hash.size--;
+        return deletedValue;
+    }
+
+    private int firstNonNullKeyPosFromEnd(
+            InlinedLoopConditionProfile nonNullKeyNotYetFound,
+            Node node) {
+        int lastKeyPos = kvStoreInsertionPos - 2;
+        while (nonNullKeyNotYetFound.profile(node,
+                lastKeyPos > 0 && kvStore[lastKeyPos] == null)) {
+            lastKeyPos -= 2;
+        }
+        return lastKeyPos;
+    }
+
+    private int firstNonNullKeyPosFromBeginning(
+            InlinedLoopConditionProfile nonNullKeyNotYetFound,
+            InlinedConditionProfile nonNullKeyFound,
+            Node node) {
+        int firstKeyPos = 0;
+        while (nonNullKeyNotYetFound.profile(node,
+                firstKeyPos < kvStoreInsertionPos && kvStore[firstKeyPos] == null)) {
+            firstKeyPos += 2;
+        }
+        // Means the loop must have exited because we found a non-null key
+        if (nonNullKeyFound.profile(node, firstKeyPos < kvStoreInsertionPos)) {
+            return firstKeyPos;
+        }
+        return KEY_NOT_FOUND;
+    }
+
+    private CompactHashStore copy() {
+        return new CompactHashStore(index.clone(), kvStore.clone(), kvStoreInsertionPos, numSlotsForIndexRebuild);
+    }
+
+    /** @param h a hash code
+     * @param max the length of the index array
+     * @return An even index ranging from 0 to max-1 */
+    private static int getIndexPosFromHash(int h, int max) {
+        return h & (max - 2);
+    }
+
+    private static int incrementIndexPos(int pos, int max) {
+        return (pos + 2) & (max - 1);
+    }
+
+    public void getAdjacentObjects(Set<Object> reachable) {
+        for (int i = 0; i < kvStoreInsertionPos; i += 2) {
+            if (kvStore[i] != null) {
+                ObjectGraph.addProperty(reachable, kvStore[i]);
+                ObjectGraph.addProperty(reachable, kvStore[i + 1]);
+            }
+        }
+    }
+
+    /** Given : A key and its hash
+     * <p>
+     * Returns : A pair of positions (array indices), the first of which is where the key's hash is stored in the index
+     * array, and the second is where the key itself is stored in the KV Store array
+     * <p>
+     * If the key doesn't exist, returns KEY_NOT_FOUND
+     * <p>
+     * NOTE : The node encodes a pair of integers as a long, this avoids allocations at the expense of readability */
+    @GenerateUncached
+    abstract static class GetHashPosAndKvPosForKeyNode extends RubyBaseNode {
+        public abstract long execute(Object key, int hash, boolean compareByIdentity, int[] index, Object[] kvStore);
+
+        @Specialization
+        long getHashPosAndKvPos(Object key, int hash, boolean compareByIdentity, int[] index, Object[] kvStore,
+                @Cached CompareHashKeysNode.AssumingEqualHashes compareHashKeysNode,
+                @Cached GetHashNextPosInIndexNode getNextHashPos,
+                @Cached @Exclusive InlinedConditionProfile passedKeyIsEqualToFoundKey,
+                @Cached @Exclusive InlinedConditionProfile relocationPossible,
+                @Cached @Exclusive InlinedLoopConditionProfile keyHashFound,
+                @Bind("$node") Node node) {
+            int startPos = getIndexPosFromHash(hash, index.length);
+            long result = getNextHashPos.execute(startPos, hash, index, INVALID_ARRAY_POSITION, startPos);
+
+            int firstHashPosInIndex = IntPair.second(result);
+            int relocationPos = IntPair.first(result);
+
+            int nextHashPos = firstHashPosInIndex;
+            while (keyHashFound.profile(node, nextHashPos != HASH_NOT_FOUND)) {
+                int kvPos = index[nextHashPos + 1] - 1;
+                Object otherKey = kvStore[kvPos];
+
+                relocateHashIfPossible(nextHashPos, relocationPos, index,
+                        relocationPossible, node);
+
+                if (passedKeyIsEqualToFoundKey.profile(node,
+                        compareHashKeysNode.execute(compareByIdentity, key, otherKey))) {
+                    return IntPair.mk(nextHashPos, kvPos);
+                }
+
+                int next = incrementIndexPos(nextHashPos, index.length);
+                result = getNextHashPos.execute(next, hash, index, relocationPos, startPos);
+                nextHashPos = IntPair.second(result);
+                relocationPos = IntPair.first(result);
+            }
+
+            return KEY_NOT_FOUND;
+        }
+    }
+
+    static final class IntPair {
+        public static long mk(int first, int second) {
+            return (((long) first) << 32) | (second & 0xffffffffL);
+        }
+
+        public static int first(long pair) {
+            return (int) (pair >> 32);
+        }
+
+        public static int second(long pair) {
+            return (int) pair;
+        }
+    }
+
+    @GenerateUncached
+    abstract static class GetHashNextPosInIndexNode extends RubyBaseNode {
+        public abstract long execute(int startingFromPos, int hash, int[] index, int relocationPos, int stop);
+
+        @Specialization
+        long getHashNextPos(int startingFromPos, int hash, int[] index, int stop,
+                @Cached @Exclusive InlinedConditionProfile slotIsDeleted,
+                @Cached @Exclusive InlinedConditionProfile slotIsUnused,
+                @Cached @Exclusive InlinedConditionProfile hashFound,
+                @Cached @Exclusive InlinedConditionProfile noValidFirstDeletedSlot,
+                @Cached @Exclusive InlinedLoopConditionProfile stopNotYetReached,
+                @Bind("$node") Node node) {
+            int nextHashPos = startingFromPos;
+            int firstDeletedSlot = INVALID_ARRAY_POSITION;
+            do {
+                if (slotIsUnused.profile(node, index[nextHashPos + 1] == INDEX_SLOT_UNUSED_MARKER)) {
+                    return HASH_NOT_FOUND;
+                }
+
+                if (slotIsDeleted.profile(node, index[nextHashPos + 1] == INDEX_SLOT_DELETED_MARKER)) {
+                    if (noValidFirstDeletedSlot.profile(node, firstDeletedSlot == INVALID_ARRAY_POSITION)) {
+                        firstDeletedSlot = nextHashPos;
+                    }
+                } else if (hashFound.profile(node, index[nextHashPos] == hash)) {
+                    return IntPair.mk(firstDeletedSlot, nextHashPos);
+                }
+
+                nextHashPos = incrementIndexPos(nextHashPos, index.length);
+            } while (stopNotYetReached.profile(node, nextHashPos != stop));
+
+            return HASH_NOT_FOUND;
+        }
+    }
+
+    @GenerateUncached
+    abstract static class GetHashPosForKeyAtKvPosNode extends RubyBaseNode {
+        public abstract int execute(int hash, int kvPos, int[] index);
+
+        @Specialization
+        int getHashPos(int hash, int kvPos, int[] index,
+                @Cached @Exclusive InlinedConditionProfile keyFound,
+                @Cached @Exclusive InlinedConditionProfile relocationPossible,
+                @Cached @Exclusive InlinedLoopConditionProfile keyHashFound,
+                @Cached GetHashNextPosInIndexNode getNextHashPos,
+                @Bind("$node") Node node) {
+            int startPos = getIndexPosFromHash(hash, index.length);
+            long result = getNextHashPos.execute(startPos, hash, index, INVALID_ARRAY_POSITION, startPos);
+
+            int firstHashPos = IntPair.second(result);
+            int relocationPos = IntPair.first(result);
+
+            int nextPos = firstHashPos;
+            while (keyHashFound.profile(node, nextPos != HASH_NOT_FOUND)) {
+                int kvPosition = index[nextPos + 1] - 1;
+
+                relocateHashIfPossible(nextPos, relocationPos, index,
+                        relocationPossible, node);
+
+                if (keyFound.profile(node, kvPos == kvPosition)) {
+                    return nextPos;
+                }
+
+                int next = incrementIndexPos(nextPos, index.length);
+                result = getNextHashPos.execute(next, hash, index, relocationPos, startPos);
+                nextPos = IntPair.second(result);
+                relocationPos = IntPair.first(result);
+            }
+            return HASH_NOT_FOUND;
+        }
+    }
+
+    @GenerateUncached
+    @ImportStatic(CompactHashStore.class)
+    abstract static class SetKvAtNode extends RubyBaseNode {
+        public abstract boolean execute(RubyHash hash, CompactHashStore store, int kvPos, int keyHash, Object frozenKey,
+                Object value);
+
+        // key already exist, very fast because there is no need to touch the index
+        @Specialization(guards = "kvPos != KEY_NOT_FOUND")
+        boolean keyAlreadyExistsWithDifferentValue(
+                RubyHash hash, CompactHashStore store, int kvPos, int keyHash, Object frozenKey, Object value) {
+            store.kvStore[kvPos + 1] = value;
+            return false;
+        }
+
+        // setting the key is a relatively expensive insertion
+        @Specialization(guards = "kvPos == KEY_NOT_FOUND")
+        static boolean keyDoesntExist(
+                RubyHash hash, CompactHashStore store, int kvPos, int keyHash, Object frozenKey, Object value,
+                @Cached @Exclusive InlinedConditionProfile kvResizingIsNeeded,
+                @Cached @Exclusive InlinedConditionProfile indexResizingIsNotNeeded,
+                @Cached @Exclusive InlinedLoopConditionProfile indexSlotUnavailable,
+                @Cached @Exclusive InlinedLoopConditionProfile idxSlotUnavailable,
+                @Cached @Exclusive InlinedLoopConditionProfile tillIndexArrayEnd,
+                @Bind("$node") Node node) {
+            resizeIndexIfNeeded(store, hash.size,
+                    indexResizingIsNotNeeded, idxSlotUnavailable, tillIndexArrayEnd, node);
+            resizeKvStoreIfNeeded(store,
+                    kvResizingIsNeeded, node);
+
+            int pos = store.kvStoreInsertionPos;
+            insertIntoKv(store, frozenKey, value);
+            insertIntoIndex(keyHash, pos + 1, store.index,
+                    indexSlotUnavailable, node);
+
+            hash.size++;
+            return true;
+        }
+
+        private static void insertIntoIndex(int keyHash, int kvPos, int[] index,
+                InlinedLoopConditionProfile unavailableSlot,
+                Node node) {
+            int pos = getIndexPosFromHash(keyHash, index.length);
+
+            boolean slotFilled = index[pos + 1] > INDEX_SLOT_UNUSED_MARKER;
+            while (unavailableSlot.profile(node, slotFilled)) {
+                pos = incrementIndexPos(pos, index.length);
+                slotFilled = index[pos + 1] > INDEX_SLOT_UNUSED_MARKER;
+            }
+
+            index[pos] = keyHash;
+            index[pos + 1] = kvPos;
+        }
+
+        private static void insertIntoKv(CompactHashStore store, Object key, Object value) {
+            store.kvStore[store.kvStoreInsertionPos] = key;
+            store.kvStore[store.kvStoreInsertionPos + 1] = value;
+            store.kvStoreInsertionPos += 2;
+        }
+
+        @TruffleBoundary
+        private static void resizeIndexIfNeeded(CompactHashStore store, int size,
+                InlinedConditionProfile indexResizingIsNotNeeded,
+                InlinedLoopConditionProfile indexSlotUnavailable,
+                InlinedLoopConditionProfile tillArrayEnd,
+                Node node) {
+            if (indexResizingIsNotNeeded.profile(node,
+                    size < store.numSlotsForIndexRebuild)) {
+                return;
+            }
+
+            int[] oldIndex = store.index;
+            store.index = new int[2 * oldIndex.length];
+
+            for (int i = 0; tillArrayEnd.inject(node, i < oldIndex.length); i += 2) {
+                int hash = oldIndex[i];
+                int kvPos = oldIndex[i + 1];
+
+                insertIntoIndex(hash, kvPos, store.index,
+                        indexSlotUnavailable, node);
+            }
+            store.numSlotsForIndexRebuild = (int) (oldIndex.length * THRESHOLD_LOAD_FACTOR_FOR_INDEX_REBUILD);
+        }
+
+        private static void resizeKvStoreIfNeeded(CompactHashStore store,
+                InlinedConditionProfile kvResizingIsNeeded,
+                Node node) {
+            if (kvResizingIsNeeded.profile(node, store.kvStoreInsertionPos >= store.kvStore.length)) {
+                store.kvStore = Arrays.copyOf(store.kvStore, 2 * store.kvStore.length);
+            }
+        }
+    }
+
+    private static void relocateHashIfPossible(int currPos, int relocationPos, int[] index,
+            InlinedConditionProfile relocationPossible,
+            Node node) {
+        if (relocationPossible.profile(node, relocationPos != INVALID_ARRAY_POSITION)) {
+            index[relocationPos] = index[currPos];
+            index[relocationPos + 1] = index[currPos + 1];
+            index[currPos + 1] = INDEX_SLOT_DELETED_MARKER;
+        }
+    }
+
+    public static final class CompactHashLiteralNode extends HashLiteralNode {
+        @Child HashStoreLibrary hashlib;
+
+        public CompactHashLiteralNode(RubyNode[] keyValues) {
+            super(keyValues);
+            hashlib = insert(HashStoreLibrary.createDispatched());
+        }
+
+        @ExplodeLoop
+        @Override
+        public Object execute(VirtualFrame frame) {
+            CompactHashStore store = new CompactHashStore(keyValues.length);
+            RubyHash hash = new RubyHash(coreLibrary().hashClass,
+                    getLanguage().hashShape,
+                    getContext(),
+                    store,
+                    0,
+                    false);
+            for (int i = 0; i < keyValues.length; i += 2) {
+                Object key = keyValues[i].execute(frame);
+                Object val = keyValues[i + 1].execute(frame);
+
+                hashlib.set(store, hash, key, val, false);
+            }
+            return hash;
+        }
+
+        @Override
+        public RubyNode cloneUninitialized() {
+            var copy = new CompactHashLiteralNode(cloneUninitialized(keyValues));
+            return copy.copyFlags(this);
+        }
+    }
+}

--- a/src/main/java/org/truffleruby/core/hash/library/CompactHashStore.java
+++ b/src/main/java/org/truffleruby/core/hash/library/CompactHashStore.java
@@ -314,6 +314,7 @@ public final class CompactHashStore {
         return ArrayHelpers.createArray(RubyContext.get(node), RubyLanguage.get(node), new Object[]{ key, val });
     }
 
+    @TruffleBoundary
     @ExportMessage
     void rehash(RubyHash hash,
             @Cached @Shared HashingNodes.ToHash hashFunction,

--- a/src/main/java/org/truffleruby/core/hash/library/CompactHashStore.java
+++ b/src/main/java/org/truffleruby/core/hash/library/CompactHashStore.java
@@ -188,7 +188,7 @@ public final class CompactHashStore {
             @Cached @Exclusive PropagateSharingNode propagateSharingForVal,
             @Cached SetKvAtNode setKv,
             @Bind("$node") Node node) {
-        var frozenKey = freezeKey.executeFreezeIfNeeded(key, byIdentity);
+        var frozenKey = freezeKey.executeFreezeIfNeeded(node, key, byIdentity);
         int keyHash = hashFunction.execute(frozenKey, byIdentity);
         int keyKvPos = IntPair.second(
                 getHashPosAndKvPos.execute(frozenKey, keyHash, byIdentity, index, kvStore));

--- a/src/main/java/org/truffleruby/core/hash/library/CompactHashStore.java
+++ b/src/main/java/org/truffleruby/core/hash/library/CompactHashStore.java
@@ -134,7 +134,7 @@ public final class CompactHashStore {
     }
 
     public CompactHashStore(int capacity) {
-        if (capacity < 1 || capacity > (1 << 28)) {
+        if (capacity < 1 || capacity >= (1 << 28)) {
             throw shouldNotReachHere();
         }
 
@@ -152,7 +152,7 @@ public final class CompactHashStore {
     }
 
     private static int roundUpwardsToNearestPowerOf2(int num) {
-        return Integer.highestOneBit(num - 1) << 1;
+        return Integer.highestOneBit(num) << 1; // rounds powers of 2 themselves : 1 => 2, 2 => 4, 3 => 4, 4 => 8, ...
     }
 
     public void putHashKeyValue(int hashcode, Object key, Object value) {

--- a/src/main/java/org/truffleruby/core/hash/library/CompactHashStore.java
+++ b/src/main/java/org/truffleruby/core/hash/library/CompactHashStore.java
@@ -255,7 +255,7 @@ public final class CompactHashStore {
         int i = 0;
         int callbackIdx = 0;
         try {
-            for (; loopProfile.inject(node, i < kvStore.length); i += 2) {
+            for (; loopProfile.inject(node, i < kvStoreInsertionPos); i += 2) {
                 if (keyNotNull.profile(node, kvStore[i] != null)) {
                     callback.accept(callbackIdx, kvStore[i], kvStore[i + 1], state);
                     callbackIdx++;

--- a/src/main/java/org/truffleruby/core/hash/library/CompactHashStore.java
+++ b/src/main/java/org/truffleruby/core/hash/library/CompactHashStore.java
@@ -628,18 +628,18 @@ public final class CompactHashStore {
         @ExplodeLoop
         @Override
         public Object execute(VirtualFrame frame) {
-            CompactHashStore store = new CompactHashStore(keyValues.length);
+            CompactHashStore store = new CompactHashStore(getNumberOfEntries());
             RubyHash hash = new RubyHash(coreLibrary().hashClass,
                     getLanguage().hashShape,
                     getContext(),
                     store,
                     0,
                     false);
+
             for (int i = 0; i < keyValues.length; i += 2) {
                 Object key = keyValues[i].execute(frame);
-                Object val = keyValues[i + 1].execute(frame);
-
-                hashes.set(store, hash, key, val, false);
+                Object value = keyValues[i + 1].execute(frame);
+                hashes.set(store, hash, key, value, false);
             }
             return hash;
         }

--- a/src/main/java/org/truffleruby/core/hash/library/CompactHashStore.java
+++ b/src/main/java/org/truffleruby/core/hash/library/CompactHashStore.java
@@ -22,6 +22,7 @@ import com.oracle.truffle.api.dsl.GenerateCached;
 import com.oracle.truffle.api.dsl.GenerateInline;
 import org.truffleruby.RubyContext;
 import org.truffleruby.RubyLanguage;
+import org.truffleruby.annotations.SuppressFBWarnings;
 import org.truffleruby.collections.PEBiFunction;
 import org.truffleruby.core.array.ArrayHelpers;
 import org.truffleruby.core.array.ArrayUtils;
@@ -567,6 +568,7 @@ public final class CompactHashStore {
         }
 
         // setting a new key is more expensive
+        @SuppressFBWarnings("IP_PARAMETER_IS_DEAD_BUT_OVERWRITTEN")
         @Specialization(guards = "keyPos < 0")
         static boolean keyDoesntExist(
                 Node node,

--- a/src/main/java/org/truffleruby/core/hash/library/HashStoreLibrary.java
+++ b/src/main/java/org/truffleruby/core/hash/library/HashStoreLibrary.java
@@ -61,9 +61,9 @@ public abstract class HashStoreLibrary extends Library {
     public abstract Object lookupOrDefault(Object store, Frame frame, RubyHash hash, Object key,
             PEBiFunction defaultNode);
 
-    /** Associates the key with the value and returns true only if the hash changed as a result of the operation (i.e.
-     * returns false if the key was already associated with the value). {@code byIdentity} indicates whether the key
-     * should be compared using Java identity, or using {@link SameOrEqlNode} semantics. */
+    /** Associates the key with the value and returns true only if the hash didn't contain the key before the operation
+     * (i.e. returns false if and only if the key was already associated with any value). {@code byIdentity} indicates
+     * whether the key should be compared using Java identity,or using {@link SameOrEqlNode} semantics. */
     @Abstract
     public abstract boolean set(Object store, RubyHash hash, Object key, Object value, boolean byIdentity);
 
@@ -103,7 +103,7 @@ public abstract class HashStoreLibrary extends Library {
     public abstract RubyArray shift(Object store, RubyHash hash);
 
     /** Re-hashes the keys in the hash (if the keys are mutable objects, then changes to these objects may change the
-     * hash. */
+     * hash.) */
     @Abstract
     public abstract void rehash(Object store, RubyHash hash);
 
@@ -116,7 +116,7 @@ public abstract class HashStoreLibrary extends Library {
         void accept(int index, Object key, Object value, Object state);
     }
 
-    /** Call the block with an key-value entry. If the block has > 1 arity, passes the key and the value as arguments,
+    /** Call the block with a key-value entry. If the block has > 1 arity, passes the key and the value as arguments,
      * otherwise passes an array containing the key and the value as single argument. */
     @GenerateUncached
     @GenerateInline(false)

--- a/src/main/java/org/truffleruby/core/hash/library/HashStoreLibrary.java
+++ b/src/main/java/org/truffleruby/core/hash/library/HashStoreLibrary.java
@@ -11,6 +11,7 @@ package org.truffleruby.core.hash.library;
 
 import org.truffleruby.collections.PEBiFunction;
 import org.truffleruby.core.array.RubyArray;
+import org.truffleruby.core.basicobject.ReferenceEqualNode;
 import org.truffleruby.core.hash.HashGuards;
 import org.truffleruby.core.hash.RubyHash;
 import org.truffleruby.core.kernel.KernelNodes.SameOrEqlNode;
@@ -64,7 +65,7 @@ public abstract class HashStoreLibrary extends Library {
 
     /** Associates the key with the value and returns true only if the hash didn't contain the key before the operation
      * (i.e. returns false if and only if the key was already associated with any value). {@code byIdentity} indicates
-     * whether the key should be compared using Java identity,or using {@link SameOrEqlNode} semantics. */
+     * whether the key should be compared using {@link ReferenceEqualNode} or {@link SameOrEqlNode}. */
     @Abstract
     public abstract boolean set(Object store, RubyHash hash, Object key, Object value, boolean byIdentity);
 
@@ -99,8 +100,8 @@ public abstract class HashStoreLibrary extends Library {
     @Abstract
     public abstract void replace(Object store, RubyHash hash, RubyHash dest);
 
-    /** Removes a key-value pair from the hash and returns it as the two-item array [key, value], or null if the hash is
-     * empty. */
+    /** Removes the first key-value pair in insertion order from the hash and returns it as the two-item array [key,
+     * value]. */
     @Abstract
     public abstract RubyArray shift(Object store, RubyHash hash);
 

--- a/src/main/java/org/truffleruby/core/hash/library/HashStoreLibrary.java
+++ b/src/main/java/org/truffleruby/core/hash/library/HashStoreLibrary.java
@@ -9,6 +9,15 @@
  */
 package org.truffleruby.core.hash.library;
 
+import org.truffleruby.collections.PEBiFunction;
+import org.truffleruby.core.array.RubyArray;
+import org.truffleruby.core.hash.HashGuards;
+import org.truffleruby.core.hash.RubyHash;
+import org.truffleruby.core.kernel.KernelNodes.SameOrEqlNode;
+import org.truffleruby.core.proc.RubyProc;
+import org.truffleruby.language.RubyBaseNode;
+import org.truffleruby.language.yield.CallBlockNode;
+
 import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.GenerateInline;
@@ -23,14 +32,6 @@ import com.oracle.truffle.api.library.LibraryFactory;
 import com.oracle.truffle.api.nodes.EncapsulatingNodeReference;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.profiles.InlinedConditionProfile;
-import org.truffleruby.collections.PEBiFunction;
-import org.truffleruby.core.array.RubyArray;
-import org.truffleruby.core.hash.HashGuards;
-import org.truffleruby.core.hash.RubyHash;
-import org.truffleruby.core.kernel.KernelNodes.SameOrEqlNode;
-import org.truffleruby.core.proc.RubyProc;
-import org.truffleruby.language.RubyBaseNode;
-import org.truffleruby.language.yield.CallBlockNode;
 
 /** Library for accessing and manipulating the storage used for representing hashes. This includes reading, modifying,
  * and copy the storage. */
@@ -83,13 +84,14 @@ public abstract class HashStoreLibrary extends Library {
     @Abstract
     public abstract Object deleteLast(Object store, RubyHash hash, Object key);
 
-    /** Calls {@code callback} on every entry in the hash, returning the state object. */
+    /** Calls {@code callback} on every entry in the hash, returning the state object. The callback object MUST be
+     * passed sequential increasing indices starting from 0 */
     @Abstract
     public abstract Object eachEntry(Object store, RubyHash hash, EachEntryCallback callback, Object state);
 
     /** Same as {@link #eachEntry(Object, RubyHash, EachEntryCallback, Object)} but guaranteed to be safe to use if the
-     * hash is modified during iteration. In particular, the guarantee is that the same entry won't be processed
-     * twice. */
+     * hash is modified during iteration. In particular, the guarantee is that the same entry won't be processed twice.
+     * The callback object MUST be passed sequential increasing indices starting from 0 */
     @Abstract
     public abstract Object eachEntrySafe(Object store, RubyHash hash, EachEntryCallback callback, Object state);
 

--- a/src/main/java/org/truffleruby/core/hash/library/PackedHashStoreLibrary.java
+++ b/src/main/java/org/truffleruby/core/hash/library/PackedHashStoreLibrary.java
@@ -63,12 +63,6 @@ public final class PackedHashStoreLibrary {
     private static final int ELEMENTS_PER_ENTRY = 3;
     public static final int TOTAL_ELEMENTS = MAX_ENTRIES * ELEMENTS_PER_ENTRY;
 
-    private static final boolean bigHashTypeIsCompact;
-    static {
-        String hashType = System.getProperty("BigHashStrategy");
-        bigHashTypeIsCompact = hashType != null && hashType.equalsIgnoreCase("compact");
-    }
-
     // region Utilities
 
     public static Object[] createStore() {
@@ -241,13 +235,18 @@ public final class PackedHashStoreLibrary {
                 return true;
             }
 
-            if (bigHashTypeIsCompact) {
-                promoteToCompact(hash, store, size);
-            } else {
-                promoteToBuckets(hash, store, size);
-            }
+            promoteToBigHash(store, hash, size);
+
             hashes.set(hash.store, hash, key2, value, byIdentity);
             return true;
+        }
+
+        private static void promoteToBigHash(Object[] store, RubyHash hash, int size) {
+            if (HashLiteralNode.BigHashConfiguredStrategy.isBuckets) {
+                promoteToBuckets(hash, store, size);
+            } else {
+                promoteToCompact(hash, store, size);
+            }
         }
     }
 

--- a/src/main/java/org/truffleruby/core/hash/library/PackedHashStoreLibrary.java
+++ b/src/main/java/org/truffleruby/core/hash/library/PackedHashStoreLibrary.java
@@ -63,6 +63,12 @@ public final class PackedHashStoreLibrary {
     private static final int ELEMENTS_PER_ENTRY = 3;
     public static final int TOTAL_ELEMENTS = MAX_ENTRIES * ELEMENTS_PER_ENTRY;
 
+    private static final boolean bigHashTypeIsCompact;
+    static {
+        String hashType = System.getProperty("BigHashStrategy");
+        bigHashTypeIsCompact = hashType != null && hashType.equalsIgnoreCase("compact");
+    }
+
     // region Utilities
 
     public static Object[] createStore() {
@@ -235,7 +241,11 @@ public final class PackedHashStoreLibrary {
                 return true;
             }
 
-            promoteToCompact(hash, store, size);
+            if (bigHashTypeIsCompact) {
+                promoteToCompact(hash, store, size);
+            } else {
+                promoteToBuckets(hash, store, size);
+            }
             hashes.set(hash.store, hash, key2, value, byIdentity);
             return true;
         }

--- a/src/main/java/org/truffleruby/core/hash/library/PackedHashStoreLibrary.java
+++ b/src/main/java/org/truffleruby/core/hash/library/PackedHashStoreLibrary.java
@@ -158,7 +158,7 @@ public final class PackedHashStoreLibrary {
     private static void promoteToCompact(RubyHash hash, Object[] store) {
         CompactHashStore newStore = new CompactHashStore(MAX_ENTRIES);
         for (int n = 0; n < MAX_ENTRIES; n++) {
-            newStore.putHashKeyValue(getHashed(store, n), getKey(store, n), getValue(store, n));
+            newStore.insertHashKeyValue(getHashed(store, n), getKey(store, n), getValue(store, n));
         }
         hash.store = newStore;
         hash.size = MAX_ENTRIES;

--- a/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
+++ b/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
@@ -218,31 +218,22 @@ public abstract class KernelNodes {
 
     /** Check if operands are the same object or call #eql? */
     @GenerateUncached
+    @GenerateCached(false)
+    @GenerateInline
     public abstract static class SameOrEqlNode extends RubyBaseNode {
 
-        @NeverDefault
-        public static SameOrEqlNode create() {
-            return KernelNodesFactory.SameOrEqlNodeGen.create();
+        public static boolean executeUncached(Object a, Object b) {
+            return KernelNodesFactory.SameOrEqlNodeGen.getUncached().execute(null, a, b);
         }
 
-        public static SameOrEqlNode getUncached() {
-            return KernelNodesFactory.SameOrEqlNodeGen.getUncached();
-        }
+        public abstract boolean execute(Node node, Object a, Object b);
 
-        public abstract boolean execute(Object a, Object b);
-
-        @Specialization(guards = "referenceEqual.execute(this, a, b)")
-        boolean refEqual(Object a, Object b,
-                @Cached @Shared ReferenceEqualNode referenceEqual) {
-            return true;
-        }
-
-        @Specialization(replaces = "refEqual")
-        boolean refEqualOrEql(Object a, Object b,
-                @Cached @Shared ReferenceEqualNode referenceEqual,
-                @Cached DispatchNode eql,
+        @Specialization
+        static boolean refEqualOrEql(Node node, Object a, Object b,
+                @Cached ReferenceEqualNode referenceEqual,
+                @Cached(inline = false) DispatchNode eql,
                 @Cached BooleanCastNode booleanCast) {
-            return referenceEqual.execute(this, a, b) || booleanCast.execute(this, eql.call(a, "eql?", b));
+            return referenceEqual.execute(node, a, b) || booleanCast.execute(node, eql.call(a, "eql?", b));
         }
     }
 

--- a/src/main/java/org/truffleruby/extra/RubyConcurrentMap.java
+++ b/src/main/java/org/truffleruby/extra/RubyConcurrentMap.java
@@ -52,7 +52,7 @@ public final class RubyConcurrentMap extends RubyDynamicObject {
                 return false;
             } else {
                 // Last resort - we have to actually call eql?
-                return SameOrEqlNode.getUncached().execute(key, otherKey.key);
+                return SameOrEqlNode.executeUncached(key, otherKey.key);
             }
         }
     }

--- a/src/main/java/org/truffleruby/options/LanguageOptions.java
+++ b/src/main/java/org/truffleruby/options/LanguageOptions.java
@@ -43,6 +43,8 @@ public final class LanguageOptions {
     public final boolean LAZY_TRANSLATION_USER;
     /** --backtraces-omit-unused=true */
     public final boolean BACKTRACES_OMIT_UNUSED;
+    /** --buckets-big-hash=false */
+    public final boolean BIG_HASH_STRATEGY_IS_BUCKETS;
     /** --lazy-translation-log=false */
     public final boolean LAZY_TRANSLATION_LOG;
     /** --constant-dynamic-lookup-log=false */
@@ -141,6 +143,7 @@ public final class LanguageOptions {
         STDLIB_AS_INTERNAL = options.get(OptionsCatalog.STDLIB_AS_INTERNAL_KEY);
         LAZY_TRANSLATION_USER = options.hasBeenSet(OptionsCatalog.LAZY_TRANSLATION_USER_KEY) ? options.get(OptionsCatalog.LAZY_TRANSLATION_USER_KEY) : LAZY_CALLTARGETS;
         BACKTRACES_OMIT_UNUSED = options.get(OptionsCatalog.BACKTRACES_OMIT_UNUSED_KEY);
+        BIG_HASH_STRATEGY_IS_BUCKETS = options.get(OptionsCatalog.BIG_HASH_STRATEGY_IS_BUCKETS_KEY);
         LAZY_TRANSLATION_LOG = options.get(OptionsCatalog.LAZY_TRANSLATION_LOG_KEY);
         LOG_DYNAMIC_CONSTANT_LOOKUP = options.get(OptionsCatalog.LOG_DYNAMIC_CONSTANT_LOOKUP_KEY);
         LAZY_BUILTINS = options.hasBeenSet(OptionsCatalog.LAZY_BUILTINS_KEY) ? options.get(OptionsCatalog.LAZY_BUILTINS_KEY) : LAZY_CALLTARGETS;
@@ -208,6 +211,8 @@ public final class LanguageOptions {
                 return LAZY_TRANSLATION_USER;
             case "ruby.backtraces-omit-unused":
                 return BACKTRACES_OMIT_UNUSED;
+            case "ruby.buckets-big-hash":
+                return BIG_HASH_STRATEGY_IS_BUCKETS;
             case "ruby.lazy-translation-log":
                 return LAZY_TRANSLATION_LOG;
             case "ruby.constant-dynamic-lookup-log":
@@ -310,6 +315,7 @@ public final class LanguageOptions {
                one.get(OptionsCatalog.STDLIB_AS_INTERNAL_KEY).equals(two.get(OptionsCatalog.STDLIB_AS_INTERNAL_KEY)) &&
                one.get(OptionsCatalog.LAZY_TRANSLATION_USER_KEY).equals(two.get(OptionsCatalog.LAZY_TRANSLATION_USER_KEY)) &&
                one.get(OptionsCatalog.BACKTRACES_OMIT_UNUSED_KEY).equals(two.get(OptionsCatalog.BACKTRACES_OMIT_UNUSED_KEY)) &&
+               one.get(OptionsCatalog.BIG_HASH_STRATEGY_IS_BUCKETS_KEY).equals(two.get(OptionsCatalog.BIG_HASH_STRATEGY_IS_BUCKETS_KEY)) &&
                one.get(OptionsCatalog.LAZY_TRANSLATION_LOG_KEY).equals(two.get(OptionsCatalog.LAZY_TRANSLATION_LOG_KEY)) &&
                one.get(OptionsCatalog.LOG_DYNAMIC_CONSTANT_LOOKUP_KEY).equals(two.get(OptionsCatalog.LOG_DYNAMIC_CONSTANT_LOOKUP_KEY)) &&
                one.get(OptionsCatalog.LAZY_BUILTINS_KEY).equals(two.get(OptionsCatalog.LAZY_BUILTINS_KEY)) &&
@@ -426,6 +432,13 @@ public final class LanguageOptions {
         newValue = newOptions.BACKTRACES_OMIT_UNUSED;
         if (!newValue.equals(oldValue)) {
             logger.fine("not reusing pre-initialized context: --backtraces-omit-unused differs, was: " + oldValue + " and is now: " + newValue);
+            return false;
+        }
+
+        oldValue = oldOptions.BIG_HASH_STRATEGY_IS_BUCKETS;
+        newValue = newOptions.BIG_HASH_STRATEGY_IS_BUCKETS;
+        if (!newValue.equals(oldValue)) {
+            logger.fine("not reusing pre-initialized context: --buckets-big-hash differs, was: " + oldValue + " and is now: " + newValue);
             return false;
         }
 

--- a/src/main/java/org/truffleruby/options/Options.java
+++ b/src/main/java/org/truffleruby/options/Options.java
@@ -93,8 +93,6 @@ public final class Options {
     public final boolean EXCEPTIONS_WARN_OUT_OF_MEMORY;
     /** --backtraces-interleave-java=false */
     public final boolean BACKTRACES_INTERLEAVE_JAVA;
-    /** --buckets-big-hash=false */
-    public final boolean BIG_HASH_STRATEGY;
     /** --backtraces-on-interrupt=false */
     public final boolean BACKTRACE_ON_INTERRUPT;
     /** --backtraces-sigalrm=!EMBEDDED */
@@ -249,7 +247,6 @@ public final class Options {
         EXCEPTIONS_WARN_STACKOVERFLOW = options.get(OptionsCatalog.EXCEPTIONS_WARN_STACKOVERFLOW_KEY);
         EXCEPTIONS_WARN_OUT_OF_MEMORY = options.get(OptionsCatalog.EXCEPTIONS_WARN_OUT_OF_MEMORY_KEY);
         BACKTRACES_INTERLEAVE_JAVA = options.get(OptionsCatalog.BACKTRACES_INTERLEAVE_JAVA_KEY);
-        BIG_HASH_STRATEGY = options.get(OptionsCatalog.BIG_HASH_STRATEGY_KEY);
         BACKTRACE_ON_INTERRUPT = options.get(OptionsCatalog.BACKTRACE_ON_INTERRUPT_KEY);
         BACKTRACE_ON_SIGALRM = options.hasBeenSet(OptionsCatalog.BACKTRACE_ON_SIGALRM_KEY) ? options.get(OptionsCatalog.BACKTRACE_ON_SIGALRM_KEY) : !EMBEDDED;
         BACKTRACE_ON_RAISE = options.get(OptionsCatalog.BACKTRACE_ON_RAISE_KEY);
@@ -381,8 +378,6 @@ public final class Options {
                 return EXCEPTIONS_WARN_OUT_OF_MEMORY;
             case "ruby.backtraces-interleave-java":
                 return BACKTRACES_INTERLEAVE_JAVA;
-            case "ruby.buckets-big-hash":
-                return BIG_HASH_STRATEGY;
             case "ruby.backtraces-on-interrupt":
                 return BACKTRACE_ON_INTERRUPT;
             case "ruby.backtraces-sigalrm":

--- a/src/main/java/org/truffleruby/options/Options.java
+++ b/src/main/java/org/truffleruby/options/Options.java
@@ -93,6 +93,8 @@ public final class Options {
     public final boolean EXCEPTIONS_WARN_OUT_OF_MEMORY;
     /** --backtraces-interleave-java=false */
     public final boolean BACKTRACES_INTERLEAVE_JAVA;
+    /** --buckets-big-hash=false */
+    public final boolean BIG_HASH_STRATEGY;
     /** --backtraces-on-interrupt=false */
     public final boolean BACKTRACE_ON_INTERRUPT;
     /** --backtraces-sigalrm=!EMBEDDED */
@@ -247,6 +249,7 @@ public final class Options {
         EXCEPTIONS_WARN_STACKOVERFLOW = options.get(OptionsCatalog.EXCEPTIONS_WARN_STACKOVERFLOW_KEY);
         EXCEPTIONS_WARN_OUT_OF_MEMORY = options.get(OptionsCatalog.EXCEPTIONS_WARN_OUT_OF_MEMORY_KEY);
         BACKTRACES_INTERLEAVE_JAVA = options.get(OptionsCatalog.BACKTRACES_INTERLEAVE_JAVA_KEY);
+        BIG_HASH_STRATEGY = options.get(OptionsCatalog.BIG_HASH_STRATEGY_KEY);
         BACKTRACE_ON_INTERRUPT = options.get(OptionsCatalog.BACKTRACE_ON_INTERRUPT_KEY);
         BACKTRACE_ON_SIGALRM = options.hasBeenSet(OptionsCatalog.BACKTRACE_ON_SIGALRM_KEY) ? options.get(OptionsCatalog.BACKTRACE_ON_SIGALRM_KEY) : !EMBEDDED;
         BACKTRACE_ON_RAISE = options.get(OptionsCatalog.BACKTRACE_ON_RAISE_KEY);
@@ -378,6 +381,8 @@ public final class Options {
                 return EXCEPTIONS_WARN_OUT_OF_MEMORY;
             case "ruby.backtraces-interleave-java":
                 return BACKTRACES_INTERLEAVE_JAVA;
+            case "ruby.buckets-big-hash":
+                return BIG_HASH_STRATEGY;
             case "ruby.backtraces-on-interrupt":
                 return BACKTRACE_ON_INTERRUPT;
             case "ruby.backtraces-sigalrm":

--- a/src/main/java/org/truffleruby/parser/ReloadArgumentsTranslator.java
+++ b/src/main/java/org/truffleruby/parser/ReloadArgumentsTranslator.java
@@ -114,7 +114,7 @@ public final class ReloadArgumentsTranslator extends Translator {
                 keyValues[2 * i] = key;
                 keyValues[2 * i + 1] = value;
             }
-            kwArgsNode = HashLiteralNode.create(keyValues);
+            kwArgsNode = HashLiteralNode.create(keyValues, language);
         }
 
         if (node.hasKeyRest()) {

--- a/src/main/java/org/truffleruby/parser/YARPReloadArgumentsTranslator.java
+++ b/src/main/java/org/truffleruby/parser/YARPReloadArgumentsTranslator.java
@@ -92,7 +92,7 @@ public final class YARPReloadArgumentsTranslator extends AbstractNodeVisitor<Rub
                 keyValues[2 * i] = key;
                 keyValues[2 * i + 1] = value;
             }
-            kwArgsNode = HashLiteralNode.create(keyValues);
+            kwArgsNode = HashLiteralNode.create(keyValues, language);
         }
 
         if (parametersNode.keyword_rest != null) {

--- a/src/main/java/org/truffleruby/parser/YARPTranslator.java
+++ b/src/main/java/org/truffleruby/parser/YARPTranslator.java
@@ -1358,7 +1358,7 @@ public class YARPTranslator extends AbstractNodeVisitor<RubyNode> {
     @Override
     public RubyNode visitHashNode(Nodes.HashNode node) {
         if (node.elements.length == 0) { // an empty Hash literal like h = {}
-            final RubyNode rubyNode = HashLiteralNode.create(RubyNode.EMPTY_ARRAY);
+            final RubyNode rubyNode = HashLiteralNode.create(RubyNode.EMPTY_ARRAY, language);
             return assignPositionAndFlags(node, rubyNode);
         }
 
@@ -1370,7 +1370,7 @@ public class YARPTranslator extends AbstractNodeVisitor<RubyNode> {
                 // This case is for splats {a: 1, **{b: 2}, c: 3}
                 if (!keyValues.isEmpty()) {
                     final RubyNode hashLiteralSoFar = HashLiteralNode
-                            .create(keyValues.toArray(RubyNode.EMPTY_ARRAY));
+                            .create(keyValues.toArray(RubyNode.EMPTY_ARRAY), language);
                     hashConcats.add(hashLiteralSoFar);
                 }
                 hashConcats.add(HashCastNodeGen.HashCastASTNodeGen.create(assocSplatNode.value.accept(this)));
@@ -1393,7 +1393,7 @@ public class YARPTranslator extends AbstractNodeVisitor<RubyNode> {
         }
 
         if (!keyValues.isEmpty()) {
-            final RubyNode hashLiteralSoFar = HashLiteralNode.create(keyValues.toArray(RubyNode.EMPTY_ARRAY));
+            final RubyNode hashLiteralSoFar = HashLiteralNode.create(keyValues.toArray(RubyNode.EMPTY_ARRAY), language);
             hashConcats.add(hashLiteralSoFar);
         }
 

--- a/src/options.yml
+++ b/src/options.yml
@@ -117,6 +117,9 @@ EXPERT:
     EXCEPTIONS_WARN_OUT_OF_MEMORY: [exceptions-warn-out-of-memory, boolean, true, Warn when an out-of-memory error is thrown]
     BACKTRACES_INTERLEAVE_JAVA: [backtraces-interleave-java, boolean, false, Interleave Java stacktraces into the Ruby backtrace]
     BACKTRACES_OMIT_UNUSED: [backtraces-omit-unused, boolean, true, Omit backtraces that should be unused as they have pure rescue expressions]
+    
+    # Big Hash Strategy
+    BIG_HASH_STRATEGY: [buckets-big-hash, boolean, false, 'Whether to use chaining-style bukcets hash store for hash tables exceeding the small hash limit']
 
     # Print backtraces at key events
     BACKTRACE_ON_INTERRUPT: [backtraces-on-interrupt, boolean, false, Show the backtraces of all Threads on Ctrl+C]

--- a/src/options.yml
+++ b/src/options.yml
@@ -23,6 +23,7 @@ LANGUAGE_OPTIONS:
 - PACK_UNROLL_LIMIT
 - NO_HOME_PROVIDED
 - COVERAGE_GLOBAL
+- BIG_HASH_STRATEGY_IS_BUCKETS
 # Inline cache sizes
 - DEFAULT_CACHE
 - METHOD_LOOKUP_CACHE
@@ -119,7 +120,7 @@ EXPERT:
     BACKTRACES_OMIT_UNUSED: [backtraces-omit-unused, boolean, true, Omit backtraces that should be unused as they have pure rescue expressions]
     
     # Big Hash Strategy
-    BIG_HASH_STRATEGY: [buckets-big-hash, boolean, false, 'Whether to use chaining-style bukcets hash store for hash tables exceeding the small hash limit']
+    BIG_HASH_STRATEGY_IS_BUCKETS: [buckets-big-hash, boolean, false, 'Whether to use chaining-style bukcets hash store for hash tables exceeding the small hash limit']
 
     # Print backtraces at key events
     BACKTRACE_ON_INTERRUPT: [backtraces-on-interrupt, boolean, false, Show the backtraces of all Threads on Ctrl+C]

--- a/src/shared/java/org/truffleruby/shared/options/OptionsCatalog.java
+++ b/src/shared/java/org/truffleruby/shared/options/OptionsCatalog.java
@@ -64,7 +64,7 @@ public final class OptionsCatalog {
     public static final OptionKey<Boolean> EXCEPTIONS_WARN_OUT_OF_MEMORY_KEY = new OptionKey<>(true);
     public static final OptionKey<Boolean> BACKTRACES_INTERLEAVE_JAVA_KEY = new OptionKey<>(false);
     public static final OptionKey<Boolean> BACKTRACES_OMIT_UNUSED_KEY = new OptionKey<>(true);
-    public static final OptionKey<Boolean> BIG_HASH_STRATEGY_KEY = new OptionKey<>(false);
+    public static final OptionKey<Boolean> BIG_HASH_STRATEGY_IS_BUCKETS_KEY = new OptionKey<>(false);
     public static final OptionKey<Boolean> BACKTRACE_ON_INTERRUPT_KEY = new OptionKey<>(false);
     public static final OptionKey<Boolean> BACKTRACE_ON_SIGALRM_KEY = new OptionKey<>(!EMBEDDED_KEY.getDefaultValue());
     public static final OptionKey<Boolean> BACKTRACE_ON_RAISE_KEY = new OptionKey<>(false);
@@ -520,8 +520,8 @@ public final class OptionsCatalog {
             .usageSyntax("")
             .build();
 
-    public static final OptionDescriptor BIG_HASH_STRATEGY = OptionDescriptor
-            .newBuilder(BIG_HASH_STRATEGY_KEY, "ruby.buckets-big-hash")
+    public static final OptionDescriptor BIG_HASH_STRATEGY_IS_BUCKETS = OptionDescriptor
+            .newBuilder(BIG_HASH_STRATEGY_IS_BUCKETS_KEY, "ruby.buckets-big-hash")
             .help("Whether to use chaining-style bukcets hash store for hash tables exceeding the small hash limit")
             .category(OptionCategory.EXPERT)
             .stability(OptionStability.EXPERIMENTAL)
@@ -1435,7 +1435,7 @@ public final class OptionsCatalog {
             case "ruby.backtraces-omit-unused":
                 return BACKTRACES_OMIT_UNUSED;
             case "ruby.buckets-big-hash":
-                return BIG_HASH_STRATEGY;
+                return BIG_HASH_STRATEGY_IS_BUCKETS;
             case "ruby.backtraces-on-interrupt":
                 return BACKTRACE_ON_INTERRUPT;
             case "ruby.backtraces-sigalrm":
@@ -1691,7 +1691,7 @@ public final class OptionsCatalog {
             EXCEPTIONS_WARN_OUT_OF_MEMORY,
             BACKTRACES_INTERLEAVE_JAVA,
             BACKTRACES_OMIT_UNUSED,
-            BIG_HASH_STRATEGY,
+            BIG_HASH_STRATEGY_IS_BUCKETS,
             BACKTRACE_ON_INTERRUPT,
             BACKTRACE_ON_SIGALRM,
             BACKTRACE_ON_RAISE,

--- a/src/shared/java/org/truffleruby/shared/options/OptionsCatalog.java
+++ b/src/shared/java/org/truffleruby/shared/options/OptionsCatalog.java
@@ -64,6 +64,7 @@ public final class OptionsCatalog {
     public static final OptionKey<Boolean> EXCEPTIONS_WARN_OUT_OF_MEMORY_KEY = new OptionKey<>(true);
     public static final OptionKey<Boolean> BACKTRACES_INTERLEAVE_JAVA_KEY = new OptionKey<>(false);
     public static final OptionKey<Boolean> BACKTRACES_OMIT_UNUSED_KEY = new OptionKey<>(true);
+    public static final OptionKey<Boolean> BIG_HASH_STRATEGY_KEY = new OptionKey<>(false);
     public static final OptionKey<Boolean> BACKTRACE_ON_INTERRUPT_KEY = new OptionKey<>(false);
     public static final OptionKey<Boolean> BACKTRACE_ON_SIGALRM_KEY = new OptionKey<>(!EMBEDDED_KEY.getDefaultValue());
     public static final OptionKey<Boolean> BACKTRACE_ON_RAISE_KEY = new OptionKey<>(false);
@@ -514,6 +515,14 @@ public final class OptionsCatalog {
     public static final OptionDescriptor BACKTRACES_OMIT_UNUSED = OptionDescriptor
             .newBuilder(BACKTRACES_OMIT_UNUSED_KEY, "ruby.backtraces-omit-unused")
             .help("Omit backtraces that should be unused as they have pure rescue expressions")
+            .category(OptionCategory.EXPERT)
+            .stability(OptionStability.EXPERIMENTAL)
+            .usageSyntax("")
+            .build();
+
+    public static final OptionDescriptor BIG_HASH_STRATEGY = OptionDescriptor
+            .newBuilder(BIG_HASH_STRATEGY_KEY, "ruby.buckets-big-hash")
+            .help("Whether to use chaining-style bukcets hash store for hash tables exceeding the small hash limit")
             .category(OptionCategory.EXPERT)
             .stability(OptionStability.EXPERIMENTAL)
             .usageSyntax("")
@@ -1425,6 +1434,8 @@ public final class OptionsCatalog {
                 return BACKTRACES_INTERLEAVE_JAVA;
             case "ruby.backtraces-omit-unused":
                 return BACKTRACES_OMIT_UNUSED;
+            case "ruby.buckets-big-hash":
+                return BIG_HASH_STRATEGY;
             case "ruby.backtraces-on-interrupt":
                 return BACKTRACE_ON_INTERRUPT;
             case "ruby.backtraces-sigalrm":
@@ -1680,6 +1691,7 @@ public final class OptionsCatalog {
             EXCEPTIONS_WARN_OUT_OF_MEMORY,
             BACKTRACES_INTERLEAVE_JAVA,
             BACKTRACES_OMIT_UNUSED,
+            BIG_HASH_STRATEGY,
             BACKTRACE_ON_INTERRUPT,
             BACKTRACE_ON_SIGALRM,
             BACKTRACE_ON_RAISE,

--- a/tool/generate-cext-trampoline.rb
+++ b/tool/generate-cext-trampoline.rb
@@ -109,12 +109,12 @@ static inline bool rb_tr_exception_from_java(void) {
 }
 
 RBIMPL_ATTR_NORETURN()
-static inline void rb_tr_exception_from_java_jump(void) {
+static inline void rb_tr_exception_from_java_jump(const char *function) {
   if (LIKELY(rb_tr_jmp_buf != NULL)) {
     // fprintf(stderr, "There was an exception, longjmp()'ing");
     RUBY_LONGJMP(*rb_tr_jmp_buf, 1);
   } else {
-    fprintf(stderr, "ERROR: There was an exception in Java but rb_tr_jmp_buf is NULL.");
+    fprintf(stderr, "ERROR: There was a Java exception when returning from %s() but rb_tr_jmp_buf is NULL.", function);
     abort();
   }
 }
@@ -217,7 +217,7 @@ C
       else
         f.puts "  if (UNLIKELY(rb_tr_exception_from_java())) {"
       end
-      f.puts "    rb_tr_exception_from_java_jump();"
+      f.puts "    rb_tr_exception_from_java_jump(#{function_name.dump});"
       f.puts "  }"
       f.puts "  UNREACHABLE;" if no_return
     else
@@ -229,7 +229,7 @@ C
       end
       f.puts "  #{return_type} _result = impl_#{function_name}(#{argument_names});"
       f.puts "  if (UNLIKELY(rb_tr_exception_from_java())) {"
-      f.puts "    rb_tr_exception_from_java_jump();"
+      f.puts "    rb_tr_exception_from_java_jump(#{function_name.dump});"
       f.puts "  }"
       f.puts "  return _result;"
     end


### PR DESCRIPTION
This implements a "Compact" approach to hash tables, described at a high level 
[here](https://blog.toit.io/hash-maps-that-dont-hate-you-1a96150b492a).  TLDR : This is a representation strategy that efficiently (hopefully!) allows insertion-order preserving hash tables. It aims to replace the BucketHashStorage strategy.

Currently appears to pass all the tests. 