### PR TITLE
Remove rb_gc_force_recycle

### DIFF
--- a/lib/cext/include/ruby/internal/gc.h
+++ b/lib/cext/include/ruby/internal/gc.h
@@ -844,7 +844,4 @@ rb_obj_write(
     return a;
 }
 
-RBIMPL_ATTR_DEPRECATED(("Will be removed soon"))
-static inline void rb_gc_force_recycle(VALUE _obj){ (void)_obj; }
-
 #endif /* RBIMPL_GC_H */

--- a/lib/cext/include/truffleruby/truffleruby-abi-version.h
+++ b/lib/cext/include/truffleruby/truffleruby-abi-version.h
@@ -25,6 +25,6 @@
 // and cannot reach the same version while having different ABI
 // ($TRUFFLERUBY_VERSION is never the same as $RUBY_VERSION).
 
-#define TRUFFLERUBY_ABI_VERSION "3.4.7.3"
+#define TRUFFLERUBY_ABI_VERSION "3.4.7.4"
 
 #endif


### PR DESCRIPTION
This is probably the most trivial change listed in #3883. Since I don't really think the failing CI in #4085 is caused by the change in that case, this seems like a nice way to retry that CI step with a different branch.