### PR TITLE
Cleanup failure tags for comparable specs

### DIFF
--- a/spec/tags/core/comparable/clamp_tags.txt
+++ b/spec/tags/core/comparable/clamp_tags.txt
@@ -1,7 +1,0 @@
-fails:Comparable#clamp with endless range returns minimum value of the range parameters if less than it
-fails:Comparable#clamp with endless range always returns self if greater than minimum value of the range parameters
-fails:Comparable#clamp with endless range works with exclusive range
-fails:Comparable#clamp with beginless range returns maximum value of the range parameters if greater than it
-fails:Comparable#clamp with beginless range always returns self if less than maximum value of the range parameters
-fails:Comparable#clamp with beginless-and-endless range always returns self
-fails:Comparable#clamp with beginless-and-endless range works with exclusive range


### PR DESCRIPTION
> - [ ] Consider adding a ChangeLog entry, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.

Once again: not worth a Changelog entry

(And I'm not actively searching for these, I'm just looking for things that look easy to fix and keep ending up with obsolete tags ;) )