### PR TITLE
Handle positional or keywords args for Struct without keyword_init: true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Compatibility:
 * Fix `Coverage.supported?` and raise `TypeError` if argument is not Symbol (#3039, @andrykonchin).
 * Accept options argument to `Regexp.{new,compile}` of String and warn for unknown types (#3039, @rwstauner).
 * Implement `Time#deconstruct_keys` from Ruby 3.2 (#3039, @rwstauner).
+* Handle either positional or keywords arguments by default in `Struct.new` (#3039, @rwstauner).
 
 Performance:
 

--- a/spec/tags/core/struct/initialize_tags.txt
+++ b/spec/tags/core/struct/initialize_tags.txt
@@ -1,2 +1,0 @@
-fails:Struct#initialize warns about passing only keyword arguments
-fails:Struct#initialize can be initialized with keyword arguments

--- a/spec/tags/core/struct/new_tags.txt
+++ b/spec/tags/core/struct/new_tags.txt
@@ -1,1 +1,0 @@
-fails:Struct.new on subclasses accepts keyword arguments to initialize


### PR DESCRIPTION
I'm not 100% sure I'm understanding the desired behavior correctly.

If `keyword_init: true` then keywords only.
If `keyword_init: false` then positional only.
If `keyword_init: nil` (default) then allow either.

Looking at https://docs.ruby-lang.org/en/3.2/Struct.html#method-c-new I think the change we want is to allow either style when nil?

I had a hard time deciding what tests appeared relevant, I wonder if we want any more specs.