### PR TITLE
Add `Integer#ceilvdiv`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Compatibility:
 * Implement the `Data` class from Ruby 3.2 (#3039, @moste00, @eregon).
 * Make `Coverage.start` and `Coverage.result` accept parameters (#3149, @mtortonesi, @andrykonchin).
 * Implement `rb_check_funcall()` (@eregon).
+* Add `Integer#ceildiv` method (#3039, @simonlevasseur, @nirvdrum).
 
 Performance:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Bug fixes:
 * Fix `Range#bsearch` and raise `TypeError` when range boundaries are non-numeric and block not passed (@andrykonchin).
 * Fix using the `--cpusampler` profiler when there are custom unblock functions for `rb_thread_call_without_gvl()` (#3013, @eregon).
 * Fix recursive raising `FrozenError` exception when redefined `#inspect` modifies an object (#3388, @andrykonchin).
+* Fix `Integer#div` returning the wrong object type when the divisor is a `Rational` (@simonlevasseur, @nirvdrum).
 
 Compatibility:
 

--- a/spec/ruby/core/integer/div_spec.rb
+++ b/spec/ruby/core/integer/div_spec.rb
@@ -143,4 +143,12 @@ describe "Integer#div" do
       -> { @bignum.div(-0) }.should raise_error(ZeroDivisionError)
     end
   end
+
+  context "rational" do
+    it "returns self divided by the given argument as an Integer" do
+      2.div(6/5r).should == 1
+      1.div(6/5r).should == 0
+      5.div(6/5r).should == 4
+    end
+  end
 end

--- a/spec/tags/core/integer/ceildiv_tags.txt
+++ b/spec/tags/core/integer/ceildiv_tags.txt
@@ -1,1 +1,0 @@
-fails:Integer#ceildiv returns a quotient of division which is rounded up to the nearest integer

--- a/src/main/java/org/truffleruby/core/numeric/IntegerNodes.java
+++ b/src/main/java/org/truffleruby/core/numeric/IntegerNodes.java
@@ -49,6 +49,7 @@ import org.truffleruby.core.string.RubyString;
 import org.truffleruby.language.NoImplicitCastsToLong;
 import org.truffleruby.language.NotProvided;
 import org.truffleruby.language.RubyBaseNode;
+import org.truffleruby.language.RubyGuards;
 import org.truffleruby.language.WarnNode;
 import org.truffleruby.language.control.RaiseException;
 import org.truffleruby.language.dispatch.DispatchNode;
@@ -495,15 +496,18 @@ public abstract class IntegerNodes {
         @Specialization
         Object idiv(Object a, Object b,
                 @Cached InlinedConditionProfile zeroProfile,
-                @Cached FloatToIntegerNode floatToIntegerNode) {
+                @Cached FloatToIntegerNode floatToIntegerNode,
+                @Cached DispatchNode floorNode) {
             Object quotient = divNode.executeDiv(a, b);
             if (quotient instanceof Double) {
                 if (zeroProfile.profile(this, (double) b == 0.0)) {
                     throw new RaiseException(getContext(), coreExceptions().zeroDivisionError(this));
                 }
                 return floatToIntegerNode.execute(this, Math.floor((double) quotient));
-            } else {
+            } else if (RubyGuards.isRubyInteger(quotient)) {
                 return quotient;
+            } else {
+                return floorNode.call(quotient, "floor");
             }
         }
 

--- a/src/main/ruby/truffleruby/core/integer.rb
+++ b/src/main/ruby/truffleruby/core/integer.rb
@@ -88,6 +88,10 @@ class Integer < Numeric
     ((self / x) + 1) * x
   end
 
+  def ceildiv(other)
+    -div(-other)
+  end
+
   def coerce(other)
     if Primitive.is_a?(other, Integer)
       return [other, self]


### PR DESCRIPTION
This PR implements the new Ruby 3.2 method `Integer#ceildiv`. In the process of implementing it, we discovered that `Integer#idiv` was broken with a `Rational` divisor. Since `ceildiv` is implemented by using `idiv`, we combined that fix into this PR.

/cc @simonlevasseur 