### PR TITLE
Fix Comparable#clamp when given infinite interval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Compatibility:
 * Implement `rb_struct_initialize()` for both `Struct` and `Data` (#3997, @eregon).
 * Fix `Hash#{select,slice,transform_values}` and `Hash.[]` methods and retain `compare_by_identity` flag (@andrykonchin).
 * Fix `Hash#reject` and do not retain `default` and `default_proc` values (@andrykonchin).
+* Fix `Comparable#clamp` when the given an infinite interval (#3945, @andrykonchin).
 
 Performance:
 

--- a/spec/ruby/core/comparable/clamp_spec.rb
+++ b/spec/ruby/core/comparable/clamp_spec.rb
@@ -40,6 +40,39 @@ describe 'Comparable#clamp' do
     c.clamp(one, two).should equal(two)
   end
 
+  context 'max is nil' do
+    it 'returns min if less than it' do
+      one = ComparableSpecs::WithOnlyCompareDefined.new(1)
+      c = ComparableSpecs::Weird.new(0)
+      c.clamp(one, nil).should equal(one)
+    end
+
+    it 'always returns self if greater than min' do
+      one = ComparableSpecs::WithOnlyCompareDefined.new(1)
+      c = ComparableSpecs::Weird.new(2)
+      c.clamp(one, nil).should equal(c)
+    end
+  end
+
+  context 'min is nil' do
+    it 'returns max if greater than it' do
+      one = ComparableSpecs::WithOnlyCompareDefined.new(1)
+      c = ComparableSpecs::Weird.new(2)
+      c.clamp(nil, one).should equal(one)
+    end
+
+    it 'always returns self if less than max' do
+      one = ComparableSpecs::WithOnlyCompareDefined.new(1)
+      c = ComparableSpecs::Weird.new(0)
+      c.clamp(nil, one).should equal(c)
+    end
+  end
+
+  it 'always returns self when min is nil and max is nil' do
+    c = ComparableSpecs::Weird.new(1)
+    c.clamp(nil, nil).should equal(c)
+  end
+
   it 'returns self if within the given range parameters' do
     one = ComparableSpecs::WithOnlyCompareDefined.new(1)
     two = ComparableSpecs::WithOnlyCompareDefined.new(2)

--- a/spec/ruby/core/comparable/fixtures/classes.rb
+++ b/spec/ruby/core/comparable/fixtures/classes.rb
@@ -7,6 +7,7 @@ module ComparableSpecs
     end
 
     def <=>(other)
+      return nil if other.nil?
       self.value <=> other.value
     end
   end

--- a/src/main/ruby/truffleruby/core/comparable.rb
+++ b/src/main/ruby/truffleruby/core/comparable.rb
@@ -83,9 +83,13 @@ module Comparable
     if Primitive.undefined?(max)
       range = min
       raise TypeError, "wrong argument type #{Primitive.class(range)} (expected Range)" unless Primitive.is_a?(range, Range)
-      raise ArgumentError, 'cannot clamp with an exclusive range' if range.exclude_end?
+      raise ArgumentError, 'cannot clamp with an exclusive range' if range.exclude_end? && !Primitive.nil?(range.end)
       min, max = range.begin, range.end
     end
+
+    return self if Primitive.nil?(min) && Primitive.nil?(max)
+    return self <= max ? self : max if Primitive.nil?(min)
+    return self >= min ? self : min if Primitive.nil?(max)
 
     comp = min <=> max
     raise ArgumentError, 'min argument must be smaller than max argument' if Primitive.nil?(comp) or comp > 0


### PR DESCRIPTION
Changes:
- fixed Comparable#clamp called with endless/beginningless interval
- specs for range argument are taken as-is from https://github.com/ruby/spec/pull/1296 (they aren' synced yet)

Closes #3945