### PR TITLE
Add lambda keyword argument to Proc#parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Compatibility:
 * Do not autosplat a proc that accepts a single positional argument and keywords (#3039, @andrykonchin).
 * Support passing anonymous * and ** parameters as method call arguments (#3039, @andrykonchin).
 * Handle either positional or keywords arguments by default in `Struct.new` (#3039, @rwstauner).
+* Support `lambda` keyword argument in `Proc#parameters` (#3039, @thomasmarshall, @goyox86).
 
 Performance:
 

--- a/spec/ruby/core/proc/parameters_spec.rb
+++ b/spec/ruby/core/proc/parameters_spec.rb
@@ -33,6 +33,16 @@ describe "Proc#parameters" do
     it "regards named parameters in lambda as optional if lambda: false keyword used" do
       -> x { }.parameters(lambda: false).first.first.should == :opt
     end
+
+    it "regards named parameters in procs and lambdas as required if lambda keyword is truthy" do
+      proc {|x| }.parameters(lambda: 123).first.first.should == :req
+      -> x { }.parameters(lambda: 123).first.first.should == :req
+    end
+
+    it "ignores the lambda keyword if it is nil" do
+      proc {|x|}.parameters(lambda: nil).first.first.should == :opt
+      -> x { }.parameters(lambda: nil).first.first.should == :req
+    end
   end
 
   it "regards optional keyword parameters in procs as optional" do

--- a/spec/tags/core/proc/parameters_tags.txt
+++ b/spec/tags/core/proc/parameters_tags.txt
@@ -1,6 +1,3 @@
-fails:Proc#parameters sets the first element of each sub-Array to :req for required argument if lambda keyword used
-fails:Proc#parameters regards named parameters in procs as required if lambda keyword used
-fails:Proc#parameters regards named parameters in lambda as optional if lambda: false keyword used
 fails:Proc#parameters adds rest arg with name * for "star" argument
 fails:Proc#parameters adds keyrest arg with ** as a name for "double star" argument
 fails:Proc#parameters adds block arg with name & for anonymous block argument

--- a/src/main/java/org/truffleruby/core/proc/ProcNodes.java
+++ b/src/main/java/org/truffleruby/core/proc/ProcNodes.java
@@ -203,14 +203,16 @@ public abstract class ProcNodes {
 
     }
 
-    @CoreMethod(names = "parameters")
-    public abstract static class ParametersNode extends CoreMethodArrayArgumentsNode {
+    @Primitive(name = "proc_parameters")
+    public abstract static class ParametersNode extends PrimitiveArrayArgumentsNode {
 
         @TruffleBoundary
         @Specialization
-        RubyArray parameters(RubyProc proc) {
+        RubyArray parameters(RubyProc proc, Object lambdaObject) {
             final ArgumentDescriptor[] argsDesc = proc.getArgumentDescriptors();
-            final boolean isLambda = proc.type == ProcType.LAMBDA;
+            final boolean isLambda = (lambdaObject == nil)
+                    ? proc.type == ProcType.LAMBDA
+                    : !Boolean.FALSE.equals(lambdaObject);
             return ArgumentDescriptorUtils
                     .argumentDescriptorsToParameters(getLanguage(), getContext(), argsDesc, isLambda);
         }

--- a/src/main/ruby/truffleruby/core/proc.rb
+++ b/src/main/ruby/truffleruby/core/proc.rb
@@ -128,4 +128,8 @@ class Proc
       end
     end
   end
+
+  def parameters(lambda: nil)
+    Primitive.proc_parameters(self, lambda)
+  end
 end


### PR DESCRIPTION
Part of #3039.

This adds the `lambda` keyword argument to `Proc#parameters` as per https://bugs.ruby-lang.org/issues/15357.