### PR TITLE
Implement Integer.sqrt for large integers

### DIFF
--- a/spec/tags/core/integer/sqrt_tags.txt
+++ b/spec/tags/core/integer/sqrt_tags.txt
@@ -1,1 +1,0 @@
-fails:Integer.sqrt returns the integer square root of the argument

--- a/src/main/ruby/truffleruby/core/integer.rb
+++ b/src/main/ruby/truffleruby/core/integer.rb
@@ -350,7 +350,17 @@ class Integer < Numeric
   def self.sqrt(n)
     n = Primitive.rb_to_int(n)
     raise Math::DomainError if n.negative?
-    Math.sqrt(n).floor
+    return Math.sqrt(n).floor if n < 0xfffffffffffff
+
+    shift = n.bit_length / 4
+    x = sqrt(n >> (2 * shift)) << shift
+    x = (x + n / x) / 2
+    xx = x * x
+    while xx > n
+      xx -= 2 * x - 1
+      x -= 1
+    end
+    x
   end
 
   private def upto_internal(val)


### PR DESCRIPTION
Implement Integer.sqrt algorithm used in CRuby (Newton's method)
https://github.com/ruby/ruby/pull/10274

This spec now passes
```ruby
Integer.sqrt(10**400).should == 10**200
```

### Calculation

`(x + n / x) / 2.0` is always greater or equal to `square_root(n)` if there is no calculation error.
Integer arithmetic `(x + n / x) / 2` is greater than `square_root(n)` OR equal to `square_root(n).floor`
After `x -= 1 while x*x > n`, `x` will be the expected return value of `Integer.sqrt(n)`
Newton's method ensures this while loop is executed only a few times. Experimentally, it's executed only once.
