### PR TITLE
Show the FFI pointer size information if it's available when inpecting the object.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Compatibility:
 * Add `rb_syserr_new` function (@rwstauner).
 * Add `Enumerator#product` (#3039, @itarato).
 * Add `Module#const_added` (#3039,  @itarato).
+* Show the pointer size information (if available) in `FFI::Pointer#inspect` (@nirvdrum).
 
 Performance:
 

--- a/src/main/ruby/truffleruby/core/truffle/ffi/pointer.rb
+++ b/src/main/ruby/truffleruby/core/truffle/ffi/pointer.rb
@@ -98,7 +98,12 @@ module Truffle::FFI
         sign = ''
       end
 
-      "#<#{Primitive.class(self).name} address=#{sign}0x#{addr.to_s(16)}>"
+      size = Primitive.pointer_size(self)
+      if size != UNBOUNDED
+        "#<#{Primitive.class(self).name} address=#{sign}0x#{addr.to_s(16)} size=#{size}>"
+      else
+        "#<#{Primitive.class(self).name} address=#{sign}0x#{addr.to_s(16)}>"
+      end
     end
 
     def null?


### PR DESCRIPTION
I've opened an _ffi_ PR with relevant [spec changes](https://github.com/ffi/ffi/pull/1041). I've run them locally to verify they fail without this PR and pass with these changes. The _ffi_ PR is failing CI on _truffleruby-head_ pending the merge of this PR.