### PR TITLE
Store deduped paths in $LOADED_FEATURES

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Compatibility:
 * Add `Refinement#refined_class` (#3039, @itarato).
 * Add `rb_hash_new_capa` function (#3039, @itarato).
 * Fix `Encoding::Converter#primitive_convert` and raise `FrozenError` when a destination buffer argument is frozen (@andrykonchin).
+* Deduplicate strings in `$LOADED_FEATURES` (#3182, @rwstauner).
 
 Performance:
 

--- a/spec/ruby/core/kernel/shared/require.rb
+++ b/spec/ruby/core/kernel/shared/require.rb
@@ -325,6 +325,12 @@ describe :kernel_require, shared: true do
       @path = File.expand_path("load_fixture.rb", CODE_LOADING_DIR)
     end
 
+    it "stores a deduped path" do
+      path = -@path
+      @object.require(path).should be_true
+      $LOADED_FEATURES.last.should equal(path)
+    end
+
     it "stores an absolute path" do
       @object.require(@path).should be_true
       $LOADED_FEATURES.should include(@path)

--- a/src/main/ruby/truffleruby/core/truffle/feature_loader.rb
+++ b/src/main/ruby/truffleruby/core/truffle/feature_loader.rb
@@ -218,7 +218,7 @@ module Truffle
     # Add feature to $LOADED_FEATURES and the index, called from RequireNode
     def self.provide_feature(feature)
       raise '$LOADED_FEATURES is frozen; cannot append feature' if $LOADED_FEATURES.frozen?
-      #feature.freeze # TODO freeze these but post-boot.rb issue using replace
+      feature = -feature unless Truffle::Boot.preinitializing?
       with_synchronized_features do
         get_loaded_features_index
         $LOADED_FEATURES << feature
@@ -294,7 +294,7 @@ module Truffle
         @loaded_features_index.clear
         $LOADED_FEATURES.map! do |val|
           val = StringValue(val)
-          #val.freeze # TODO freeze these but post-boot.rb issue using replace
+          val = -val unless Truffle::Boot.preinitializing?
           val
         end
         $LOADED_FEATURES.each_with_index do |val, idx|


### PR DESCRIPTION
This is probably naive and incomplete, but I managed to get it to work and now I can share it to ask how it should be done.

I noticed that bootsnap has some tests where it assumes the items in $LOADED_FEATURES are deduplicated strings:
https://github.com/Shopify/bootsnap/blob/2ea29bed2c027d8eb6a008d78db4a46ce68d1fa4/test/load_path_cache/cache_test.rb#L173-L181

It seems to be the case in CRuby so I added a spec for it and wanted to see what it would take in TruffleRuby.
I did find some existing comments about it so it seems like something we wanted to pursue here.

I don't even know if I'm using the right terminology (deduped strings)
and this is the first time I encountered the `post-boot` stuff
so I'd be glad for any feedback or direction in how to accomplish this correctly.

`$LOAD_PATH` also contains frozen strings in ruby, but i didn't dig further to figure out how that might be accomplished.  If you have any pointers I'd be glad to integrate that.

Thanks!