### PR TITLE
Update search_nonascii() from ruby/ruby@3dd928c284

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ New features:
 Bug fixes:
 
 * Fix `Integer#ceil` and `Float#ceil` with negative precision (#3911, @trinistr).
+* Update `search_nonascii()` to not rely on undefined behavior (#4110, @eregon).
 
 Compatibility:
 

--- a/lib/cext/include/truffleruby/truffleruby-abi-version.h
+++ b/lib/cext/include/truffleruby/truffleruby-abi-version.h
@@ -25,6 +25,6 @@
 // and cannot reach the same version while having different ABI
 // ($TRUFFLERUBY_VERSION is never the same as $RUBY_VERSION).
 
-#define TRUFFLERUBY_ABI_VERSION "3.4.7.6"
+#define TRUFFLERUBY_ABI_VERSION "3.4.7.7"
 
 #endif


### PR DESCRIPTION
* See https://bugs.ruby-lang.org/issues/21715
* Fixes https://github.com/truffleruby/truffleruby/issues/4110