### PR TITLE
Optimize feature loading when require is called with absolute .rb path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Compatibility:
 Performance:
 
 * Optimize calls with `ruby2_keywords` forwarding by deciding it per call site instead of per callee thanks to [my fix in CRuby 3.2](https://bugs.ruby-lang.org/issues/18625) (@eregon).
+* Optimize feature loading when require is called with an absolute path to a .rb file (@rwstauner).
 
 Changes:
 

--- a/spec/ruby/core/kernel/shared/require.rb
+++ b/spec/ruby/core/kernel/shared/require.rb
@@ -212,6 +212,32 @@ end
 
 describe :kernel_require, shared: true do
   describe "(path resolution)" do
+    it "loads .rb file when passed absolute path without extension" do
+      path = File.expand_path "load_fixture", CODE_LOADING_DIR
+      @object.send(@method, path).should be_true
+      # This should _not_ be [:no_ext]
+      ScratchPad.recorded.should == [:loaded]
+    end
+
+    platform_is :linux, :darwin do
+      it "loads c-extension file when passed absolute path without extension when no .rb is present" do
+        path = File.join CODE_LOADING_DIR, "a", "load_fixture"
+        -> { @object.send(@method, path) }.should raise_error(Exception, /file too short/)
+      end
+    end
+
+    platform_is :darwin do
+      it "loads .bundle file when passed absolute path with .so" do
+        path = File.join CODE_LOADING_DIR, "a", "load_fixture.so"
+        -> { @object.send(@method, path) }.should raise_error(Exception, /load_fixture\.bundle.+file too short/)
+      end
+    end
+
+    it "does not try an extra .rb if the path already ends in .rb" do
+      path = File.join CODE_LOADING_DIR, "d", "load_fixture.rb"
+      -> { @object.send(@method, path) }.should raise_error(LoadError)
+    end
+
     # For reference see [ruby-core:24155] in which matz confirms this feature is
     # intentional for security reasons.
     it "does not load a bare filename unless the current working directory is in $LOAD_PATH" do

--- a/spec/ruby/fixtures/code/d/load_fixture.rb.rb
+++ b/spec/ruby/fixtures/code/d/load_fixture.rb.rb
@@ -1,0 +1,1 @@
+ScratchPad << :rbrb

--- a/spec/tags/core/kernel/require_tags.txt
+++ b/spec/tags/core/kernel/require_tags.txt
@@ -2,8 +2,6 @@ slow:Kernel#require (concurrently) blocks based on the path
 slow:Kernel.require (concurrently) blocks based on the path
 slow:Kernel#require ($LOADED_FEATURES) unicode_normalize is part of core and not $LOADED_FEATURES
 slow:Kernel.require ($LOADED_FEATURES) unicode_normalize is part of core and not $LOADED_FEATURES
-fails:Kernel#require (non-extensioned path) loads a .rb extensioned file when a C-extension file exists on an earlier load path
-fails:Kernel#require (non-extensioned path) does not load a feature twice when $LOAD_PATH has been modified
 slow:Kernel#require ($LOADED_FEATURES) complex, enumerator, rational, thread, ruby2_keywords are already required
 slow:Kernel.require ($LOADED_FEATURES) complex, enumerator, rational, thread, ruby2_keywords are already required
 slow:Kernel#require complex, enumerator, rational, thread, ruby2_keywords, fiber are already required

--- a/src/main/java/org/truffleruby/platform/Platform.java
+++ b/src/main/java/org/truffleruby/platform/Platform.java
@@ -34,6 +34,7 @@ public abstract class Platform extends BasicPlatform {
 
     public static final String LIB_SUFFIX = determineLibSuffix();
     public static final String CEXT_SUFFIX = OS == OS_TYPE.DARWIN ? ".bundle" : LIB_SUFFIX;
+    public static final boolean CEXT_SUFFIX_IS_SO = CEXT_SUFFIX.equals(".so");
 
     private static String determineLibSuffix() {
         switch (OS) {


### PR DESCRIPTION
If `require` is called with an absolute path like `/path/to/thing.rb` we can try that as is first rather than trying `.rb.rb` and `.rb.so` first.

After enabling bootsnap's LoadPathCache on TruffleRuby we noticed that it was still doing a lot of ENOENT stat calls and found that it was trying odd-looking suffixes first:

```
$ bin/jt ruby --ruby.log-feature-location -e 'require "#{ENV["PWD"]}/tmp/rws.rb"' 2>&1 | grep rws.rb
  'require "#{ENV["PWD"]}/tmp/rws.rb"'
[ruby] INFO: starting search from -e:1 for feature /rws-data/repos/truffleruby-ws/truffleruby/tmp/rws.rb...
[ruby] INFO: trying /rws-data/repos/truffleruby-ws/truffleruby/tmp/rws.rb.rb...
[ruby] INFO: trying /rws-data/repos/truffleruby-ws/truffleruby/tmp/rws.rb.so...
[ruby] INFO: trying /rws-data/repos/truffleruby-ws/truffleruby/tmp/rws.rb...
[ruby] INFO: found in /rws-data/repos/truffleruby-ws/truffleruby/tmp/rws.rb
found rws.rb
```

With this change it only has to try one file (instead of three):
```
$ bin/jt ruby --ruby.log-feature-location -e 'require "#{ENV["PWD"]}/tmp/rws.rb"' 2>&1 | grep rws.rb
  'require "#{ENV["PWD"]}/tmp/rws.rb"'
[ruby] INFO: starting search from -e:1 for feature /rws-data/repos/truffleruby-ws/truffleruby/tmp/rws.rb...
[ruby] INFO: trying /rws-data/repos/truffleruby-ws/truffleruby/tmp/rws.rb...
[ruby] INFO: found in /rws-data/repos/truffleruby-ws/truffleruby/tmp/rws.rb
found rws.rb
```

I considered making this check "if the path has an extension", but since the next condition looks specifically for `.so` and does something extra I thought leaving it as `.rb` might be safest.

I tried to dig through the history of the file for extra context on the rest of this function.
The only one that stood to me was 8d10af1b5457cab89213b9ac01e74e2467a0dce8 but I don't fully understand the scenario there.

I also wasn't sure if there are tests that were worth adding for this... have any pointers?

What do you think?  Does this make sense?  Is there other opportunity for improvement to this function?