### PR TITLE
Hash.[] raises for elements that are not arrays

### DIFF
--- a/spec/tags/core/hash/constructor_tags.txt
+++ b/spec/tags/core/hash/constructor_tags.txt
@@ -1,1 +1,0 @@
-fails:Hash.[] raises for elements that are not arrays

--- a/src/main/ruby/truffleruby/core/hash.rb
+++ b/src/main/ruby/truffleruby/core/hash.rb
@@ -52,10 +52,7 @@ class Hash
     hash = new
     associate_array.each_with_index do |array, i|
       unless array.respond_to? :to_ary
-        warn "wrong element type #{Primitive.class(array)} at #{i} (expected array)"
-        warn 'ignoring wrong elements is deprecated, remove them explicitly'
-        warn 'this causes ArgumentError in the next release'
-        next
+        raise ArgumentError, "wrong element type #{Primitive.class(array)} at #{i} (expected array)"
       end
       array = array.to_ary
       unless (1..2).cover? array.size


### PR DESCRIPTION
The warning "ArgumentError in the next release" was added in TruffleRuby 20.1.0 back in 2020, and was compatible with Ruby 2.6.

Commit that added the code: commit 3bc34279daed09f584ad83d2fddc8549600e8433