### PR TITLE
Report polymorphism for `sprintf` nodes.

### DIFF
--- a/src/annotations/java/org/truffleruby/annotations/Split.java
+++ b/src/annotations/java/org/truffleruby/annotations/Split.java
@@ -14,7 +14,7 @@ public enum Split {
     DEFAULT,
     ALWAYS,
     HEURISTIC,
-    /** Disallow splitting for this CallTarget, which avoids making a eager uninitialized copy of the AST. Useful
+    /** Disallow splitting for this CallTarget, which avoids making an eager uninitialized copy of the AST. Useful
      * notably for methods not specializing on their arguments and just calling a TruffleBoundary. */
     NEVER
 }

--- a/src/main/java/org/truffleruby/cext/CExtNodes.java
+++ b/src/main/java/org/truffleruby/cext/CExtNodes.java
@@ -34,6 +34,7 @@ import org.truffleruby.RubyLanguage;
 import org.truffleruby.annotations.CoreMethod;
 import org.truffleruby.annotations.CoreModule;
 import org.truffleruby.annotations.Primitive;
+import org.truffleruby.annotations.Split;
 import org.truffleruby.annotations.Visibility;
 import org.truffleruby.builtins.CoreMethodArrayArgumentsNode;
 import org.truffleruby.builtins.PrimitiveArrayArgumentsNode;
@@ -2029,8 +2030,7 @@ public abstract class CExtNodes {
         }
     }
 
-    @CoreMethod(names = "rb_tr_sprintf", onSingleton = true, required = 3)
-    @ReportPolymorphism
+    @CoreMethod(names = "rb_tr_sprintf", onSingleton = true, required = 3, split = Split.ALWAYS)
     public abstract static class RBSprintfNode extends CoreMethodArrayArgumentsNode {
 
         @Specialization(guards = "libFormat.isRubyString(format)", limit = "1")
@@ -2069,6 +2069,7 @@ public abstract class CExtNodes {
 
     @GenerateInline
     @GenerateCached(false)
+    @ReportPolymorphism
     public abstract static class RBSprintfInnerNode extends RubyBaseNode {
 
         public abstract BytesResult execute(Node node, AbstractTruffleString format, RubyEncoding encoding,

--- a/src/main/java/org/truffleruby/core/array/ArrayNodes.java
+++ b/src/main/java/org/truffleruby/core/array/ArrayNodes.java
@@ -1491,8 +1491,7 @@ public abstract class ArrayNodes {
 
     }
 
-    @CoreMethod(names = "pack", required = 1)
-    @ReportPolymorphism
+    @CoreMethod(names = "pack", required = 1, split = Split.ALWAYS)
     public abstract static class ArrayPackNode extends CoreMethodArrayArgumentsNode {
 
         @Specialization
@@ -1506,6 +1505,7 @@ public abstract class ArrayNodes {
 
     @GenerateCached(false)
     @GenerateInline
+    @ReportPolymorphism
     public abstract static class PackNode extends RubyBaseNode {
 
         public abstract RubyString execute(Node node, RubyArray array, Object format);

--- a/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
+++ b/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
@@ -1616,8 +1616,8 @@ public abstract class KernelNodes {
 
     }
 
-    @CoreMethod(names = { "format", "sprintf" }, isModuleFunction = true, rest = true, required = 1)
-    @ReportPolymorphism
+    @CoreMethod(names = { "format", "sprintf" }, isModuleFunction = true, rest = true, required = 1,
+            split = Split.ALWAYS)
     public abstract static class SprintfNode extends CoreMethodArrayArgumentsNode {
 
         static final String GVAR_DEBUG = "$DEBUG";

--- a/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
+++ b/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
@@ -1665,6 +1665,7 @@ public abstract class KernelNodes {
 
     @GenerateInline
     @GenerateCached(false)
+    @ReportPolymorphism
     public abstract static class SprintfInnerNode extends RubyBaseNode {
 
         public abstract BytesResult execute(Node node, AbstractTruffleString format, RubyEncoding encoding,

--- a/src/main/java/org/truffleruby/language/dispatch/DispatchNode.java
+++ b/src/main/java/org/truffleruby/language/dispatch/DispatchNode.java
@@ -300,12 +300,10 @@ public abstract class DispatchNode extends SpecialVariablesSendingNode {
         return callNode.execute(frame, method, receiver, rubyArgs);
     }
 
-
     /** This will be called from the {@link CallInternalMethodNode} child whenever it creates a new
      * {@link DirectCallNode}. */
     public final void applySplittingInliningStrategy(RootCallTarget callTarget, String methodName,
             DirectCallNode callNode) {
-
 
         final Options options = getContext().getOptions();
 

--- a/src/main/ruby/truffleruby/core/io.rb
+++ b/src/main/ruby/truffleruby/core/io.rb
@@ -1664,6 +1664,7 @@ class IO
     fmt = StringValue(fmt)
     write sprintf(fmt, *args)
   end
+  Truffle::Graal.always_split(instance_method(:printf))
 
   def read(length = nil, buffer = nil)
     ensure_open_and_readable
@@ -2485,6 +2486,7 @@ class IO::BidirectionalPipe < IO
   def printf(fmt, *args)
     @write.printf(fmt, *args)
   end
+  Truffle::Graal.always_split(instance_method(:printf))
 
   def putc(obj)
     @write.putc(obj)

--- a/src/main/ruby/truffleruby/core/kernel.rb
+++ b/src/main/ruby/truffleruby/core/kernel.rb
@@ -721,6 +721,8 @@ module Kernel
     nil
   end
   module_function :printf
+  Truffle::Graal.always_split(instance_method(:printf))
+  Truffle::Graal.always_split(method(:printf))
 
   private def pp(*args)
     require 'pp'

--- a/src/main/ruby/truffleruby/core/string.rb
+++ b/src/main/ruby/truffleruby/core/string.rb
@@ -1392,10 +1392,12 @@ class String
     end
     Primitive.string_unpack(self, format, offset)
   end
+  Truffle::Graal.always_split(instance_method(:unpack))
 
   def unpack1(format, offset: undefined)
     unpack(format, offset: offset).first
   end
+  Truffle::Graal.always_split(instance_method(:unpack1))
 
   def unicode_normalize(form = :nfc)
     require 'unicode_normalize/normalize.rb' unless defined? UnicodeNormalize


### PR DESCRIPTION
While looking at the performance of a large Rails application, I saw that we were creating new `CallTarget` on each call to `String#%`. The [generic specialization](https://github.com/oracle/truffleruby/blob/92b4cddcc4924394096d49778e07b4da3578223b/src/main/java/org/truffleruby/core/kernel/KernelNodes.java#L1689-L1696) compiles the `sprintf` expression from scratch on each call, resulting in the [creation of a new call target](https://github.com/oracle/truffleruby/blob/92b4cddcc4924394096d49778e07b4da3578223b/src/main/java/org/truffleruby/core/format/printf/PrintfCompiler.java#L45-L49).

The `sprintf` code can be invoked in a few different ways, but the one that stood out to me was `String#%`. Rails will create a request ID for each request to make tracking logs and such easier. The ActiveSupport code for creating the UUID [uses a static format string](https://github.com/rails/rails/blob/6f0d1ad14b92b9f5906e44740fce8b4f1c7075dc/activesupport/lib/active_support/core_ext/digest/uuid.rb#L38), but the `sprintf` nodes are already megamorphic by the time this code is called. I saw it go megamorphic by [loading the URI library](https://github.com/ruby/uri/blob/a0425d965940c670b942fcf1e1645c8a573e2698/lib/uri/common.rb#L291-L294).

I suspect format strings are mostly static and splitting would make most call sites monomorphic. This simple change demonstrably splits with the following example:

```ruby
def foo(format)
 format % [123]
end

loop do
  foo "%#{rand(3)}d"
  foo "%s"
end
```

For call sites with > 3 format strings we could add a global cache, like we do for regular expressions. That could cut down on the creation of unique call targets, but that's out of scope for this PR and I don't have any evidence of it being a real world problem at the moment.