### PR TITLE
Remove constant `Random::DEFAULT`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Bug fixes:
 * Fix using the `--cpusampler` profiler when there are custom unblock functions for `rb_thread_call_without_gvl()` (#3013, @eregon).
 * Fix recursive raising `FrozenError` exception when redefined `#inspect` modifies an object (#3388, @andrykonchin).
 * Fix `Integer#div` returning the wrong object type when the divisor is a `Rational` (@simonlevasseur, @nirvdrum).
+* Remove constant `Random::DEFAULT` (#3039, @patricklinpl)
 
 Compatibility:
 

--- a/spec/tags/core/random/default_tags.txt
+++ b/spec/tags/core/random/default_tags.txt
@@ -1,2 +1,0 @@
-slow:Random::DEFAULT changes seed on reboot
-fails:Random::DEFAULT is no longer defined

--- a/src/main/ruby/truffleruby/core/random.rb
+++ b/src/main/ruby/truffleruby/core/random.rb
@@ -53,9 +53,6 @@ class Truffle::CustomRandomizer < Truffle::Randomizer
 end
 
 class Random
-  DEFAULT = self
-  deprecate_constant :DEFAULT
-
   def self.new_seed
     Primitive.thread_randomizer.generate_seed
   end


### PR DESCRIPTION
Part of https://github.com/oracle/truffleruby/issues/3039

Remove constant `Random::DEFAULT`