### PR TITLE
Improve code for error message for incorrect type in Hash.[]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ Compatibility:
 * Fix splatting a `BasicObject` block parameter which `respond_to?(:to_ary)` (#4129, @eregon).
 * `Integer#**` no longer returns infinity for large results but either computes the result as an Integer or raises an `ArgumentError` (#4133, @eregon).
 * `Hash#to_proc` returns a lambda with an arity of 1 (#4138, @herwinw).
-* `Hash.[]` now raises the correct error message for `nil`, `true` and `false` as argument ( #4140, @herwinw).
+* `Hash.[]` now raises the correct error message for `nil`, `true` and `false` as argument (#4140, #4146, @herwinw).
 
 Performance:
 

--- a/src/main/ruby/truffleruby/core/hash.rb
+++ b/src/main/ruby/truffleruby/core/hash.rb
@@ -52,7 +52,7 @@ class Hash
     hash = new
     associate_array.each_with_index do |array, i|
       unless array.respond_to? :to_ary
-        type = Primitive.boolean_or_nil?(array) ? array.inspect : Primitive.class(array)
+        type = Truffle::ExceptionOperations.to_class_name(array)
         raise ArgumentError, "wrong element type #{type} at #{i} (expected array)"
       end
       array = array.to_ary


### PR DESCRIPTION
Use a more generic operation to create the type in the error message.

- [x] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
