### PR TITLE
Remove patch for RSpec #ripper_supported?

### DIFF
--- a/lib/patches/rspec/support.rb
+++ b/lib/patches/rspec/support.rb
@@ -25,13 +25,6 @@ require Primitive.get_original_require(__FILE__)
 
 module RSpec
   module Support
-    module RubyFeatures
-      module_function
-      def ripper_supported?
-        true
-      end
-    end
-
     def self.define_optimized_require_for_rspec(lib, &require_relative)
       name = "require_rspec_#{lib}"
 


### PR DESCRIPTION
* Upstream sets it to false, so we should respect that: https://github.com/rspec/rspec/blob/6fd9256cfcb2db18be654f39fdecd7421b023122/rspec-support/lib/rspec/support/ruby_features.rb#L91 Since https://github.com/rspec/rspec/commit/b624664643959be9f624739291192355bdc40a10 https://github.com/rspec/rspec-support/pull/541
* It was switched to true in truffleruby in https://github.com/truffleruby/truffleruby/commit/72b62e27581c275b43ae87b2fc00c2c70f715e27
* Ripper is no longer that slow on truffleruby but still gets in the way of seeing the real test failure, so it seems best to not use it for RSpec.

- [x] Consider adding a ChangeLog entry, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
