### PR TITLE
Cleanup failure tags for hash specs

### DIFF
--- a/spec/tags/core/hash/new_tags.txt
+++ b/spec/tags/core/hash/new_tags.txt
@@ -1,3 +1,2 @@
-fails:Hash.new emits a deprecation warning if keyword arguments are passed
 fails:Hash.new accepts a capacity: argument
 fails:Hash.new raises an error if unknown keyword arguments are passed

--- a/spec/tags/core/hash/shift_tags.txt
+++ b/spec/tags/core/hash/shift_tags.txt
@@ -1,2 +1,0 @@
-fails:Hash#shift calls #default with nil if the Hash is empty
-fails:Hash#shift returns (computed) default for empty hashes


### PR DESCRIPTION
> - [ ] Consider adding a ChangeLog entry, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.

I don't think this is worth an entry in the changelog.