### PR TITLE
Log StackOverflowError and OutOfMemoryError using a native write(2) call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Bug fixes:
 * Fix `TypeError` from `Kernel#respond_to?` to show the class of the name argument and not self (@eregon).
 * Fix `super` with methods not accepting keywords like `def foo(**nil)` (#4168, @eregon).
 * Fix potential race conditions when multiple methods of the same file are lazily translated concurrently (#4182, @eregon).
+* Fix `IndexOutOfBoundsException` happening on stack overflow (#4193, #4199, @eregon).
 
 Compatibility:
 

--- a/src/main/c/rubysignal/src/rubysignal.c
+++ b/src/main/c/rubysignal/src/rubysignal.c
@@ -8,6 +8,7 @@
  * GNU Lesser General Public License version 2.1.
  */
 #include "org_truffleruby_signal_LibRubySignal.h"
+#include <errno.h>
 #include <locale.h>
 #include <pthread.h>
 #include <signal.h>
@@ -15,6 +16,30 @@
 #include <sys/syscall.h>
 
 _Static_assert(sizeof(pthread_t) == sizeof(jlong), "Expected sizeof(pthread_t) == sizeof(jlong)");
+
+static void write_to_stderr(const char *msg, ssize_t len) {
+  while (len > 0) {
+    ssize_t n = write(STDERR_FILENO, msg, len);
+    if (n > 0) {
+      msg += n;
+      len -= n;
+    } else if (n == -1 && errno == EINTR) {
+      continue;
+    } else {
+      break;
+    }
+  }
+}
+
+JNIEXPORT void JNICALL Java_org_truffleruby_signal_LibRubySignal_warnStackOverflowError(JNIEnv *env, jclass clazz) {
+  static const char message[] = "[ruby] WARNING StackOverflowError\n";
+  write_to_stderr(message, sizeof(message) - 1);
+}
+
+JNIEXPORT void JNICALL Java_org_truffleruby_signal_LibRubySignal_warnOutOfMemoryError(JNIEnv *env, jclass clazz) {
+  static const char message[] = "[ruby] WARNING OutOfMemoryError\n";
+  write_to_stderr(message, sizeof(message) - 1);
+}
 
 JNIEXPORT void JNICALL Java_org_truffleruby_signal_LibRubySignal_setupLocale(JNIEnv *env, jclass clazz) {
   setlocale(LC_ALL, "C");

--- a/src/main/java/org/truffleruby/RubyLanguage.java
+++ b/src/main/java/org/truffleruby/RubyLanguage.java
@@ -891,6 +891,9 @@ public final class RubyLanguage extends TruffleLanguage<RubyContext> {
     }
 
     private void setupLocale(Env env, String rubyHome) {
+        // Always load LibRubySignal because it might be used by TranslateExceptionNode
+        LibRubySignal.loadLibrary(rubyHome, Platform.LIB_SUFFIX);
+
         // CRuby does setlocale(LC_CTYPE, "") because this is needed to get the locale encoding with nl_langinfo(CODESET).
         // This means every locale category except LC_CTYPE remains the initial "C".
         // LC_CTYPE is set according to environment variables (LC_ALL, LC_CTYPE, LANG).
@@ -901,14 +904,12 @@ public final class RubyLanguage extends TruffleLanguage<RubyContext> {
         if (env.getOptions().get(OptionsCatalog.EMBEDDED_KEY)) {
             if (ImageInfo.inImageRuntimeCode()) {
                 // Only do this on Native Image, to handle the case of the embedder setting UseSystemLocale=false.
-                LibRubySignal.loadLibrary(rubyHome, Platform.LIB_SUFFIX);
                 LibRubySignal.setupLocaleOnlyCTYPE();
             } else {
                 // Nothing to do, JVM and Native Image UseSystemLocale=true already did setlocale(LC_ALL, "")
                 // so there is no need to setlocale(LC_CTYPE, "").
             }
         } else {
-            LibRubySignal.loadLibrary(rubyHome, Platform.LIB_SUFFIX);
             LibRubySignal.setupLocale();
         }
     }

--- a/src/main/java/org/truffleruby/core/thread/ThreadManager.java
+++ b/src/main/java/org/truffleruby/core/thread/ThreadManager.java
@@ -60,7 +60,6 @@ import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.TruffleStackTrace;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.object.Shape;
-import org.truffleruby.shared.Platform;
 import org.truffleruby.signal.LibRubySignal;
 
 public final class ThreadManager {
@@ -83,7 +82,6 @@ public final class ThreadManager {
     private final ConcurrentWeakSet<Thread> rubyManagedThreads = new ConcurrentWeakSet<>();
 
     private boolean nativeInterrupt;
-    private boolean useLibRubySignal;
     private Timer nativeInterruptTimer;
     private ThreadLocal<Interrupter> nativeCallInterrupter;
 
@@ -94,11 +92,7 @@ public final class ThreadManager {
     }
 
     public void initialize() {
-        useLibRubySignal = context.getOptions().NATIVE_PLATFORM;
-        nativeInterrupt = context.getOptions().NATIVE_INTERRUPT && useLibRubySignal;
-        if (useLibRubySignal) {
-            LibRubySignal.loadLibrary(language.getRubyHome(), Platform.LIB_SUFFIX);
-        }
+        nativeInterrupt = context.getOptions().NATIVE_INTERRUPT && context.getOptions().NATIVE_PLATFORM;
         if (nativeInterrupt) {
             LibRubySignal.setupSIGVTALRMEmptySignalHandler();
 
@@ -384,7 +378,7 @@ public final class ThreadManager {
 
     public void start(RubyThread thread, Thread javaThread) {
         final var isSameThread = javaThread == Thread.currentThread();
-        if (isSameThread && useLibRubySignal) {
+        if (isSameThread) {
             thread.nativeThreadId = LibRubySignal.getNativeThreadID();
         }
 

--- a/src/main/java/org/truffleruby/language/methods/TranslateExceptionNode.java
+++ b/src/main/java/org/truffleruby/language/methods/TranslateExceptionNode.java
@@ -34,6 +34,7 @@ import com.oracle.truffle.api.dsl.UnsupportedSpecializationException;
 import com.oracle.truffle.api.nodes.ControlFlowException;
 import com.oracle.truffle.api.nodes.Node;
 import org.truffleruby.language.control.TerminationException;
+import org.truffleruby.signal.LibRubySignal;
 
 @GenerateUncached
 @GenerateInline(inlineByDefault = true)
@@ -131,8 +132,8 @@ public abstract class TranslateExceptionNode extends RubyBaseNode {
         boolean ignore = InitStackOverflowClassesEagerlyNode.ignore(error);
         if (!ignore) {
             if (context.getOptions().EXCEPTIONS_WARN_STACKOVERFLOW) {
-                // We cannot afford to initialize the Log class
-                System.err.print("[ruby] WARNING StackOverflowError\n");
+                // We cannot afford to use more Java frames
+                LibRubySignal.warnStackOverflowError();
             }
 
             logJavaException(context, node, error);
@@ -144,8 +145,8 @@ public abstract class TranslateExceptionNode extends RubyBaseNode {
     @TruffleBoundary
     private static RubyException translateOutOfMemory(Node node, RubyContext context, OutOfMemoryError error) {
         if (context.getOptions().EXCEPTIONS_WARN_OUT_OF_MEMORY) {
-            // We cannot afford to initialize the Log class
-            System.err.print("[ruby] WARNING OutOfMemoryError\n");
+            // We cannot afford to use more Java frames
+            LibRubySignal.warnOutOfMemoryError();
         }
 
         logJavaException(context, node, error);

--- a/src/signal/java/org/truffleruby/signal/LibRubySignal.java
+++ b/src/signal/java/org/truffleruby/signal/LibRubySignal.java
@@ -17,6 +17,10 @@ public abstract class LibRubySignal {
         System.load(path);
     }
 
+    public static native void warnStackOverflowError();
+
+    public static native void warnOutOfMemoryError();
+
     public static native void setupLocale();
 
     public static native void setupLocaleOnlyCTYPE();


### PR DESCRIPTION
* Fixes https://github.com/truffleruby/truffleruby/issues/4193.
* Fixes https://github.com/truffleruby/truffleruby/issues/4199.

- [x] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
