### PR TITLE
Set the source position for all synthesized call nodes via createCallNode()

### DIFF
--- a/spec/truffle/parsing/fixtures/case/with_expression_and_when/with_else_branch.yaml
+++ b/spec/truffle/parsing/fixtures/case/with_expression_and_when/with_else_branch.yaml
@@ -80,8 +80,8 @@ ast: |
                                   flags = 0
                                   integerCaseEqualAssumption = Assumption(valid, name=core method is not overridden:)
                                   parameters = RubyCallNodeParameters{methodName='===', descriptor=NoKeywordArgumentsDescriptor, isSplatted=false, ignoreVisibility=true, isVCall=false, isSafeNavigation=false, isAttrAssign=false}
-                                  sourceCharIndex = -1
-                                  sourceLength = 0
+                                  sourceCharIndex = 13
+                                  sourceLength = 2
                               children:
                                   leftNode_ =
                                       IntegerFixnumLiteralNode
@@ -112,8 +112,8 @@ ast: |
                                               flags = 0
                                               integerCaseEqualAssumption = Assumption(valid, name=core method is not overridden:)
                                               parameters = RubyCallNodeParameters{methodName='===', descriptor=NoKeywordArgumentsDescriptor, isSplatted=false, ignoreVisibility=true, isVCall=false, isSafeNavigation=false, isAttrAssign=false}
-                                              sourceCharIndex = -1
-                                              sourceLength = 0
+                                              sourceCharIndex = 35
+                                              sourceLength = 6
                                           children:
                                               leftNode_ =
                                                   IntegerFixnumLiteralNode

--- a/spec/truffle/parsing/fixtures/case/with_expression_and_when/with_multiple_values.yaml
+++ b/spec/truffle/parsing/fixtures/case/with_expression_and_when/with_multiple_values.yaml
@@ -80,8 +80,8 @@ ast: |
                                               flags = 0
                                               integerCaseEqualAssumption = Assumption(valid, name=core method is not overridden:)
                                               parameters = RubyCallNodeParameters{methodName='===', descriptor=NoKeywordArgumentsDescriptor, isSplatted=false, ignoreVisibility=true, isVCall=false, isSafeNavigation=false, isAttrAssign=false}
-                                              sourceCharIndex = -1
-                                              sourceLength = 0
+                                              sourceCharIndex = 13
+                                              sourceLength = 2
                                           children:
                                               leftNode_ =
                                                   IntegerFixnumLiteralNode
@@ -105,8 +105,8 @@ ast: |
                                               flags = 0
                                               integerCaseEqualAssumption = Assumption(valid, name=core method is not overridden:)
                                               parameters = RubyCallNodeParameters{methodName='===', descriptor=NoKeywordArgumentsDescriptor, isSplatted=false, ignoreVisibility=true, isVCall=false, isSafeNavigation=false, isAttrAssign=false}
-                                              sourceCharIndex = -1
-                                              sourceLength = 0
+                                              sourceCharIndex = 17
+                                              sourceLength = 4
                                           children:
                                               leftNode_ =
                                                   FloatLiteralNode

--- a/spec/truffle/parsing/fixtures/case/with_expression_and_when/with_single_value.yaml
+++ b/spec/truffle/parsing/fixtures/case/with_expression_and_when/with_single_value.yaml
@@ -79,8 +79,8 @@ ast: |
                                   flags = 0
                                   integerCaseEqualAssumption = Assumption(valid, name=core method is not overridden:)
                                   parameters = RubyCallNodeParameters{methodName='===', descriptor=NoKeywordArgumentsDescriptor, isSplatted=false, ignoreVisibility=true, isVCall=false, isSafeNavigation=false, isAttrAssign=false}
-                                  sourceCharIndex = -1
-                                  sourceLength = 0
+                                  sourceCharIndex = 13
+                                  sourceLength = 2
                               children:
                                   leftNode_ =
                                       IntegerFixnumLiteralNode
@@ -111,8 +111,8 @@ ast: |
                                               flags = 0
                                               integerCaseEqualAssumption = Assumption(valid, name=core method is not overridden:)
                                               parameters = RubyCallNodeParameters{methodName='===', descriptor=NoKeywordArgumentsDescriptor, isSplatted=false, ignoreVisibility=true, isVCall=false, isSafeNavigation=false, isAttrAssign=false}
-                                              sourceCharIndex = -1
-                                              sourceLength = 0
+                                              sourceCharIndex = 35
+                                              sourceLength = 6
                                           children:
                                               leftNode_ =
                                                   IntegerFixnumLiteralNode

--- a/spec/truffle/parsing/fixtures/case/with_expression_and_when/with_splat_operator.yaml
+++ b/spec/truffle/parsing/fixtures/case/with_expression_and_when/with_splat_operator.yaml
@@ -30,8 +30,8 @@ ast: |
                       methodName = "when_splat"
                       notEmptyKeywordsProfile = false
                       notRuby2KeywordsHashProfile = false
-                      sourceCharIndex = -1
-                      sourceLength = 0
+                      sourceCharIndex = 13
+                      sourceLength = 4
                   children:
                       arguments = [
                           SplatCastNodeGen

--- a/spec/truffle/parsing/fixtures/case/with_expression_and_when/with_splat_operator_and_following_element.yaml
+++ b/spec/truffle/parsing/fixtures/case/with_expression_and_when/with_splat_operator_and_following_element.yaml
@@ -30,8 +30,8 @@ ast: |
                       methodName = "when_splat"
                       notEmptyKeywordsProfile = false
                       notRuby2KeywordsHashProfile = false
-                      sourceCharIndex = -1
-                      sourceLength = 0
+                      sourceCharIndex = 13
+                      sourceLength = 8
                   children:
                       arguments = [
                           ArrayConcatNode

--- a/spec/truffle/parsing/fixtures/case/with_expression_and_when/with_splat_operator_and_following_elements.yaml
+++ b/spec/truffle/parsing/fixtures/case/with_expression_and_when/with_splat_operator_and_following_elements.yaml
@@ -30,8 +30,8 @@ ast: |
                       methodName = "when_splat"
                       notEmptyKeywordsProfile = false
                       notRuby2KeywordsHashProfile = false
-                      sourceCharIndex = -1
-                      sourceLength = 0
+                      sourceCharIndex = 13
+                      sourceLength = 16
                   children:
                       arguments = [
                           ArrayConcatNode

--- a/spec/truffle/parsing/fixtures/case/with_expression_and_when/with_splat_operator_and_preceding_and_following_element.yaml
+++ b/spec/truffle/parsing/fixtures/case/with_expression_and_when/with_splat_operator_and_preceding_and_following_element.yaml
@@ -30,8 +30,8 @@ ast: |
                       methodName = "when_splat"
                       notEmptyKeywordsProfile = false
                       notRuby2KeywordsHashProfile = false
-                      sourceCharIndex = -1
-                      sourceLength = 0
+                      sourceCharIndex = 13
+                      sourceLength = 16
                   children:
                       arguments = [
                           ArrayConcatNode

--- a/spec/truffle/parsing/fixtures/case/with_expression_and_when/with_splat_operator_and_preceding_and_following_elements.yaml
+++ b/spec/truffle/parsing/fixtures/case/with_expression_and_when/with_splat_operator_and_preceding_and_following_elements.yaml
@@ -30,8 +30,8 @@ ast: |
                       methodName = "when_splat"
                       notEmptyKeywordsProfile = false
                       notRuby2KeywordsHashProfile = false
-                      sourceCharIndex = -1
-                      sourceLength = 0
+                      sourceCharIndex = 13
+                      sourceLength = 30
                   children:
                       arguments = [
                           ArrayConcatNode

--- a/spec/truffle/parsing/fixtures/case/with_expression_and_when/with_splat_operator_and_preceding_element.yaml
+++ b/spec/truffle/parsing/fixtures/case/with_expression_and_when/with_splat_operator_and_preceding_element.yaml
@@ -30,8 +30,8 @@ ast: |
                       methodName = "when_splat"
                       notEmptyKeywordsProfile = false
                       notRuby2KeywordsHashProfile = false
-                      sourceCharIndex = -1
-                      sourceLength = 0
+                      sourceCharIndex = 13
+                      sourceLength = 8
                   children:
                       arguments = [
                           ArrayConcatNode

--- a/spec/truffle/parsing/fixtures/case/with_expression_and_when/with_splat_operator_and_preceding_elements.yaml
+++ b/spec/truffle/parsing/fixtures/case/with_expression_and_when/with_splat_operator_and_preceding_elements.yaml
@@ -30,8 +30,8 @@ ast: |
                       methodName = "when_splat"
                       notEmptyKeywordsProfile = false
                       notRuby2KeywordsHashProfile = false
-                      sourceCharIndex = -1
-                      sourceLength = 0
+                      sourceCharIndex = 13
+                      sourceLength = 16
                   children:
                       arguments = [
                           ArrayConcatNode

--- a/spec/truffle/parsing/fixtures/case/with_expression_and_when/with_string_literal_in_when_clause.yaml
+++ b/spec/truffle/parsing/fixtures/case/with_expression_and_when/with_string_literal_in_when_clause.yaml
@@ -22,8 +22,8 @@ ast: |
                       flags = 0
                       integerCaseEqualAssumption = Assumption(valid, name=core method is not overridden:)
                       parameters = RubyCallNodeParameters{methodName='===', descriptor=NoKeywordArgumentsDescriptor, isSplatted=false, ignoreVisibility=true, isVCall=false, isSafeNavigation=false, isAttrAssign=false}
-                      sourceCharIndex = -1
-                      sourceLength = 0
+                      sourceCharIndex = 13
+                      sourceLength = 5
                   children:
                       leftNode_ =
                           FrozenStringLiteralNode

--- a/src/main/java/org/truffleruby/parser/YARPPatternMatchingTranslator.java
+++ b/src/main/java/org/truffleruby/parser/YARPPatternMatchingTranslator.java
@@ -390,7 +390,8 @@ public final class YARPPatternMatchingTranslator extends YARPBaseTranslator {
 
     private RubyNode matchValue(Nodes.Node value) {
         RubyNode translatedValue = value.accept(yarpTranslator);
-        return createCallNode(translatedValue, "===", currentValueToMatch);
+        var rubyNode = createCallNode(translatedValue, "===", currentValueToMatch);
+        return assignPositionAndFlags(value, rubyNode);
     }
 
 }

--- a/src/main/java/org/truffleruby/parser/YARPTranslator.java
+++ b/src/main/java/org/truffleruby/parser/YARPTranslator.java
@@ -1053,6 +1053,7 @@ public class YARPTranslator extends YARPBaseTranslator {
                             whenConditionNode,
                             NodeUtil.cloneNode(readPredicateNode) };
                     final RubyNode predicateNode = createCallNode(receiver, "when_splat", arguments);
+                    assignPositionOnly(whenConditions, predicateNode);
 
                     // create `if` node
                     final RubyNode thenNode = translateNodeOrNil(whenNode.statements);
@@ -1073,6 +1074,7 @@ public class YARPTranslator extends YARPBaseTranslator {
                         final RubyNode receiver = whenCondition.accept(this);
                         final RubyNode[] arguments = new RubyNode[]{ NodeUtil.cloneNode(readPredicateNode) };
                         final RubyNode nextPredicateNode = createCallNode(receiver, "===", arguments);
+                        assignPositionAndFlags(whenCondition, nextPredicateNode);
 
                         if (predicateNode == null) {
                             predicateNode = nextPredicateNode;


### PR DESCRIPTION
* Notably improves the backtrace when a condition in a multi-line `case/when condition/end` raises.

I noticed the backtrace for https://github.com/truffleruby/truffleruby/issues/4106 was imprecise and only gave the start line of the method when it should point at the Regexp in the multi-line case/when that is failing.