### PR TITLE
Remove "fails:" tags that are passing now

### DIFF
--- a/spec/tags/core/binding/irb_tags.txt
+++ b/spec/tags/core/binding/irb_tags.txt
@@ -1,2 +1,1 @@
 slow:Binding#irb creates an IRB session with the binding in scope
-fails:Binding#irb creates an IRB session with the binding in scope

--- a/spec/tags/core/dir/element_reference_tags.txt
+++ b/spec/tags/core/dir/element_reference_tags.txt
@@ -1,6 +1,3 @@
-fails:Dir.[] result is sorted by default
-fails:Dir.[] result is sorted with sort: true
-fails:Dir.[] sort: false returns same files
 fails:Dir.[] raises an ArgumentError if sort: is not true or false
 fails:Dir.[] matches dotfiles except .. with '.*'
 fails:Dir.[] matches dotfiles in the current directory except .. with '.**'

--- a/spec/tags/core/encoding/list_tags.txt
+++ b/spec/tags/core/encoding/list_tags.txt
@@ -1,1 +1,0 @@
-fails:Encoding.list includes CESU-8 encoding

--- a/spec/tags/core/enumerator/new_tags.txt
+++ b/spec/tags/core/enumerator/new_tags.txt
@@ -1,2 +1,1 @@
-fails:Enumerator.new when passed a block defines iteration with block, yielder argument and treating it as a proc
 fails:Enumerator.new no block given raises

--- a/spec/tags/core/exception/no_method_error_tags.txt
+++ b/spec/tags/core/exception/no_method_error_tags.txt
@@ -1,1 +1,0 @@
-fails:NoMethodError#message uses #name to display the receiver if it is a class or a module

--- a/spec/tags/core/file/expand_path_tags.txt
+++ b/spec/tags/core/file/expand_path_tags.txt
@@ -19,5 +19,3 @@ slow:File.expand_path raises an Encoding::CompatibilityError if the external enc
 slow:File.expand_path does not modify the string argument
 slow:File.expand_path does not modify a HOME string argument
 slow:File.expand_path returns a String when passed a String subclass
-fails:File.expand_path when HOME is not set uses the user database when passed '~' if HOME is nil
-fails:File.expand_path when HOME is not set uses the user database when passed '~/' if HOME is nil

--- a/spec/tags/core/file/printf_tags.txt
+++ b/spec/tags/core/file/printf_tags.txt
@@ -3,14 +3,5 @@ fails:File#printf other formats c supports Unicode characters
 fails:File#printf other formats s does not try to convert with to_str
 fails:File#printf flags # applies to format o does nothing for negative argument
 fails:File#printf flags # applies to formats bBxX does nothing for zero argument
-fails:File#printf flags # applies to formats aAeEfgG forces a decimal point to be added, even if no digits follow
-fails:File#printf flags # applies to gG does not remove trailing zeros
-fails:File#printf flags - left-justifies the result of conversion if width is specified
-fails:File#printf flags 0 (zero) applies to numeric formats bBdiouxXaAeEfgG and width is specified uses radix-1 when displays negative argument as a two's complement
-fails:File#printf flags * left-justifies the result if width is negative
-fails:File#printf flags * left-justifies the result if specified with $ argument is negative
-fails:File#printf precision string formats determines the maximum number of characters to be copied from the string
-fails:File#printf reference by name %{name} style supports flags, width and precision
-fails:File#printf other formats % alone raises an ArgumentError
 fails:File#printf other formats c displays only the first character if argument is a string of several characters
 fails:File#printf other formats c displays no characters if argument is an empty string

--- a/spec/tags/core/integer/chr_tags.txt
+++ b/spec/tags/core/integer/chr_tags.txt
@@ -1,1 +1,0 @@
-fails:Integer#chr with an encoding argument returns a String encoding self interpreted as a codepoint in the CESU-8 encoding

--- a/spec/tags/core/io/for_fd_tags.txt
+++ b/spec/tags/core/io/for_fd_tags.txt
@@ -1,4 +1,2 @@
 fails:IO.for_fd ignores the :encoding option when the :external_encoding option is present
 fails:IO.for_fd ignores the :encoding option when the :internal_encoding option is present
-fails:IO.for_fd raises ArgumentError for nil options
-fails:IO.for_fd raises ArgumentError if passed a hash for mode and nil for options

--- a/spec/tags/core/io/new_tags.txt
+++ b/spec/tags/core/io/new_tags.txt
@@ -1,4 +1,2 @@
 fails:IO.new ignores the :encoding option when the :external_encoding option is present
 fails:IO.new ignores the :encoding option when the :internal_encoding option is present
-fails:IO.new raises ArgumentError for nil options
-fails:IO.new raises ArgumentError if passed a hash for mode and nil for options

--- a/spec/tags/core/io/open_tags.txt
+++ b/spec/tags/core/io/open_tags.txt
@@ -1,5 +1,3 @@
 fails:IO.open propagates an exception raised by #close that is a StandardError
 fails:IO.open ignores the :encoding option when the :external_encoding option is present
 fails:IO.open ignores the :encoding option when the :internal_encoding option is present
-fails:IO.open raises ArgumentError for nil options
-fails:IO.open raises ArgumentError if passed a hash for mode and nil for options

--- a/spec/tags/core/kernel/Complex_tags.txt
+++ b/spec/tags/core/kernel/Complex_tags.txt
@@ -1,1 +1,0 @@
-fails:Kernel.Complex() when passed exception: false and non-numeric String arguments swallows an error

--- a/spec/tags/core/kernel/proc_tags.txt
+++ b/spec/tags/core/kernel/proc_tags.txt
@@ -1,1 +1,0 @@
-fails:Kernel#proc raises an ArgumentError when passed no block

--- a/spec/tags/core/kernel/warn_tags.txt
+++ b/spec/tags/core/kernel/warn_tags.txt
@@ -4,7 +4,3 @@ slow:Kernel#warn does not call Warning.warn if self is the Warning module
 slow:Kernel#warn avoids recursion if Warning#warn is redefined and calls super
 slow:Kernel#warn :uplevel keyword argument skips <internal: core library methods defined in Ruby
 fails:Kernel#warn :uplevel keyword argument skips <internal: core library methods defined in Ruby
-fails:Kernel#warn :uplevel keyword argument accepts :category keyword with a symbol
-fails:Kernel#warn :uplevel keyword argument accepts :category keyword with nil
-fails:Kernel#warn :uplevel keyword argument accepts :category keyword with object convertible to symbol
-fails:Kernel#warn :uplevel keyword argument raises if :category keyword is not nil and not convertible to symbol

--- a/spec/tags/core/main/private_tags.txt
+++ b/spec/tags/core/main/private_tags.txt
@@ -1,1 +1,0 @@
-fails:main#private returns argument

--- a/spec/tags/core/main/public_tags.txt
+++ b/spec/tags/core/main/public_tags.txt
@@ -1,1 +1,0 @@
-fails:main#public returns argument

--- a/spec/tags/core/module/class_eval_tags.txt
+++ b/spec/tags/core/module/class_eval_tags.txt
@@ -1,3 +1,2 @@
 fails:Module#class_eval activates refinements from the eval scope
-fails:Module#class_eval activates refinements from the eval scope with block
 fails:Module#class_eval raises an ArgumentError when more than 3 arguments are given

--- a/spec/tags/core/module/const_added_tags.txt
+++ b/spec/tags/core/module/const_added_tags.txt
@@ -1,8 +1,0 @@
-fails:Module#const_added is a private instance method
-fails:Module#const_added returns nil in the default implementation
-fails:Module#const_added is called when a new constant is assigned on self
-fails:Module#const_added is called when a new constant is assigned on self through const_set
-fails:Module#const_added is called when a new module is defined under self
-fails:Module#const_added is called when a new class is defined under self
-fails:Module#const_added is called when an autoload is defined
-fails:Module#const_added is called with a precise caller location with the line of definition

--- a/spec/tags/core/module/module_eval_tags.txt
+++ b/spec/tags/core/module/module_eval_tags.txt
@@ -1,3 +1,2 @@
 fails:Module#module_eval activates refinements from the eval scope
-fails:Module#module_eval activates refinements from the eval scope with block
 fails:Module#module_eval raises an ArgumentError when more than 3 arguments are given

--- a/spec/tags/core/module/prepend_tags.txt
+++ b/spec/tags/core/module/prepend_tags.txt
@@ -1,3 +1,2 @@
-fails:Module#prepend reports the class for the owner of a method aliased from the prepended module
 fails:Module#prepend uses only new module when dupping the module
 fails:Module#prepend prepends a module if it is included in a super class

--- a/spec/tags/core/numeric/step_tags.txt
+++ b/spec/tags/core/numeric/step_tags.txt
@@ -1,15 +1,8 @@
 fails:Numeric#step with positional args when no block is given returns an Enumerator::ArithmeticSequence when step is 0
-fails:Numeric#step with positional args when no block is given returns an Enumerator::ArithmeticSequence when not passed a block and self > stop
-fails:Numeric#step with positional args when no block is given returns an Enumerator::ArithmeticSequence when not passed a block and self < stop
 fails:Numeric#step with positional args when no block is given returns an Enumerator::ArithmeticSequence when step is 0.0
 fails:Numeric#step with positional args when no block is given returned Enumerator::ArithmeticSequence size is infinity when step is 0
 fails:Numeric#step with positional args when no block is given returned Enumerator::ArithmeticSequence size is infinity when step is 0.0
-fails:Numeric#step with positional args when no block is given returned Enumerator::ArithmeticSequence type returns an instance of Enumerator::ArithmeticSequence
 fails:Numeric#step with keyword arguments when no block is given returns an Enumerator::ArithmeticSequence when step is 0
-fails:Numeric#step with keyword arguments when no block is given returns an Enumerator::ArithmeticSequence when not passed a block and self > stop
-fails:Numeric#step with keyword arguments when no block is given returns an Enumerator::ArithmeticSequence when not passed a block and self < stop
 fails:Numeric#step with mixed arguments when no block is given returns an Enumerator::ArithmeticSequence when step is 0
-fails:Numeric#step with mixed arguments when no block is given returns an Enumerator::ArithmeticSequence when not passed a block and self > stop
-fails:Numeric#step with mixed arguments when no block is given returns an Enumerator::ArithmeticSequence when not passed a block and self < stop
 fails:Numeric#step with mixed arguments  raises an ArgumentError when step is 0
 fails:Numeric#step with mixed arguments raises an ArgumentError when step is 0.0

--- a/spec/tags/core/proc/source_location_tags.txt
+++ b/spec/tags/core/proc/source_location_tags.txt
@@ -1,1 +1,0 @@
-fails:Proc#source_location returns nil for a core method that has been proc-ified

--- a/spec/tags/core/process/groups_tags.txt
+++ b/spec/tags/core/process/groups_tags.txt
@@ -1,2 +1,1 @@
 slow:Process.groups gets an Array of the gids of groups in the supplemental group access list
-fails:Process.groups gets an Array of the gids of groups in the supplemental group access list

--- a/spec/tags/core/process/groups_tags.txt
+++ b/spec/tags/core/process/groups_tags.txt
@@ -1,1 +1,2 @@
 slow:Process.groups gets an Array of the gids of groups in the supplemental group access list
+fails(fails consistently on darwin):Process.groups gets an Array of the gids of groups in the supplemental group access list

--- a/spec/tags/core/process/kill_tags.txt
+++ b/spec/tags/core/process/kill_tags.txt
@@ -12,6 +12,3 @@ slow:Process.kill signals the process group if the signal number is negative
 slow:Process.kill signals the process group if the short signal name starts with a minus sign
 slow:Process.kill signals the process group if the full signal name starts with a minus sign
 fails(flaky):Process.kill signals the process group if the short signal name starts with a minus sign
-fails:Process.kill signals the process group if the PID is zero
-fails:Process.kill signals the process group if the signal number is negative
-fails:Process.kill signals the process group if the full signal name starts with a minus sign

--- a/spec/tags/core/process/ppid_tags.txt
+++ b/spec/tags/core/process/ppid_tags.txt
@@ -1,1 +1,0 @@
-fails:Process.ppid returns the process id of the parent of this process

--- a/spec/tags/core/process/ppid_tags.txt
+++ b/spec/tags/core/process/ppid_tags.txt
@@ -1,0 +1,1 @@
+slow:Process.ppid returns the process id of the parent of this process

--- a/spec/tags/core/string/byteslice_tags.txt
+++ b/spec/tags/core/string/byteslice_tags.txt
@@ -1,2 +1,0 @@
-fails:String#byteslice with index, length returns String instances
-fails:String#byteslice with Range returns String instances

--- a/spec/tags/core/string/valid_encoding_tags.txt
+++ b/spec/tags/core/string/valid_encoding_tags.txt
@@ -1,1 +1,0 @@
-fails:String#valid_encoding? returns true for IBM720 encoding self is valid in

--- a/spec/tags/core/warning/element_set_tags.txt
+++ b/spec/tags/core/warning/element_set_tags.txt
@@ -1,3 +1,2 @@
 slow:Warning.[]= emits and suppresses warnings for :deprecated
 slow:Warning.[]= :experimental emits and suppresses warnings for :experimental
-fails:Warning.[]= :experimental emits and suppresses warnings for :experimental

--- a/spec/tags/language/END_tags.txt
+++ b/spec/tags/language/END_tags.txt
@@ -11,4 +11,3 @@ slow:The END keyword runs only once for multiple calls
 slow:The END keyword warns when END is used in a method
 slow:The END keyword END blocks and at_exit callbacks are mixed runs them all in reverse order of registration
 slow:The END keyword is affected by the toplevel assignment
-fails(prism, https://github.com/ruby/prism/issues/2082):The END keyword warns when END is used in a method

--- a/spec/tags/language/assignments_tags.txt
+++ b/spec/tags/language/assignments_tags.txt
@@ -1,4 +1,1 @@
-fails:Assignments using += using compounded constants causes side-effects of the module part to be applied only once (when assigns)
-fails:Assignments using += using an accessor ignores method visibility when receiver is self
-fails:Assignments using += using a #[] ignores method visibility when receiver is self
 fails:Assignments using += using a #[] splatted argument calls #to_a only once

--- a/spec/tags/language/block_tags.txt
+++ b/spec/tags/language/block_tags.txt
@@ -1,2 +1,0 @@
-fails:Post-args with optional args with a circular argument reference raises a SyntaxError if using an existing local with the same name as the argument
-fails:Post-args with optional args with a circular argument reference raises a SyntaxError if there is an existing method with the same name as the argument

--- a/spec/tags/language/def_tags.txt
+++ b/spec/tags/language/def_tags.txt
@@ -1,3 +1,1 @@
-fails:An instance method raises FrozenError with the correct class name
 fails:A singleton method definition raises FrozenError with the correct class name
-fails:An instance method with a default argument raises a SyntaxError when there is an existing method with the same name as the local variable

--- a/spec/tags/language/defined_tags.txt
+++ b/spec/tags/language/defined_tags.txt
@@ -1,14 +1,4 @@
 fails:The defined? keyword for a scoped constant returns nil when a constant is defined on top-level but not on the class
-fails:The defined? keyword for a scoped constant returns nil when an undefined constant is scoped to a defined constant
-fails:The defined? keyword for a top-level scoped constant returns nil when an undefined constant is scoped to a defined constant
-fails:The defined? keyword for a self-send method call scoped constant returns nil if the last constant is not defined in the scope chain
-fails:The defined? keyword for a receiver method call scoped constant returns nil if the last constant is not defined in the scope chain
-fails:The defined? keyword for a module method call scoped constant returns nil if the last constant in the scope chain is not defined
-fails:The defined? keyword for a variable scoped constant returns nil if the instance scoped constant is not defined
-fails:The defined? keyword for a variable scoped constant returns nil if the global scoped constant is not defined
-fails:The defined? keyword for a variable scoped constant returns nil if the class scoped constant is not defined
-fails:The defined? keyword for a variable scoped constant returns nil if the local scoped constant is not defined
 fails:The defined? keyword when called with a method name in a void context warns about the void context when parsing it
-fails:The defined? keyword for an expression returns 'expression' for an assigning a fully qualified constant with '+='
 fails:The defined? keyword for an expression &&= returns 'expression' for assigning a fully qualified constant with '&&='
 fails:The defined? keyword for an expression ||= returns 'expression' for assigning a fully qualified constant with '||='

--- a/spec/tags/language/lambda_tags.txt
+++ b/spec/tags/language/lambda_tags.txt
@@ -1,4 +1,0 @@
-fails:A lambda literal -> () { } assigns variables from parameters with circular optional argument reference raises a SyntaxError if using an existing local with the same name as the argument
-fails:A lambda literal -> () { } assigns variables from parameters with circular optional argument reference raises a SyntaxError if there is an existing method with the same name as the argument
-fails(https://github.com/ruby/prism/issues/2067):"A lambda literal -> () { } assigns variables from parameters for definition \n    @a = -> (a: @a = -> (a: 1) { a }, b:) do\n      [a, b]\n    end"
-fails(https://github.com/ruby/prism/issues/2067):"A lambda expression 'lambda { ... }' assigns variables from parameters for definition \n    @a = lambda do |a: (@a = -> (a: 1) { a }), b:|\n      [a, b]\n    end"

--- a/spec/tags/language/magic_comment_tags.txt
+++ b/spec/tags/language/magic_comment_tags.txt
@@ -47,14 +47,9 @@ slow:Magic comments in an -e argument are optional
 slow:Magic comments in an -e argument are case-insensitive
 slow:Magic comments in an -e argument must be at the first line
 slow:Magic comments in an -e argument must be the first token of the line
+fails:Magic comments in an -e argument do not cause bytes to be mangled by passing them through the wrong encoding
 slow:Magic comments in an -e argument can be after the shebang
 slow:Magic comments in an -e argument can take Emacs style
 slow:Magic comments in an -e argument can take vim style
 slow:Magic comments in an -e argument determine __ENCODING__
 slow:Magic comments in an -e argument do not cause bytes to be mangled by passing them through the wrong encoding
-fails:Magic comments in an -e argument are case-insensitive
-fails:Magic comments in an -e argument can be after the shebang
-fails:Magic comments in an -e argument can take Emacs style
-fails:Magic comments in an -e argument can take vim style
-fails:Magic comments in an -e argument determine __ENCODING__
-fails:Magic comments in an -e argument do not cause bytes to be mangled by passing them through the wrong encoding

--- a/spec/tags/language/method_tags.txt
+++ b/spec/tags/language/method_tags.txt
@@ -1,9 +1,1 @@
-fails:An endless method definition without arguments for definition 'def m() = 42'
-fails:An endless method definition with arguments for definition 'def m(a, b) = a + b'
-fails:"An endless method definition with multiline body for definition \n    def m(n) =\n      if n > 2\n        m(n - 2) + m(n - 1)\n      else\n        1\n      end"
-fails:"An endless method definition with args forwarding for definition \n    def mm(word, num:)\n      word * num\n    end\n    def m(...) = mm(...) + mm(...)"
-fails:kwarg with omitted value in a method call accepts short notation 'kwarg' in method call for definition 'def call(*args, **kwargs) = [args, kwargs]'
-fails:"kwarg with omitted value in a method call with methods and local variables for definition \n    def call(*args, **kwargs) = [args, kwargs]\n    def bar\n      "baz"\n    end\n    def foo(val)\n      call bar:, val:\n    end"
-fails:An endless method definition without arguments without parenthesis for definition 'def m = 42'
-fails:Inside 'endless' method definitions allows method calls without parenthesis
 fails:A method assigns local variables from method parameters for definition 'def m(a, **nil); a end;'

--- a/spec/tags/language/numbers_tags.txt
+++ b/spec/tags/language/numbers_tags.txt
@@ -1,1 +1,0 @@
-fails:A number literal can be a float literal with trailing 'r' to represent a Rational

--- a/spec/tags/language/optional_assignments_tags.txt
+++ b/spec/tags/language/optional_assignments_tags.txt
@@ -1,5 +1,2 @@
-fails:Optional constant assignment with &&= causes side-effects of the module part to be applied only once (when assigns)
-fails:Optional variable assignments using ||= using a #[] ignores method visibility when receiver is self
-fails:Optional variable assignments using &&= using a #[] ignores method visibility when receiver is self
 fails:Optional variable assignments using ||= using a #[] splatted argument calls #to_a only once
 fails:Optional variable assignments using &&= using a #[] splatted argument calls #to_a only once

--- a/spec/tags/language/regexp/character_classes_tags.txt
+++ b/spec/tags/language/regexp/character_classes_tags.txt
@@ -1,1 +1,0 @@
-fails(https://github.com/ruby/prism/issues/2116):Regexp with character classes supports [[:alpha:][:digit:][:etc:]] (predefined character classes)

--- a/spec/tags/language/regexp/grouping_tags.txt
+++ b/spec/tags/language/regexp/grouping_tags.txt
@@ -1,1 +1,0 @@
-fails(https://github.com/ruby/prism/issues/2116):Regexps with grouping raises a SyntaxError when parentheses aren't balanced

--- a/spec/tags/language/regexp/modifiers_tags.txt
+++ b/spec/tags/language/regexp/modifiers_tags.txt
@@ -1,2 +1,0 @@
-fails(https://github.com/ruby/prism/issues/2116):Regexps with modifiers supports (?imx-imx) (inline modifiers)
-fails(https://github.com/ruby/prism/issues/2116):Regexps with modifiers supports (?imx-imx:expr) (scoped inline modifiers)

--- a/spec/tags/language/regexp_tags.txt
+++ b/spec/tags/language/regexp_tags.txt
@@ -1,2 +1,1 @@
 fails(https://github.com/ruby/prism/issues/2115):Literal Regexps matches against $_ (last input) in a conditional if no explicit matchee provided
-fails(https://github.com/ruby/prism/issues/2116):Literal Regexps throws SyntaxError for malformed literals

--- a/spec/tags/language/super_tags.txt
+++ b/spec/tags/language/super_tags.txt
@@ -1,1 +1,0 @@
-fails:The super keyword without explicit arguments that are '_'

--- a/spec/tags/language/symbol_tags.txt
+++ b/spec/tags/language/symbol_tags.txt
@@ -1,3 +1,2 @@
 slow:A Symbol literal inherits the encoding of the magic comment and can have a binary encoding
-fails(cannot parse a Symbol with binary encoding and non-ASCII characters):A Symbol literal inherits the encoding of the magic comment and can have a binary encoding
 fails(https://github.com/ruby/prism/issues/2129):A Symbol literal raises an EncodingError at parse time when Symbol with invalid bytes

--- a/spec/tags/truffle/methods_tags.txt
+++ b/spec/tags/truffle/methods_tags.txt
@@ -81,24 +81,16 @@ fails:Public methods on StringIO should not include to_yaml_properties
 fails:Public methods on StringIO should not include yaml_initialize
 fails:Public methods on StringIO should include set_encoding_by_bom
 fails:Public methods on Process.singleton_class should include getsid
-fails:Public methods on ENV.singleton_class should include clone
-fails:Public methods on ENV.singleton_class should include dup
 fails:Public methods on GC.singleton_class should include using_rvargc?
 fails:Public methods on Class should include attached_object
 fails:Public methods on Enumerable should include to_set
-fails:Public methods on Exception should include detailed_message
 fails:Public methods on Fiber should include storage
 fails:Public methods on Fiber should include storage=
-fails:Public methods on File should not include path
-fails:Public methods on File should not include to_path
 fails:Public methods on GC.singleton_class should include stat_heap
 fails:Public methods on IO should not include nread
 fails:Public methods on IO should not include ready?
-fails:Public methods on IO should include path
 fails:Public methods on IO should include timeout
 fails:Public methods on IO should include timeout=
-fails:Public methods on IO should include to_path
-fails:Public methods on Integer should include ceildiv
 fails:Public methods on Kernel should not include =~
 fails:Public methods on Method should not include private?
 fails:Public methods on Method should not include protected?

--- a/spec/tags/truffle/methods_tags.txt
+++ b/spec/tags/truffle/methods_tags.txt
@@ -100,9 +100,6 @@ fails:Public methods on IO should include timeout=
 fails:Public methods on IO should include to_path
 fails:Public methods on Integer should include ceildiv
 fails:Public methods on Kernel should not include =~
-fails:Public methods on MatchData should include byteoffset
-fails:Public methods on MatchData should include deconstruct
-fails:Public methods on MatchData should include deconstruct_keys
 fails:Public methods on Method should not include private?
 fails:Public methods on Method should not include protected?
 fails:Public methods on Method should not include public?


### PR DESCRIPTION
I noticed the MatchData ones were unnecessary, then ran `jt purge spec/truffle/methods_spec.rb` and it found more.

I also ran `tool/run_each_spec.rb`.
There were a few other fails tags with what sounded like manually added descriptions so I kept them:

spec/tags/core/file/ftype_tags.txt
-fails(depends on cwd length):File.ftype returns 'socket' when the file is a socket

spec/tags/core/process/kill_tags.txt
-fails(flaky):Process.kill signals the process group if the short signal name starts with a minus sign

spec/tags/core/process/setpriority_tags.txt
-fails(with EACCES Permission denied in some CIs):Process.setpriority sets the scheduling priority for a specified process group

spec/tags/core/process/spawn_tags.txt
-fails(spurious failure):Process.spawn when passed close_others: false does not close file descriptors >= 3 in the child process if fds are set close_on_exec=false -fails(spurious failure):Process.spawn when passed close_others: false closes file descriptors >= 3 in the child process because they are set close_on_exec by default -fails(spurious failure):Process.spawn when passed close_others: true closes file descriptors >= 3 in the child process even if fds are set close_on_exec=false

spec/tags/core/thread/raise_tags.txt
-fails(spurious failure):Thread#raise on a running thread can go unhandled