### PR TITLE
Limit max encodings to 256 and raise error

### DIFF
--- a/spec/ruby/core/encoding/replicate_spec.rb
+++ b/spec/ruby/core/encoding/replicate_spec.rb
@@ -75,6 +75,13 @@ describe "Encoding#replicate" do
     end
   end
 
+  ruby_version_is "3.2"..."3.3" do
+    it "raises EncodingError if too many encodings" do
+      code = '1_000.times {|i| Encoding::US_ASCII.replicate("R_#{i}") }'
+      ruby_exe(code, args: "2>&1", exit_status: 1).should.include?('too many encoding (> 256) (EncodingError)')
+    end
+  end
+
   ruby_version_is "3.3" do
     it "has been removed" do
       Encoding::US_ASCII.should_not.respond_to?(:replicate, true)

--- a/spec/ruby/optional/capi/encoding_spec.rb
+++ b/spec/ruby/optional/capi/encoding_spec.rb
@@ -2,7 +2,7 @@
 require_relative 'spec_helper'
 require_relative 'fixtures/encoding'
 
-load_extension('encoding')
+extension_path = load_extension('encoding')
 
 describe :rb_enc_get_index, shared: true do
   it "returns the index of the encoding of a String" do
@@ -719,6 +719,29 @@ describe "C-API Encoding function" do
       str, length = @s.ONIGENC_MBC_CASE_FOLD('$'.encode(Encoding::UTF_16BE))
       length.should == 2
       str.bytes.should == [0, 0x24]
+    end
+  end
+
+  describe "rb_define_dummy_encoding" do
+    it "defines the dummy encoding" do
+      @s.rb_define_dummy_encoding("FOO")
+      enc = Encoding.find("FOO")
+      enc.should.dummy?
+    end
+
+    it "returns the index of the dummy encoding" do
+      index = @s.rb_define_dummy_encoding("BAR")
+      index.should == Encoding.list.size - 1
+    end
+
+    ruby_version_is "3.2" do
+      it "raises EncodingError if too many encodings" do
+        code = <<-RUBY
+          require #{extension_path.dump}
+          1_000.times {|i| CApiEncodingSpecs.new.rb_define_dummy_encoding(\"R_\#{i}\") }
+        RUBY
+        ruby_exe(code, args: "2>&1", exit_status: 1).should.include?('too many encoding (> 256) (EncodingError)')
+      end
     end
   end
 end

--- a/spec/ruby/optional/capi/ext/encoding_spec.c
+++ b/spec/ruby/optional/capi/ext/encoding_spec.c
@@ -320,6 +320,10 @@ static VALUE encoding_spec_rb_enc_left_char_head(VALUE self, VALUE str, VALUE of
   return LONG2NUM(result - ptr);
 }
 
+static VALUE encoding_spec_rb_define_dummy_encoding(VALUE self, VALUE name) {
+  return INT2NUM(rb_define_dummy_encoding(RSTRING_PTR(name)));
+}
+
 void Init_encoding_spec(void) {
   VALUE cls;
   native_rb_encoding_pointer = (rb_encoding**) malloc(sizeof(rb_encoding*));
@@ -379,6 +383,7 @@ void Init_encoding_spec(void) {
   rb_define_method(cls, "rb_uv_to_utf8", encoding_spec_rb_uv_to_utf8, 2);
   rb_define_method(cls, "ONIGENC_MBC_CASE_FOLD", encoding_spec_ONIGENC_MBC_CASE_FOLD, 1);
   rb_define_method(cls, "rb_enc_left_char_head", encoding_spec_rb_enc_left_char_head, 2);
+  rb_define_method(cls, "rb_define_dummy_encoding", encoding_spec_rb_define_dummy_encoding, 1);
 }
 
 #ifdef __cplusplus

--- a/spec/tags/core/encoding/replicate_tags.txt
+++ b/spec/tags/core/encoding/replicate_tags.txt
@@ -1,0 +1,1 @@
+slow:Encoding#replicate raises EncodingError if too many encodings

--- a/spec/tags/optional/capi/encoding_tags.txt
+++ b/spec/tags/optional/capi/encoding_tags.txt
@@ -5,3 +5,4 @@ fails:C-API Encoding function rb_enc_copy sets the encoding of a Regexp to that 
 fails:C-API Encoding function rb_enc_get_index returns -1 for an object without an encoding
 fails:C-API Encoding function rb_enc_set_index raises an ArgumentError for a non-encoding capable object
 fails:C-API Encoding function ENCODING_SET raises an ArgumentError for a non-encoding capable object
+slow:C-API Encoding function rb_define_dummy_encoding raises EncodingError if too many encodings

--- a/src/main/java/org/truffleruby/core/encoding/EncodingManager.java
+++ b/src/main/java/org/truffleruby/core/encoding/EncodingManager.java
@@ -206,6 +206,10 @@ public final class EncodingManager {
         return ArrayUtils.copyOf(ENCODING_LIST_BY_ENCODING_INDEX, ENCODING_LIST_BY_ENCODING_INDEX.length);
     }
 
+    public int getNumberOfEncodings() {
+        return ENCODING_LIST_BY_ENCODING_INDEX.length;
+    }
+
     @TruffleBoundary
     public RubyEncoding getRubyEncoding(String name) {
         final String normalizedName = name.toLowerCase(Locale.ENGLISH);

--- a/src/main/java/org/truffleruby/core/encoding/EncodingNodes.java
+++ b/src/main/java/org/truffleruby/core/encoding/EncodingNodes.java
@@ -705,6 +705,12 @@ public abstract class EncodingNodes {
 
         @TruffleBoundary
         private static RubyEncoding replicate(Node node, String name, RubyEncoding encoding) {
+            if (getContext(node).getEncodingManager().getNumberOfEncodings() >= Encodings.MAX_NUMBER_OF_ENCODINGS) {
+                throw new RaiseException(
+                        getContext(node),
+                        coreExceptions(node).encodingErrorTooManyEncodings(Encodings.MAX_NUMBER_OF_ENCODINGS, node));
+            }
+
             return getContext(node).getEncodingManager().replicateEncoding(encoding, name);
         }
 
@@ -726,6 +732,12 @@ public abstract class EncodingNodes {
 
         @TruffleBoundary
         private static RubyEncoding createDummy(Node node, String name) {
+            if (getContext(node).getEncodingManager().getNumberOfEncodings() >= Encodings.MAX_NUMBER_OF_ENCODINGS) {
+                throw new RaiseException(
+                        getContext(node),
+                        coreExceptions(node).encodingErrorTooManyEncodings(Encodings.MAX_NUMBER_OF_ENCODINGS, node));
+            }
+
             return getContext(node).getEncodingManager().createDummyEncoding(name);
         }
 

--- a/src/main/java/org/truffleruby/core/encoding/Encodings.java
+++ b/src/main/java/org/truffleruby/core/encoding/Encodings.java
@@ -37,6 +37,7 @@ import java.nio.charset.StandardCharsets;
 public final class Encodings {
 
     public static final int INITIAL_NUMBER_OF_ENCODINGS = EncodingDB.getEncodings().size();
+    public static final int MAX_NUMBER_OF_ENCODINGS = 256;
     public static final RubyEncoding US_ASCII = initializeUsAscii();
     private static final RubyEncoding[] BUILT_IN_ENCODINGS = initializeRubyEncodings();
 

--- a/src/main/java/org/truffleruby/core/exception/CoreExceptions.java
+++ b/src/main/java/org/truffleruby/core/exception/CoreExceptions.java
@@ -1139,6 +1139,15 @@ public final class CoreExceptions {
     }
 
     @TruffleBoundary
+    public RubyException encodingErrorTooManyEncodings(int maxSize, Node currentNode) {
+        RubyClass exceptionClass = context.getCoreLibrary().encodingErrorClass;
+        String message = StringUtils.format("too many encoding (> %d)", maxSize);
+        RubyString errorMessage = StringOperations.createUTF8String(context, language, message);
+
+        return ExceptionOperations.createRubyException(context, exceptionClass, errorMessage, currentNode, null);
+    }
+
+    @TruffleBoundary
     public RubyException encodingCompatibilityErrorIncompatible(RubyEncoding a, RubyEncoding b, Node currentNode) {
         return encodingCompatibilityError(
                 StringUtils.format("incompatible character encodings: %s and %s", a, b),


### PR DESCRIPTION
Part of #3039.

This limits the max number of encodings when calling `rb_define_dummy_encoding` and raise `EncodingError` as per [Ruby issue 18949](https://bugs.ruby-lang.org/issues/18949). Tests inspired by [this](https://github.com/ruby/ruby/blob/a4e4e3b1f1bd66ce9121c0ba2a1926e2459106dc/test/-ext-/string/test_too_many_dummy_encodings.rb#L11) from MRI.