### PR TITLE
Support tailwindruby-css's native platform gems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Bug fixes:
 Compatibility:
 
 * Fix extra warnings for `Kernel#sprintf` (#3938, @eregon).
+* Support using tailwindcss-ruby's native platform gems (@nirvdrum).
 
 Performance:
 

--- a/lib/truffle/rubygems/defaults/truffleruby.rb
+++ b/lib/truffle/rubygems/defaults/truffleruby.rb
@@ -30,5 +30,5 @@ end
 
 class Gem::Platform
   # The list of gems we want to install precompiled (using the local platform) on TruffleRuby
-  REUSE_AS_BINARY_ON_TRUFFLERUBY = %w[libv8 libv8-node sass-embedded sorbet-static] + Truffle::Boot.get_option('reuse-precompiled-gems')
+  REUSE_AS_BINARY_ON_TRUFFLERUBY = %w[libv8 libv8-node sass-embedded sorbet-static tailwindcss-ruby] + Truffle::Boot.get_option('reuse-precompiled-gems')
 end


### PR DESCRIPTION
The _tailwindcss-ruby_ gem packages up the `tailwindcss` executable so any CSS files using TailwindCSS can be compiled. Running `rails new my_app --css=tailwind` with Rails 8 will add the _tailwindcss-rails_ gem to the _Gemfile_, which in turn will depend on _tailwindcss-ruby_. Given the growing popularity of TailwindCSS, this is an increasingly popular configuration for Rails. Currently, running `./bin/rails test` will result in the following runtime exception:

```
bin/rails aborted!
Tailwindcss::Ruby::UnsupportedPlatformException: tailwindcss-ruby does not support the x86_64-linux platform (Tailwindcss::Ruby::UnsupportedPlatformException)
See https://github.com/flavorjones/tailwindcss-ruby#using-a-local-installation-of-tailwindcss
for more details.
```

I think that error message is misleading; the real issue is that the gem is using the _ruby_ platform. While manually installing the `tailwindcss` executable would fix the issue, we can make this work out of the box.

Using `export TRUFFLERUBYOPT="--experimental-options --reuse-precompiled-gems=tailwindcss-ruby"`,  I've verified that using the native platform gem for x86_64-linux works fine. I have no reason to believe any other native platform will be a problem. This PR adds _tailwindcss-ruby_ to our default list of gems that we allow to reuse published native gems so that _tailwindcss-ruby_ installs and functions correctly out of the box.