### PR TITLE
Support timezone object argument to Time.{at,new} and Time#{getlocal,localtime}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Compatibility:
 * Add `Dir.for_fd` (#3681, @andrykonchin).
 * Add `Dir.fchdir` (#3681, @andrykonchin).
 * Add `Dir#chdir` (#3681, @andrykonchin).
+* Support Timezone argument to `Time.{new,at}` and `Time#{getlocal,localtime}` (#1717, @patricklinpl, @manefz, @rwstauner).
 
 Performance:
 

--- a/spec/ruby/core/time/getlocal_spec.rb
+++ b/spec/ruby/core/time/getlocal_spec.rb
@@ -128,7 +128,7 @@ describe "Time#getlocal" do
 
       -> {
         Time.utc(2000, 1, 1, 12, 0, 0).getlocal(zone)
-      }.should raise_error(TypeError, /can't convert \w+ into an exact number/)
+      }.should raise_error(TypeError)
     end
 
     it "does not raise exception if timezone does not implement #local_to_utc method" do

--- a/spec/ruby/core/time/getlocal_spec.rb
+++ b/spec/ruby/core/time/getlocal_spec.rb
@@ -14,6 +14,7 @@ describe "Time#getlocal" do
     t = Time.gm(2007, 1, 9, 12, 0, 0).getlocal(3630)
     t.should == Time.new(2007, 1, 9, 13, 0, 30, 3630)
     t.utc_offset.should == 3630
+    t.zone.should be_nil
   end
 
   platform_is_not :windows do

--- a/spec/ruby/core/time/localtime_spec.rb
+++ b/spec/ruby/core/time/localtime_spec.rb
@@ -128,6 +128,17 @@ describe "Time#localtime" do
     end
   end
 
+  describe "with an argument that responds to #utc_to_local" do
+    it "coerces using #utc_to_local" do
+      o = mock('string')
+      o.should_receive(:utc_to_local).and_return(Time.new(2007, 1, 9, 13, 0, 0, 3600))
+      t = Time.gm(2007, 1, 9, 12, 0, 0)
+      t.localtime(o)
+      t.should == Time.new(2007, 1, 9, 13, 0, 0, 3600)
+      t.utc_offset.should == 3600
+    end
+  end
+
   it "raises ArgumentError if the String argument is not of the form (+|-)HH:MM" do
     t = Time.now
     -> { t.localtime("3600") }.should raise_error(ArgumentError)

--- a/spec/ruby/core/time/new_spec.rb
+++ b/spec/ruby/core/time/new_spec.rb
@@ -226,7 +226,7 @@ describe "Time.new with a timezone argument" do
 
     -> {
       Time.new(2000, 1, 1, 12, 0, 0, zone)
-    }.should raise_error(TypeError, /can't convert \w+ into an exact number/)
+    }.should raise_error(TypeError)
   end
 
   it "does not raise exception if timezone does not implement #utc_to_local method" do

--- a/spec/tags/core/time/at_tags.txt
+++ b/spec/tags/core/time/at_tags.txt
@@ -1,2 +1,1 @@
-fails:Time.at :in keyword argument could be a timezone object
 fails:Time.at passed non-Time, non-Numeric with an argument that responds to #to_r needs for the argument to respond to #to_int too

--- a/spec/tags/core/time/getlocal_tags.txt
+++ b/spec/tags/core/time/getlocal_tags.txt
@@ -3,6 +3,5 @@ fails:Time#getlocal with an argument that responds to #to_r coerces using #to_r
 fails:Time#getlocal raises ArgumentError if the argument represents a value less than or equal to -86400 seconds
 fails:Time#getlocal raises ArgumentError if the argument represents a value greater than or equal to 86400 seconds
 fails:Time#getlocal with a timezone argument returns a Time in the timezone
-fails:Time#getlocal with a timezone argument raises TypeError if timezone does not implement #utc_to_local method
 fails:Time#getlocal with a timezone argument subject's class implements .find_timezone method calls .find_timezone to build a time object if passed zone name as a timezone argument
 fails:Time#getlocal with a timezone argument subject's class implements .find_timezone method does not call .find_timezone if passed any not string/numeric/timezone timezone argument

--- a/spec/tags/core/time/getlocal_tags.txt
+++ b/spec/tags/core/time/getlocal_tags.txt
@@ -3,8 +3,6 @@ fails:Time#getlocal with an argument that responds to #to_r coerces using #to_r
 fails:Time#getlocal raises ArgumentError if the argument represents a value less than or equal to -86400 seconds
 fails:Time#getlocal raises ArgumentError if the argument represents a value greater than or equal to 86400 seconds
 fails:Time#getlocal with a timezone argument returns a Time in the timezone
-fails:Time#getlocal with a timezone argument accepts timezone argument that must have #local_to_utc and #utc_to_local methods
 fails:Time#getlocal with a timezone argument raises TypeError if timezone does not implement #utc_to_local method
-fails:Time#getlocal with a timezone argument does not raise exception if timezone does not implement #local_to_utc method
 fails:Time#getlocal with a timezone argument subject's class implements .find_timezone method calls .find_timezone to build a time object if passed zone name as a timezone argument
 fails:Time#getlocal with a timezone argument subject's class implements .find_timezone method does not call .find_timezone if passed any not string/numeric/timezone timezone argument

--- a/spec/tags/core/time/getlocal_tags.txt
+++ b/spec/tags/core/time/getlocal_tags.txt
@@ -2,6 +2,5 @@ fails:Time#getlocal returns a Time with a UTC offset of the specified number of 
 fails:Time#getlocal with an argument that responds to #to_r coerces using #to_r
 fails:Time#getlocal raises ArgumentError if the argument represents a value less than or equal to -86400 seconds
 fails:Time#getlocal raises ArgumentError if the argument represents a value greater than or equal to 86400 seconds
-fails:Time#getlocal with a timezone argument returns a Time in the timezone
 fails:Time#getlocal with a timezone argument subject's class implements .find_timezone method calls .find_timezone to build a time object if passed zone name as a timezone argument
 fails:Time#getlocal with a timezone argument subject's class implements .find_timezone method does not call .find_timezone if passed any not string/numeric/timezone timezone argument

--- a/spec/tags/core/time/minus_tags.txt
+++ b/spec/tags/core/time/minus_tags.txt
@@ -1,3 +1,2 @@
 fails:Time#- maintains subseconds precision
 fails:Time#- maintains precision
-fails:Time#- zone is a timezone object preserves time zone

--- a/spec/tags/core/time/new_tags.txt
+++ b/spec/tags/core/time/new_tags.txt
@@ -3,7 +3,6 @@ fails:Time.new with a utc_offset argument with an argument that responds to #to_
 fails:Time.new with a utc_offset argument raises ArgumentError if the argument represents a value less than or equal to -86400 seconds
 fails:Time.new with a utc_offset argument raises ArgumentError if the argument represents a value greater than or equal to 86400 seconds
 fails:Time.new with a timezone argument returns a Time in the timezone
-fails:Time.new with a timezone argument accepts timezone argument that must have #local_to_utc and #utc_to_local methods
 fails:Time.new with a timezone argument raises TypeError if timezone does not implement #local_to_utc method
 fails:Time.new with a timezone argument does not raise exception if timezone does not implement #utc_to_local method
 fails:Time.new with a timezone argument the #abbr method is used by '%Z' in #strftime

--- a/spec/tags/core/time/new_tags.txt
+++ b/spec/tags/core/time/new_tags.txt
@@ -4,15 +4,8 @@ fails:Time.new with a utc_offset argument raises ArgumentError if the argument r
 fails:Time.new with a utc_offset argument raises ArgumentError if the argument represents a value greater than or equal to 86400 seconds
 fails:Time.new with a timezone argument returns a Time in the timezone
 fails:Time.new with a timezone argument raises TypeError if timezone does not implement #local_to_utc method
-fails:Time.new with a timezone argument does not raise exception if timezone does not implement #utc_to_local method
 fails:Time.new with a timezone argument the #abbr method is used by '%Z' in #strftime
-fails:Time.new with a timezone argument returned value by #utc_to_local and #local_to_utc methods could be Time instance
-fails:Time.new with a timezone argument returned value by #utc_to_local and #local_to_utc methods could be Time subclass instance
-fails:Time.new with a timezone argument returned value by #utc_to_local and #local_to_utc methods could be any object with #to_i method
-fails:Time.new with a timezone argument returned value by #utc_to_local and #local_to_utc methods could have any #zone and #utc_offset because they are ignored
-fails:Time.new with a timezone argument returned value by #utc_to_local and #local_to_utc methods leads to raising Argument error if difference between argument and result is too large
 fails:Time.new with a timezone argument Time-like argument of #utc_to_local and #local_to_utc methods implements subset of Time methods
-fails:Time.new with a timezone argument Time-like argument of #utc_to_local and #local_to_utc methods has attribute values the same as a Time object in UTC
 fails:Time.new with a timezone argument #name method uses the optional #name method for marshaling
 fails:Time.new with a timezone argument #name method cannot marshal Time if #name method isn't implemented
 fails:Time.new with a timezone argument subject's class implements .find_timezone method calls .find_timezone to build a time object at loading marshaled data

--- a/spec/tags/core/time/new_tags.txt
+++ b/spec/tags/core/time/new_tags.txt
@@ -3,7 +3,6 @@ fails:Time.new with a utc_offset argument with an argument that responds to #to_
 fails:Time.new with a utc_offset argument raises ArgumentError if the argument represents a value less than or equal to -86400 seconds
 fails:Time.new with a utc_offset argument raises ArgumentError if the argument represents a value greater than or equal to 86400 seconds
 fails:Time.new with a timezone argument the #abbr method is used by '%Z' in #strftime
-fails:Time.new with a timezone argument Time-like argument of #utc_to_local and #local_to_utc methods implements subset of Time methods
 fails:Time.new with a timezone argument #name method uses the optional #name method for marshaling
 fails:Time.new with a timezone argument #name method cannot marshal Time if #name method isn't implemented
 fails:Time.new with a timezone argument subject's class implements .find_timezone method calls .find_timezone to build a time object at loading marshaled data

--- a/spec/tags/core/time/new_tags.txt
+++ b/spec/tags/core/time/new_tags.txt
@@ -2,7 +2,6 @@ fails:Time.new with a utc_offset argument returns a Time with a UTC offset of th
 fails:Time.new with a utc_offset argument with an argument that responds to #to_r coerces using #to_r
 fails:Time.new with a utc_offset argument raises ArgumentError if the argument represents a value less than or equal to -86400 seconds
 fails:Time.new with a utc_offset argument raises ArgumentError if the argument represents a value greater than or equal to 86400 seconds
-fails:Time.new with a timezone argument returns a Time in the timezone
 fails:Time.new with a timezone argument raises TypeError if timezone does not implement #local_to_utc method
 fails:Time.new with a timezone argument the #abbr method is used by '%Z' in #strftime
 fails:Time.new with a timezone argument Time-like argument of #utc_to_local and #local_to_utc methods implements subset of Time methods
@@ -11,7 +10,6 @@ fails:Time.new with a timezone argument #name method cannot marshal Time if #nam
 fails:Time.new with a timezone argument subject's class implements .find_timezone method calls .find_timezone to build a time object at loading marshaled data
 fails:Time.new with a timezone argument subject's class implements .find_timezone method calls .find_timezone to build a time object if passed zone name as a timezone argument
 fails:Time.new with a timezone argument subject's class implements .find_timezone method does not call .find_timezone if passed any not string/numeric/timezone timezone argument
-fails:Time.new with a timezone argument :in keyword argument could be a timezone object
 fails:Time.new with a timezone argument Time.new with a String argument accepts precision keyword argument and truncates specified digits of sub-second part
 fails:Time.new with a timezone argument Time.new with a String argument converts precision keyword argument into Integer if is not nil
 fails:Time.new with a timezone argument Time.new with a String argument raise TypeError is can't convert precision keyword argument into Integer

--- a/spec/tags/core/time/new_tags.txt
+++ b/spec/tags/core/time/new_tags.txt
@@ -2,7 +2,6 @@ fails:Time.new with a utc_offset argument returns a Time with a UTC offset of th
 fails:Time.new with a utc_offset argument with an argument that responds to #to_r coerces using #to_r
 fails:Time.new with a utc_offset argument raises ArgumentError if the argument represents a value less than or equal to -86400 seconds
 fails:Time.new with a utc_offset argument raises ArgumentError if the argument represents a value greater than or equal to 86400 seconds
-fails:Time.new with a timezone argument raises TypeError if timezone does not implement #local_to_utc method
 fails:Time.new with a timezone argument the #abbr method is used by '%Z' in #strftime
 fails:Time.new with a timezone argument Time-like argument of #utc_to_local and #local_to_utc methods implements subset of Time methods
 fails:Time.new with a timezone argument #name method uses the optional #name method for marshaling

--- a/spec/tags/core/time/plus_tags.txt
+++ b/spec/tags/core/time/plus_tags.txt
@@ -1,2 +1,1 @@
 fails:Time#+ maintains subseconds precision
-fails:Time#+ zone is a timezone object preserves time zone

--- a/spec/tags/library/time/to_time_tags.txt
+++ b/spec/tags/library/time/to_time_tags.txt
@@ -1,1 +1,0 @@
-fails:Time#to_time returns itself in the same timezone

--- a/src/main/java/org/truffleruby/core/time/TimeNodes.java
+++ b/src/main/java/org/truffleruby/core/time/TimeNodes.java
@@ -409,9 +409,8 @@ public abstract class TimeNodes {
 
     @Primitive(name = "time_set_zone")
     public abstract static class TimeSetZoneNode extends PrimitiveArrayArgumentsNode {
-        @Specialization(guards = "strings.isRubyString(this, zone)", limit = "1")
-        Object timeSetZone(RubyTime time, Object zone,
-                @Cached RubyStringLibrary strings) {
+        @Specialization
+        Object timeSetZone(RubyTime time, Object zone) {
             time.zone = zone;
             return zone;
         }

--- a/src/main/ruby/truffleruby/core/time.rb
+++ b/src/main/ruby/truffleruby/core/time.rb
@@ -37,6 +37,10 @@
 class Time
   include Comparable
 
+  # Time#to_time is defined in date_core.c but it's just `return self`
+  # so we can make it available for use without having to `require "date"`.
+  alias_method :to_time, :itself
+
   def inspect
     str = strftime('%Y-%m-%d %H:%M:%S')
 

--- a/src/main/ruby/truffleruby/core/time.rb
+++ b/src/main/ruby/truffleruby/core/time.rb
@@ -107,13 +107,15 @@ class Time
   def zone
     zone = Primitive.time_zone(self)
 
-    if zone && zone.ascii_only?
-      zone.encode Encoding::US_ASCII
-    elsif zone && Encoding.default_internal
-      zone.encode Encoding.default_internal
-    else
-      zone
+    if zone && Primitive.is_a?(zone, String)
+      if zone.ascii_only?
+        return zone.encode Encoding::US_ASCII
+      elsif Encoding.default_internal
+        return zone.encode Encoding.default_internal
+      end
     end
+
+    zone
   end
 
   # Random number for hash codes. Stops hashes for similar values in

--- a/src/main/ruby/truffleruby/core/time.rb
+++ b/src/main/ruby/truffleruby/core/time.rb
@@ -186,7 +186,9 @@ class Time
     if to_utc
       Primitive.time_utctime(self)
     else
-      Primitive.time_localtime(self, offset)
+      result = Primitive.time_localtime(self, offset)
+      Truffle::TimeOperations.set_zone_if_object(result, zone_or_offset)
+      result
     end
   end
 
@@ -371,6 +373,7 @@ class Time
         result = is_utc ? Primitive.time_utctime(result) : Primitive.time_localtime(result, offset)
       end
       if result
+        Truffle::TimeOperations.set_zone_if_object(result, timezone)
         return result
       end
 
@@ -431,9 +434,12 @@ class Time
         if utc_offset_in_utc?(utc_offset)
           utc_offset = :utc
         else
+          zone = utc_offset
           utc_offset = Truffle::Type.coerce_to_utc_offset(utc_offset, Time.utc(year, month, day, hour, minute, second), :local_to_utc)
         end
-        Truffle::TimeOperations.compose(self, utc_offset, year, month, day, hour, minute, second)
+        result = Truffle::TimeOperations.compose(self, utc_offset, year, month, day, hour, minute, second)
+        Truffle::TimeOperations.set_zone_if_object(result, zone)
+        result
       end
     end
 

--- a/src/main/ruby/truffleruby/core/truffle/time_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/time_operations.rb
@@ -121,5 +121,14 @@ module Truffle
         Truffle::Type.coerce_to_utc_offset(utc_offset)
       end
     end
+
+    # When a timezone object is used (via its utc_to_local or local_to_utc methods)
+    # the resulting time object gets its zone set to be the object
+    # (but this isn't done when the zone is just an integer offset or string abbreviation).
+    def self.set_zone_if_object(time, zone)
+      return if Primitive.nil?(zone) || Primitive.is_a?(zone, Integer) || Primitive.is_a?(zone, String)
+
+      Primitive.time_set_zone(time, zone)
+    end
   end
 end

--- a/src/main/ruby/truffleruby/core/type.rb
+++ b/src/main/ruby/truffleruby/core/type.rb
@@ -486,6 +486,8 @@ module Truffle
 
       if Primitive.is_a? offset, String
         offset = Truffle::Type.coerce_string_to_utc_offset(offset)
+      elsif Primitive.respond_to?(offset, :utc_to_local, false)
+        offset = offset.utc_to_local(Time.now).utc_offset
       else
         offset = Truffle::Type.coerce_to_exact_num(offset)
       end


### PR DESCRIPTION
This adds (at least some) support for the "Timezone Objects" interfaces to several `Time` methods as described in
https://docs.ruby-lang.org/en/3.3/Time.html#class-Time-label-Timezone+Objects

It was difficult to discern how it all should work but between the CRuby source code and the specs (and tracing what methods were being called on our objects) I think we figured it out.

We started this six months ago as part of HackDays and didn't get very far, then I resurrected it this week.

closes #1717