### PR TITLE
Implement no args Struct.new constructor in Ruby 3.3

### DIFF
--- a/spec/truffleruby.next-specs
+++ b/spec/truffleruby.next-specs
@@ -9,6 +9,7 @@
 # Use spec/ruby/core/nil/nil_spec.rb as a dummy file to avoid being empty (what causes mspec to error)
 spec/ruby/core/nil/nil_spec.rb
 
+spec/ruby/core/struct/new_spec.rb
 spec/ruby/core/warning/element_reference_spec.rb
 spec/ruby/core/warning/element_set_spec.rb
 

--- a/src/main/ruby/truffleruby/core/struct.rb
+++ b/src/main/ruby/truffleruby/core/struct.rb
@@ -33,7 +33,7 @@ class Struct
     alias_method :subclass_new, :new
   end
 
-  def self.new(klass_name, *attrs, keyword_init: nil, &block)
+  def self.new(klass_name = nil, *attrs, keyword_init: nil, &block)
     if klass_name
       if Primitive.is_a?(klass_name, Symbol) # Truffle: added to avoid exception and match MRI
         attrs.unshift klass_name


### PR DESCRIPTION
Ruby 3.3 introduces a new 0 args constructor for Struct. This PR implements that compatibility in Truffleruby.