### PR TITLE
Raising a RuntimeError when calling Kernel#binding from a C/non-ruby frame.

### DIFF
--- a/spec/tags/optional/capi/binding_tags.txt
+++ b/spec/tags/optional/capi/binding_tags.txt
@@ -1,2 +1,1 @@
 fails:CApiBindingSpecs Kernel#binding gives the top-most Ruby binding when called from C
-fails:CApiBindingSpecs Kernel#binding raises when called from C


### PR DESCRIPTION
Ruby 3.2 compatibility.

Addresses "Kernel#binding raises RuntimeError if called from a non-Ruby frame
(such as a method defined in C)." defined in https://github.com/oracle/truffleruby/issues/3039 

CRuby: https://bugs.ruby-lang.org/issues/18487

Used the same stack walking as seen in https://github.com/Shopify/truffleruby/blob/90bfaa00401778f11849dbca05eb1bd008271c1b/src/main/java/org/truffleruby/language/arguments/ReadCallerVariablesNode.java#L46
