### PR TITLE
Fix `warn` with explicit `nil` uplevel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Compatibility:
 
 * Fix extra warnings for `Kernel#sprintf` (#3938, @eregon).
 * Support using tailwindcss-ruby's native platform gems (@nirvdrum).
+* Fix a `TypeError` when calling `Kernel#warn` with explicit `uplevel: nil` (@earlopain).
 
 Performance:
 

--- a/spec/tags/core/kernel/warn_tags.txt
+++ b/spec/tags/core/kernel/warn_tags.txt
@@ -4,4 +4,3 @@ slow:Kernel#warn does not call Warning.warn if self is the Warning module
 slow:Kernel#warn avoids recursion if Warning#warn is redefined and calls super
 slow:Kernel#warn :uplevel keyword argument skips <internal: core library methods defined in Ruby
 fails:Kernel#warn :uplevel keyword argument skips <internal: core library methods defined in Ruby
-fails:Kernel#warn :uplevel keyword argument doesn't show the caller when the uplevel is `nil`

--- a/src/main/ruby/truffleruby/core/kernel.rb
+++ b/src/main/ruby/truffleruby/core/kernel.rb
@@ -635,7 +635,7 @@ module Kernel
         return nil unless Warning[category]
       end
 
-      prefix = if Primitive.undefined?(uplevel)
+      prefix = if Primitive.undefined?(uplevel) || Primitive.nil?(uplevel)
                  ''
                else
                  uplevel = Primitive.rb_to_int(uplevel)


### PR DESCRIPTION
I see that you don't have to sign the Oracle CLA anymore so I thought I take the oportunity and fix a simple spec that I recently added.