### PR TITLE
Allow splitting of Truffle::CExt.set_mark_list_on_object.

### DIFF
--- a/src/main/java/org/truffleruby/cext/CExtNodes.java
+++ b/src/main/java/org/truffleruby/cext/CExtNodes.java
@@ -1887,6 +1887,7 @@ public abstract class CExtNodes {
     }
 
     @CoreMethod(names = "set_mark_list_on_object", onSingleton = true, required = 1)
+    @ReportPolymorphism
     public abstract static class SetMarkList extends CoreMethodArrayArgumentsNode {
 
         @Specialization


### PR DESCRIPTION
While looking at performance of a production Rails application, I saw a lot of splitting attributed to the [wrappers that TruffleRuby creates for `rb_define_method`](https://github.com/oracle/truffleruby/blob/95c8d7f5a7b7015cf8ef4042b418b8cb6a187aec/lib/truffle/truffle/cext_ruby.rb#L24-L43). Ultimately, I think this boils down to `WriteObjectFieldNode`, which is used by [`set_mark_list_on_object`](https://github.com/oracle/truffleruby/blob/95c8d7f5a7b7015cf8ef4042b418b8cb6a187aec/src/main/java/org/truffleruby/cext/CExtNodes.java#L1894), reporting polymorphism. I had traced the problematic node back to a usage of `NIO::Selector` within Puma, where an object is apparently shared across threads causing the `WriteObjectFieldNode` instance to become polymorphic.

I do not have a simple reproduction. I tried to use the nio4r example code to induce the behavior, but to adequately handle the multi-threaded part I found I was basically rewriting Puma's reactors. Instead, I deployed this change out to my production environment and observed that the repeated splitting of simple methods like `Integer#==` ceased.