### PR TITLE
Don't quote any UTF8 letters in symbol inspect output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Compatibility:
 * Fix extra warnings for `Kernel#sprintf` (#3938, @eregon).
 * Support using tailwindcss-ruby's native platform gems (@nirvdrum).
 * Fix a `TypeError` when calling `Kernel#warn` with explicit `uplevel: nil` (@earlopain).
+* Fix inspect output of symbols that contain non-ASCII letters (@earlopain).
 
 Performance:
 

--- a/spec/ruby/core/symbol/inspect_spec.rb
+++ b/spec/ruby/core/symbol/inspect_spec.rb
@@ -96,6 +96,10 @@ describe "Symbol#inspect" do
     :"foo "    => ":\"foo \"",
     :" foo"    => ":\" foo\"",
     :" "       => ":\" \"",
+
+    :"ê"       => ":ê",
+    :"测"      => ":测",
+    :"🦊"      => ":🦊",
   }
 
   symbols.each do |input, expected|

--- a/spec/tags/core/symbol/inspect_tags.txt
+++ b/spec/tags/core/symbol/inspect_tags.txt
@@ -1,0 +1,1 @@
+fails:Symbol#inspect returns self as a symbol literal for :🦊

--- a/src/main/ruby/truffleruby/core/symbol.rb
+++ b/src/main/ruby/truffleruby/core/symbol.rb
@@ -62,9 +62,9 @@ class Symbol
     str = to_s
 
     case str
-    when /\A(\$|@@?)[a-z_][a-z_\d]*\z/i,                      # Variable names
-         /\A[a-z_][a-z_\d]*[=?!]?\z/i,                        # Method names
-         /\A\$(-[a-z_\d]|[+~:?<_\/'"$.,`!;\\=*>&@]|\d+)\z/i,  # Special global variables
+    when /\A(\$|@@?)[\p{L}_][\p{L}_\d]*\z/i,                    # Variable names
+         /\A[\p{L}_][\p{L}_\d]*[=?!]?\z/i,                      # Method names
+         /\A\$(-[\p{L}_\d]|[+~:?<_\/'"$.,`!;\\=*>&@]|\d+)\z/i,  # Special global variables
          /\A([|^&\/%~`!]|!=|!~|<<|>>|<=>|===?|=~|[<>]=?|[+-]@?|\*\*?|\[\]=?)\z/ # Operators
       ":#{str}"
     else


### PR DESCRIPTION
Ref https://github.com/truffleruby/truffleruby/issues/3999

Emojis (and more?) should also not be quoted though. It does fix two of the cases I know of, without implementing the whole of `rb_str_symname_p` (which it probably should do).

This makes it a bit better but doesn't fix the whole issue. There is also a unicode property for emojis but it matches plain numbers, among other things. Perhaps the regexp can be tweaked to satisfy the tests but I don't think that would really improve the situation much. I see this PR as basically just adding tests.