### PR TITLE
Fix `Range#cover?` on begin-less ranges and non-integer values.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ New features:
 
 Bug fixes:
 
+* Fix `Range#cover?` on begin-less ranges and non-integer values (@nirvdrum, @rwstauner).
 
 Compatibility:
 

--- a/spec/ruby/core/range/shared/cover_and_include.rb
+++ b/spec/ruby/core/range/shared/cover_and_include.rb
@@ -20,13 +20,24 @@ describe :range_cover_and_include, shared: true do
   end
 
   it "returns true if other is an element of self for endless ranges" do
-    eval("(1..)").send(@method, 2.4).should == true
-    eval("(0.5...)").send(@method, 2.4).should == true
+    (1..).send(@method, 2.4).should == true
+    (0.5...).send(@method, 2.4).should == true
   end
 
   it "returns true if other is an element of self for beginless ranges" do
     (..10).send(@method, 2.4).should == true
     (...10.5).send(@method, 2.4).should == true
+  end
+
+  it "returns false if values are not comparable" do
+    (1..10).send(@method, nil).should == false
+    (1...10).send(@method, nil).should == false
+
+    (..10).send(@method, nil).should == false
+    (...10).send(@method, nil).should == false
+
+    (1..).send(@method, nil).should == false
+    (1...).send(@method, nil).should == false
   end
 
   it "compares values using <=>" do

--- a/src/main/ruby/truffleruby/core/truffle/range_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/range_operations.rb
@@ -122,13 +122,15 @@ module Truffle
       if !Primitive.nil?(range.begin)
         # MRI uses <=> to compare, so must we.
         cmp = (range.begin <=> value)
-        return false unless cmp
+        return false if Primitive.nil?(cmp)
         return false if Comparable.compare_int(cmp) > 0
       end
 
       # Check upper bound.
       if !Primitive.nil?(range.end)
         cmp = (value <=> range.end)
+        return false if Primitive.nil?(cmp)
+
         if range.exclude_end?
           return false if Comparable.compare_int(cmp) >= 0
         else


### PR DESCRIPTION
In particular, we need this method to work when passed `nil`, which we've observed occurring in the frozen_record gem.