### PR TITLE
Update method specs for `MatchData#bytebegin` and `MatchData#byteend`.

### DIFF
--- a/spec/tags/truffle/methods_tags.txt
+++ b/spec/tags/truffle/methods_tags.txt
@@ -102,3 +102,5 @@ fails:Public methods on String should include dup
 fails:Public methods on UnboundMethod should include dup
 fails:Public methods on StringIO should include pread
 fails:Public methods on Digest::Base.singleton_class should not include inherited
+fails:Public methods on MatchData should not include bytebegin
+fails:Public methods on MatchData should not include byteend


### PR DESCRIPTION
CI has been failing on _master_ since the merge of #4042. This PR updates the tests that check for extra methods defined on core classes to account for `MatchData#bytebegin` and `MatchData#byteend` now being defined.