### PR TITLE
Support digest plugins

### DIFF
--- a/lib/cext/include/ruby/digest.h
+++ b/lib/cext/include/ruby/digest.h
@@ -1,0 +1,73 @@
+/************************************************
+
+  digest.h - header file for ruby digest modules
+
+  $Author$
+  created at: Fri May 25 08:54:56 JST 2001
+
+
+  Copyright (C) 2001-2006 Akinori MUSHA
+
+  $RoughId: digest.h,v 1.3 2001/07/13 15:38:27 knu Exp $
+  $Id$
+
+************************************************/
+
+#include "ruby.h"
+
+#define RUBY_DIGEST_API_VERSION	3
+
+typedef int (*rb_digest_hash_init_func_t)(void *);
+typedef void (*rb_digest_hash_update_func_t)(void *, unsigned char *, size_t);
+typedef int (*rb_digest_hash_finish_func_t)(void *, unsigned char *);
+
+typedef struct {
+    int api_version;
+    size_t digest_len;
+    size_t block_len;
+    size_t ctx_size;
+    rb_digest_hash_init_func_t init_func;
+    rb_digest_hash_update_func_t update_func;
+    rb_digest_hash_finish_func_t finish_func;
+} rb_digest_metadata_t;
+
+#define DEFINE_UPDATE_FUNC_FOR_UINT(name) \
+void \
+rb_digest_##name##_update(void *ctx, unsigned char *ptr, size_t size) \
+{ \
+    const unsigned int stride = 16384; \
+ \
+    for (; size > stride; size -= stride, ptr += stride) { \
+        name##_Update(ctx, ptr, stride); \
+    } \
+    /* Since size <= stride, size should fit into an unsigned int */ \
+    if (size > 0) name##_Update(ctx, ptr, (unsigned int)size); \
+}
+
+#define DEFINE_FINISH_FUNC_FROM_FINAL(name) \
+int \
+rb_digest_##name##_finish(void *ctx, unsigned char *ptr) \
+{ \
+    return name##_Final(ptr, ctx); \
+}
+
+static inline VALUE
+rb_digest_namespace(void)
+{
+    rb_require("digest");
+    return rb_path2class("Digest");
+}
+
+static inline ID
+rb_id_metadata(void)
+{
+    return rb_intern_const("metadata");
+}
+
+static inline VALUE
+rb_digest_make_metadata(const rb_digest_metadata_t *meta)
+{
+#undef RUBY_UNTYPED_DATA_WARNING
+#define RUBY_UNTYPED_DATA_WARNING 0
+    return rb_obj_freeze(Data_Wrap_Struct(0, 0, 0, (void *)meta));
+}

--- a/lib/cext/include/truffleruby/truffleruby-abi-version.h
+++ b/lib/cext/include/truffleruby/truffleruby-abi-version.h
@@ -20,6 +20,6 @@
 // $RUBY_VERSION must be the same as TruffleRuby.LANGUAGE_VERSION.
 // $ABI_NUMBER starts at 1 and is incremented for every ABI-incompatible change.
 
-#define TRUFFLERUBY_ABI_VERSION "3.3.7.2"
+#define TRUFFLERUBY_ABI_VERSION "3.3.7.3"
 
 #endif

--- a/lib/truffle/truffle/cext_ruby.rb
+++ b/lib/truffle/truffle/cext_ruby.rb
@@ -13,7 +13,7 @@ module Truffle::CExt
   # Methods defined in this file are not considered as Ruby code implementing MRI C parts,
   # see org.truffleruby.cext.CExtNodes.BlockProcNode
 
-  # methods defined with rb_define_method are normal Ruby methods therefore they cannot be defined in the cext.rb file
+  # methods defined with rb_define_method are normal Ruby methods therefore they cannot be defined in the cext.rb
   # file because blocks passed as arguments would be skipped by org.truffleruby.cext.CExtNodes.BlockProcNode
   def rb_define_method(mod, name, function, argc)
     if argc < -2 or 15 < argc

--- a/spec/ruby/optional/capi/digest_spec.rb
+++ b/spec/ruby/optional/capi/digest_spec.rb
@@ -1,0 +1,99 @@
+require_relative 'spec_helper'
+
+require 'fiddle'
+
+load_extension('digest')
+
+describe "C-API Digest functions" do
+  before :each do
+    @s = CApiDigestSpecs.new
+  end
+
+  describe "rb_digest_make_metadata" do
+    before :each do
+      @metadata = @s.rb_digest_make_metadata
+    end
+
+    it "should store the block length" do
+      @s.block_length(@metadata).should == 40
+    end
+
+    it "should store the digest length" do
+      @s.digest_length(@metadata).should == 20
+    end
+
+    it "should store the context size" do
+      @s.context_size(@metadata).should == 129
+    end
+  end
+
+  describe "digest plugin" do
+    before :each do
+      @s = CApiDigestSpecs.new
+      @digest = Digest::TestDigest.new
+
+      # A pointer to the CTX type defined in the extension for this spec. Digest does not make the context directly
+      # accessible as part of its API. However, to ensure we are properly loading the plugin, it's useful to have
+      # direct access to the context pointer to verify its contents.
+      @context = Fiddle::Pointer.new(@s.context(@digest))
+    end
+
+    it "should report the block length" do
+      @digest.block_length.should == 40
+    end
+
+    it "should report the digest length" do
+      @digest.digest_length.should == 20
+    end
+
+    it "should initialize the context" do
+      # Our test plugin always writes the string "Initialized\n" when its init function is called.
+      verify_context("Initialized\n")
+    end
+
+    it "should update the digest" do
+      @digest.update("hello world")
+
+      # Our test plugin always writes the string "Updated: <data>\n" when its update function is called.
+      current = "Initialized\nUpdated: hello world"
+      verify_context(current)
+
+      @digest << "blah"
+
+      current = "Initialized\nUpdated: hello worldUpdated: blah"
+      verify_context(current)
+    end
+
+    it "should finalize the digest" do
+      @digest.update("")
+
+      finish_string = @digest.instance_eval { finish }
+
+      # We expect the plugin to write out the last `@digest.digest_length` bytes, followed by the string "Finished\n".
+      #
+      finish_string.should == "d\nUpdated: Finished\n"
+      finish_string.encoding.should == Encoding::ASCII_8BIT
+    end
+
+    it "should reset the context" do
+      @digest.update("foo")
+      verify_context("Initialized\nUpdated: foo")
+
+      @digest.reset
+
+      # The context will be recreated as a result of the `reset` so we must fetch the latest context pointer.
+      @context = Fiddle::Pointer.new(@s.context(@digest))
+
+      verify_context("Initialized\n")
+    end
+
+    def verify_context(current_body)
+      # In the CTX type, the length of the current context contents is stored in the first byte.
+      byte_count = @context[0]
+      byte_count.should == current_body.bytesize
+
+      # After the size byte follows a string.
+      @context[1, byte_count].should == current_body
+    end
+  end
+end

--- a/spec/ruby/optional/capi/ext/digest_spec.c
+++ b/spec/ruby/optional/capi/ext/digest_spec.c
@@ -1,0 +1,166 @@
+#include "ruby.h"
+#include "rubyspec.h"
+
+#include "ruby/digest.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define DIGEST_LENGTH 20
+#define BLOCK_LENGTH 40
+
+const char *init_string = "Initialized\n";
+const char *update_string = "Updated: ";
+const char *finish_string = "Finished\n";
+
+#define PAYLOAD_SIZE 128
+
+typedef struct CTX {
+  uint8_t pos;
+  char payload[PAYLOAD_SIZE];
+} CTX;
+
+void* context = NULL;
+
+int digest_spec_plugin_init(void *raw_ctx) {
+    // Make the context accessible to tests. This isn't safe, but there's no way to access the context otherwise.
+    context = raw_ctx;
+ 
+    struct CTX *ctx = (struct CTX *)raw_ctx;
+    size_t len = strlen(init_string);
+
+    // Clear the payload since this init function will be invoked as part of the `reset` operation.
+    memset(ctx->payload, 0, PAYLOAD_SIZE);
+
+    // Write a simple value we can verify in tests.
+    // This is not what a real digest would do, but we're using a dummy digest plugin to test interactions.
+    memcpy(ctx->payload, init_string, len);
+    ctx->pos = (uint8_t) len;
+
+    return 1;
+}
+
+void digest_spec_plugin_update(void *raw_ctx, unsigned char *ptr, size_t size) {
+    struct CTX *ctx = (struct CTX *)raw_ctx;
+    size_t update_str_len = strlen(update_string);
+    
+    if (ctx->pos + update_str_len + size >= PAYLOAD_SIZE) {
+        rb_raise(rb_eRuntimeError, "update size too large; reset the digest and write fewer updates");
+    }
+
+    // Write the supplied value to the payload so it can be easily verified in test.
+    // This is not what a real digest would do, but we're using a dummy digest plugin to test interactions.
+    memcpy(ctx->payload + ctx->pos, update_string, update_str_len);
+    ctx->pos += update_str_len;
+
+    memcpy(ctx->payload + ctx->pos, ptr, size);
+    ctx->pos += size;
+
+    return;
+}
+
+int digest_spec_plugin_finish(void *raw_ctx, unsigned char *ptr) {
+    struct CTX *ctx = (struct CTX *)raw_ctx;
+    size_t finish_string_len = strlen(finish_string);
+    
+    // We're always going to write DIGEST_LENGTH bytes. In a real plugin, this would be the digest value. Here we
+    // write out a text string in order to make validation in tests easier.
+    //
+    // In order to delineate the output more clearly from an `Digest#update` call, we always write out the
+    // `finish_string` message. That leaves `DIGEST_LENGTH - finish_string_len` bytes to read out of the context.
+    size_t context_bytes = DIGEST_LENGTH - finish_string_len;
+
+    memcpy(ptr, ctx->payload + (ctx->pos - context_bytes), context_bytes);
+    memcpy(ptr + context_bytes, finish_string, finish_string_len);
+
+    return 1;
+}
+
+static const rb_digest_metadata_t metadata = {
+    // The RUBY_DIGEST_API_VERSION value comes from ruby/digest.h and may vary based on the Ruby being tested. Since
+    // it isn't publicly exposed in the digest gem, we ignore for these tests. Either the test hard-codes an expected
+    // value and is subject to breaking depending on the Ruby being run or we publicly expose `RUBY_DIGEST_API_VERSION`,
+    // in which case the test would pass trivially.
+    RUBY_DIGEST_API_VERSION,
+    DIGEST_LENGTH,
+    BLOCK_LENGTH,
+    sizeof(CTX),
+    (rb_digest_hash_init_func_t) digest_spec_plugin_init,
+    (rb_digest_hash_update_func_t) digest_spec_plugin_update,
+    (rb_digest_hash_finish_func_t) digest_spec_plugin_finish,
+};
+
+// The `get_metadata_ptr` function is not publicly available in the digest gem. However, we need to use
+// to extract the `rb_digest_metadata_t*` value set up by the plugin so we reproduce and adjust the
+// definition here.
+//
+// Taken and adapted from https://github.com/ruby/digest/blob/v3.2.0/ext/digest/digest.c#L558-L568
+static rb_digest_metadata_t * get_metadata_ptr(VALUE obj) {
+    rb_digest_metadata_t *algo;
+
+#ifdef DIGEST_USE_RB_EXT_RESOLVE_SYMBOL
+    // In the digest gem there is an additional data type check performed before reading the value out.
+    // Since the type definition isn't public, we can't use it as part of a type check here so we omit it.
+    // This is safe to do because this code is intended to only load digest plugins written as part of this test suite.
+    algo = RTYPEDDATA_DATA(obj);
+#else
+# undef RUBY_UNTYPED_DATA_WARNING
+# define RUBY_UNTYPED_DATA_WARNING 0
+    Data_Get_Struct(obj, rb_digest_metadata_t, algo);
+#endif
+
+    return algo;
+}
+
+VALUE digest_spec_rb_digest_make_metadata(VALUE self) {
+    return rb_digest_make_metadata(&metadata);
+}
+
+VALUE digest_spec_block_length(VALUE self, VALUE meta) {
+    rb_digest_metadata_t* algo = get_metadata_ptr(meta);
+
+    return SIZET2NUM(algo->block_len);
+}
+
+VALUE digest_spec_digest_length(VALUE self, VALUE meta) {
+    rb_digest_metadata_t* algo = get_metadata_ptr(meta);
+
+    return SIZET2NUM(algo->digest_len);
+}
+
+VALUE digest_spec_context_size(VALUE self, VALUE meta) {
+    rb_digest_metadata_t* algo = get_metadata_ptr(meta);
+
+    return SIZET2NUM(algo->ctx_size);
+}
+
+#define PTR2NUM(x) (rb_int2inum((intptr_t)(void *)(x)))
+
+VALUE digest_spec_context(VALUE self, VALUE digest) {
+    return PTR2NUM(context);
+}
+
+void Init_digest_spec(void) {
+    VALUE cls;
+
+    cls = rb_define_class("CApiDigestSpecs", rb_cObject);
+    rb_define_method(cls, "rb_digest_make_metadata", digest_spec_rb_digest_make_metadata, 0);
+    rb_define_method(cls, "block_length", digest_spec_block_length, 1);
+    rb_define_method(cls, "digest_length", digest_spec_digest_length, 1);
+    rb_define_method(cls, "context_size", digest_spec_context_size, 1);
+    rb_define_method(cls, "context", digest_spec_context, 1);
+
+    VALUE mDigest, cDigest_Base, cDigest;
+
+    mDigest = rb_define_module("Digest");
+    mDigest = rb_digest_namespace();
+    cDigest_Base = rb_const_get(mDigest, rb_intern_const("Base"));
+
+    cDigest = rb_define_class_under(mDigest, "TestDigest", cDigest_Base);
+    rb_iv_set(cDigest, "metadata", rb_digest_make_metadata(&metadata));
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/spec/truffle/methods/Digest::Base.singleton_class.txt
+++ b/spec/truffle/methods/Digest::Base.singleton_class.txt
@@ -1,0 +1,1 @@
+inherited


### PR DESCRIPTION
# Overview

The _digest_ gem is a default gem that has a standard C API for contributing new digest algorithms. The gem includes several built-in digest algorithms and they all make use of this plugin mechanism. However, TruffleRuby does not run the real [digest source](https://github.com/ruby/digest) when a caller uses `require digest`. Rather, TruffleRuby reimplements the _digest_ API in Ruby and Java, allowing it to make use of the JVM's `MessageDigest` instances.

Generally, this reimplementation is seamless. The `Digest` API has not changed in many years and TruffleRuby ships with support for all of the included digest algorithms. While running the _digest_ native extension would work on TruffleRuby, it would be slower than using the optimized JVM code.

This, however, has presented a problem when it comes to _digest_ plugins: since we don't run the native code, we can't load native plugins. We've had an issue open for 6.5 years [asking for this support](https://github.com/oracle/truffleruby/issues/1390). This PR adds support for loading _digest_ plugins using FFI to work with TruffleRuby's reimplementation.

When an unknown digest is loaded, we now include the `Truffle::Digest::Plugin` module, which will override functionality from `Digest::Base`. The current built-in digest algorithms (e.g., MD5 and SHA256) will continue to work as they have been in TruffleRuby. But, new algorithms that adhere to the _digest_ gem's API will now load and function.

# BLAKE3

As a motivating example, this PR allows Shopify's [BLAKE3 gem](https://github.com/Shopify/blake3-rb), which is written in Rust, to load and execute on TruffleRuby. The _blake3-rb_ Ruby test suite passes 100%. The gem ships with another test suite for Cargo that does not pass due to ongoing work with _rb-sys_. These tests load the compiled extension into a Rust test runner and do not impact the typical execution mode of running _blake3-rb_ from a gem.

I looked for other _digest_ plugins to work against, but was unable to find any that work with the latest _digest_ gem even on MRI. If anyone has a gem in particular that they would like to me to check, I'm happy to do so, provided it works with MRI.

# Testing

This PR also adds some C extension tests for the plugin support. Despite not strictly being part of the MRI extension API, I placed them with other extension specs because _digest_ is a default gem and it's expected that API works out of the box. I struggled a bit with finding the right balance in testing the API boundary without recreating all of the `Digest` Ruby specs we already have. I settled on two groups of tests:

* one that verifies simple data fields the metadata object
* one that verifies the callback functions in the metadata object by exposing and inspecting the context object, which isn't exposed as part of the `Digest` Ruby API

For the callback tests I wrote a simple _digest_ plugin that writes to the context in straightforward ways. The plugin doesn't actually perform any hashing of values, but rather writes text strings that can be easily verified in the specs. I'm open to suggestions if this form of testing is too indirect.

# Benchmarks

The _blake3-rb_ gem ships with some benchmarks. I ran the [string benchmarks](https://github.com/Shopify/blake3-rb/blob/a979df83cf63e1e985874323b02ae58a6ba00676/bench/string.rb) on my workstation. I didn't fully tune for benchmarks so please take the numbers with a grain of salt. I'm running Ubuntu 24.04.2 (kernel: 6.8.0-55-generic) on a Ryzen 9800X3D processor with the `performance` governor.

```
truffleruby 25.0.0-dev-b0b60d25*, like ruby 3.3.7, GraalVM CE JVM [x86_64-linux]
Warming up --------------------------------------
        Digest::SHA1   247.000 i/100ms
      Digest::SHA256   234.000 i/100ms
         Digest::MD5   105.000 i/100ms
      Blake3::Digest   927.000 i/100ms
Calculating -------------------------------------
        Digest::SHA1      2.202k (± 1.5%) i/s  (454.09 μs/i) -     11.115k in   5.048372s
      Digest::SHA256      2.092k (± 0.9%) i/s  (477.98 μs/i) -     10.530k in   5.033589s
         Digest::MD5      1.005k (± 0.7%) i/s  (994.79 μs/i) -      5.040k in   5.014001s
      Blake3::Digest     10.069k (± 8.6%) i/s   (99.31 μs/i) -     50.058k in   5.043939s

Comparison:
      Blake3::Digest:    10069.3 i/s
        Digest::SHA1:     2202.2 i/s - 4.57x  slower
      Digest::SHA256:     2092.1 i/s - 4.81x  slower
         Digest::MD5:     1005.2 i/s - 10.02x  slower
```

Running through FFI doesn't appear to introduce too large of an overhead. I've verified that the _blake3-rb_ extension is using SIMD instructions by way of the BLAKE3 Rust library. Absent built-in support for BLAKE3 in the JVM, I'm skeptical that a pure Java implementation would do much better.

The string benchmark, however, processes strings of various lengths in each benchmark. I had seen fairly large variance in performance depending on the length of a string. That's worth exploring in more depth.

For comparison, here's what I get with MRI 3.4.2:

```
ruby 3.4.2 (2025-02-15 revision d2930f8e7a) +PRISM [x86_64-linux]
Warming up --------------------------------------
        Digest::SHA1   131.000 i/100ms
      Digest::SHA256    43.000 i/100ms
         Digest::MD5    91.000 i/100ms
      Blake3::Digest     1.096k i/100ms
Calculating -------------------------------------
        Digest::SHA1      1.311k (± 0.3%) i/s  (762.60 μs/i) -      6.681k in   5.094972s
      Digest::SHA256    436.367 (± 0.2%) i/s    (2.29 ms/i) -      2.193k in   5.025595s
         Digest::MD5    910.901 (± 0.1%) i/s    (1.10 ms/i) -      4.641k in   5.094968s
      Blake3::Digest     11.022k (± 0.6%) i/s   (90.72 μs/i) -     55.896k in   5.071335s

Comparison:
      Blake3::Digest:    11022.3 i/s
        Digest::SHA1:     1311.3 i/s - 8.41x  slower
         Digest::MD5:      910.9 i/s - 12.10x  slower
      Digest::SHA256:      436.4 i/s - 25.26x  slower
```
