### PR TITLE
Remove deprecated methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Compatibility:
 * Do not autosplat a proc that accepts a single positional argument and keywords (#3039, @andrykonchin).
 * Support passing anonymous * and ** parameters as method call arguments (#3039, @andrykonchin).
 * Handle either positional or keywords arguments by default in `Struct.new` (#3039, @rwstauner).
+* Remove deprecated methods `Dir.exists?`, `File.exists?`, and `Kernel#=~` (#3039, @patricklinpl).
 
 Performance:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ Compatibility:
 * Do not autosplat a proc that accepts a single positional argument and keywords (#3039, @andrykonchin).
 * Support passing anonymous * and ** parameters as method call arguments (#3039, @andrykonchin).
 * Handle either positional or keywords arguments by default in `Struct.new` (#3039, @rwstauner).
-* Remove deprecated methods `Dir.exists?`, `File.exists?`, and `Kernel#=~` (#3039, @patricklinpl).
+* Remove deprecated methods `Dir.exists?`, `File.exists?`, and `Kernel#=~` (#3039, @patricklinpl, @nirvdrum).
 
 Performance:
 

--- a/lib/truffle/pathname.rb
+++ b/lib/truffle/pathname.rb
@@ -1084,10 +1084,6 @@ class Pathname    # * mixed *
   alias delete unlink
 end
 
-class Pathname
-  undef =~
-end
-
 module Kernel
   # create a pathname object.
   #

--- a/spec/tags/core/dir/exist_tags.txt
+++ b/spec/tags/core/dir/exist_tags.txt
@@ -1,1 +1,0 @@
-fails:Dir.exists? has been removed

--- a/spec/tags/core/file/exist_tags.txt
+++ b/spec/tags/core/file/exist_tags.txt
@@ -1,1 +1,0 @@
-fails:File.exists? has been removed

--- a/spec/tags/core/kernel/match_tags.txt
+++ b/spec/tags/core/kernel/match_tags.txt
@@ -1,1 +1,0 @@
-fails:Kernel#=~ is no longer defined

--- a/src/main/ruby/truffleruby/core/dir.rb
+++ b/src/main/ruby/truffleruby/core/dir.rb
@@ -206,7 +206,6 @@ class Dir
     def exist?(path)
       PrivateFile.directory?(path)
     end
-    alias_method :exists?, :exist?
 
     def home(user = nil)
       user = StringValue(user) unless Primitive.nil?(user)

--- a/src/main/ruby/truffleruby/core/file.rb
+++ b/src/main/ruby/truffleruby/core/file.rb
@@ -1149,7 +1149,6 @@ class File < IO
   class << self
     alias_method :delete,   :unlink
     alias_method :empty?,   :zero?
-    alias_method :exists?,  :exist?
     alias_method :fnmatch?, :fnmatch
   end
 

--- a/src/main/ruby/truffleruby/core/kernel.rb
+++ b/src/main/ruby/truffleruby/core/kernel.rb
@@ -181,13 +181,8 @@ module Kernel
   end
   module_function :` # `
 
-  def =~(other)
-    warn "deprecated Object#=~ is called on #{Primitive.class(self)}; it always returns nil", uplevel: 1 if $VERBOSE
-    nil
-  end
-
   def !~(other)
-    r = self =~ other ? false : true
+    r = self.respond_to?(:=~) ? !(self =~ other) : true
     Primitive.regexp_last_match_set(Primitive.caller_special_variables, $~)
     r
   end


### PR DESCRIPTION
Part of https://github.com/oracle/truffleruby/issues/3039

Remove deprecated methods:

- `Dir.exists?` 
- `File.exists?`
- `Kernel#=~`