### PR TITLE
The --single-threaded option should default to false, even if embedded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Performance:
 
 Changes:
 
+* The `--single-threaded` option now defaults to false also when embedding TruffleRuby (#3958, @eregon).
 
 Memory Footprint:
 

--- a/doc/user/polyglot.md
+++ b/doc/user/polyglot.md
@@ -234,9 +234,7 @@ The [JRuby migration guide](jruby-migration.md) includes some more examples.
 ## Threading and Interop
 
 Ruby is designed to be a multi-threaded language and much of the ecosystem expects threads to be available.
-This may be incompatible with other Truffle languages which do not support threading, so you can disable the creation of
-multiple threads with the option `--single-threaded`.
-This option is set by default unless the Ruby launcher is used, as part of the embedded configuration, described below.
+This may be incompatible with other Truffle languages which do not support threading like JavaScript, so you can disable the creation of multiple threads with the option `--single-threaded`.
 
 When this option is enabled, the `timeout` module will warn that the timeouts are being ignored, and signal handlers will warn that a signal has been caught but will not run the handler, as both of these features would require starting new threads.
 
@@ -244,7 +242,6 @@ When this option is enabled, the `timeout` module will warn that the timeouts ar
 
 When used outside of the Ruby launcher - such as from another language's launcher via the polyglot interface, embedded using the native polyglot library, or embedded in a Java application via the GraalVM SDK - TruffleRuby will be automatically configured to work more cooperatively within another application.
 This includes options such as not installing an interrupt signal handler, and using the I/O streams from the Graal SDK.
-It also turns on the single-threaded mode, as described above.
 
 It will also warn when you explicitly do things that may not work well when embedded, such as installing your own signal handlers.
 

--- a/spec/truffle/options/embedded_spec.rb
+++ b/spec/truffle/options/embedded_spec.rb
@@ -22,7 +22,7 @@ describe "The --embedded option" do
   end
 
   it "sets dependent options when set manually" do
-    ruby_exe("p Truffle::Boot.get_option('single-threaded')", options: "--experimental-options --embedded").should == "true\n"
+    ruby_exe("p Truffle::Boot.get_option('polyglot-stdio')", options: "--experimental-options --embedded").should == "true\n"
   end
 
   it "when enabled can run basic expressions" do

--- a/src/main/java/org/truffleruby/options/Options.java
+++ b/src/main/java/org/truffleruby/options/Options.java
@@ -59,7 +59,7 @@ public final class Options {
     public final boolean NATIVE_INTERRUPT;
     /** --platform-handle-interrupt=!EMBEDDED */
     public final boolean HANDLE_INTERRUPT;
-    /** --single-threaded=!env.isCreateThreadAllowed() || EMBEDDED */
+    /** --single-threaded=!env.isCreateThreadAllowed() || false */
     public final boolean SINGLE_THREADED;
     /** --polyglot-stdio=EMBEDDED || !NATIVE_PLATFORM */
     public final boolean POLYGLOT_STDIO;
@@ -228,7 +228,7 @@ public final class Options {
         NATIVE_PLATFORM = env.isNativeAccessAllowed() && (options.get(OptionsCatalog.NATIVE_PLATFORM_KEY));
         NATIVE_INTERRUPT = options.hasBeenSet(OptionsCatalog.NATIVE_INTERRUPT_KEY) ? options.get(OptionsCatalog.NATIVE_INTERRUPT_KEY) : NATIVE_PLATFORM;
         HANDLE_INTERRUPT = options.hasBeenSet(OptionsCatalog.HANDLE_INTERRUPT_KEY) ? options.get(OptionsCatalog.HANDLE_INTERRUPT_KEY) : !EMBEDDED;
-        SINGLE_THREADED = !env.isCreateThreadAllowed() || (options.hasBeenSet(OptionsCatalog.SINGLE_THREADED_KEY) ? options.get(OptionsCatalog.SINGLE_THREADED_KEY) : EMBEDDED);
+        SINGLE_THREADED = !env.isCreateThreadAllowed() || (options.get(OptionsCatalog.SINGLE_THREADED_KEY));
         POLYGLOT_STDIO = options.hasBeenSet(OptionsCatalog.POLYGLOT_STDIO_KEY) ? options.get(OptionsCatalog.POLYGLOT_STDIO_KEY) : EMBEDDED || !NATIVE_PLATFORM;
         HOST_INTEROP = env.isHostLookupAllowed() && (options.get(OptionsCatalog.HOST_INTEROP_KEY));
         TRACE_CALLS = options.get(OptionsCatalog.TRACE_CALLS_KEY);

--- a/src/options.yml
+++ b/src/options.yml
@@ -90,7 +90,7 @@ EXPERT:
     NATIVE_PLATFORM: [platform-native, boolean, ['env.isNativeAccessAllowed() && ', true], Enables native calls via Truffle NFI for internal functionality]
     NATIVE_INTERRUPT: [platform-native-interrupt, boolean, NATIVE_PLATFORM, Use the SIGVTALRM signal to interrupt native blocking calls]
     HANDLE_INTERRUPT: [platform-handle-interrupt, boolean, '!EMBEDDED', Handle the interrupt signal and raise an Interrupt exception]
-    SINGLE_THREADED: [single-threaded, boolean, ['!env.isCreateThreadAllowed() || ', EMBEDDED], Use only a single thread to be compatible with languages not supporting multithreading]
+    SINGLE_THREADED: [single-threaded, boolean, ['!env.isCreateThreadAllowed() || ', false], Use only a single thread to be compatible with languages not supporting multithreading]
     POLYGLOT_STDIO: [polyglot-stdio, boolean, EMBEDDED || !NATIVE_PLATFORM, Use standard IO streams from the Graal-SDK polyglot API configuration]
     HOST_INTEROP: [interop-host, boolean, ['env.isHostLookupAllowed() && ', true], Allow interoperability with the host language (Java)]
 

--- a/src/shared/java/org/truffleruby/shared/options/OptionsCatalog.java
+++ b/src/shared/java/org/truffleruby/shared/options/OptionsCatalog.java
@@ -41,7 +41,7 @@ public final class OptionsCatalog {
     public static final OptionKey<Boolean> NATIVE_PLATFORM_KEY = new OptionKey<>(true);
     public static final OptionKey<Boolean> NATIVE_INTERRUPT_KEY = new OptionKey<>(NATIVE_PLATFORM_KEY.getDefaultValue());
     public static final OptionKey<Boolean> HANDLE_INTERRUPT_KEY = new OptionKey<>(!EMBEDDED_KEY.getDefaultValue());
-    public static final OptionKey<Boolean> SINGLE_THREADED_KEY = new OptionKey<>(EMBEDDED_KEY.getDefaultValue());
+    public static final OptionKey<Boolean> SINGLE_THREADED_KEY = new OptionKey<>(false);
     public static final OptionKey<Boolean> POLYGLOT_STDIO_KEY = new OptionKey<>(EMBEDDED_KEY.getDefaultValue() || !NATIVE_PLATFORM_KEY.getDefaultValue());
     public static final OptionKey<Boolean> HOST_INTEROP_KEY = new OptionKey<>(true);
     public static final OptionKey<Boolean> TRACE_CALLS_KEY = new OptionKey<>(true);

--- a/src/test-embedding/java/org/truffleruby/test/embedding/ContextPermissionsTest.java
+++ b/src/test-embedding/java/org/truffleruby/test/embedding/ContextPermissionsTest.java
@@ -86,13 +86,13 @@ public class ContextPermissionsTest {
 
     @Test
     public void testThreadsNoNative() throws Throwable {
-        // The ruby.single_threaded option needs to be set because --single-threaded defaults to --embedded.
         try (Context context = Context
                 .newBuilder("ruby")
                 .allowCreateThread(true)
-                .allowExperimentalOptions(true)
-                .option("ruby.single-threaded", "false")
                 .build()) {
+            String option = "Truffle::Boot.get_option('single-threaded')";
+            Assert.assertEquals(false, context.eval("ruby", option).asBoolean());
+
             Assert.assertEquals(3, context.eval("ruby", "1 + 2").asInt());
 
             Assert.assertEquals(7, context.eval("ruby", "Thread.new { 3 + 4 }.value").asInt());
@@ -111,8 +111,6 @@ public class ContextPermissionsTest {
     public void testNoThreadsEnforcesSingleThreadedOption() throws Throwable {
         try (Context context = Context
                 .newBuilder("ruby")
-                .allowExperimentalOptions(true)
-                .option("ruby.single-threaded", "false")
                 .build()) {
             String option = "Truffle::Boot.get_option('single-threaded')";
             Assert.assertEquals(true, context.eval("ruby", option).asBoolean());


### PR DESCRIPTION
* Since embedded doesn't imply using a single-threaded language (like JavaScript).
* If the Context builder create-thread permission is not granted, then the option is still set automatically.
* Fixes https://github.com/truffleruby/truffleruby/issues/3958