### PR TITLE
Reduce empty array allocations

### DIFF
--- a/src/main/java/org/truffleruby/core/array/MultipleAssignmentNode.java
+++ b/src/main/java/org/truffleruby/core/array/MultipleAssignmentNode.java
@@ -144,6 +144,10 @@ public final class MultipleAssignmentNode extends RubyContextSourceAssignableNod
     }
 
     protected AssignableNode[] cloneUninitializedAssignable(AssignableNode[] nodes) {
+        if (nodes.length == 0) {
+            return AssignableNode.EMPTY_ARRAY;
+        }
+
         AssignableNode[] copies = new AssignableNode[nodes.length];
         for (int i = 0; i < nodes.length; i++) {
             copies[i] = nodes[i].cloneUninitializedAssignable();

--- a/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
+++ b/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
@@ -416,6 +416,7 @@ public abstract class KernelNodes {
     @GenerateInline(inlineByDefault = true)
     public abstract static class CopyInstanceVariablesNode extends RubyBaseNode {
 
+        public static final DynamicObjectLibrary[] EMPTY_DYNAMIC_OBJECT_LIBRARY_ARRAY = new DynamicObjectLibrary[0];
         public static final PropertyGetter[] EMPTY_PROPERTY_GETTER_ARRAY = new PropertyGetter[0];
 
         public abstract RubyDynamicObject execute(Node node, RubyDynamicObject newObject, RubyDynamicObject from);
@@ -466,6 +467,10 @@ public abstract class KernelNodes {
         }
 
         protected DynamicObjectLibrary[] createWriteFieldNodes(PropertyGetter[] propertyGetters) {
+            if (propertyGetters.length == 0) {
+                return EMPTY_DYNAMIC_OBJECT_LIBRARY_ARRAY;
+            }
+
             final DynamicObjectLibrary[] nodes = new DynamicObjectLibrary[propertyGetters.length];
             for (int i = 0; i < propertyGetters.length; i++) {
                 nodes[i] = DynamicObjectLibrary.getFactory().createDispatched(1);

--- a/src/main/java/org/truffleruby/core/symbol/RubySymbol.java
+++ b/src/main/java/org/truffleruby/core/symbol/RubySymbol.java
@@ -40,6 +40,8 @@ public final class RubySymbol extends ImmutableRubyObjectNotCopyable implements 
 
     private static final int CLASS_SALT = 92021474; // random number, stops hashes for similar values but different classes being the same, static because we want deterministic hashes
 
+    public static final RubySymbol[] EMPTY_ARRAY = new RubySymbol[0];
+
     public final RubyEncoding encoding;
     private final String string;
     public final TruffleString tstring;

--- a/src/main/java/org/truffleruby/language/arguments/CheckKeywordArityNode.java
+++ b/src/main/java/org/truffleruby/language/arguments/CheckKeywordArityNode.java
@@ -117,6 +117,11 @@ public final class CheckKeywordArityNode extends RubyBaseNode {
 
     static RubySymbol[] keywordsAsSymbols(RubyLanguage language, Arity arity) {
         final String[] names = arity.getKeywordArguments();
+
+        if (names.length == 0) {
+            return RubySymbol.EMPTY_ARRAY;
+        }
+
         final RubySymbol[] symbols = new RubySymbol[names.length];
         for (int i = 0; i < names.length; i++) {
             symbols[i] = language.getSymbol(names[i]);

--- a/src/main/java/org/truffleruby/parser/YARPMultiTargetNodeTranslator.java
+++ b/src/main/java/org/truffleruby/parser/YARPMultiTargetNodeTranslator.java
@@ -78,10 +78,7 @@ public final class YARPMultiTargetNodeTranslator extends AbstractNodeVisitor<Ass
                 true,
                 null);
 
-        final AssignableNode[] preNodes = new AssignableNode[node.lefts.length];
-        for (int i = 0; i < node.lefts.length; i++) {
-            preNodes[i] = node.lefts[i].accept(this);
-        }
+        final AssignableNode[] preNodes = processAssignables(node.lefts);
 
         final AssignableNode restNode;
         if (node.rest != null) {
@@ -97,10 +94,7 @@ public final class YARPMultiTargetNodeTranslator extends AbstractNodeVisitor<Ass
             restNode = null;
         }
 
-        final AssignableNode[] postNodes = new AssignableNode[node.rights.length];
-        for (int i = 0; i < node.rights.length; i++) {
-            postNodes[i] = node.rights[i].accept(this);
-        }
+        final AssignableNode[] postNodes = processAssignables(node.rights);
 
         // prolog is supposed to be executed in the outer MultipleAssignmentNode (in multi-assignment only)
         final var multipleAssignmentNode = new MultipleAssignmentNode(
@@ -111,6 +105,18 @@ public final class YARPMultiTargetNodeTranslator extends AbstractNodeVisitor<Ass
                 splatCastNode,
                 rhsNode);
         return multipleAssignmentNode;
+    }
+
+    private AssignableNode[] processAssignables(Nodes.Node[] nodes) {
+        if (nodes.length == 0) {
+            return MultipleAssignmentNode.EMPTY_ASSIGNABLES;
+        }
+
+        final AssignableNode[] assignables = new AssignableNode[nodes.length];
+        for (int i = 0; i < nodes.length; i++) {
+            assignables[i] = nodes[i].accept(this);
+        }
+        return assignables;
     }
 
     @Override


### PR DESCRIPTION
While looking a heap dump taken from a load test against a Rails 7.1 application, I saw thousands of empty array allocations. I don't think these amount to much more than a few megabytes of memory, but eliminating them was easy and it cleans up the profile a bit. 