### PR TITLE
Make Primitive.always_split usable outside the truffleruby repository

### DIFF
--- a/src/main/java/org/truffleruby/extra/TruffleGraalNodes.java
+++ b/src/main/java/org/truffleruby/extra/TruffleGraalNodes.java
@@ -54,7 +54,7 @@ import java.lang.management.ManagementFactory;
 @CoreModule("Truffle::Graal")
 public abstract class TruffleGraalNodes {
 
-    @Primitive(name = "always_split")
+    @Primitive(name = "always_split", isPublic = true)
     public abstract static class AlwaysSplitNode extends PrimitiveArrayArgumentsNode {
         @TruffleBoundary
         @Specialization


### PR DESCRIPTION
* It is useful for e.g. StringScanner.

- [x] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
