### PR TITLE
Include {Boolean,Integer,Long,Double}#valueOf for embedding TruffleRuby via JNI

### DIFF
--- a/src/main/java/META-INF/native-image/dev.truffleruby.internal/runtime/reachability-metadata.json
+++ b/src/main/java/META-INF/native-image/dev.truffleruby.internal/runtime/reachability-metadata.json
@@ -56,6 +56,34 @@
         { "name": "of", "parameterTypes": ["java.lang.String", "[Ljava.lang.String;"] }
       ]
     },
+    {
+      "type": "java.lang.Boolean",
+      "jniAccessible": true,
+      "methods": [
+        { "name": "valueOf", "parameterTypes": ["boolean"] }
+      ]
+    },
+    {
+      "type": "java.lang.Integer",
+      "jniAccessible": true,
+      "methods": [
+        { "name": "valueOf", "parameterTypes": ["int"] }
+      ]
+    },
+    {
+      "type": "java.lang.Long",
+      "jniAccessible": true,
+      "methods": [
+        { "name": "valueOf", "parameterTypes": ["long"] }
+      ]
+    },
+    {
+      "type": "java.lang.Double",
+      "jniAccessible": true,
+      "methods": [
+        { "name": "valueOf", "parameterTypes": ["double"] }
+      ]
+    },
     { "type": "java.nio.file.WatchEvent$Modifier" }
   ],
   "resources": [


### PR DESCRIPTION
* They are necessary to call TruffleRuby methods with primitive values.
* The 4 types match RubyGuards.isPrimitive().

- [x] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
