### PR TITLE
Kernel#lambda raises when given non-lambda, non-literal block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Compatibility:
 * Support `symbolize_names` argument to `MatchData#named_captures` (#3681, @rwstauner).
 * Support `Proc#initialize_{dup,copy}` for subclasses (#3681, @rwstauner).
 * Remove deprecated `Encoding#replicate` method (#3681, @rwstauner).
+* `Kernel#lambda` with now raises `ArgumentError` when given a non-lambda, non-literal block (#3681, @Th3-M4jor).
 
 Performance:
 

--- a/spec/tags/core/kernel/lambda_tags.txt
+++ b/spec/tags/core/kernel/lambda_tags.txt
@@ -1,3 +1,2 @@
 fails:Kernel.lambda creates a lambda-style Proc when called with zsuper
 fails:Kernel.lambda does not create lambda-style Procs when captured with #method
-fails:Kernel.lambda when called without a literal block raises when proc isn't a lambda

--- a/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
+++ b/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
@@ -1148,23 +1148,17 @@ public abstract class KernelNodes {
             return ProcOperations.createLambdaFromBlock(getContext(), getLanguage(), block);
         }
 
-        @Specialization(guards = { "!isLiteralBlock(block)", "block.isProc()" })
-        RubyProc lambdaFromExistingProc(RubyProc block,
-                @Cached WarnNode warnNode) {
-            if (warnNode.shouldWarnForDeprecation()) {
-                warnNode.warningMessage(
-                        getContext().getCallStack().getTopMostUserSourceSection(),
-                        "lambda without a literal block is deprecated; use the proc without lambda instead");
-            }
-
-            // If the argument isn't a literal, its original behaviour (proc or lambda) is preserved.
+        @Specialization(guards = { "!isLiteralBlock(block)", "block.isLambda()" })
+        RubyProc lambdaFromExistingLambda(RubyProc block) {
+            // If the argument isn't a literal, its original behaviour is preserved only if its a lambda.
             return block;
         }
 
-        @Specialization(guards = { "!isLiteralBlock(block)", "block.isLambda()" })
+        @Specialization(guards = { "!isLiteralBlock(block)", "block.isProc()" })
         RubyProc lambdaFromExistingProc(RubyProc block) {
-            // If the argument isn't a literal, its original behaviour (proc or lambda) is preserved.
-            return block;
+            throw new RaiseException(
+                    getContext(),
+                    coreExceptions().argumentError("the lambda method requires a literal block", this));
         }
 
         @TruffleBoundary


### PR DESCRIPTION
Makes it so that when `Kernel#lambda` is given a non-lambda, non-literal block an `ArgumentError` will be raised.