### PR TITLE
Look up `install` from the `PATH` rather than a hard-coded location.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Compatibility:
 * Update `Kernel#singleton_method` to implement Ruby 3.4 singleton ancestor lookup semantics (#3883, @nirvdrum).
 * Rewrite `Range#step` to handle many more cases, including non-`Numeric` step values using the `+`-based iteration semantics introduced in Ruby 3.4 (#3883, @nirvdrum).
 * `Process.spawn` now raises `Errno::EACCES` instead of `Errno::ENOENT` when the file exists but is not executable (#4176, @alessandro54).
+* Support building native extensions on systems that don't follow the Filesystem Hierarchy Standard (FHS), such as NixOS (@nirvdrum).
 
 Performance:
 

--- a/lib/cext/include/truffleruby/truffleruby-abi-version.h
+++ b/lib/cext/include/truffleruby/truffleruby-abi-version.h
@@ -25,6 +25,6 @@
 // and cannot reach the same version while having different ABI
 // ($TRUFFLERUBY_VERSION is never the same as $RUBY_VERSION).
 
-#define TRUFFLERUBY_ABI_VERSION "3.4.9.1"
+#define TRUFFLERUBY_ABI_VERSION "3.4.9.2"
 
 #endif

--- a/lib/truffle/rbconfig.rb
+++ b/lib/truffle/rbconfig.rb
@@ -171,7 +171,7 @@ module RbConfig
     'host'              => host,
     'host_os'           => host_os_full,
     'includedir'        => includedir,
-    'INSTALL'           => '/usr/bin/install -c',
+    'INSTALL'           => 'install -c',
     'LDFLAGS'           => ldflags,
     'libdirname'        => 'libdir',
     'LIBEXT'            => 'a',


### PR DESCRIPTION
NixOS and potentially other systems don't place `install` in /usr/bin but rather adjust the `PATH` to include the location of the `install` binary.

- [x] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
