### PR TITLE
Display "unhandled exception" as the message for `RuntimeError` instances with an empty message.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Compatibility:
 * Show the pointer size information (if available) in `FFI::Pointer#inspect` (@nirvdrum).
 * Implement performance warnings (`Warning[:performance]`) like in CRuby 3.3 (@eregon).
 * The output of `Marshal.dump` is now compatible with CRuby for `Rational` and `Complex` instances (#3228, @eregon).
+* Display "unhandled exception" as the message for `RuntimeError` instances with an empty message (#3255, @nirvdrum).
 
 Performance:
 

--- a/spec/ruby/core/exception/full_message_spec.rb
+++ b/spec/ruby/core/exception/full_message_spec.rb
@@ -46,6 +46,33 @@ describe "Exception#full_message" do
     full_message[0].should.end_with?("': Some runtime error (RuntimeError)\n")
   end
 
+  describe "includes details about whether an exception was handled" do
+    describe "RuntimeError" do
+      it "should report as unhandled if message is empty" do
+        err = RuntimeError.new("")
+
+        err.full_message.should =~ /unhandled exception/
+        err.full_message(highlight: true).should =~ /unhandled exception/
+        err.full_message(highlight: false).should =~ /unhandled exception/
+      end
+
+      it "should not report as unhandled if the message is not empty" do
+        err = RuntimeError.new("non-empty")
+        
+        err.full_message.should !~ /unhandled exception/
+        err.full_message(highlight: true).should !~ /unhandled exception/
+        err.full_message(highlight: false).should !~ /unhandled exception/
+      end
+    end
+
+    describe "generic Error" do
+      it "should not report as unhandled in any event" do
+        StandardError.new("").full_message.should !~ /unhandled exception/
+        StandardError.new("non-empty").full_message.should !~ /unhandled exception/
+      end
+    end
+  end
+
   it "shows the exception class at the end of the first line of the message when the message contains multiple lines" do
     begin
       line = __LINE__; raise "first line\nsecond line"


### PR DESCRIPTION
FIxes #3255. Once this is merged we can remove two more test exclusions in the IRB test suite.

/cc @st0012 