### PR TITLE
Add --metrics-profile-require=total to log the total searching/parsing/translating time

### DIFF
--- a/src/main/java/org/truffleruby/RubyContext.java
+++ b/src/main/java/org/truffleruby/RubyContext.java
@@ -62,6 +62,7 @@ import org.truffleruby.core.symbol.RubySymbol;
 import org.truffleruby.core.thread.ThreadManager;
 import org.truffleruby.core.time.GetTimeZoneNode;
 import org.truffleruby.debug.MetricsProfiler;
+import org.truffleruby.debug.MetricsProfiler.MetricKind;
 import org.truffleruby.language.CallStackManager;
 import org.truffleruby.language.LexicalScope;
 import org.truffleruby.language.RubyBaseNode;
@@ -82,6 +83,7 @@ import org.truffleruby.platform.TruffleNFIPlatform;
 import org.truffleruby.shared.Metrics;
 import org.truffleruby.shared.TruffleRuby;
 import org.truffleruby.shared.options.OptionsCatalog;
+import org.truffleruby.shared.options.Profile;
 import org.truffleruby.shared.options.RubyOptionTypes;
 
 import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
@@ -497,6 +499,15 @@ public final class RubyContext {
         threadManager.checkNoRunningThreads();
 
         Signals.restoreDefaultHandlers();
+
+        if (options.METRICS_PROFILE_REQUIRE == Profile.TOTAL) {
+            for (MetricKind metricKind : MetricKind.VALUES) {
+                if (!metricKind.nested) {
+                    RubyLanguage.LOGGER.info("total %11s time: %dms".formatted(metricKind,
+                            metricsProfiler.totals.get(metricKind.ordinal()) / 1_000_000));
+                }
+            }
+        }
 
         if (options.PRINT_INTERNED_TSTRING_STATS) {
             RubyLanguage.LOGGER.info("tstrings re-used: " + language.tstringCache.getTStringsReusedCount());

--- a/src/main/java/org/truffleruby/debug/MetricsProfiler.java
+++ b/src/main/java/org/truffleruby/debug/MetricsProfiler.java
@@ -11,6 +11,7 @@ package org.truffleruby.debug;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLongArray;
 import java.util.function.Supplier;
 
 import org.truffleruby.RubyContext;
@@ -23,10 +24,34 @@ import com.oracle.truffle.api.RootCallTarget;
 
 public final class MetricsProfiler {
 
+    public enum MetricKind {
+        SEARCHING("searching", false),
+        PARSING("parsing", false),
+        TRANSLATING("translating", false),
+        REQUIRE("require", true),
+        EXECUTE("execute", true);
+
+        private final String name;
+        public final boolean nested;
+
+        MetricKind(String name, boolean nested) {
+            this.name = name;
+            this.nested = nested;
+        }
+
+        @Override
+        public String toString() {
+            return name;
+        }
+
+        public static MetricKind[] VALUES = values();
+    }
+
     private final RubyLanguage language;
     private final RubyContext context;
     /** We need to use the same CallTarget for the same name to appear as one entry to the profiler */
     private final Map<String, RootCallTarget> summaryCallTargets = new ConcurrentHashMap<>();
+    public final AtomicLongArray totals = new AtomicLongArray(MetricKind.VALUES.length);
 
     public MetricsProfiler(RubyLanguage language, RubyContext context) {
         this.language = language;
@@ -34,8 +59,23 @@ public final class MetricsProfiler {
     }
 
     @TruffleBoundary
-    public <T> T callWithMetrics(String metricKind, String feature, Supplier<T> supplier) {
-        if (context.getOptions().METRICS_PROFILE_REQUIRE != Profile.NONE) {
+    public <T> T callWithMetrics(MetricKind metricKind, String feature, Supplier<T> supplier) {
+        Profile metricsProfileRequire = context.getOptions().METRICS_PROFILE_REQUIRE;
+        if (metricsProfileRequire != Profile.NONE) {
+            // Ignore nested metrics as their totals wouldn't make sense as they would sum overlapping durations
+            if (metricsProfileRequire == Profile.TOTAL && !metricKind.nested) {
+                T result;
+                long before = System.nanoTime();
+                try {
+                    result = supplier.get();
+                } finally {
+                    long after = System.nanoTime();
+                    long duration = after - before;
+                    totals.addAndGet(metricKind.ordinal(), duration);
+                }
+                return result;
+            }
+
             final RootCallTarget callTarget = getCallTarget(metricKind, feature);
             return callAndCast(callTarget, supplier);
         } else {
@@ -43,7 +83,7 @@ public final class MetricsProfiler {
         }
     }
 
-    private <T> RootCallTarget getCallTarget(String metricKind, String feature) {
+    private <T> RootCallTarget getCallTarget(MetricKind metricKind, String feature) {
         final String name;
         if (context.getOptions().METRICS_PROFILE_REQUIRE == Profile.DETAIL) {
             name = "metrics " + metricKind + " " + language.getPathRelativeToHome(feature);

--- a/src/main/java/org/truffleruby/language/loader/FeatureLoader.java
+++ b/src/main/java/org/truffleruby/language/loader/FeatureLoader.java
@@ -36,6 +36,7 @@ import org.truffleruby.core.string.RubyString;
 import org.truffleruby.core.string.StringOperations;
 import org.truffleruby.core.support.IONodes.IOThreadBufferAllocateNode;
 import org.truffleruby.core.thread.RubyThread;
+import org.truffleruby.debug.MetricsProfiler.MetricKind;
 import org.truffleruby.extra.TruffleRubyNodes;
 import org.truffleruby.extra.ffi.Pointer;
 import org.truffleruby.interop.InteropNodes;
@@ -277,7 +278,7 @@ public final class FeatureLoader {
     @TruffleBoundary
     public String findFeature(String feature) {
         return context.getMetricsProfiler().callWithMetrics(
-                "searching",
+                MetricKind.SEARCHING,
                 feature,
                 () -> findFeatureImpl(feature));
     }

--- a/src/main/java/org/truffleruby/language/loader/RequireNode.java
+++ b/src/main/java/org/truffleruby/language/loader/RequireNode.java
@@ -25,6 +25,7 @@ import org.truffleruby.cext.ValueWrapperManager;
 import org.truffleruby.core.cast.BooleanCastNode;
 import org.truffleruby.core.string.StringOperations;
 import org.truffleruby.core.string.StringUtils;
+import org.truffleruby.debug.MetricsProfiler.MetricKind;
 import org.truffleruby.language.RubyBaseNode;
 import org.truffleruby.language.RubyConstant;
 import org.truffleruby.language.WarningNode;
@@ -70,7 +71,7 @@ public abstract class RequireNode extends RubyBaseNode {
         try {
             //intern() to improve footprint
             return getContext().getMetricsProfiler().callWithMetrics(
-                    "require",
+                    MetricKind.REQUIRE,
                     feature,
                     () -> requireConsideringAutoload(feature, internedExpandedPath, pathString));
         } finally {
@@ -236,7 +237,7 @@ public abstract class RequireNode extends RubyBaseNode {
             requireMetric("before-execute-" + feature);
             try {
                 getContext().getMetricsProfiler().callWithMetrics(
-                        "execute",
+                        MetricKind.EXECUTE,
                         feature,
                         () -> deferredCall.call(callNode));
             } finally {

--- a/src/main/java/org/truffleruby/parser/YARPTranslatorDriver.java
+++ b/src/main/java/org/truffleruby/parser/YARPTranslatorDriver.java
@@ -51,6 +51,7 @@ import org.truffleruby.core.binding.SetBindingFrameForEvalNode;
 import org.truffleruby.core.encoding.Encodings;
 import org.truffleruby.core.encoding.TStringUtils;
 import org.truffleruby.core.string.StringOperations;
+import org.truffleruby.debug.MetricsProfiler.MetricKind;
 import org.truffleruby.language.DataNode;
 import org.truffleruby.language.EmitWarningsNode;
 import org.truffleruby.language.LexicalScope;
@@ -163,7 +164,7 @@ public final class YARPTranslatorDriver {
         if (parseResult == null) {
             printParseTranslateExecuteMetric("before-parsing", context, source);
             parseResult = context.getMetricsProfiler().callWithMetrics(
-                    "parsing",
+                    MetricKind.PARSING,
                     source.getName(),
                     () -> parseToYARPAST(rubySource, sourcePath, sourceBytes, localsInScopes,
                             language.options.FROZEN_STRING_LITERALS, options, parserContext));
@@ -241,7 +242,7 @@ public final class YARPTranslatorDriver {
         printParseTranslateExecuteMetric("before-translate", context, source);
         try {
             truffleNode = context.getMetricsProfiler().callWithMetrics(
-                    "translating",
+                    MetricKind.TRANSLATING,
                     source.getName(),
                     () -> node.accept(translator));
         } finally {

--- a/src/shared/java/org/truffleruby/shared/options/Profile.java
+++ b/src/shared/java/org/truffleruby/shared/options/Profile.java
@@ -13,6 +13,7 @@ import java.util.Locale;
 
 public enum Profile {
     NONE,
+    TOTAL,
     SUMMARY,
     DETAIL;
 


### PR DESCRIPTION


- [x] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
