### PR TITLE
Support `Proc#initialize_{dup,copy}` for subclasses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Compatibility:
 * Add `Dir.for_fd` (#3681, @andrykonchin).
 * Add `Dir.fchdir` (#3681, @andrykonchin).
 * Add `Dir#chdir` (#3681, @andrykonchin).
+* Support `Proc#initialize_{dup,copy}` for subclasses (#3681, @rwstauner).
 
 Performance:
 

--- a/spec/ruby/core/proc/clone_spec.rb
+++ b/spec/ruby/core/proc/clone_spec.rb
@@ -1,4 +1,5 @@
 require_relative '../../spec_helper'
+require_relative 'fixtures/common'
 require_relative 'shared/dup'
 
 describe "Proc#clone" do
@@ -10,6 +11,20 @@ describe "Proc#clone" do
       proc.freeze
       proc.frozen?.should == true
       proc.clone.frozen?.should == true
+    end
+  end
+
+  ruby_version_is "3.3" do
+    it "calls #initialize_copy on subclass" do
+      obj = ProcSpecs::MyProc2.new(:a, 2) { }
+      dup = obj.clone
+
+      dup.should_not equal(obj)
+      dup.class.should == ProcSpecs::MyProc2
+
+      dup.first.should == :a
+      dup.second.should == 2
+      dup.initializer.should == :copy
     end
   end
 end

--- a/spec/ruby/core/proc/dup_spec.rb
+++ b/spec/ruby/core/proc/dup_spec.rb
@@ -1,4 +1,5 @@
 require_relative '../../spec_helper'
+require_relative 'fixtures/common'
 require_relative 'shared/dup'
 
 describe "Proc#dup" do
@@ -9,5 +10,19 @@ describe "Proc#dup" do
     proc.freeze
     proc.frozen?.should == true
     proc.dup.frozen?.should == false
+  end
+
+  ruby_version_is "3.3" do
+    it "calls #initialize_dup on subclass" do
+      obj = ProcSpecs::MyProc2.new(:a, 2) { }
+      dup = obj.dup
+
+      dup.should_not equal(obj)
+      dup.class.should == ProcSpecs::MyProc2
+
+      dup.first.should == :a
+      dup.second.should == 2
+      dup.initializer.should == :dup
+    end
   end
 end

--- a/spec/ruby/core/proc/fixtures/common.rb
+++ b/spec/ruby/core/proc/fixtures/common.rb
@@ -32,7 +32,21 @@ module ProcSpecs
       @second = b
     end
 
-    attr_reader :first, :second
+    attr_reader :first, :second, :initializer
+
+    def initialize_copy(other)
+      super
+      @initializer = :copy
+      @first = other.first
+      @second = other.second
+    end
+
+    def initialize_dup(other)
+      super
+      @initializer = :dup
+      @first = other.first
+      @second = other.second
+    end
   end
 
   class Arity

--- a/src/main/java/org/truffleruby/core/proc/ProcOperations.java
+++ b/src/main/java/org/truffleruby/core/proc/ProcOperations.java
@@ -10,6 +10,7 @@
 package org.truffleruby.core.proc;
 
 import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.object.Shape;
 import org.truffleruby.RubyContext;
 import org.truffleruby.RubyLanguage;
@@ -20,6 +21,7 @@ import org.truffleruby.language.control.FrameOnStackMarker;
 import org.truffleruby.language.methods.DeclarationContext;
 import org.truffleruby.language.methods.InternalMethod;
 import org.truffleruby.language.methods.SharedMethodInfo;
+import org.truffleruby.language.objects.AllocationTracing;
 import org.truffleruby.language.threadlocal.SpecialVariableStorage;
 
 import com.oracle.truffle.api.RootCallTarget;
@@ -121,6 +123,24 @@ public abstract class ProcOperations {
         // Inefficient otherwise, check upstream, in a guard if possible.
         assert block.type == ProcType.LAMBDA;
         return convertBlock(context, language, block, ProcType.PROC);
+    }
+
+    public static RubyProc duplicate(RubyClass procClass, Shape shape, RubyProc proc, Node node) {
+        final RubyProc copy = new RubyProc(
+                procClass,
+                shape,
+                proc.type,
+                proc.arity,
+                proc.argumentDescriptors,
+                proc.callTargets,
+                proc.callTarget,
+                proc.declarationFrame,
+                proc.declarationVariables,
+                proc.declaringMethod,
+                proc.frameOnStackMarker,
+                proc.declarationContext);
+        AllocationTracing.trace(copy, node);
+        return copy;
     }
 
     public static Object getSelf(RubyProc proc) {


### PR DESCRIPTION
Previously dup/clone was a single method, so I separated it in order to differentiate which `initialize_*` method gets called, but I was wondering if there was another way to do that (like introspecting the method name?).

I made a helper in ProcOperations to reduce a duplicated long method call, but it's not very complicated, so let me know if you prefer to just have it inlined.
