### PR TITLE
Add sass-embedded to REUSE_AS_BINARY_ON_TRUFFLERUBY

### DIFF
--- a/lib/truffle/rubygems/defaults/truffleruby.rb
+++ b/lib/truffle/rubygems/defaults/truffleruby.rb
@@ -30,5 +30,5 @@ end
 
 class Gem::Platform
   # The list of gems we want to install precompiled (using the local platform) on TruffleRuby
-  REUSE_AS_BINARY_ON_TRUFFLERUBY = %w[libv8 libv8-node sorbet-static]
+  REUSE_AS_BINARY_ON_TRUFFLERUBY = %w[libv8 libv8-node sass-embedded sorbet-static]
 end


### PR DESCRIPTION
I'm the maintainer of `sass-embedded` gem. This gem has "native extension" that is a Dart VM binary executable, which is completely independent and not linked to libruby. On the platform "ruby", there is a `Rakefile` based extension that downloads the correct binary for the current platform, and it is extremely slow on TruffleRuby comparing to MRI (likely due to `Rakefile` extension launching a child `rake` process etc). Therefore, it's better to just use the pre-compiled gems that bundles the binary to speed up the installation.
