### PR TITLE
Move var-args and struct-by-value functions to libtrufflerubytrampoline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Compatibility:
 * `Rational#**` no longer returns a Float, it will raise an ArgumentError if the result is too big (#4105, @herwinw).
 * The dummy `Encoding::UTF_16` and `Encoding::UTF_32` encodings are now regular single-byte dummy encodings (#4083, @eregon).
 * Implement `rb_interned_str()` and `rb_interned_str_cstr()` (#4018, @herwinw).
+* Define C API var-args and struct-by-value functions as non-inline to support taking their address (#3396, @eregon).
 
 Performance:
 

--- a/lib/cext/include/ruby/internal/error.h
+++ b/lib/cext/include/ruby/internal/error.h
@@ -116,11 +116,6 @@ RBIMPL_ATTR_FORMAT(RBIMPL_PRINTF_FORMAT, 2, 3)
  */
 void rb_raise(VALUE exc, const char *fmt, ...);
 
-#ifdef TRUFFLERUBY
-RBIMPL_ATTR_NORETURN()
-void rb_tr_fatal_va_list(const char *fmt, va_list args);
-#endif
-
 RBIMPL_ATTR_NORETURN()
 RBIMPL_ATTR_NONNULL((1))
 RBIMPL_ATTR_FORMAT(RBIMPL_PRINTF_FORMAT, 1, 2)
@@ -133,21 +128,7 @@ RBIMPL_ATTR_FORMAT(RBIMPL_PRINTF_FORMAT, 1, 2)
  * @exception  rb_eFatal  An exception that you cannot rescue.
  * @note       It never returns.
  */
-#ifdef TRUFFLERUBY
-static inline void rb_fatal(const char *fmt, ...) {
-    va_list args;
-    va_start(args, fmt);
-    rb_tr_fatal_va_list(fmt, args);
-    va_end(args);
-}
-#else
 void rb_fatal(const char *fmt, ...);
-#endif
-
-#ifdef TRUFFLERUBY
-RBIMPL_ATTR_NORETURN()
-void rb_tr_bug_va_list(const char *fmt, va_list args);
-#endif
 
 RBIMPL_ATTR_COLD()
 RBIMPL_ATTR_NORETURN()
@@ -169,16 +150,7 @@ RBIMPL_ATTR_FORMAT(RBIMPL_PRINTF_FORMAT, 1, 2)
  * @param[in]  fmt  Format specifier string compatible with rb_sprintf().
  * @note       It never returns.
  */
-#ifdef TRUFFLERUBY
-static inline void rb_bug(const char *fmt, ...) {
-    va_list args;
-    va_start(args, fmt);
-    rb_tr_bug_va_list(fmt, args);
-    va_end(args);
-}
-#else
 void rb_bug(const char *fmt, ...);
-#endif
 
 RBIMPL_ATTR_NORETURN()
 RBIMPL_ATTR_NONNULL(())
@@ -513,10 +485,6 @@ VALUE *rb_ruby_debug_ptr(void);
  */
 #define ruby_debug   (*rb_ruby_debug_ptr())
 
-#ifdef TRUFFLERUBY
-void rb_tr_warn_va_list(const char *fmt, va_list args);
-#endif
-
 /* reports if $VERBOSE is true */
 RBIMPL_ATTR_NONNULL((1))
 RBIMPL_ATTR_FORMAT(RBIMPL_PRINTF_FORMAT, 1, 2)
@@ -540,18 +508,7 @@ RBIMPL_ATTR_FORMAT(RBIMPL_PRINTF_FORMAT, 1, 2)
  *
  * Above description is in fact inaccurate.  This API interfaces with Ractors.
  */
-#ifdef TRUFFLERUBY
-static inline void rb_warning(const char *fmt, ...) {
-    if (RTEST(ruby_verbose)) {
-        va_list args;
-        va_start(args, fmt);
-        rb_tr_warn_va_list(fmt, args);
-        va_end(args);
-    }
-}
-#else
 void rb_warning(const char *fmt, ...);
-#endif
 
 RBIMPL_ATTR_NONNULL((2))
 RBIMPL_ATTR_FORMAT(RBIMPL_PRINTF_FORMAT, 2, 3)
@@ -598,23 +555,7 @@ RBIMPL_ATTR_FORMAT(RBIMPL_PRINTF_FORMAT, 1, 2)
  *             nothing if $VERBOSE is nil.
  * @param[in]  fmt  Format specifier string compatible with rb_sprintf().
  */
-#ifdef TRUFFLERUBY
-static inline void rb_warn(const char *fmt, ...) {
-    if (!NIL_P(ruby_verbose)) {
-        va_list args;
-        va_start(args, fmt);
-        rb_tr_warn_va_list(fmt, args);
-        va_end(args);
-    }
-}
-#else
 void rb_warn(const char *fmt, ...);
-#endif
-
-#ifdef TRUFFLERUBY
-bool rb_warning_category_enabled_p(rb_warning_category_t category);
-void rb_tr_category_warn_va_list(rb_warning_category_t category, const char *fmt, va_list args);
-#endif
 
 RBIMPL_ATTR_COLD()
 RBIMPL_ATTR_NONNULL((2))
@@ -625,18 +566,7 @@ RBIMPL_ATTR_FORMAT(RBIMPL_PRINTF_FORMAT, 2, 3)
  * @param[in]  cat  Category e.g. deprecated.
  * @param[in]  fmt  Format specifier string compatible with rb_sprintf().
  */
-#ifdef TRUFFLERUBY
-static inline void rb_category_warn(rb_warning_category_t category, const char *fmt, ...) {
-    if (!NIL_P(ruby_verbose) && rb_warning_category_enabled_p(category)) {
-        va_list args;
-        va_start(args, fmt);
-        rb_tr_category_warn_va_list(category, fmt, args);
-        va_end(args);
-    }
-}
-#else
 void rb_category_warn(rb_warning_category_t cat, const char *fmt, ...);
-#endif
 
 RBIMPL_ATTR_NONNULL((1, 3))
 RBIMPL_ATTR_FORMAT(RBIMPL_PRINTF_FORMAT, 3, 4)

--- a/lib/cext/include/ruby/internal/intern/array.h
+++ b/lib/cext/include/ruby/internal/intern/array.h
@@ -88,10 +88,6 @@ VALUE rb_ary_new(void);
  */
 VALUE rb_ary_new_capa(long capa);
 
-#ifdef TRUFFLERUBY
-VALUE rb_tr_ary_new_from_args_va_list(long n, va_list args);
-#endif
-
 /**
  * Constructs an array from the passed objects.
  *
@@ -99,17 +95,7 @@ VALUE rb_tr_ary_new_from_args_va_list(long n, va_list args);
  * @param[in]  ...  Arbitrary ruby objects, filled into the returning array.
  * @return     An array of size `n`, whose contents are the passed objects.
  */
-#ifdef TRUFFLERUBY
-static inline VALUE rb_ary_new_from_args(long n, ...) {
-    va_list args;
-    va_start(args, n);
-    VALUE array = rb_tr_ary_new_from_args_va_list(n, args);
-    va_end(args);
-    return array;
-}
-#else
 VALUE rb_ary_new_from_args(long n, ...);
-#endif
 
 /**
  * Identical to rb_ary_new_from_args(), except how objects are passed.

--- a/lib/cext/include/ruby/internal/intern/struct.h
+++ b/lib/cext/include/ruby/internal/intern/struct.h
@@ -29,10 +29,6 @@ RBIMPL_SYMBOL_EXPORT_BEGIN()
 
 /* struct.c */
 
-#ifdef TRUFFLERUBY
-VALUE rb_tr_struct_new_va_list(VALUE klass, va_list args);
-#endif
-
 /**
  * Creates an instance of the given struct.
  *
@@ -43,21 +39,7 @@ VALUE rb_tr_struct_new_va_list(VALUE klass, va_list args);
  * @note       Number of variadic arguments must much that of the passed klass'
  *             fields.
  */
-#ifdef TRUFFLERUBY
-static inline VALUE rb_struct_new(VALUE klass, ...) {
-    va_list args;
-    va_start(args, klass);
-    VALUE result = rb_tr_struct_new_va_list(klass, args);
-    va_end(args);
-    return result;
-}
-#else
 VALUE rb_struct_new(VALUE klass, ...);
-#endif
-
-#ifdef TRUFFLERUBY
-VALUE rb_tr_struct_define_va_list(const char *name, va_list args);
-#endif
 
 /**
  * Defines a struct class.
@@ -80,21 +62,7 @@ VALUE rb_tr_struct_define_va_list(const char *name, va_list args);
  * Not  seriously  checked but  it  seems  this  function  does not  share  its
  * implementation with how `Struct.new` is implemented...?
  */
-#ifdef TRUFFLERUBY
-static inline VALUE rb_struct_define(const char *name, ...) {
-    va_list args;
-    va_start(args, name);
-    VALUE result = rb_tr_struct_define_va_list(name, args);
-    va_end(args);
-    return result;
-}
-#else
 VALUE rb_struct_define(const char *name, ...);
-#endif
-
-#ifdef TRUFFLERUBY
-VALUE rb_tr_struct_define_under_va_list(VALUE space, const char *name, va_list args);
-#endif
 
 RBIMPL_ATTR_NONNULL((2))
 /**
@@ -115,17 +83,7 @@ RBIMPL_ATTR_NONNULL((2))
  * @note        The GC does not collect nor move classes returned by this
  *              function. They are immortal.
  */
-#ifdef TRUFFLERUBY
-static inline VALUE rb_struct_define_under(VALUE space, const char *name, ...) {
-    va_list args;
-    va_start(args, name);
-    VALUE result = rb_tr_struct_define_under_va_list(space, name, args);
-    va_end(args);
-    return result;
-}
-#else
 VALUE rb_struct_define_under(VALUE space, const char *name, ...);
-#endif
 
 /**
  * Identical to  rb_struct_new(), except it  takes the  field values as  a Ruby
@@ -246,10 +204,6 @@ RBIMPL_ATTR_NONNULL((2))
  */
 VALUE rb_struct_define_without_accessor_under(VALUE outer, const char *class_name, VALUE super, rb_alloc_func_t alloc, ...);
 
-#ifdef TRUFFLERUBY
-VALUE rb_tr_data_define_va_list(VALUE super, va_list args);
-#endif
-
 /**
  * Defines an anonymous data class.
  *
@@ -264,17 +218,7 @@ VALUE rb_tr_data_define_va_list(VALUE super, va_list args);
  * @note       The GC does not collect nor move classes returned by this
  *             function. They are immortal.
  */
-#ifdef TRUFFLERUBY
-static inline VALUE rb_data_define(VALUE super, ...) {
-    va_list args;
-    va_start(args, super);
-    VALUE result = rb_tr_data_define_va_list(super == 0 ? Qnil : super, args);
-    va_end(args);
-    return result;
-}
-#else
 VALUE rb_data_define(VALUE super, ...);
-#endif
 
 RBIMPL_SYMBOL_EXPORT_END()
 

--- a/lib/cext/include/ruby/internal/intern/thread.h
+++ b/lib/cext/include/ruby/internal/intern/thread.h
@@ -196,14 +196,7 @@ VALUE rb_thread_create(VALUE (*f)(void *g), void *g);
  * @param[in]  time           Duration.
  * @exception  rb_eInterrupt  Interrupted.
  */
-#ifdef TRUFFLERUBY
-void rb_tr_thread_wait_for(struct timeval* time);
-static inline void rb_thread_wait_for(struct timeval time) {
-    rb_tr_thread_wait_for(&time);
-}
-#else
 void rb_thread_wait_for(struct timeval time);
-#endif
 
 /**
  * Obtains the "current" thread.

--- a/lib/cext/include/ruby/internal/intern/time.h
+++ b/lib/cext/include/ruby/internal/intern/time.h
@@ -105,10 +105,6 @@ VALUE rb_time_timespec_new(const struct timespec *ts, int offset);
  */
 VALUE rb_time_num_new(VALUE timev, VALUE off);
 
-#ifdef TRUFFLERUBY
-void rb_tr_time_interval(VALUE num, struct timeval *result);
-#endif
-
 /**
  * Creates  a  "time  interval".   This   basically  converts  an  instance  of
  * ::rb_cNumeric  into  a struct  `timeval`,  but  for instance  negative  time
@@ -119,19 +115,7 @@ void rb_tr_time_interval(VALUE num, struct timeval *result);
  * @exception  rb_eRangeError  `num` is out of range of `timeval::tv_sec`.
  * @return     A struct that represents the identical time to `num`.
  */
-#ifdef TRUFFLERUBY
-static inline struct timeval rb_time_interval(VALUE num) {
-    struct timeval result;
-    rb_tr_time_interval(num, &result);
-    return result;
-}
-#else
 struct timeval rb_time_interval(VALUE num);
-#endif
-
-#ifdef TRUFFLERUBY
-void rb_tr_time_timeval(VALUE time, struct timeval *result);
-#endif
 
 /**
  * Converts an  instance of rb_cTime  to a  struct timeval that  represents the
@@ -143,10 +127,6 @@ void rb_tr_time_timeval(VALUE time, struct timeval *result);
  * @return     A struct that represents the identical time to `num`.
  */
 struct timeval rb_time_timeval(VALUE time);
-
-#ifdef TRUFFLERUBY
-void rb_tr_time_timespec(VALUE time, struct timespec *result);
-#endif
 
 /**
  * Identical to rb_time_timeval(), except for return type.

--- a/lib/cext/include/ruby/internal/iterator.h
+++ b/lib/cext/include/ruby/internal/iterator.h
@@ -135,10 +135,6 @@ VALUE rb_each(VALUE obj);
  */
 VALUE rb_yield(VALUE val);
 
-#ifdef TRUFFLERUBY
-VALUE rb_tr_yield_values_va_list(int n, va_list args);
-#endif
-
 /**
  * Identical to rb_yield(),  except it takes variadic number  of parameters and
  * pass them to the block.
@@ -148,17 +144,7 @@ VALUE rb_tr_yield_values_va_list(int n, va_list args);
  * @exception  rb_eLocalJumpError  There is no block given.
  * @return     Evaluated value of the given block.
  */
-#ifdef TRUFFLERUBY
-static inline VALUE rb_yield_values(int n, ...) {
-    va_list args;
-    va_start(args, n);
-    VALUE result = rb_tr_yield_values_va_list(n, args);
-    va_end(args);
-    return result;
-}
-#else
 VALUE rb_yield_values(int n, ...);
-#endif
 
 /**
  * Identical to rb_yield_values(),  except it takes the parameters as a C array
@@ -377,10 +363,6 @@ VALUE rb_block_call_kw(VALUE obj, ID mid, int argc, const VALUE *argv, rb_block_
  */
 VALUE rb_rescue(VALUE (*b_proc)(VALUE), VALUE data1, VALUE (*r_proc)(VALUE, VALUE), VALUE data2);
 
-#ifdef TRUFFLERUBY
-VALUE rb_tr_rescue2_va_list(VALUE (*b_proc)(VALUE), VALUE data1, VALUE (*r_proc)(VALUE, VALUE), VALUE data2, va_list args);
-#endif
-
 /**
  * An equivalent of `rescue` clause.
  *
@@ -403,17 +385,7 @@ VALUE rb_tr_rescue2_va_list(VALUE (*b_proc)(VALUE), VALUE data1, VALUE (*r_proc)
  * @see            rb_protect
  * @ingroup        exception
  */
-#ifdef TRUFFLERUBY
-static inline VALUE rb_rescue2(VALUE (*b_proc)(VALUE), VALUE data1, VALUE (*r_proc)(VALUE, VALUE), VALUE data2, ...) {
-    va_list args;
-    va_start(args, data2);
-    VALUE result = rb_tr_rescue2_va_list(b_proc, data1, r_proc, data2, args);
-    va_end(args);
-    return result;
-}
-#else
 VALUE rb_rescue2(VALUE (*b_proc)(VALUE), VALUE data1, VALUE (*r_proc)(VALUE, VALUE), VALUE data2, ...);
-#endif
 
 /**
  * Identical to  rb_rescue2(), except  it takes  `va_list` instead  of variadic

--- a/lib/cext/include/truffleruby/truffleruby-abi-version.h
+++ b/lib/cext/include/truffleruby/truffleruby-abi-version.h
@@ -25,6 +25,6 @@
 // and cannot reach the same version while having different ABI
 // ($TRUFFLERUBY_VERSION is never the same as $RUBY_VERSION).
 
-#define TRUFFLERUBY_ABI_VERSION "3.4.7.8"
+#define TRUFFLERUBY_ABI_VERSION "3.4.7.9"
 
 #endif

--- a/src/main/c/cext-trampoline/Makefile
+++ b/src/main/c/cext-trampoline/Makefile
@@ -29,7 +29,7 @@ endif
 ROOT := $(realpath ../../../..)
 RUBY_HDR_DIR := $(ROOT)/lib/cext/include
 
-OBJECT_FILES := trampoline.o st.o strlcpy.o cext_constants.o
+OBJECT_FILES := trampoline.o st.o strlcpy.o cext_constants.o varargs.o struct_by_value.o
 
 libtrufflerubytrampoline.$(SOEXT): $(OBJECT_FILES) Makefile
 	$(Q) $(CC) -shared $(LDFLAGS) -o $@ $(OBJECT_FILES) $(LIBS)

--- a/src/main/c/cext-trampoline/struct_by_value.c
+++ b/src/main/c/cext-trampoline/struct_by_value.c
@@ -1,0 +1,62 @@
+/* Copyright (c) 2026, TruffleRuby contributors
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Returning a struct by value from Sulong to NFI is not supported.
+// So we need to declare such functions here and call a `rb_tr_` variant which takes a struct pointer instead.
+
+#include <ruby.h>
+
+void rb_tr_time_interval(VALUE num, struct timeval *result);
+
+struct timeval rb_time_interval(VALUE num) {
+  struct timeval result;
+  rb_tr_time_interval(num, &result);
+  return result;
+}
+
+void rb_tr_time_timeval(VALUE time, struct timeval *result);
+
+struct timeval rb_time_timeval(VALUE time) {
+  struct timeval result;
+  rb_tr_time_timeval(time, &result);
+  return result;
+}
+
+void rb_tr_time_timespec(VALUE time, struct timespec *result);
+
+struct timespec rb_time_timespec(VALUE time) {
+  struct timespec result;
+  rb_tr_time_timespec(time, &result);
+  return result;
+}
+
+void rb_tr_thread_wait_for(struct timeval* time);
+
+void rb_thread_wait_for(struct timeval time) {
+  rb_tr_thread_wait_for(&time);
+}

--- a/src/main/c/cext-trampoline/varargs.c
+++ b/src/main/c/cext-trampoline/varargs.c
@@ -1,0 +1,157 @@
+/* Copyright (c) 2026, TruffleRuby contributors
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from
+ *    this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// C does not support forwarding varargs (...).
+// So we need to declare varargs functions here and call a `rb_tr_*_va_list` variant which takes a va_list instead.
+
+#include <ruby.h>
+
+#include <internal_all.h>
+
+VALUE rb_tr_ary_new_from_args_va_list(long n, va_list args);
+
+VALUE rb_ary_new_from_args(long n, ...) {
+  va_list args;
+  va_start(args, n);
+  VALUE array = rb_tr_ary_new_from_args_va_list(n, args);
+  va_end(args);
+  return array;
+}
+
+RBIMPL_ATTR_NORETURN()
+void rb_tr_fatal_va_list(const char *fmt, va_list args);
+
+void rb_fatal(const char *fmt, ...) {
+  va_list args;
+  va_start(args, fmt);
+  rb_tr_fatal_va_list(fmt, args);
+  va_end(args);
+}
+
+RBIMPL_ATTR_NORETURN()
+void rb_tr_bug_va_list(const char *fmt, va_list args);
+
+void rb_bug(const char *fmt, ...) {
+  va_list args;
+  va_start(args, fmt);
+  rb_tr_bug_va_list(fmt, args);
+  va_end(args);
+}
+
+void rb_tr_warn_va_list(const char *fmt, va_list args);
+
+void rb_warning(const char *fmt, ...) {
+  if (RTEST(ruby_verbose)) {
+    va_list args;
+    va_start(args, fmt);
+    rb_tr_warn_va_list(fmt, args);
+    va_end(args);
+  }
+}
+
+void rb_warn(const char *fmt, ...) {
+  if (!NIL_P(ruby_verbose)) {
+    va_list args;
+    va_start(args, fmt);
+    rb_tr_warn_va_list(fmt, args);
+    va_end(args);
+  }
+}
+
+bool rb_warning_category_enabled_p(rb_warning_category_t category);
+void rb_tr_category_warn_va_list(rb_warning_category_t category, const char *fmt, va_list args);
+
+void rb_category_warn(rb_warning_category_t category, const char *fmt, ...) {
+  if (!NIL_P(ruby_verbose) && rb_warning_category_enabled_p(category)) {
+    va_list args;
+    va_start(args, fmt);
+    rb_tr_category_warn_va_list(category, fmt, args);
+    va_end(args);
+  }
+}
+
+VALUE rb_tr_struct_new_va_list(VALUE klass, va_list args);
+
+VALUE rb_struct_new(VALUE klass, ...) {
+  va_list args;
+  va_start(args, klass);
+  VALUE result = rb_tr_struct_new_va_list(klass, args);
+  va_end(args);
+  return result;
+}
+
+VALUE rb_tr_struct_define_va_list(const char *name, va_list args);
+
+VALUE rb_struct_define(const char *name, ...) {
+  va_list args;
+  va_start(args, name);
+  VALUE result = rb_tr_struct_define_va_list(name, args);
+  va_end(args);
+  return result;
+}
+
+VALUE rb_tr_struct_define_under_va_list(VALUE space, const char *name, va_list args);
+
+VALUE rb_struct_define_under(VALUE space, const char *name, ...) {
+  va_list args;
+  va_start(args, name);
+  VALUE result = rb_tr_struct_define_under_va_list(space, name, args);
+  va_end(args);
+  return result;
+}
+
+VALUE rb_tr_data_define_va_list(VALUE super, va_list args);
+
+VALUE rb_data_define(VALUE super, ...) {
+  va_list args;
+  va_start(args, super);
+  VALUE result = rb_tr_data_define_va_list(super == 0 ? Qnil : super, args);
+  va_end(args);
+  return result;
+}
+
+VALUE rb_tr_yield_values_va_list(int n, va_list args);
+
+#undef rb_yield_values
+VALUE rb_yield_values(int n, ...) {
+  va_list args;
+  va_start(args, n);
+  VALUE result = rb_tr_yield_values_va_list(n, args);
+  va_end(args);
+  return result;
+}
+
+VALUE rb_tr_rescue2_va_list(VALUE (*b_proc)(VALUE), VALUE data1, VALUE (*r_proc)(VALUE, VALUE), VALUE data2, va_list args);
+
+VALUE rb_rescue2(VALUE (*b_proc)(VALUE), VALUE data1, VALUE (*r_proc)(VALUE, VALUE), VALUE data2, ...) {
+    va_list args;
+    va_start(args, data2);
+    VALUE result = rb_tr_rescue2_va_list(b_proc, data1, r_proc, data2, args);
+    va_end(args);
+    return result;
+}

--- a/src/main/c/cext/call.c
+++ b/src/main/c/cext/call.c
@@ -134,6 +134,8 @@ VALUE rb_yield_splat(VALUE values) {
   }
 }
 
+VALUE rb_tr_ary_new_from_args_va_list(long n, va_list args);
+
 VALUE rb_tr_yield_values_va_list(int n, va_list args) {
   VALUE values = rb_tr_ary_new_from_args_va_list(n, args);
   return rb_yield_splat(values);

--- a/src/main/c/cext/io.c
+++ b/src/main/c/cext/io.c
@@ -180,6 +180,8 @@ int rb_wait_for_single_fd(int fd, int events, struct timeval *tv) {
   return polyglot_as_i32(polyglot_invoke(RUBY_CEXT, "rb_wait_for_single_fd", fd, events, tv_sec, tv_usec));
 }
 
+void rb_tr_time_interval(VALUE num, struct timeval *result);
+
 // The only difference between this implementation and CRuby's one
 // is that a fiber scheduler isn't supported here
 VALUE rb_io_wait(VALUE io, VALUE events, VALUE timeout) {
@@ -190,7 +192,7 @@ VALUE rb_io_wait(VALUE io, VALUE events, VALUE timeout) {
   struct timeval *tv = NULL;
 
   if (timeout != Qnil) {
-    tv_storage = rb_time_interval(timeout);
+    rb_tr_time_interval(timeout, &tv_storage);
     tv = &tv_storage;
   }
 

--- a/tool/generate-cext-trampoline.rb
+++ b/tool/generate-cext-trampoline.rb
@@ -196,7 +196,7 @@ C
       if full_arg == "void"
         ""
       elsif full_arg == "..."
-        raise "C does not allow to forward varargs:\n#{declaration}\nInstead copy the approach used for rb_yield_values() or rb_sprintf()\n\n"
+        raise "C does not allow to forward varargs:\n#{declaration}\nSee src/main/c/cext-trampoline/varargs.c\n\n"
       else
         name1 or name2 or raise "Could not find argument name for #{full_arg}"
       end
@@ -233,23 +233,6 @@ C
     f.puts "}"
     f.puts
   end
-
-  f.puts <<C
-// Return struct-by-value functions
-
-struct timeval rb_time_timeval(VALUE time) {
-  struct timeval result;
-  rb_tr_time_timeval(time, &result);
-  return result;
-}
-
-struct timespec rb_time_timespec(VALUE time) {
-  struct timespec result;
-  rb_tr_time_timespec(time, &result);
-  return result;
-}
-
-C
 
   f.puts <<C
 // Init functions


### PR DESCRIPTION
* This will allow rb-sys and magnus to reference such functions, see https://github.com/truffleruby/truffleruby/issues/3396#issuecomment-2580778963