### PR TITLE
Implement `MatchData#bytebegin` and `MatchData#byteend` for Ruby 3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Compatibility:
 * Fix `Hash#reject` and do not retain `default` and `default_proc` values (@andrykonchin).
 * Fix `Comparable#clamp` when the given an infinite interval (#3945, @andrykonchin).
 * `File.path` now checks for `\0` and encoding (#4047, @nobu).
+* Implement `MatchData#bytebegin` and `MatchData#byteend` for Ruby 3.4 (#3883, @Schwad).
 
 Performance:
 

--- a/spec/truffleruby.next-specs
+++ b/spec/truffleruby.next-specs
@@ -8,3 +8,6 @@
 
 # Use spec/ruby/core/nil/nil_spec.rb as a dummy file to avoid being empty (what causes mspec to error)
 spec/ruby/core/nil/nil_spec.rb
+
+spec/ruby/core/matchdata/bytebegin_spec.rb
+spec/ruby/core/matchdata/byteend_spec.rb

--- a/src/main/ruby/truffleruby/core/match_data.rb
+++ b/src/main/ruby/truffleruby/core/match_data.rb
@@ -45,6 +45,16 @@ class MatchData
     [Primitive.match_data_byte_begin(self, backref), Primitive.match_data_byte_end(self, backref)]
   end
 
+  def bytebegin(idx)
+    backref = backref_from_arg(idx)
+    Primitive.match_data_byte_begin(self, backref)
+  end
+
+  def byteend(idx)
+    backref = backref_from_arg(idx)
+    Primitive.match_data_byte_end(self, backref)
+  end
+
   def offset(idx)
     [self.begin(idx), self.end(idx)]
   end


### PR DESCRIPTION
Part of: https://github.com/truffleruby/truffleruby/issues/3883

These methods return the byte-based offset of the start/end of a match, complementing the existing `byteoffset` method which returns both as an array.

The primitives already exist (used by byteoffset), so this simply exposes them individually following the same pattern as begin/end methods.

Ruby feature: https://bugs.ruby-lang.org/issues/20576 

Specs: 

* `spec/ruby/core/matchdata/bytebegin_spec.rb`
*  `spec/ruby/core/matchdata/byteend_spec.rb`