### PR TITLE
Add version-related keys to RbConfig::CONFIG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Compatibility:
 
 * Fix `Module#include` so a module included into a reopened nested module is added into an ancestors chain (#3570, @andrykonchin).
 * Fix `Kernel#eval` to ignore shebang with non-Ruby interpreter (#3623, @andrykonchin).
+* Add `MAJOR`, `MINOR`, `TEENY`, `PATCHLEVEL`, `RUBY_API_VERSION`, and `RUBY_PROGRAM_VERSION` to `RbConfig::CONFIG` (#3396, @rwstauner).
 
 Performance:
 

--- a/lib/cext/include/truffleruby/truffleruby-abi-version.h
+++ b/lib/cext/include/truffleruby/truffleruby-abi-version.h
@@ -20,6 +20,6 @@
 // $RUBY_VERSION must be the same as TruffleRuby.LANGUAGE_VERSION.
 // $ABI_NUMBER starts at 1 and is incremented for every ABI-incompatible change.
 
-#define TRUFFLERUBY_ABI_VERSION "3.2.4.1"
+#define TRUFFLERUBY_ABI_VERSION "3.2.4.2"
 
 #endif

--- a/lib/truffle/rbconfig.rb
+++ b/lib/truffle/rbconfig.rb
@@ -154,6 +154,8 @@ module RbConfig
 
   warnflags = warnflags.join(' ')
 
+  major, minor, teeny = RUBY_VERSION.split('.')
+
   # Sorted alphabetically using sort(1)
   CONFIG = {
     'AR'                => ar,
@@ -200,11 +202,14 @@ module RbConfig
     'libtruffleruby'    => libtruffleruby,
     'libtrufflerubytrampoline' => libtrufflerubytrampoline,
     'MAKEDIRS'          => 'mkdir -p',
+    'MAJOR'             => major,
     'MKDIR_P'           => 'mkdir -p',
+    'MINOR'             => minor,
     'NULLCMD'           => ':',
     'OBJEXT'            => 'o',
     'optflags'          => optflags,
     'OUTFLAG'           => '-o ',
+    'PATCHLEVEL'        => "#{RUBY_PATCHLEVEL}",
     'PATH_SEPARATOR'    => File::PATH_SEPARATOR.dup,
     'PKG_CONFIG'        => 'pkg-config',
     'prefix'            => prefix,
@@ -214,9 +219,11 @@ module RbConfig
     'RMDIR'             => rmdir,
     'RMDIRS'            => "#{rmdir} -p",
     'RPATHFLAG'         => ' -Wl,-rpath,%1$-s',
+    'RUBY_API_VERSION'  => ruby_abi_version.dup,
     'RUBY_BASE_NAME'    => ruby_base_name,
     'ruby_install_name' => ruby_install_name,
     'RUBY_INSTALL_NAME' => ruby_install_name,
+    'RUBY_PROGRAM_VERSION' => RUBY_VERSION.dup,
     'RUBYW_INSTALL_NAME'=> '',
     'ruby_version'      => ruby_abi_version.dup,
     'rubyarchhdrdir'    => rubyhdrdir.dup,
@@ -226,6 +233,7 @@ module RbConfig
     'sysconfdir'        => "#{prefix}/etc", # doesn't exist, as in MRI
     'target_cpu'        => host_cpu,
     'target_os'         => host_os,
+    'TEENY'             => teeny,
     'UNICODE_VERSION'   => Primitive.encoding_unicode_version,
     'UNICODE_EMOJI_VERSION' => Primitive.encoding_unicode_emoji_version,
     'warnflags'         => warnflags,

--- a/spec/ruby/library/rbconfig/rbconfig_spec.rb
+++ b/spec/ruby/library/rbconfig/rbconfig_spec.rb
@@ -9,6 +9,13 @@ describe 'RbConfig::CONFIG' do
     end
   end
 
+  it 'has MAJOR, MINOR, TEENY, and PATCHLEVEL matching RUBY_VERSION and RUBY_PATCHLEVEL' do
+    major, minor, teeny = RUBY_VERSION.split('.')
+    RbConfig::CONFIG.values_at("MAJOR", "MINOR", "TEENY", "PATCHLEVEL").should == [
+      major, minor, teeny, RUBY_PATCHLEVEL.to_s
+    ]
+  end
+
   # These directories have no meanings before the installation.
   guard -> { RbConfig::TOPDIR } do
     it "['rubylibdir'] returns the directory containing Ruby standard libraries" do


### PR DESCRIPTION
This adds some of the entries mentioned in #3396
that `rb-sys` looks for:

https://github.com/oxidize-rb/rb-sys/blob/086d3a2a2992b66c4b84eacad7c7a92bf67725b5/crates/rb-sys-build/src/rb_config.rs#L344-L346
https://github.com/oxidize-rb/rb-sys/blob/086d3a2a2992b66c4b84eacad7c7a92bf67725b5/crates/rb-sys-build/src/rb_config.rs#L183
https://github.com/oxidize-rb/rb-sys/blob/086d3a2a2992b66c4b84eacad7c7a92bf67725b5/crates/rb-sys/build/main.rs#L123
