### PR TITLE
Make Thread::{Queue,SizedQueue}#freeze raise TypeError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ Compatibility:
 * Support serializing of `Data` instances into Marshal format (#3726, @andrykonchin).
 * `Array#pack` now raises `ArgumentError` for unknown directives (#3681, @Th3-M4jor).
 * `String#unpack` now raises `ArgumentError` for unknown directives (#3681, @Th3-M4jor).
+* `Thread::Queue#freeze` now raises `TypeError` when called (#3681, @Th3-M4jor).
+* `Thread::SizedQueue#freeze` now raises `TypeError` when called (#3681, @Th3-M4jor).
 
 Performance:
 

--- a/lib/truffle/thread.rb
+++ b/lib/truffle/thread.rb
@@ -41,6 +41,10 @@ class Thread
     end
     alias_method :shift, :pop
     alias_method :deq, :pop
+
+    def freeze
+      raise TypeError, "cannot freeze #{self}"
+    end
   end
 
   class SizedQueue
@@ -62,5 +66,9 @@ class Thread
     end
     alias_method :<<, :push
     alias_method :enq, :push
+
+    def freeze
+      raise TypeError, "cannot freeze #{self}"
+    end
   end
 end

--- a/spec/tags/core/queue/freeze_tags.txt
+++ b/spec/tags/core/queue/freeze_tags.txt
@@ -1,1 +1,0 @@
-fails:Queue#freeze raises an exception when freezing

--- a/spec/tags/core/sizedqueue/freeze_tags.txt
+++ b/spec/tags/core/sizedqueue/freeze_tags.txt
@@ -1,1 +1,0 @@
-fails:SizedQueue#freeze raises an exception when freezing


### PR DESCRIPTION
Makes it so that attempting to freeze a `Thread::Queue` and `Thread::SizedQueue` will raise a `TypeError`