### PR TITLE
Update `compatibility.md` re. TruffleRuby 24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ Memory Footprint:
 New features:
 
 * C/C++ extensions are now compiled using the system toolchain and executed natively instead of using GraalVM LLVM (Sulong). This leads to faster startup, no warmup, better compatibility, smaller distribution and faster installation for C/C++ extensions (#3118, @eregon).
-* Full support for the Ruby 3.2 and Ruby 3.3 syntax by adopting the [Prism](https://github.com/ruby/prism) parser, which is about twice as fast as the old parser (#3117, #3038, #3039, @andrykonchin, @eregon).
+* Full support for the Ruby 3.2 (and Ruby 3.3) _syntax_ by adopting the [Prism](https://github.com/ruby/prism) parser, which is about twice as fast as the old parser (#3117, #3038, #3039, @andrykonchin, @eregon).
 * Pattern matching is now fully supported (#3332, #2683, @eregon, @razetime).
 
 Bug fixes:

--- a/doc/user/compatibility.md
+++ b/doc/user/compatibility.md
@@ -36,14 +36,12 @@ In the C API, the preprocessor macro `TRUFFLERUBY` is defined, which can be chec
 ## Ruby 3.x Features
 
 Most features of Ruby 3.2 and earlier are supported in TruffleRuby.
-However some features are not yet implemented.
+However, some features are not yet implemented.
 See the following issues for details:
 
 * [Ruby 3.2 features](https://github.com/oracle/truffleruby/issues/3039)
 * [Ruby 3.1 features](https://github.com/oracle/truffleruby/issues/2733)
 * [Ruby 3.0 features](https://github.com/oracle/truffleruby/issues/2453)
-* [Pattern Matching](https://github.com/oracle/truffleruby/issues/3332)
-* [Endless methods](https://github.com/oracle/truffleruby/issues/3038)
 
 ## Features Entirely Missing
 


### PR DESCRIPTION
> * Full support for the Ruby 3.2 and Ruby 3.3 syntax by adopting the Prism parser, which is about twice as fast as the old parser.
> * Pattern matching is now fully supported.
> 
> ⸺ https://github.com/oracle/truffleruby/releases/tag/graal-24.0.0