### PR TITLE
Add distributions to create the release archives of the standalone under release/

### DIFF
--- a/mx.truffleruby/suite.py
+++ b/mx.truffleruby/suite.py
@@ -1092,6 +1092,20 @@ suite = {
             },
         },
 
+        "TRUFFLERUBY_NATIVE_STANDALONE_RELEASE_ARCHIVE": {
+            "class": "TruffleRubyReleaseArchive",
+            "standalone_dist": "TRUFFLERUBY_NATIVE_STANDALONE",
+            "community_dir_name": "truffleruby-community-<version>-<graalvm_os>-<arch>",
+            "enterprise_dir_name": "truffleruby-<version>-<graalvm_os>-<arch>",
+        },
+
+        "TRUFFLERUBY_JVM_STANDALONE_RELEASE_ARCHIVE": {
+            "class": "TruffleRubyReleaseArchive",
+            "standalone_dist": "TRUFFLERUBY_JVM_STANDALONE",
+            "community_dir_name": "truffleruby-community-jvm-<version>-<graalvm_os>-<arch>",
+            "enterprise_dir_name": "truffleruby-jvm-<version>-<graalvm_os>-<arch>",
+        },
+
         "TRUFFLERUBY-TEST-EMBEDDING": {
             "testDistribution": True,
             "dependencies": [


### PR DESCRIPTION
A bit like it worked before https://github.com/truffleruby/truffleruby/pull/3968 but no Maven involved, just store the archives compressed on disk under `release/`.

Also the distribution name is normal/static instead of dynamic, and the archive has the right dir name and archive name always.
For example:
```
$ jt -q mx path TRUFFLERUBY_JVM_STANDALONE_RELEASE_ARCHIVE  
.../truffleruby/release/truffleruby-community-jvm-33.0.0-dev-linux-amd64.tar.gz
$ tar tf .../truffleruby/mxbuild/linux-amd64/dists/truffleruby-jvm-standalone-release-archive.tar.gz | head -1 
truffleruby-community-jvm-33.0.0-dev-linux-amd64/README.md
```
Which is the same format as [previous releases](https://github.com/truffleruby/truffleruby/releases/tag/graal-25.0.0):
```
$∴ tar tf truffleruby-25.0.0-linux-amd64.tar.gz | head -n 1                        
truffleruby-25.0.0-linux-amd64/CHANGELOG.md

$ tar tf truffleruby-community-25.0.0-linux-aarch64.tar.gz | head -n 1
truffleruby-community-25.0.0-linux-aarch64/CHANGELOG.md

$ tar tf truffleruby-community-jvm-25.0.0-linux-aarch64.tar.gz | head -n 1
truffleruby-community-jvm-25.0.0-linux-aarch64/CHANGELOG.md

$ tar tf truffleruby-jvm-25.0.0-linux-aarch64.tar.gz | head -n 1          
truffleruby-jvm-25.0.0-linux-aarch64/CHANGELOG.md
```