### PR TITLE
Removing actions/cache in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,12 +29,6 @@ jobs:
     - name: Setup jt
       run: echo "$PWD/bin" >> $GITHUB_PATH
 
-    - name: Restore ~/.mx/cache
-      uses: actions/cache@v3
-      with:
-        path: ~/.mx/cache
-        key: mx-cache-lint-${{ runner.os }}-${{ hashFiles('common.json') }}
-
     - uses: ./.github/actions/setup-jvmci-graal
 
     - run: jt install eclipse
@@ -64,12 +58,6 @@ jobs:
         working-directory: build
     - name: Setup jt
       run: echo "$PWD/bin" >> $GITHUB_PATH
-
-    - name: Restore ~/.mx/cache
-      uses: actions/cache@v3
-      with:
-        path: ~/.mx/cache
-        key: mx-cache-build-${{ runner.os }}-${{ hashFiles('build/common.json') }}
 
     - uses: ./build/.github/actions/setup-jvmci-graal
 
@@ -106,12 +94,6 @@ jobs:
         working-directory: build
     - name: Setup jt
       run: echo "$PWD/bin" >> $GITHUB_PATH
-
-    - name: Restore ~/.mx/cache
-      uses: actions/cache@v3
-      with:
-        path: ~/.mx/cache
-        key: mx-cache-build-native-${{ runner.os }}-${{ hashFiles('build/common.json') }}
 
     - uses: ./build/.github/actions/setup-jvmci-graal
 
@@ -153,12 +135,6 @@ jobs:
     - name: Setup jt
       run: echo "$PWD/bin" >> $GITHUB_PATH
 
-    - name: Restore ~/.mx/cache
-      uses: actions/cache@v3
-      with:
-        path: ~/.mx/cache
-        key: mx-cache-build-${{ runner.os }}-${{ hashFiles('build/common.json') }}
-
     - uses: ./build/.github/actions/setup-jvmci-graal
 
     # platform checks
@@ -192,12 +168,6 @@ jobs:
         working-directory: build
     - name: Setup jt
       run: echo "$PWD/bin" >> $GITHUB_PATH
-
-    - name: Restore ~/.mx/cache
-      uses: actions/cache@v3
-      with:
-        path: ~/.mx/cache
-        key: mx-cache-build-${{ runner.os }}-${{ hashFiles('build/common.json') }}
 
     - uses: ./build/.github/actions/setup-jvmci-graal
 


### PR DESCRIPTION
Seems basically the same time as https://github.com/truffleruby/truffleruby/actions/runs/18351455921 so let's remove it for simplicity. And avoiding hitting cache limits. Also caching by `runner.os` is probably not enough (should be keyed by arch too).