### PR TITLE
Make Set available as a built-in class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Compatibility:
 * Do not autosplat a proc that accepts a single positional argument and keywords (#3039, @andrykonchin).
 * Support passing anonymous * and ** parameters as method call arguments (#3039, @andrykonchin).
 * Handle either positional or keywords arguments by default in `Struct.new` (#3039, @rwstauner).
+* Set is now available as a builtin class without the need for `require "set"` (#3039, @patricklinpl).
 
 Performance:
 

--- a/src/main/ruby/truffleruby/core/enumerable.rb
+++ b/src/main/ruby/truffleruby/core/enumerable.rb
@@ -1102,6 +1102,11 @@ module Enumerable
     Enumerator::Chain.new(self, *enums)
   end
 
+  # Makes a set from the enumerable object with given arguments.
+  def to_set(klass = Set, *args, &block)
+    klass.new(self, *args, &block)
+  end
+
 end
 
 class Array

--- a/src/main/ruby/truffleruby/core/lazy_rubygems.rb
+++ b/src/main/ruby/truffleruby/core/lazy_rubygems.rb
@@ -28,5 +28,7 @@ Truffle::Boot.delay do
       # Defined by RbConfig
       autoload :CROSS_COMPILING, 'rbconfig'
     end
+
+    autoload :Set, 'set'
   end
 end


### PR DESCRIPTION
Part of https://github.com/oracle/truffleruby/issues/3039

Set is now available as a built-in class without the need for require "set"