### PR TITLE
Fix splitting for step_non_float_exclude_end

### DIFF
--- a/src/main/ruby/truffleruby/core/truffle/numeric_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/numeric_operations.rb
@@ -79,7 +79,7 @@ module Truffle
         end
       end
     end
-    Primitive.always_split singleton_class, :step_non_float
+    Primitive.always_split singleton_class, :step_non_float_exclude_end
 
     def self.step_float(value, limit, step, desc, exclude_end)
       n = float_step_size(value, limit, step, exclude_end)


### PR DESCRIPTION
- [x] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
