### PR TITLE
Array inject accept strings

### DIFF
--- a/spec/ruby/core/enumerable/shared/inject.rb
+++ b/spec/ruby/core/enumerable/shared/inject.rb
@@ -18,6 +18,10 @@ describe :enumerable_inject, shared: true do
     EnumerableSpecs::Numerous.new(1, 2, 3).send(@method, 10, :-).should == 4
   end
 
+  it "can take a string as the second argument" do
+    EnumerableSpecs::Numerous.new(1, 2, 3).send(@method, 10, "-").should == 4
+  end
+
   it "ignores the block if two arguments" do
     -> {
       EnumerableSpecs::Numerous.new(1, 2, 3).send(@method, 10, :-) { raise "we never get here"}.should == 4
@@ -39,6 +43,10 @@ describe :enumerable_inject, shared: true do
 
   it "can take a symbol argument" do
     EnumerableSpecs::Numerous.new(10, 1, 2, 3).send(@method, :-).should == 4
+  end
+
+  it "can take a string argument" do
+    EnumerableSpecs::Numerous.new(10, 1, 2, 3).send(@method, "-").should == 4
   end
 
   it "without argument takes a block with an accumulator (with first element as initial value) and the current element. Value of block becomes new accumulator" do


### PR DESCRIPTION
Attempt to address https://github.com/oracle/truffleruby/issues/2931. This expands the specialisations for InjectNode to accept strings in place of symbols.

Local test:
```
➜  truffleruby git:(master) ✗ jt ruby -e "p [2,3].inject('*')"
$ /.../ruby \
  --experimental-options \
  --core-load-path=/.../truffleruby/src/main/ruby/truffleruby \
  -e \
  p\ \[2,3\].inject\(\'\*\'\)
6
➜  truffleruby git:(master) ✗ jt ruby -e "p [2,3].inject(3, '*')"
Using Interpreted TruffleRuby: mxbuild/truffleruby-jvm
$ /.../truffleruby/mxbuild/truffleruby-jvm/languages/ruby/bin/ruby \
  --experimental-options \
  --core-load-path=/.../truffleruby/src/main/ruby/truffleruby \
  -e \
  p\ \[2,3\].inject\(3,\ \'\*\'\)
18
```