### PR TITLE
Properly handle argument Socket::INADDR_ANY in Socket.sockaddr_in.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Compatibility:
 * Promote `File#path` and `File#to_path` to `IO#path` and `IO#to_path` and make IO#new accept an optional `path:` keyword argument (#3039, @moste00)
 * Display "unhandled exception" as the message for `RuntimeError` instances with an empty message (#3255, @nirvdrum).
 * Set `RbConfig::CONFIG['configure_args']` for openssl and libyaml (#3170, #3303, @eregon).
+* Support `Socket.sockaddr_in(port, Socket::INADDR_ANY)` (#3361, @mtortonesi).
 
 Performance:
 

--- a/lib/truffle/socket/truffle/foreign.rb
+++ b/lib/truffle/socket/truffle/foreign.rb
@@ -266,9 +266,13 @@ module Truffle
             # to succeed on some platforms (most notably, Solaris).
             Integer(port)
             type = ::Socket::SOCK_DGRAM
-          rescue ArgumentError
+          rescue ArgumentError, TypeError
             # Ignored.
           end
+        end
+
+        if Primitive.nil?(port)
+          port = 0
         end
 
         hints = Addrinfo.new

--- a/lib/truffle/socket/truffle/foreign.rb
+++ b/lib/truffle/socket/truffle/foreign.rb
@@ -277,7 +277,7 @@ module Truffle
         hints[:ai_socktype] = type
         hints[:ai_flags]    = flags
 
-        if host and host.empty?
+        if host == ::Socket::INADDR_ANY or (host and host.empty?)
           host = '0.0.0.0'
         end
 

--- a/spec/ruby/library/socket/shared/pack_sockaddr.rb
+++ b/spec/ruby/library/socket/shared/pack_sockaddr.rb
@@ -17,6 +17,9 @@ describe :socket_pack_sockaddr_in, shared: true do
 
     sockaddr_in = Socket.public_send(@method, nil, '127.0.0.1')
     Socket.unpack_sockaddr_in(sockaddr_in).should == [0, '127.0.0.1']
+
+    sockaddr_in = Socket.public_send(@method, 80, Socket::INADDR_ANY)
+    Socket.unpack_sockaddr_in(sockaddr_in).should == [80, '0.0.0.0']
   end
 
   platform_is_not :solaris do

--- a/spec/ruby/library/socket/socket/pack_sockaddr_in_spec.rb
+++ b/spec/ruby/library/socket/socket/pack_sockaddr_in_spec.rb
@@ -2,6 +2,6 @@ require_relative '../spec_helper'
 require_relative '../fixtures/classes'
 require_relative '../shared/pack_sockaddr'
 
-describe "Socket#pack_sockaddr_in" do
+describe "Socket.pack_sockaddr_in" do
   it_behaves_like :socket_pack_sockaddr_in, :pack_sockaddr_in
 end

--- a/spec/tags/library/socket/socket/pack_sockaddr_in_tags.txt
+++ b/spec/tags/library/socket/socket/pack_sockaddr_in_tags.txt
@@ -1,1 +1,0 @@
-fails:Socket#pack_sockaddr_in packs and unpacks


### PR DESCRIPTION
Fixes #3361.