### PR TITLE
Honor --vm.XstartOnFirstThread on macOS language launchers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Bug fixes:
 
 Compatibility:
 
+* Support  `--vm.XstartOnFirstThread` on macOS, which is required for some UI libraries like `SDL` (#4228, @timfel).
 
 Performance:
 

--- a/mx.truffleruby/suite.py
+++ b/mx.truffleruby/suite.py
@@ -21,18 +21,18 @@ suite = {
             {
                 "name": "regex",
                 "subdir": True,
-                "version": "981ecb6e1be6bf4591a6dd24b48ea053221209f5",
+                "version": "5a4fef49929c7ab237d5af2d4003cd11066a5f5d",
                 "urls": [
-                    {"url": "https://github.com/oracle/graal.git", "kind": "git"},
+                    {"url": "https://github.com/truffleruby/graal.git", "kind": "git"},
                     {"url": "https://curio.ssw.jku.at/nexus/content/repositories/snapshots", "kind": "binary"},
                 ]
             },
             {
                 "name": "sulong",
                 "subdir": True,
-                "version": "981ecb6e1be6bf4591a6dd24b48ea053221209f5",
+                "version": "5a4fef49929c7ab237d5af2d4003cd11066a5f5d",
                 "urls": [
-                    {"url": "https://github.com/oracle/graal.git", "kind": "git"},
+                    {"url": "https://github.com/truffleruby/graal.git", "kind": "git"},
                     {"url": "https://curio.ssw.jku.at/nexus/content/repositories/snapshots", "kind": "binary"},
                 ]
             },


### PR DESCRIPTION
* For this we need a backport of https://github.com/oracle/graal/pull/11608 on top of the last graal 25.0 release tag.
* We do so in https://github.com/oracle/graal/compare/graal-25.0.2...truffleruby:graal:truffleruby-25.0-backports
* This is only working for graal repository changes which do not affect embedding in Java, because embedding gets the Truffle, SDK, etc release jars from Maven and so won't be affected by the changed graal import.
* In this case this affects the thin launchers which are not part of embedding jars so it's fine.

- [x] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
