### PR TITLE
Support connect_timeout keyword arg in TCPSocket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Compatibility:
 * Implement `Time#deconstruct_keys` from Ruby 3.2 (#3039, @rwstauner).
 * Do not autosplat a proc that accepts a single positional argument and keywords (#3039, @andrykonchin).
 * Support passing anonymous * and ** parameters as method call arguments (#3039, @andrykonchin).
+* Support `connect_timeout` keyword argument to `TCPSocket.{new,open}` (#3421, @manefz, @patricklinpl, @nirvdrum, @rwstauner).
 
 Performance:
 

--- a/lib/truffle/socket/tcp_socket.rb
+++ b/lib/truffle/socket/tcp_socket.rb
@@ -44,7 +44,7 @@ class TCPSocket < IPSocket
     [hostname, alternatives, family, *addresses]
   end
 
-  def initialize(host, service, local_host = nil, local_service = nil)
+  def initialize(host, service, local_host = nil, local_service = nil, connect_timeout: nil)
     @no_reverse_lookup = Primitive.class(self).do_not_reverse_lookup
 
     if host
@@ -108,7 +108,7 @@ class TCPSocket < IPSocket
       end
 
       connect_status = Truffle::Socket::Foreign
-        .connect(descriptor, Socket.sockaddr_in(port, address))
+        .connect(descriptor, Socket.sockaddr_in(port, address), connect_timeout)
 
       break if connect_status >= 0
     end

--- a/spec/tags/library/socket/tcpsocket/initialize_tags.txt
+++ b/spec/tags/library/socket/tcpsocket/initialize_tags.txt
@@ -1,8 +1,7 @@
-fails:TCPSocket#initialize raises Errno::ETIMEDOUT with :connect_timeout when no server is listening on the given address
-fails:TCPSocket#initialize with a running server connects to a server when passed connect_timeout argument
-fails:TCPSocket#initialize raises IO::TimeoutError with :connect_timeout when no server is listening on the given address
 fails:TCPSocket#initialize with a running server does not use the given block and warns to use TCPSocket::open
 fails:TCPSocket#initialize using IPv4 when a server is listening on the given address creates a socket which is set to nonblocking
 fails:TCPSocket#initialize using IPv4 when a server is listening on the given address creates a socket which is set to close on exec
 fails:TCPSocket#initialize using IPv6 when a server is listening on the given address creates a socket which is set to nonblocking
 fails:TCPSocket#initialize using IPv6 when a server is listening on the given address creates a socket which is set to close on exec
+slow:TCPSocket#initialize raises IO::TimeoutError with :connect_timeout when no server is listening on the given address
+slow:TCPSocket#initialize with a running server connects to a server when passed connect_timeout argument

--- a/spec/tags/library/socket/tcpsocket/open_tags.txt
+++ b/spec/tags/library/socket/tcpsocket/open_tags.txt
@@ -1,3 +1,2 @@
-fails:TCPSocket.open raises Errno::ETIMEDOUT with :connect_timeout when no server is listening on the given address
-fails:TCPSocket.open with a running server connects to a server when passed connect_timeout argument
-fails:TCPSocket.open raises IO::TimeoutError with :connect_timeout when no server is listening on the given address
+slow:TCPSocket.open raises IO::TimeoutError with :connect_timeout when no server is listening on the given address
+slow:TCPSocket.open with a running server connects to a server when passed connect_timeout argument

--- a/src/main/ruby/truffleruby/core/io.rb
+++ b/src/main/ruby/truffleruby/core/io.rb
@@ -38,6 +38,8 @@ class IO
 
   include Enumerable
 
+  class TimeoutError < IOError; end
+
   module WaitReadable; end
   module WaitWritable; end
 

--- a/test/mri/excludes/TestSocket_TCPSocket.rb
+++ b/test/mri/excludes/TestSocket_TCPSocket.rb
@@ -1,5 +1,4 @@
 exclude :test_initialize_failure, "needs investigation"
 exclude :test_inspect, "needs investigation"
 exclude :test_recvfrom, "needs investigation"
-exclude :test_initialize_connect_timeout, "needs investigation"
 exclude :test_initialize_resolv_timeout, "needs investigation"


### PR DESCRIPTION
Accept the `connect_timeout` keyword argument to TCPSocket.new
and wrap the connect call with `Timeout.timeout` when provided.

closes #3421