### PR TITLE
Remove the deprecated Bignum and Fixnum constants.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Bug fixes:
 * Fix recursive raising `FrozenError` exception when redefined `#inspect` modifies an object (#3388, @andrykonchin).
 * Fix `Integer#div` returning the wrong object type when the divisor is a `Rational` (@simonlevasseur, @nirvdrum).
 
+
 Compatibility:
 
 * Add `Exception#detailed_message` method (#3257, @andrykonchin).
@@ -44,6 +45,7 @@ Compatibility:
 * Do not autosplat a proc that accepts a single positional argument and keywords (#3039, @andrykonchin).
 * Support passing anonymous * and ** parameters as method call arguments (#3039, @andrykonchin).
 * Handle either positional or keywords arguments by default in `Struct.new` (#3039, @rwstauner).
+* Remove `Bignum` and `Fixnum` constants (#3039, @patricklinpl, @manefz, @nirvdrum).
 
 Performance:
 

--- a/spec/tags/core/integer/constants_tags.txt
+++ b/spec/tags/core/integer/constants_tags.txt
@@ -1,2 +1,0 @@
-fails:Fixnum is no longer defined
-fails:Bignum is no longer defined

--- a/src/main/ruby/truffleruby/core/integer.rb
+++ b/src/main/ruby/truffleruby/core/integer.rb
@@ -34,9 +34,6 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-Fixnum = Bignum = Integer
-Object.deprecate_constant :Fixnum, :Bignum
-
 class Integer < Numeric
 
   # Have a copy in Integer of the Numeric version, as MRI does


### PR DESCRIPTION
Resolves one of the tickets from #3039 

`The following deprecated constants are removed.
 [easy] Fixnum and Bignum [[Feature #12005](https://bugs.ruby-lang.org/issues/12005)]
`

Remove those deprecated constants 
