### PR TITLE
Add support for creating `Float` values from strings with the decimal part omitted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Compatibility:
 * Use `Hash` default for `#sprintf` (#4155, @eregon).
 * Implement `rb_cloexec_dup()`, `rb_cloexec_fcntl_dupfd()`, `rb_enc_check()`, `rb_str_subpos()`, `rb_str_offset()` and `rb_str_sublen()` necessary for the `readline-ext` gem (#3018, @eregon).
 * Make `rb_*str_new_static()` functions use the passed pointer as the String storage like CRuby (#3018, @eregon).
+* Add support for creating `Float` values from strings with the decimal part omitted (#3883, @nirvdrum).
 
 Performance:
 

--- a/spec/tags/core/kernel/Float_tags.txt
+++ b/spec/tags/core/kernel/Float_tags.txt
@@ -6,9 +6,7 @@ fails:Kernel.Float for hexadecimal literals does not accept _ before, after or i
 fails:Kernel#Float for hexadecimal literals does not accept _ before, after or inside the 0x prefix
 fails:Kernel.Float for hexadecimal literals interprets negative hex value
 fails:Kernel#Float for hexadecimal literals interprets negative hex value
-fails:Kernel.Float allows String representation without a fractional part
 fails:Kernel.Float for hexadecimal literals accepts a fractional part
-fails:Kernel#Float allows String representation without a fractional part
 fails:Kernel#Float for hexadecimal literals accepts a fractional part
 fails:Kernel.Float for hexadecimal literals parses negative hexadecimal string as negative float
 fails:Kernel#Float for hexadecimal literals parses negative hexadecimal string as negative float

--- a/spec/tags/core/string/to_f_tags.txt
+++ b/spec/tags/core/string/to_f_tags.txt
@@ -1,3 +1,2 @@
 fails:String#to_f stops if the underscore is not followed or preceded by a number
 fails:String#to_f raises Encoding::CompatibilityError if String is in not ASCII-compatible encoding
-fails:String#to_f allows String representation without a fractional part

--- a/src/main/java/org/truffleruby/core/string/DoubleConverter.java
+++ b/src/main/java/org/truffleruby/core/string/DoubleConverter.java
@@ -277,8 +277,9 @@ public final class DoubleConverter {
     }
 
     private boolean parseDecimalDigits() {
+        // Allow decimal point with omitted fractional part (e.g., "1.")
         if (isEOS()) {
-            return strictError();
+            return true;
         }
 
         byte value = next();
@@ -302,6 +303,10 @@ public final class DoubleConverter {
             }
             // Always add a digit after the .
             addToResult(value);
+        } else if (isExponent(value)) {
+            // Allow "1.e+0" (exponent immediately after decimal point)
+            addToResult(value);
+            return parseExponent();
         } else {
             return strictError();
         }


### PR DESCRIPTION
This adds support for constructing floating point values from strings with a the decimal portion omitted in both `Kernel.Float` and `String#to_f`. It was a feature added to Ruby 3.4 (#3883).