### PR TITLE
Make the macos-15-intel (darwin-amd64) job daily because it is much slower

### DIFF
--- a/.github/actions/platform-checks/action.yml
+++ b/.github/actions/platform-checks/action.yml
@@ -1,0 +1,29 @@
+name: 'CI checks for every platform'
+runs:
+  using: "composite"
+  steps:
+    # platform checks
+    - name: MAKEFILE_CONFIG on CRuby for comparison and convenience
+      run: ruby -e "pp RbConfig::MAKEFILE_CONFIG"
+      shell: bash
+
+    - run: ruby tool/generate-native-config.rb
+      shell: bash
+    - run: cat $(jt native_configuration_file)
+      shell: bash
+
+    - run: tool/generate-config-header.sh
+      shell: bash
+    - run: cat $(jt config_header_file)
+      shell: bash
+
+    - run: jt check_native_configuration
+      shell: bash
+    - run: jt check_config_header
+      shell: bash
+
+    # run jt test fast on each platform
+    - run: jt build # ~4-6min, 13min on macos-15-intel
+      shell: bash
+    - run: jt test fast # ~1.5min
+      shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@
 # Those differences are intentional to avoid making the CI too slow.
 name: CI
 on:
+  workflow_dispatch:
   pull_request:
   push:
     branches: [master]
@@ -119,44 +120,25 @@ jobs:
         path: ${{ github.workspace }}/truffleruby-native.tar
         include-hidden-files: true
 
-  platform_checks: # ~7-9min
+  # Keep in sync with the same job in daily.yml
+  platform_checks: # ~7-9min, ~30min on macos-15-intel
     name: platform ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 40
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-22.04-arm, macos-15-intel, macos-14]
-    defaults:
-      run:
-        # Use build/ too for consistency in steps and cache reuse
-        working-directory: build
+        # NOTE: macos-15-intel is tested in daily.yml because it's much slower
+        os: [ubuntu-22.04, ubuntu-22.04-arm, macos-14]
     steps:
     - name: Clone TruffleRuby
       uses: actions/checkout@v4
-      with:
-        path: build
     - name: Setup system Ruby
       uses: ruby/setup-ruby@v1
-      with:
-        working-directory: build
     - name: Setup jt
       run: echo "$PWD/bin" >> $GITHUB_PATH
-
-    - uses: ./build/.github/actions/setup-jvmci-graal
-
-    # platform checks
-    - name: MAKEFILE_CONFIG on CRuby for comparison and convenience
-      run: ruby -e "pp RbConfig::MAKEFILE_CONFIG"
-    - run: ruby tool/generate-native-config.rb
-    - run: cat $(jt native_configuration_file)
-    - run: tool/generate-config-header.sh
-    - run: cat $(jt config_header_file)
-    - run: jt check_native_configuration
-    - run: jt check_config_header
-    # run jt test fast on each platform
-    - run: jt build # ~4-6min, 13min on macos-15-intel
-    - run: jt test fast # ~1.5min
+    - uses: ./.github/actions/setup-jvmci-graal
+    - uses: ./.github/actions/platform-checks
 
   test_needing_build_files: # ~17min
     name: tests needing build files
@@ -164,7 +146,7 @@ jobs:
     timeout-minutes: 30
     defaults:
       run:
-        # Use build/ too for consistency in steps and cache reuse
+        # Use build/ too for consistency in steps
         working-directory: build
     steps:
     - name: Clone TruffleRuby

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1,0 +1,28 @@
+name: Daily
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 13 * * *'
+permissions:
+  contents: read
+
+jobs:
+  # Keep in sync with the same job in ci.yml
+  platform_checks: # ~7-9min, ~30min on macos-15-intel
+    name: platform ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 40
+    strategy:
+      fail-fast: false
+      matrix:
+        # NOTE: macos-15-intel is tested in daily.yml because it's much slower
+        os: [macos-15-intel]
+    steps:
+    - name: Clone TruffleRuby
+      uses: actions/checkout@v4
+    - name: Setup system Ruby
+      uses: ruby/setup-ruby@v1
+    - name: Setup jt
+      run: echo "$PWD/bin" >> $GITHUB_PATH
+    - uses: ./.github/actions/setup-jvmci-graal
+    - uses: ./.github/actions/platform-checks


### PR DESCRIPTION
* For example in https://github.com/truffleruby/truffleruby/actions/runs/18411675195?pr=3983 it took 32min and is a clear bottleneck, as that run would have taken 19min without it.