### PR TITLE
Pass through environment variables to the Native Image builder to support Nix-based systems

### DIFF
--- a/doc/contributor/workflow.md
+++ b/doc/contributor/workflow.md
@@ -5,7 +5,10 @@
 See the [Dependencies in the README](../../README.md#dependencies).
 
 The requirements include a [C compiler](../user/installing-llvm.md). Because it's a common issue, we remind macOS users
-they might need to add `export SDKROOT=$(xcrun --show-sdk-path)` to their shell profile.
+they might need to add `export SDKROOT=$(xcrun --show-sdk-path)` to their shell profile. The compiler shims in
+`/usr/bin` find the macOS SDK on their own, but the compilers they delegate to do not, so this is needed whenever
+something else comes first on the `PATH`, such as `/Library/Developer/CommandLineTools/usr/bin` or a compiler installed
+by a package manager. Without it the build fails with `'stdio.h' file not found`.
 
 Additionally, you will need:
 

--- a/mx.truffleruby/mx_truffleruby.py
+++ b/mx.truffleruby/mx_truffleruby.py
@@ -423,10 +423,23 @@ def truffleruby_standalone_deps():
     return mx_truffle.resolve_truffle_dist_names(use_optimized_runtime=include_truffle_runtime)
 
 def librubyvm_build_args():
+    args = []
+
     if mx_sdk_vm_ng.is_nativeimage_ee() and mx.get_os() == 'linux' and 'NATIVE_IMAGE_AUXILIARY_ENGINE_CACHE' not in os.environ:
-        return ['--gc=G1', '-H:-ProtectionKeys']
-    else:
-        return []
+        args += ['--gc=G1', '-H:-ProtectionKeys']
+
+    # The native-image driver sanitizes the builder JVM's environment, keeping only a
+    # small set of variables (PATH, HOME, etc.). On systems like NixOS where libraries
+    # and SDKs aren't in standard paths, the compiler and linker need additional
+    # environment variables to locate them. LIBRARY_PATH is needed on Linux for the
+    # linker to find libraries like zlib, and SDKROOT is needed on macOS for the SDK
+    # headers and libraries. The -E flag passes these through the sanitization barrier
+    # when set in the current environment, and is a no-op otherwise.
+    for env_var in ['LIBRARY_PATH', 'SDKROOT']:
+        if env_var in os.environ:
+            args.append('-E' + env_var)
+
+    return args
 
 # Commands
 

--- a/mx.truffleruby/mx_truffleruby.py
+++ b/mx.truffleruby/mx_truffleruby.py
@@ -424,10 +424,62 @@ def truffleruby_standalone_deps():
     return mx_truffle.resolve_truffle_dist_names(use_optimized_runtime=include_truffle_runtime)
 
 def librubyvm_build_args():
+    args = []
+
     if mx_sdk_vm_ng.is_nativeimage_ee() and 'NATIVE_IMAGE_AUXILIARY_ENGINE_CACHE' not in os.environ:
-        return ['--gc=G1', '-H:-ProtectionKeys']
-    else:
-        return []
+        args += ['--gc=G1', '-H:-ProtectionKeys']
+
+    args += native_image_toolchain_env_args()
+
+    return args
+
+def native_image_toolchain_env_args():
+    """Build the -E arguments the Native Image builder's C toolchain needs to find libraries and headers.
+
+    The Native Image driver sanitizes the builder's environment down to a small
+    allow-list, so variables that tell the C toolchain where to look are dropped
+    before the compiler driver ever sees them. On distributions that keep libraries
+    and headers in the usual places this goes unnoticed, because the toolchain's
+    built-in search paths are enough. On Nix there are no such built-in paths, so
+    the link fails with "cannot find -lz" unless the relevant variables are passed
+    through.
+
+    LIBRARY_PATH is what carries this in practice. It is the portable way to point a
+    compiler driver at libraries in a non-standard prefix, it is not specific to Nix,
+    and on a NixOS machine that builds without entering a development shell it is
+    typically the only one of these variables that is set at all.
+
+    SDKROOT matters on macOS because the builder compiles small query programs with
+    whatever C compiler it finds on the PATH. Only the shims in /usr/bin locate the
+    macOS SDK on their own; the compilers they delegate to, including the one under
+    /Library/Developer/CommandLineTools, cannot find even <stdio.h> without it. Any
+    PATH that puts one of those first therefore fails the query compilation seconds
+    into the build, which is why the contributor workflow asks macOS users to export
+    SDKROOT.
+
+    NIX_* covers the case where the build runs inside a Nix environment, such as
+    `nix develop`, `nix-shell`, or a nixpkgs derivation. Nix communicates library
+    locations to its compiler wrapper through these variables. NIX_LDFLAGS carries
+    the -L options, but the wrapper only applies them when its corresponding
+    NIX_CC_WRAPPER_TARGET_* variable is also present, and that name embeds the
+    platform triple. Rather than enumerate triples, re-export every NIX_* variable
+    when NIX_STORE shows we are inside such an environment.
+
+    Every branch is a no-op when the relevant variables are absent, so builds on
+    other systems are unaffected.
+    """
+    env_vars = []
+
+    if 'LIBRARY_PATH' in os.environ:
+        env_vars.append('LIBRARY_PATH')
+
+    if mx.is_darwin() and 'SDKROOT' in os.environ:
+        env_vars.append('SDKROOT')
+
+    if 'NIX_STORE' in os.environ:
+        env_vars += sorted(name for name in os.environ if name.startswith('NIX_'))
+
+    return ['-E' + name for name in env_vars]
 
 # Commands
 


### PR DESCRIPTION
I'm trying to ensure TruffleRuby builds well on Nix, with the plan to eventually upstream TruffleRuby packages. Due to the environment sanitization that Native Image does, along with Nix's non-standard location for library files, I needed to make a change to our mx config to pass through library lookup paths. It no-ops if these paths aren't set.

I think this is needed to support our [contributor workflow docs](https://github.com/truffleruby/truffleruby/blob/8429d80abcbc6a9f4061060d2e2ad23cfa905cfd/doc/contributor/workflow.md#requirements) that indicate that `SDKROOT` may be needed.