### PR TITLE
Fix Ruby 3.4 behaviour of Rational#**

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Compatibility:
 * Implement `Fiber.[]`, `Fiber.[]=`, and `Fiber#{storage,storage=}` (#4007, @nirvdrum).
 * Update `Range#size` semantics for Ruby 3.4 (#4099, @Earlopain).
 * Keyword splatting `nil` is now treated as `**{}` for Ruby 3.4 (#4100, @Earlopain).
+* `Rational#**` no longer returns a Float, it will raise an ArgumentError if the result is too big (#4105, @herwinw).
 
 Performance:
 

--- a/spec/ruby/core/rational/exponent_spec.rb
+++ b/spec/ruby/core/rational/exponent_spec.rb
@@ -108,37 +108,37 @@ describe "Rational#**" do
       it "raises an ArgumentError when self is > 1" do
         -> {
           (Rational(2) ** bignum_value)
-        }.should raise_error(ArgumentError)
+        }.should raise_error(ArgumentError, "exponent is too large")
         -> {
           (Rational(fixnum_max) ** bignum_value)
-        }.should raise_error(ArgumentError)
+        }.should raise_error(ArgumentError, "exponent is too large")
       end
 
       it "raises an ArgumentError when self is > 1 and the exponent is negative" do
         -> {
           (Rational(2) ** -bignum_value)
-        }.should raise_error(ArgumentError)
+        }.should raise_error(ArgumentError, "exponent is too large")
         -> {
           (Rational(fixnum_max) ** -bignum_value)
-        }.should raise_error(ArgumentError)
+        }.should raise_error(ArgumentError, "exponent is too large")
       end
 
       it "raises an ArgumentError when self is < -1" do
         -> {
           (Rational(-2) ** bignum_value)
-        }.should raise_error(ArgumentError)
+        }.should raise_error(ArgumentError, "exponent is too large")
         -> {
           (Rational(fixnum_min) ** bignum_value)
-        }.should raise_error(ArgumentError)
+        }.should raise_error(ArgumentError, "exponent is too large")
       end
 
       it "raises an ArgumentError when self is < -1 and the exponent is negative" do
         -> {
           (Rational(-2) ** -bignum_value)
-        }.should raise_error(ArgumentError)
+        }.should raise_error(ArgumentError, "exponent is too large")
         -> {
           (Rational(fixnum_min) ** -bignum_value)
-        }.should raise_error(ArgumentError)
+        }.should raise_error(ArgumentError, "exponent is too large")
       end
     end
 

--- a/spec/tags/core/rational/exponent_tags.txt
+++ b/spec/tags/core/rational/exponent_tags.txt
@@ -1,4 +1,0 @@
-fails:Rational#** when passed Bignum raises an ArgumentError when self is > 1
-fails:Rational#** when passed Bignum raises an ArgumentError when self is > 1 and the exponent is negative
-fails:Rational#** when passed Bignum raises an ArgumentError when self is < -1
-fails:Rational#** when passed Bignum raises an ArgumentError when self is < -1 and the exponent is negative

--- a/src/main/ruby/truffleruby/core/rational.rb
+++ b/src/main/ruby/truffleruby/core/rational.rb
@@ -87,7 +87,7 @@ class Rational < Numeric
         elsif self == -1
           Rational.__send__(:new_already_canonical, other.even? ? 1 : -1, 1)
         else
-          to_f ** other
+          raise ArgumentError, 'exponent is too large'
         end
       end
     when Float


### PR DESCRIPTION
I guess `Integer#**` can be fixed the same way, but I haven't looked too deep into it.

https://github.com/truffleruby/truffleruby/issues/3883