### PR TITLE
Ignore "bom|" prefix if file is not opened for reading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Compatibility:
 * Define `Data#initialize` to help deserializing Data instances (@eregon).
 * Fix `Rational()` and arguments type conversion (#3969, #3954 @andrykonchin).
 * Support `Rational()` with `exception` keyword argument (#3969, @andrykonchin).
+* Ignore `bom|` prefix if file is not opened for reading (#4079, @rwstauner).
 
 Performance:
 

--- a/spec/ruby/core/io/write_spec.rb
+++ b/spec/ruby/core/io/write_spec.rb
@@ -102,6 +102,13 @@ describe "IO#write on a file" do
     File.binread(@filename).should == "h\u0000\u0000\u0000i\u0000\u0000\u0000"
   end
 
+  it "ignores the 'bom|' prefix" do
+    File.open(@filename, "w", encoding: 'bom|utf-8') do |file|
+      file.write("hi")
+    end
+    File.binread(@filename).should == "hi"
+  end
+
   it "raises a invalid byte sequence error if invalid bytes are being written" do
     # pack "\xFEhi" to avoid utf-8 conflict
     xFEhi = ([254].pack('C*') + 'hi').force_encoding('utf-8')

--- a/src/main/ruby/truffleruby/core/io.rb
+++ b/src/main/ruby/truffleruby/core/io.rb
@@ -2068,7 +2068,7 @@ class IO
   def set_encoding(external, internal = nil, **options)
     if !Primitive.nil?(internal)
       unless Primitive.nil?(external) || Primitive.is_a?(external, Encoding)
-        external = Truffle::IOOperations.parse_external_enc(self, StringValue(external))
+        external = Truffle::IOOperations.parse_external_enc(self, StringValue(external), @mode)
       end
 
       unless Primitive.is_a?(internal, Encoding)

--- a/src/main/ruby/truffleruby/core/truffle/io_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/io_operations.rb
@@ -414,20 +414,24 @@ module Truffle
 
     BOM = /\Abom\|/i
 
-    def self.parse_external_enc(io, external)
+    def self.parse_external_enc(io, external, mode)
       if BOM.match?(external)
         external = external[4..-1]
-        strip_bom_for_regular_file(io) || Encoding.find(external)
-      else
-        Encoding.find(external)
+        if (mode & FMODE_READABLE) == 1
+          if found = strip_bom_for_regular_file(io)
+            return found
+          end
+        end
       end
+
+      Encoding.find(external)
     end
 
     # MRI: parse_mode_enc
     # Parses string as "external" or "external:internal" or "external:-"
     def self.parse_mode_enc(io, mode, string)
       external, internal = string.split(':', 2)
-      external = parse_external_enc(io, external)
+      external = parse_external_enc(io, external, mode)
 
       if internal
         if internal == '-' # Special case - "-" => no transcoding


### PR DESCRIPTION
The CSV gem uses this pattern:
https://github.com/ruby/csv/blob/bc69827460390a0224616b5ad1949dec01a3404d/lib/csv.rb#L1980
which causes an error with something like `CSV.open("file.csv", "wb")`.

This change produces 10 less errors when attempting to run the csv test suite.

Without the change the spec I added produces this error:

```
1)
IO#write on a file ignores the 'bom|' prefix ERROR
IOError: not opened for reading
<internal:core> core/io.rb:1355:in 'IO#ensure_open_and_readable'
<internal:core> core/io.rb:1479:in 'IO#getbyte'
<internal:core> core/truffle/io_operations.rb:577:in 'Truffle::IOOperations.strip_bom'
<internal:core> core/truffle/io_operations.rb:573:in 'Truffle::IOOperations.strip_bom_for_regular_file'
<internal:core> core/truffle/io_operations.rb:420:in 'Truffle::IOOperations.parse_external_enc'
<internal:core> core/truffle/io_operations.rb:430:in 'Truffle::IOOperations.parse_mode_enc'
<internal:core> core/io.rb:2094:in 'IO#set_encoding'
<internal:core> core/io.rb:864:in 'IO#initialize'
<internal:core> core/file.rb:1188:in 'File#initialize'
<internal:core> core/io.rb:571:in 'IO.open'
/Users/rwstauner/src/truffle-ws/truffleruby/spec/ruby/core/io/write_spec.rb:106:in 'block (2 levels) in <top (required)>'
```