### PR TITLE
Use the owner module instead of origin with UnboundMethod#{inspect,==} 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Compatibility:
 * Do not autosplat a proc that accepts a single positional argument and keywords (#3039, @andrykonchin).
 * Support passing anonymous * and ** parameters as method call arguments (#3039, @andrykonchin).
 * Handle either positional or keywords arguments by default in `Struct.new` (#3039, @rwstauner).
+* Change `UnboundMethod#{==,inspect}` to use the owner module rather than the origin (#3039, @rwstauner, @manefz, @patricklinpl)
 
 Performance:
 

--- a/spec/tags/core/unboundmethod/equal_value_tags.txt
+++ b/spec/tags/core/unboundmethod/equal_value_tags.txt
@@ -1,3 +1,0 @@
-fails:UnboundMethod#== returns true if same method but one extracted from a subclass
-fails:UnboundMethod#== returns false if same method but extracted from two different subclasses
-fails:UnboundMethod#== returns true if methods are the same but added from an included Module

--- a/spec/tags/core/unboundmethod/inspect_tags.txt
+++ b/spec/tags/core/unboundmethod/inspect_tags.txt
@@ -1,1 +1,0 @@
-fails:UnboundMethod#inspect returns a String including all details

--- a/spec/tags/core/unboundmethod/to_s_tags.txt
+++ b/spec/tags/core/unboundmethod/to_s_tags.txt
@@ -1,1 +1,0 @@
-fails:UnboundMethod#to_s returns a String including all details

--- a/src/main/java/org/truffleruby/core/method/UnboundMethodNodes.java
+++ b/src/main/java/org/truffleruby/core/method/UnboundMethodNodes.java
@@ -133,16 +133,6 @@ public abstract class UnboundMethodNodes {
 
     }
 
-    @Primitive(name = "unbound_method_origin")
-    public abstract static class OriginNode extends PrimitiveArrayArgumentsNode {
-
-        @Specialization
-        RubyModule origin(RubyUnboundMethod unboundMethod) {
-            return unboundMethod.origin;
-        }
-
-    }
-
     @CoreMethod(names = "original_name")
     public abstract static class OriginalNameNode extends CoreMethodArrayArgumentsNode {
 

--- a/src/main/java/org/truffleruby/core/method/UnboundMethodNodes.java
+++ b/src/main/java/org/truffleruby/core/method/UnboundMethodNodes.java
@@ -52,8 +52,7 @@ public abstract class UnboundMethodNodes {
 
         @Specialization
         boolean equal(RubyUnboundMethod self, RubyUnboundMethod other) {
-            return self.origin == other.origin &&
-                    MethodNodes.areInternalMethodEqual(self.method, other.method);
+            return MethodNodes.areInternalMethodEqual(self.method, other.method);
         }
 
         @Specialization(guards = "!isRubyUnboundMethod(other)")

--- a/src/main/ruby/truffleruby/core/unbound_method.rb
+++ b/src/main/ruby/truffleruby/core/unbound_method.rb
@@ -10,7 +10,7 @@
 
 class UnboundMethod
   def inspect
-    Truffle::MethodOperations.inspect_method(self, Primitive.unbound_method_origin(self), owner)
+    Truffle::MethodOperations.inspect_method(self, owner, owner)
   end
   alias_method :to_s, :inspect
 


### PR DESCRIPTION
We're only concerned with where the method was declared
(rather than the receiver of the instance_method call).

See https://github.com/ruby/ruby/pull/6855
and https://bugs.ruby-lang.org/issues/18798