### PR TITLE
Make libssl build quieter

### DIFF
--- a/mx.truffleruby/suite.py
+++ b/mx.truffleruby/suite.py
@@ -264,6 +264,7 @@ suite = {
             "buildDependencies": [
                 "LIBSSL_LAYOUT_DIST",
             ],
+            "makeTarget": "--quiet", # too noisy by default, ~4000 lines of output
             "results": ["libssl"],
             "description": "Build libssl"
         },


### PR DESCRIPTION
* 4000 lines is way too much, especially in CI where it might have a significant overhead and makes CI logs slow to load.