### PR TITLE
Re-enable full default-bundled-gems test

### DIFF
--- a/test/truffle/gems/default-bundled-gems.sh
+++ b/test/truffle/gems/default-bundled-gems.sh
@@ -16,13 +16,7 @@ cat Gemfile
 # This test only works with no bundle path set
 bundle config set --local path.system true
 
-jt ruby -S bundle lock --local
-
-# There is a bug in RubyGems/bundler version vendored in Ruby 3.3.5 so
-# `bundle install` command ignores the `--local` option and still downloads gems (default ones as well).
-# See https://github.com/rubygems/rubygems/issues/8179
-# TODO: uncomment this line and regenerate Gemfile.lock with the next updating MRI that have the bug fixed.
-# jt ruby -S bundle install --local
+jt ruby -S bundle install --local
 
 echo 'Check if Gemfile is up to date'
 git diff --exit-code .


### PR DESCRIPTION
* Now that we use a recent enough Bundler to avoid the issue.

Ref: https://github.com/ruby/rubygems/issues/8179

- [x] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
