### PR TITLE
Report polymorphism for `sprintf` nodes.

### DIFF
--- a/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
+++ b/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
@@ -1665,6 +1665,7 @@ public abstract class KernelNodes {
 
     @GenerateInline
     @GenerateCached(false)
+    @ReportPolymorphism
     public abstract static class SprintfInnerNode extends RubyBaseNode {
 
         public abstract BytesResult execute(Node node, AbstractTruffleString format, RubyEncoding encoding,


### PR DESCRIPTION
While looking at the performance of a large Rails application, I saw that we were creating new `CallTarget` on each call to `String#%`. The [generic specialization](https://github.com/oracle/truffleruby/blob/92b4cddcc4924394096d49778e07b4da3578223b/src/main/java/org/truffleruby/core/kernel/KernelNodes.java#L1689-L1696) compiles the `sprintf` expression from scratch on each call, resulting in the [creation of a new call target](https://github.com/oracle/truffleruby/blob/92b4cddcc4924394096d49778e07b4da3578223b/src/main/java/org/truffleruby/core/format/printf/PrintfCompiler.java#L45-L49).

The `sprintf` code can be invoked in a few different ways, but the one that stood out to me was `String#%`. Rails will create a request ID for each request to make tracking logs and such easier. The ActiveSupport code for creating the UUID [uses a static format string](https://github.com/rails/rails/blob/6f0d1ad14b92b9f5906e44740fce8b4f1c7075dc/activesupport/lib/active_support/core_ext/digest/uuid.rb#L38), but the `sprintf` nodes are already megamorphic by the time this code is called. I saw it go megamorphic by [loading the URI library](https://github.com/ruby/uri/blob/a0425d965940c670b942fcf1e1645c8a573e2698/lib/uri/common.rb#L291-L294).

I suspect format strings are mostly static and splitting would make most call sites monomorphic. This simple change demonstrably splits with the following example:

```ruby
def foo(format)
 format % [123]
end

loop do
  foo "%#{rand(3)}d"
  foo "%s"
end
```

For call sites with > 3 format strings we could add a global cache, like we do for regular expressions. That could cut down on the creation of unique call targets, but that's out of scope for this PR and I don't have any evidence of it being a real world problem at the moment.