### PR TITLE
Implement Time#{xmlschema,iso8601} in core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Compatibility:
 * Support an `Array` of `Thread::Backtrace::Location` in `Exception#set_backtrace` and `{Kernel,Thread,Fiber}#raise` (#3883, @eregon).
 * Try `#to_ary` coercion in `Array#assoc` and `Array#rassoc` (#4137, @herwinw).
 * Improve compatibility of `rb_scan_args()` with Ruby 3+ changes (@eregon).
+* Implement `Time#{xmlschema,iso8601}` in core like Ruby 3.4 (#3883, @eregon).
 
 Performance:
 

--- a/spec/tags/core/time/iso8601_tags.txt
+++ b/spec/tags/core/time/iso8601_tags.txt
@@ -1,5 +1,0 @@
-fails:Time#iso8601 generates ISO-8601 strings in Z for UTC times
-fails:Time#iso8601 generates ISO-8601 string with timeone offset for non-UTC times
-fails:Time#iso8601 year is always at least 4 digits
-fails:Time#iso8601 year can be more than 4 digits
-fails:Time#iso8601 year can be negative

--- a/spec/tags/core/time/xmlschema_tags.txt
+++ b/spec/tags/core/time/xmlschema_tags.txt
@@ -1,5 +1,0 @@
-fails:Time#xmlschema generates ISO-8601 strings in Z for UTC times
-fails:Time#xmlschema generates ISO-8601 string with timeone offset for non-UTC times
-fails:Time#xmlschema year is always at least 4 digits
-fails:Time#xmlschema year can be more than 4 digits
-fails:Time#xmlschema year can be negative

--- a/src/main/ruby/truffleruby/core/time.rb
+++ b/src/main/ruby/truffleruby/core/time.rb
@@ -159,6 +159,16 @@ class Time
   end
   alias_method :ctime, :asctime
 
+  def xmlschema(fraction_digits = 0)
+    fraction_digits = fraction_digits.to_i
+    s = strftime('%FT%T')
+    if fraction_digits > 0
+      s << strftime(".%#{fraction_digits}N")
+    end
+    s << (utc? ? 'Z' : strftime('%:z'))
+  end
+  alias_method :iso8601, :xmlschema
+
   def getgm
     dup.gmtime
   end


### PR DESCRIPTION
* Using the same logic as in lib/mri/time.rb.

- [x] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
