### PR TITLE
Update link to rubocop-truffleruby GitHub repo

### DIFF
--- a/tool/import-rubocop-truffleruby.sh
+++ b/tool/import-rubocop-truffleruby.sh
@@ -8,7 +8,7 @@ set -e
 SOURCE_DIR="../rubocop-truffleruby"
 SOURCE_PATH="lib/rubocop/cop/truffleruby"
 TARGET_DIR="tool/rubocop-truffleruby"
-GIT_REPO_URL="git@github.com:andrykonchin/rubocop-truffleruby.git"
+GIT_REPO_URL="git@github.com:truffleruby/rubocop-truffleruby.git"
 
 if [ ! -d "$SOURCE_DIR" ]; then
   mkdir -p $SOURCE_DIR

--- a/tool/rubocop-truffleruby/README.md
+++ b/tool/rubocop-truffleruby/README.md
@@ -2,7 +2,7 @@
 
 There are some TruffleRuby specific Rubocop copes (a Ruby linter policies) in a `./cop` directory.
 
-They are taken from a `rubocop-truffleruby` gem (https://github.com/andrykonchin/rubocop-truffleruby) and should be synchronized every time the gem is updated.
+They are taken from a `rubocop-truffleruby` gem (https://github.com/truffleruby/rubocop-truffleruby) and should be synchronized every time the gem is updated.
 
 Use `tool/import-rubocop-truffleruby.sh` Shell script to update them automatically:
 


### PR DESCRIPTION
The link was changed because the rubocop-truffleruby GitHub repo was moved into the TruffleRuby GitHub org.