### PR TITLE
Update the website URL for TruffleRuby

### DIFF
--- a/doc/user/installing-truffleruby.md
+++ b/doc/user/installing-truffleruby.md
@@ -24,7 +24,7 @@ Oracle GraalVM includes all features of GraalVM Community Edition and provides a
 * Additional Native Image features, including the [G1 garbage collector, compressed pointers](https://www.graalvm.org/latest/reference-manual/native-image/optimizations-and-performance/MemoryManagement/), [profile-guided optimization](https://www.graalvm.org/latest/reference-manual/native-image/optimizations-and-performance/PGO/), and [Software Bill of Materials](https://www.graalvm.org/latest/security-guide/native-image/#software-bill-of-materials);
 * Additional Truffle features, including [sandboxing, polyglot isolates, resource limits](https://www.graalvm.org/latest/security-guide/sandboxing/), [Auxiliary Engine Caching](https://www.graalvm.org/latest/graalvm-as-a-platform/language-implementation-framework/AuxiliaryEngineCachingEnterprise/), and a faster implementation of the Truffle Object Model.
 
-Thanks to these additional features, TruffleRuby runs [faster and more memory efficient](https://www.graalvm.org/ruby/) on Oracle GraalVM compared with GraalVM Community Edition.
+Thanks to these additional features, TruffleRuby runs faster and more memory efficient on Oracle GraalVM compared with GraalVM Community Edition.
 
 ## Download Links
 

--- a/doc/user/options.md
+++ b/doc/user/options.md
@@ -72,17 +72,17 @@ Runtime options:
 Languages:
   [id]        [name]                  [website]
   llvm        LLVM                    https://www.graalvm.org/dev/reference-manual/llvm/
-  ruby        Ruby                    https://www.graalvm.org/ruby/
+  ruby        Ruby                    https://github.com/truffleruby/truffleruby
 
 Tools:
   [id]        [name]                  [website]
-  agentscript Agent Script
+  agentscript Agent Script            
   coverage    Code Coverage           https://www.graalvm.org/tools/code-coverage/
   cpusampler  CPU Sampler             https://www.graalvm.org/tools/profiling/
   cputracer   CPU Tracer              https://www.graalvm.org/tools/profiling/
   dap         Debug Protocol Server   https://www.graalvm.org/tools/dap/
-  heap        Heap Dump
-  heapmonitor Heap Allocation Monitor
+  heap        Heap Dump               
+  heapmonitor Heap Allocation Monitor 
   insight     Insight                 https://www.graalvm.org/tools/graalvm-insight/
   inspect     Chrome Inspector        https://www.graalvm.org/tools/chrome-debugger/
   lsp         Language Server         https://www.graalvm.org/tools/lsp/

--- a/mx.truffleruby/suite.py
+++ b/mx.truffleruby/suite.py
@@ -4,7 +4,7 @@ suite = {
     "version": "25.1.0",
     "release": False,
     "groupId": "org.graalvm.ruby",
-    "url": "https://www.graalvm.org/ruby/",
+    "url": "https://github.com/truffleruby/truffleruby",
     "developer": {
         "name": "TruffleRuby",
         "email": "truffleruby@truffleruby.com",

--- a/spec/truffle/launcher_spec.rb
+++ b/spec/truffle/launcher_spec.rb
@@ -344,7 +344,7 @@ describe "The launcher" do
     check_status_and_empty_stderr
     out.should =~ /Language options/i
     out.should =~ /\bRuby\b/
-    out.should.include?('https://www.graalvm.org/ruby/')
+    out.should.include?('https://github.com/truffleruby/truffleruby')
     out.should.include?("--ruby.load-paths=")
   end
 

--- a/src/main/java/org/truffleruby/RubyLanguage.java
+++ b/src/main/java/org/truffleruby/RubyLanguage.java
@@ -155,7 +155,7 @@ import static org.truffleruby.language.RubyBaseNode.nil;
 
 @TruffleLanguage.Registration(
         name = "Ruby",
-        website = "https://www.graalvm.org/ruby/",
+        website = "https://github.com/truffleruby/truffleruby",
         contextPolicy = ContextPolicy.SHARED,
         id = TruffleRuby.LANGUAGE_ID,
         implementationName = TruffleRuby.FORMAL_NAME,


### PR DESCRIPTION
* https://www.graalvm.org/ruby/ is a redirect, so might as well point to the target URL directly.