### PR TITLE
Support Time.new with string timestamp argument and error when invalid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Compatibility:
 * Set `RbConfig::CONFIG['archincludedir']` (#3396, @andrykonchin).
 * Support the index/length arguments for the string argument to `String#bytesplice` added in 3.3 (#3656, @rwstauner).
 * Implement `rb_str_strlen()` (#3697, @Th3-M4jor).
+* Support `Time.new` with String argument and error when invalid (#3693, @rwstauner).
 
 Performance:
 

--- a/spec/ruby/core/time/new_spec.rb
+++ b/spec/ruby/core/time/new_spec.rb
@@ -663,6 +663,12 @@ describe "Time.new with a timezone argument" do
           Time.new("a\nb")
         }.should raise_error(ArgumentError, "can't parse: \"a\\nb\"")
       end
+
+      it "raises ArgumentError if string has extra characters after offset" do
+        -> {
+          Time.new("2021-11-31 00:00:59 +09:00 abc")
+        }.should raise_error(ArgumentError, "can't parse at: abc")
+      end
     end
   end
 end

--- a/spec/ruby/core/time/new_spec.rb
+++ b/spec/ruby/core/time/new_spec.rb
@@ -485,6 +485,8 @@ describe "Time.new with a timezone argument" do
         Time.new("2020-12-25 00:56:17 +0900").should == t
         Time.new("2020-12-25 00:57:47 +090130").should == t
         Time.new("2020-12-25T00:56:17+09:00").should == t
+
+        Time.new("2020-12-25T00:56:17.123456+09:00").should == Time.utc(2020, 12, 24, 15, 56, 17, 123456)
       end
 
       it "accepts precision keyword argument and truncates specified digits of sub-second part" do

--- a/spec/ruby/core/time/new_spec.rb
+++ b/spec/ruby/core/time/new_spec.rb
@@ -511,6 +511,16 @@ describe "Time.new with a timezone argument" do
         Time.new("2021-12-25 00:00:00", in: "-01:00").to_s.should == "2021-12-25 00:00:00 -0100"
       end
 
+      it "returns Time of Jan 1 for string with just year" do
+        Time.new("2021").should == Time.new(2021, 1, 1)
+        Time.new("2021").zone.should == Time.new(2021, 1, 1).zone
+        Time.new("2021").utc_offset.should == Time.new(2021, 1, 1).utc_offset
+      end
+
+      it "returns Time of Jan 1 for string with just year in timezone specified with in keyword argument" do
+        Time.new("2021", in: "+17:00").to_s.should == "2021-01-01 00:00:00 +1700"
+      end
+
       it "converts precision keyword argument into Integer if is not nil" do
         obj = Object.new
         def obj.to_int; 3; end
@@ -544,6 +554,10 @@ describe "Time.new with a timezone argument" do
         -> {
           Time.new("2020-12-25 00 +09:00")
         }.should raise_error(ArgumentError, "missing min part: 00 ")
+
+        -> {
+          Time.new("2020-12-25")
+        }.should raise_error(ArgumentError, 'no time information')
       end
 
       it "raises ArgumentError if subsecond is missing after dot" do
@@ -640,6 +654,12 @@ describe "Time.new with a timezone argument" do
         -> {
           Time.new("2021-11-31 00:00:60 +09:00".encode("utf-32le"))
         }.should raise_error(ArgumentError, "time string should have ASCII compatible encoding")
+      end
+
+      it "raises ArgumentError if string doesn't start with year" do
+        -> {
+          Time.new("a\nb")
+        }.should raise_error(ArgumentError, "can't parse: \"a\\nb\"")
       end
     end
   end

--- a/spec/ruby/core/time/new_spec.rb
+++ b/spec/ruby/core/time/new_spec.rb
@@ -556,10 +556,14 @@ describe "Time.new with a timezone argument" do
         -> {
           Time.new("2020-12-25 00 +09:00")
         }.should raise_error(ArgumentError, /missing min part: 00 |can't parse:/)
+      end
 
-        -> {
-          Time.new("2020-12-25")
-        }.should raise_error(ArgumentError, /no time information|can't parse:/)
+      ruby_version_is "3.2.3" do
+        it "raises ArgumentError if the time part is missing" do
+          -> {
+            Time.new("2020-12-25")
+          }.should raise_error(ArgumentError, /no time information|can't parse:/)
+        end
       end
 
       it "raises ArgumentError if subsecond is missing after dot" do

--- a/spec/ruby/core/time/new_spec.rb
+++ b/spec/ruby/core/time/new_spec.rb
@@ -551,105 +551,105 @@ describe "Time.new with a timezone argument" do
       it "raises ArgumentError if part of time string is missing" do
         -> {
           Time.new("2020-12-25 00:56 +09:00")
-        }.should raise_error(ArgumentError, "missing sec part: 00:56 ")
+        }.should raise_error(ArgumentError, /missing sec part: 00:56 |can't parse:/)
 
         -> {
           Time.new("2020-12-25 00 +09:00")
-        }.should raise_error(ArgumentError, "missing min part: 00 ")
+        }.should raise_error(ArgumentError, /missing min part: 00 |can't parse:/)
 
         -> {
           Time.new("2020-12-25")
-        }.should raise_error(ArgumentError, 'no time information')
+        }.should raise_error(ArgumentError, /no time information|can't parse:/)
       end
 
       it "raises ArgumentError if subsecond is missing after dot" do
         -> {
           Time.new("2020-12-25 00:56:17. +0900")
-        }.should raise_error(ArgumentError, "subsecond expected after dot: 00:56:17. ")
+        }.should raise_error(ArgumentError, /subsecond expected after dot: 00:56:17. |can't parse:/)
       end
 
       it "raises ArgumentError if String argument is not in the supported format" do
         -> {
           Time.new("021-12-25 00:00:00.123456 +09:00")
-        }.should raise_error(ArgumentError, "year must be 4 or more digits: 021")
+        }.should raise_error(ArgumentError, /year must be 4 or more digits: 021|can't parse:/)
 
         -> {
           Time.new("2020-012-25 00:56:17 +0900")
-        }.should raise_error(ArgumentError, /\Atwo digits mon is expected after [`']-': -012-25 00:\z/)
+        }.should raise_error(ArgumentError, /\Atwo digits mon is expected after [`']-': -012-25 00:\z|can't parse:/)
 
         -> {
           Time.new("2020-2-25 00:56:17 +0900")
-        }.should raise_error(ArgumentError, /\Atwo digits mon is expected after [`']-': -2-25 00:56\z/)
+        }.should raise_error(ArgumentError, /\Atwo digits mon is expected after [`']-': -2-25 00:56\z|can't parse:/)
 
         -> {
           Time.new("2020-12-215 00:56:17 +0900")
-        }.should raise_error(ArgumentError, /\Atwo digits mday is expected after [`']-': -215 00:56:\z/)
+        }.should raise_error(ArgumentError, /\Atwo digits mday is expected after [`']-': -215 00:56:\z|can't parse:/)
 
         -> {
           Time.new("2020-12-25 000:56:17 +0900")
-        }.should raise_error(ArgumentError, "two digits hour is expected:  000:56:17 ")
+        }.should raise_error(ArgumentError, /two digits hour is expected:  000:56:17 |can't parse:/)
 
         -> {
           Time.new("2020-12-25 0:56:17 +0900")
-        }.should raise_error(ArgumentError, "two digits hour is expected:  0:56:17 +0")
+        }.should raise_error(ArgumentError, /two digits hour is expected:  0:56:17 \+0|can't parse:/)
 
         -> {
           Time.new("2020-12-25 00:516:17 +0900")
-        }.should raise_error(ArgumentError, /\Atwo digits min is expected after [`']:': :516:17 \+09\z/)
+        }.should raise_error(ArgumentError, /\Atwo digits min is expected after [`']:': :516:17 \+09\z|can't parse:/)
 
         -> {
           Time.new("2020-12-25 00:6:17 +0900")
-        }.should raise_error(ArgumentError, /\Atwo digits min is expected after [`']:': :6:17 \+0900\z/)
+        }.should raise_error(ArgumentError, /\Atwo digits min is expected after [`']:': :6:17 \+0900\z|can't parse:/)
 
         -> {
           Time.new("2020-12-25 00:56:137 +0900")
-        }.should raise_error(ArgumentError, /\Atwo digits sec is expected after [`']:': :137 \+0900\z/)
+        }.should raise_error(ArgumentError, /\Atwo digits sec is expected after [`']:': :137 \+0900\z|can't parse:/)
 
         -> {
           Time.new("2020-12-25 00:56:7 +0900")
-        }.should raise_error(ArgumentError, /\Atwo digits sec is expected after [`']:': :7 \+0900\z/)
+        }.should raise_error(ArgumentError, /\Atwo digits sec is expected after [`']:': :7 \+0900\z|can't parse:/)
 
         -> {
           Time.new("2020-12-25 00:56. +0900")
-        }.should raise_error(ArgumentError, "fraction min is not supported: 00:56.")
+        }.should raise_error(ArgumentError, /fraction min is not supported: 00:56\.|can't parse:/)
 
         -> {
           Time.new("2020-12-25 00. +0900")
-        }.should raise_error(ArgumentError, "fraction hour is not supported: 00.")
+        }.should raise_error(ArgumentError, /fraction hour is not supported: 00\.|can't parse:/)
       end
 
       it "raises ArgumentError if date/time parts values are not valid" do
         -> {
           Time.new("2020-13-25 00:56:17 +09:00")
-        }.should raise_error(ArgumentError, "mon out of range")
+        }.should raise_error(ArgumentError, /mon out of range|can't parse:/)
 
         -> {
           Time.new("2020-12-32 00:56:17 +09:00")
-        }.should raise_error(ArgumentError, "mday out of range")
+        }.should raise_error(ArgumentError, /mday out of range|can't parse:/)
 
         -> {
           Time.new("2020-12-25 25:56:17 +09:00")
-        }.should raise_error(ArgumentError, "hour out of range")
+        }.should raise_error(ArgumentError, /hour out of range|can't parse:/)
 
         -> {
           Time.new("2020-12-25 00:61:17 +09:00")
-        }.should raise_error(ArgumentError, "min out of range")
+        }.should raise_error(ArgumentError, /min out of range|can't parse:/)
 
         -> {
           Time.new("2020-12-25 00:56:61 +09:00")
-        }.should raise_error(ArgumentError, "sec out of range")
+        }.should raise_error(ArgumentError, /sec out of range|can't parse:/)
 
         -> {
           Time.new("2020-12-25 00:56:17 +23:59:60")
-        }.should raise_error(ArgumentError, "utc_offset out of range")
+        }.should raise_error(ArgumentError, /utc_offset out of range|can't parse:/)
 
         -> {
           Time.new("2020-12-25 00:56:17 +24:00")
-        }.should raise_error(ArgumentError, "utc_offset out of range")
+        }.should raise_error(ArgumentError, /utc_offset out of range|can't parse:/)
 
         -> {
           Time.new("2020-12-25 00:56:17 +23:61")
-        }.should raise_error(ArgumentError, '"+HH:MM", "-HH:MM", "UTC" or "A".."I","K".."Z" expected for utc_offset: +23:61')
+        }.should raise_error(ArgumentError, /#{Regexp.escape('"+HH:MM", "-HH:MM", "UTC" or "A".."I","K".."Z" expected for utc_offset: +23:61')}|can't parse:/)
       end
 
       it "raises ArgumentError if string has not ascii-compatible encoding" do
@@ -667,7 +667,7 @@ describe "Time.new with a timezone argument" do
       it "raises ArgumentError if string has extra characters after offset" do
         -> {
           Time.new("2021-11-31 00:00:59 +09:00 abc")
-        }.should raise_error(ArgumentError, "can't parse at: abc")
+        }.should raise_error(ArgumentError, /can't parse.+ abc/)
       end
     end
   end

--- a/spec/ruby/core/time/new_spec.rb
+++ b/spec/ruby/core/time/new_spec.rb
@@ -621,31 +621,31 @@ describe "Time.new with a timezone argument" do
       it "raises ArgumentError if date/time parts values are not valid" do
         -> {
           Time.new("2020-13-25 00:56:17 +09:00")
-        }.should raise_error(ArgumentError, /mon out of range|can't parse:/)
+        }.should raise_error(ArgumentError, /(mon|argument) out of range/)
 
         -> {
           Time.new("2020-12-32 00:56:17 +09:00")
-        }.should raise_error(ArgumentError, /mday out of range|can't parse:/)
+        }.should raise_error(ArgumentError, /(mday|argument) out of range/)
 
         -> {
           Time.new("2020-12-25 25:56:17 +09:00")
-        }.should raise_error(ArgumentError, /hour out of range|can't parse:/)
+        }.should raise_error(ArgumentError, /(hour|argument) out of range/)
 
         -> {
           Time.new("2020-12-25 00:61:17 +09:00")
-        }.should raise_error(ArgumentError, /min out of range|can't parse:/)
+        }.should raise_error(ArgumentError, /(min|argument) out of range/)
 
         -> {
           Time.new("2020-12-25 00:56:61 +09:00")
-        }.should raise_error(ArgumentError, /sec out of range|can't parse:/)
+        }.should raise_error(ArgumentError, /(sec|argument) out of range/)
 
         -> {
           Time.new("2020-12-25 00:56:17 +23:59:60")
-        }.should raise_error(ArgumentError, /utc_offset out of range|can't parse:/)
+        }.should raise_error(ArgumentError, /(utc_offset|argument) out of range/)
 
         -> {
           Time.new("2020-12-25 00:56:17 +24:00")
-        }.should raise_error(ArgumentError, /utc_offset out of range|can't parse:/)
+        }.should raise_error(ArgumentError, /(utc_offset|argument) out of range/)
 
         -> {
           Time.new("2020-12-25 00:56:17 +23:61")

--- a/spec/tags/core/time/new_tags.txt
+++ b/spec/tags/core/time/new_tags.txt
@@ -20,15 +20,6 @@ fails:Time.new with a timezone argument subject's class implements .find_timezon
 fails:Time.new with a timezone argument subject's class implements .find_timezone method calls .find_timezone to build a time object if passed zone name as a timezone argument
 fails:Time.new with a timezone argument subject's class implements .find_timezone method does not call .find_timezone if passed any not string/numeric/timezone timezone argument
 fails:Time.new with a timezone argument :in keyword argument could be a timezone object
-fails:Time.new with a timezone argument Time.new with a String argument parses an ISO-8601 like format
 fails:Time.new with a timezone argument Time.new with a String argument accepts precision keyword argument and truncates specified digits of sub-second part
-fails:Time.new with a timezone argument Time.new with a String argument returns Time in timezone specified in the String argument
-fails:Time.new with a timezone argument Time.new with a String argument returns Time in timezone specified in the String argument even if the in keyword argument provided
-fails:Time.new with a timezone argument Time.new with a String argument returns Time in timezone specified with in keyword argument if timezone isn't provided in the String argument
 fails:Time.new with a timezone argument Time.new with a String argument converts precision keyword argument into Integer if is not nil
 fails:Time.new with a timezone argument Time.new with a String argument raise TypeError is can't convert precision keyword argument into Integer
-fails:Time.new with a timezone argument Time.new with a String argument raises ArgumentError if part of time string is missing
-fails:Time.new with a timezone argument Time.new with a String argument raises ArgumentError if subsecond is missing after dot
-fails:Time.new with a timezone argument Time.new with a String argument raises ArgumentError if String argument is not in the supported format
-fails:Time.new with a timezone argument Time.new with a String argument raises ArgumentError if date/time parts values are not valid
-fails:Time.new with a timezone argument Time.new with a String argument raises ArgumentError if string has not ascii-compatible encoding

--- a/src/main/ruby/truffleruby/core/time.rb
+++ b/src/main/ruby/truffleruby/core/time.rb
@@ -403,15 +403,19 @@ class Time
       time
     end
 
-    def new(year = undefined, month = nil, day = nil, hour = nil, minute = nil, second = nil, utc_offset = nil, **options)
+    def new(year = undefined, month = undefined, day = nil, hour = nil, minute = nil, second = nil, utc_offset = nil, **options)
       if utc_offset && options[:in]
         raise ArgumentError, 'timezone argument given as positional and keyword arguments'
       end
 
       utc_offset ||= options[:in]
+      month_undefined = Primitive.undefined?(month)
+      month = nil if month_undefined
 
       if Primitive.undefined?(year)
         utc_offset ? self.now.getlocal(utc_offset) : self.now
+      elsif Primitive.is_a?(year, String) && month_undefined
+        Truffle::TimeOperations.new_from_string(self, year, **options)
       elsif Primitive.nil? utc_offset
         Truffle::TimeOperations.compose(self, :local, year, month, day, hour, minute, second)
       elsif utc_offset == :std

--- a/src/main/ruby/truffleruby/core/truffle/time_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/time_operations.rb
@@ -104,62 +104,74 @@ module Truffle
         return self.compose(time_class, self.utc_offset_for_compose(offset || options[:in]), year, month, mday, hour, min, sec, usec)
       end
 
-      require 'strscan'
+      # raise ArgumentError, "can't parse: #{str.inspect}"
 
-      scanner = StringScanner.new(str)
-      year = scanner.scan(/\d+/)
+      len = str.length
+      state = [1, 0]
+      year = str.match(/^(\d+)/)&.captures&.first
       raise ArgumentError, "can't parse: #{str.inspect}" if Primitive.nil?(year)
       raise ArgumentError, "year must be 4 or more digits: #{year}" if year.length < 4
 
-      return self.compose(time_class, self.utc_offset_for_compose(options[:in]), year) if scanner.eos?
+      return self.compose(time_class, self.utc_offset_for_compose(options[:in]), year) if len == year.size
 
-      month = self.scan_for_two_digits(scanner, 'mon', '-', 1..12)
-      mday = self.scan_for_two_digits(scanner, 'mday', '-', 1..31)
+      state[1] += year.size
+      month = self.scan_for_two_digits(state, str, 'mon', '-', 1..12)
+      mday = self.scan_for_two_digits(state, str, 'mday', '-', 1..31)
 
       # Just focus on the time part now.
-      scanner.string = scanner.rest
-      hour = self.scan_for_two_digits(scanner, 'hour', /[ T]/, 0..23, 'no time information', true)
-      min = self.scan_for_two_digits(scanner, 'min', ':', 0..59, true, true)
-      sec = self.scan_for_two_digits(scanner, 'sec', ':', 0..59, true)
+      state[0] = state[1] + 1
+      hour = self.scan_for_two_digits(state, str, 'hour', /[ T]/, 0..23, 'no time information', true)
+      min = self.scan_for_two_digits(state, str, 'min', ':', 0..59, true, true)
+      sec = self.scan_for_two_digits(state, str, 'sec', ':', 0..60, true)
 
-      if scanner.scan(/\.(\d*)/)
-        usec = scanner.captures[0]
-        raise ArgumentError, "subsecond expected after dot: #{scanner.pre_match[1..]}. " if usec == ''
+      if match = str[state[1]].match(/\.(\d*)/)
+        usec = match.captures[0]
+        raise ArgumentError, "subsecond expected after dot: #{str[state[0]..state[1]]} " if usec == ''
       end
 
       utc_offset = options[:in]
-      unless scanner.eos?
-        scanner.skip(/\s+/)
-        if scanner.match?(/\S+/)
+      unless len == state[1]
+        if match = str[state[1]..].match(/\s*(\S+)/)
           # An offset provided in the string overrides any passed in via `in:`.
-          utc_offset = scanner.matched
+          utc_offset = match.captures[0]
+          state[1] += match[0].size
         end
       end
+
+      raise ArgumentError, "can't parse at:#{str[state[1]..]}" if str.length > state[1]
 
       self.compose(time_class, self.utc_offset_for_compose(utc_offset), year, month, mday, hour, min, sec, usec)
     end
 
-    def self.scan_for_two_digits(scanner, name, separator, range = nil, not_found_msg = nil, check_fraction = false)
-      digits = if scanner.scan(/#{separator}(\d+)/)
-                 scanner.captures[0]
-               elsif Primitive.true?(not_found_msg)
-                 raise ArgumentError, "missing #{name} part: #{scanner.string[1...scanner.pos]} "
-               elsif not_found_msg
-                 raise ArgumentError, not_found_msg
-               end
-
-      if digits.to_s.size != 2
-        after = " after '#{separator}'" if separator == ':' || separator == '-'
-        raise ArgumentError, "two digits #{name} is expected#{after}: #{ "#{scanner.matched}#{scanner.rest}"[0..10] }"
+    def self.scan_for_two_digits(state, str, name, separator, range = nil, not_found_msg = nil, check_fraction = false)
+      index = state[1]
+      if str.length > index && str[index].match?(separator) && str[(index + 1)].match?(/\d/)
+        subindex = index + 1
+        while str.length > subindex && str[subindex].match?(/\d/)
+          subindex += 1
+        end
+        digits = str[(index + 1)...subindex]
+      elsif Primitive.true?(not_found_msg)
+        raise ArgumentError, "missing #{name} part: #{str[state[0]..index]}"
+      elsif not_found_msg
+        raise ArgumentError, not_found_msg
       end
+
+      if digits.size != 2
+        after = " after '#{separator}'" if separator == ':' || separator == '-'
+        raise ArgumentError, "two digits #{name} is expected#{after}: #{ str[index..(index + 10)] }"
+      end
+
+      # Advance index.
+      index = state[1] = state[1] + 3
 
       num = digits.to_i
       if range && !range.include?(num)
         raise ArgumentError, "#{name} out of range"
       end
 
-      if check_fraction && scanner.peek(1) == '.'
-        raise ArgumentError, "fraction #{name} is not supported: #{ "#{scanner.pre_match}#{scanner.matched}"[1..] }."
+      if check_fraction && str[index] == '.'
+        raise ArgumentError, "fraction #{name} is not supported: #{ str[state[0]..index] }"
       end
 
       num

--- a/src/main/ruby/truffleruby/core/truffle/time_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/time_operations.rb
@@ -96,9 +96,7 @@ module Truffle
       raise ArgumentError, 'time string should have ASCII compatible encoding' unless str.encoding.ascii_compatible?
 
       # Fast path for well-formed strings.
-      # Specify the acceptable range for each component in the regexp so that if
-      # any value is out of range the match will fail and fall through.
-      if match = str.match(/\A(\d{4,5})(?:-(0[0-9]|1[012])-(0[0-9]|[12][0-9]|3[01])[ T]([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9]|60)(?:\.(\d+))?\s*(\S+)?)?\z/)
+      if match = str.match(/\A(\d{4,5})(?:-(\d{2})-(\d{2})[ T](\d{2}):(\d{2}):(\d{2})(?:\.(\d+))?\s*(\S+)?)?\z/)
         year, month, mday, hour, min, sec, usec, offset = match.captures
         return self.compose(time_class, self.utc_offset_for_compose(offset || options[:in]), year, month, mday, hour, min, sec, usec)
       end

--- a/src/main/ruby/truffleruby/core/truffle/time_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/time_operations.rb
@@ -96,8 +96,16 @@ module Truffle
       raise ArgumentError, 'time string should have ASCII compatible encoding' unless str.encoding.ascii_compatible?
 
       # Fast path for well-formed strings.
-      if match = str.match(/\A(\d{4,5})(?:-(\d{2})-(\d{2})[ T](\d{2}):(\d{2}):(\d{2})(?:\.(\d+))?\s*(\S+)?)?\z/)
-        year, month, mday, hour, min, sec, usec, offset = match.captures
+      if /\A (?<year>\d{4,5})
+             (?:
+               - (?<month>\d{2})
+               - (?<mday> \d{2})
+               [ T] (?<hour> \d{2})
+                  : (?<min>  \d{2})
+                  : (?<sec>  \d{2})
+                  (?:\. (?<usec> \d+) )?
+              \s* (?<offset>\S+)?
+             )?\z/x =~ str
         return self.compose(time_class, self.utc_offset_for_compose(offset || options[:in]), year, month, mday, hour, min, sec, usec)
       end
 

--- a/src/main/ruby/truffleruby/core/truffle/time_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/time_operations.rb
@@ -97,84 +97,13 @@ module Truffle
 
       # Fast path for well-formed strings.
       # Specify the acceptable range for each component in the regexp so that if
-      # any value is out of range the match will fail and fall through to the
-      # scanner code below.
+      # any value is out of range the match will fail and fall through.
       if match = str.match(/\A(\d{4,5})(?:-(0[0-9]|1[012])-(0[0-9]|[12][0-9]|3[01])[ T]([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9]|60)(?:\.(\d+))?\s*(\S+)?)?\z/)
         year, month, mday, hour, min, sec, usec, offset = match.captures
         return self.compose(time_class, self.utc_offset_for_compose(offset || options[:in]), year, month, mday, hour, min, sec, usec)
       end
 
-      # raise ArgumentError, "can't parse: #{str.inspect}"
-
-      len = str.length
-      state = [1, 0]
-      year = str.match(/^(\d+)/)&.captures&.first
-      raise ArgumentError, "can't parse: #{str.inspect}" if Primitive.nil?(year)
-      raise ArgumentError, "year must be 4 or more digits: #{year}" if year.length < 4
-
-      return self.compose(time_class, self.utc_offset_for_compose(options[:in]), year) if len == year.size
-
-      state[1] += year.size
-      month = self.scan_for_two_digits(state, str, 'mon', '-', 1..12)
-      mday = self.scan_for_two_digits(state, str, 'mday', '-', 1..31)
-
-      # Just focus on the time part now.
-      state[0] = state[1] + 1
-      hour = self.scan_for_two_digits(state, str, 'hour', /[ T]/, 0..23, 'no time information', true)
-      min = self.scan_for_two_digits(state, str, 'min', ':', 0..59, true, true)
-      sec = self.scan_for_two_digits(state, str, 'sec', ':', 0..60, true)
-
-      if match = str[state[1]].match(/\.(\d*)/)
-        usec = match.captures[0]
-        raise ArgumentError, "subsecond expected after dot: #{str[state[0]..state[1]]} " if usec == ''
-      end
-
-      utc_offset = options[:in]
-      unless len == state[1]
-        if match = str[state[1]..].match(/\s*(\S+)/)
-          # An offset provided in the string overrides any passed in via `in:`.
-          utc_offset = match.captures[0]
-          state[1] += match[0].size
-        end
-      end
-
-      raise ArgumentError, "can't parse at:#{str[state[1]..]}" if str.length > state[1]
-
-      self.compose(time_class, self.utc_offset_for_compose(utc_offset), year, month, mday, hour, min, sec, usec)
-    end
-
-    def self.scan_for_two_digits(state, str, name, separator, range = nil, not_found_msg = nil, check_fraction = false)
-      index = state[1]
-      if str.length > index && str[index].match?(separator) && str[(index + 1)].match?(/\d/)
-        subindex = index + 1
-        while str.length > subindex && str[subindex].match?(/\d/)
-          subindex += 1
-        end
-        digits = str[(index + 1)...subindex]
-      elsif Primitive.true?(not_found_msg)
-        raise ArgumentError, "missing #{name} part: #{str[state[0]..index]}"
-      elsif not_found_msg
-        raise ArgumentError, not_found_msg
-      end
-
-      if digits.size != 2
-        after = " after '#{separator}'" if separator == ':' || separator == '-'
-        raise ArgumentError, "two digits #{name} is expected#{after}: #{ str[index..(index + 10)] }"
-      end
-
-      # Advance index.
-      index = state[1] = state[1] + 3
-
-      num = digits.to_i
-      if range && !range.include?(num)
-        raise ArgumentError, "#{name} out of range"
-      end
-
-      if check_fraction && str[index] == '.'
-        raise ArgumentError, "fraction #{name} is not supported: #{ str[state[0]..index] }"
-      end
-
-      num
+      raise ArgumentError, "can't parse: #{str.inspect}"
     end
 
     def self.utc_offset_for_compose(utc_offset)


### PR DESCRIPTION
closes #3693

Use a regexp to quickly detect if a timestamp string is valid.
If it isn't raise an ArgumentError for consistency with CRuby 3.2+.

I added a few new specs for behavior I noticed that I didn't see in the existing specs.
It's not that difficult to match the existing error messages, but I'm not sure how valuable they are.

Here are some examples of the differences:

```
Expected ArgumentError (missing sec part: 00:56 )
but got: ArgumentError (can't parse: "2020-12-25 00:56 +09:00")

Expected ArgumentError (subsecond expected after dot: 00:56:17. )
but got: ArgumentError (can't parse: "2020-12-25 00:56:17. +0900")

Expected ArgumentError (year must be 4 or more digits: 021)
but got: ArgumentError (can't parse: "021-12-25 00:00:00.123456 +09:00")

Expected ArgumentError (mon out of range)
but got: ArgumentError (can't parse: "2020-13-25 00:56:17 +09:00")
```

As discussed, this relaxes the error message specs to keep the code simple.

This removes the "fails" tags for the "Time.new with a String argument" specs except for the three `precision` related ones which TruffleRuby isn't doing anything with yet.