### PR TITLE
Implement `String#append_as_bytes`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Bug fixes:
 
 
 Compatibility:
+* Implement `String#append_as_bytes` for Ruby 3.4 (#4087, @Earlopain).
 
 
 Performance:

--- a/spec/ruby/core/string/append_as_bytes_spec.rb
+++ b/spec/ruby/core/string/append_as_bytes_spec.rb
@@ -7,14 +7,16 @@ describe "String#append_bytes" do
       -> { str.append_as_bytes("\xE2\x82") }.should raise_error(FrozenError)
     end
 
-    it "allows creating broken strings" do
+    it "allows creating broken strings in UTF8" do
       str = +"hello"
       str.append_as_bytes("\xE2\x82")
       str.valid_encoding?.should == false
 
       str.append_as_bytes("\xAC")
       str.valid_encoding?.should == true
+    end
 
+    it "allows creating broken strings in UTF_32" do
       str = "abc".encode(Encoding::UTF_32LE)
       str.append_as_bytes("def")
       str.encoding.should == Encoding::UTF_32LE

--- a/spec/tags/core/string/append_as_bytes_tags.txt
+++ b/spec/tags/core/string/append_as_bytes_tags.txt
@@ -1,7 +1,1 @@
-fails:String#append_bytes doesn't allow to mutate frozen strings
-fails:String#append_bytes allows creating broken strings
-fails:String#append_bytes never changes the receiver encoding
-fails:String#append_bytes accepts variadic String or Integer arguments
-fails:String#append_bytes truncates integers to the least significant byte
-fails:String#append_bytes wraps negative integers
-fails:String#append_bytes only accepts strings or integers, and doesn't attempt to cast with #to_str or #to_int
+fails:String#append_bytes allows creating broken strings in UTF_32

--- a/spec/tags/truffle/methods_tags.txt
+++ b/spec/tags/truffle/methods_tags.txt
@@ -107,7 +107,6 @@ fails:Public methods on Array should include freeze
 fails:Public methods on GC.singleton_class should include config
 fails:Public methods on Hash should include freeze
 fails:Public methods on SizedQueue should not include freeze
-fails:Public methods on String should include append_as_bytes
 fails:Public methods on Time should include iso8601
 fails:Public methods on Time should include xmlschema
 fails:Public methods on BasicSocket should include read_nonblock

--- a/src/main/ruby/truffleruby/core/string.rb
+++ b/src/main/ruby/truffleruby/core/string.rb
@@ -1177,6 +1177,21 @@ class String
     nil
   end
 
+  def append_as_bytes(*args)
+    Primitive.check_mutable_string self
+
+    args.each do |arg|
+      case arg
+      when String
+        Primitive.string_byte_append(self, arg)
+      when Integer
+        Primitive.string_byte_append(self, (arg % 256).chr)
+      else
+        raise TypeError, "wrong argument type #{Primitive.class(arg).name} (expected String or Integer)"
+      end
+    end
+  end
+
   def byteindex(str, start = 0)
     is_regex_pattern = Primitive.is_a?(str, Regexp)
 

--- a/src/main/ruby/truffleruby/core/truffle/polyglot_methods.rb
+++ b/src/main/ruby/truffleruby/core/truffle/polyglot_methods.rb
@@ -60,6 +60,10 @@ module Polyglot
       to_s.[]=(...)
     end
 
+    def append_as_bytes(...)
+      to_s.append_as_bytes(...)
+    end
+
     def ascii_only?(...)
       to_s.ascii_only?(...)
     end


### PR DESCRIPTION
A Ruby 3.4 addition (#3883)

Tweak specs so that UTF32 runs separately. It can handle other encodings just fine, there seems to be something specific to UTF32 that truffleruby can't handle.