### PR TITLE
Implement rb_frame_method_id_and_class internal API.

### DIFF
--- a/src/main/c/cext/call.c
+++ b/src/main/c/cext/call.c
@@ -214,3 +214,7 @@ VALUE rb_eval_cmd_kw(VALUE cmd, VALUE args, int kw_splat) {
     return RUBY_CEXT_INVOKE("rb_eval_string", cmd);
   }
 }
+
+int rb_frame_method_id_and_class(ID *idp, VALUE *klassp) {
+    return RUBY_CEXT_INVOKE("rb_frame_method_id_and_class", idp, klassp);
+}


### PR DESCRIPTION
This commit implements the rb_frame_method_and_id internal API, that is needed by the rice gem. The corresponding changeset represents a first but hopefully significant step to get the torch.rb gem working on Truffleruby.