### PR TITLE
Add a deprecation warning for Encoding#replicate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Compatibility:
 * Do not autosplat a proc that accepts a single positional argument and keywords (#3039, @andrykonchin).
 * Support passing anonymous * and ** parameters as method call arguments (#3039, @andrykonchin).
 * Handle either positional or keywords arguments by default in `Struct.new` (#3039, @rwstauner).
+* Add a deprecation warning for `Encoding#replicate` (#3039, @patricklinpl, @manefz, @nirvdrum).
 
 Performance:
 

--- a/spec/tags/core/encoding/replicate_tags.txt
+++ b/spec/tags/core/encoding/replicate_tags.txt
@@ -1,1 +1,0 @@
-fails:Encoding#replicate warns about deprecation

--- a/src/main/ruby/truffleruby/core/encoding.rb
+++ b/src/main/ruby/truffleruby/core/encoding.rb
@@ -139,6 +139,8 @@ class Encoding
   end
 
   def replicate(name)
+    warn 'Encoding#replicate is deprecated and will be removed in Ruby 3.3; use the original encoding instead', category: :deprecated, uplevel: 1
+
     Truffle::EncodingOperations.replicate_encoding(self, name)
   end
 


### PR DESCRIPTION
Resolves one of the tasks from #3039 

The following task 
`
[easy, pure ruby] Encoding#replicate has been deprecated and will be removed in 3.3. [[Feature #18949](https://bugs.ruby-lang.org/issues/18949)]
`

Adds a deprecation warning for Encoding#replicate (ruby 3.2) 
It will be removed in the 3.3 version