### PR TITLE
Raise a proper exception when using an object from an inner context after the inner context has been closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ New features:
 
 Bug fixes:
 
+* Raise a `RuntimeError` when using an object from a `Polyglot::InnerContext` after it has been closed (#4061, @eregon).
 
 Compatibility:
 

--- a/spec/truffle/interop/polyglot/inner_context_spec.rb
+++ b/spec/truffle/interop/polyglot/inner_context_spec.rb
@@ -59,9 +59,13 @@ describe "Polyglot::InnerContext" do
       obj = context.eval('ruby', 'Object.new')
     end
 
-    -> { context.eval('ruby', '42') }.should raise_error(RuntimeError, 'This Polyglot::InnerContext is closed')
+    -> {
+      context.eval('ruby', '42')
+    }.should raise_error(RuntimeError, 'This Polyglot::InnerContext has been closed, cannot use it anymore')
 
-    # obj.object_id # throws a IllegalStateException which cannot be caught: GR-45031
+    -> {
+      obj.object_id
+    }.should raise_error(RuntimeError, 'This Polyglot::InnerContext has been closed, cannot use it anymore')
   end
 
   it "raises ArgumentError for an unknown language" do
@@ -82,7 +86,7 @@ describe "Polyglot::InnerContext" do
     -> {
       in_synchronize = true
       context.eval('ruby', 'loop { }')
-    }.should raise_error(RuntimeError, 'Polyglot::InnerContext was terminated forcefully')
+    }.should raise_error(RuntimeError, 'This Polyglot::InnerContext was terminated forcefully, cannot use it anymore')
     th.join
   end
 

--- a/src/main/java/org/truffleruby/interop/PolyglotNodes.java
+++ b/src/main/java/org/truffleruby/interop/PolyglotNodes.java
@@ -187,6 +187,8 @@ public abstract class PolyglotNodes {
                 RubyArray languageOptions,
                 boolean inheritAllAccess,
                 Object codeSharing,
+                RubyProc onClosedCallback,
+                RubyProc onExitedCallback,
                 RubyProc onCancelledCallback) {
             String[] permittedLanguages = new String[languages.size];
             int i = 0;
@@ -209,6 +211,8 @@ public abstract class PolyglotNodes {
                     .initializeCreatorContext(false)
                     .inheritAllAccess(inheritAllAccess)
                     .forceSharing(codeSharingBoolean)
+                    .onClosed(() -> CallBlockNode.yieldUncached(onClosedCallback))
+                    .onExited((exitCode) -> CallBlockNode.yieldUncached(onExitedCallback, exitCode))
                     .onCancelled(() -> CallBlockNode.yieldUncached(onCancelledCallback))
                     .build();
 
@@ -280,17 +284,6 @@ public abstract class PolyglotNodes {
             final Object result;
             try {
                 result = rubyInnerContext.innerContext.evalPublic(node, source);
-            } catch (IllegalStateException closed) {
-                errorProfile.enter(node);
-                throw new RaiseException(
-                        getContext(node),
-                        coreExceptions(node).runtimeError("This Polyglot::InnerContext is closed", node));
-            } catch (ThreadDeath closed) {
-                errorProfile.enter(node);
-                throw new RaiseException(
-                        getContext(node),
-                        coreExceptions(node).runtimeError("Polyglot::InnerContext was terminated forcefully",
-                                node));
             } catch (IllegalArgumentException unknownLanguage) {
                 errorProfile.enter(node);
                 throw new RaiseException(

--- a/src/main/ruby/truffleruby/core/truffle/polyglot.rb
+++ b/src/main/ruby/truffleruby/core/truffle/polyglot.rb
@@ -15,18 +15,24 @@ module Polyglot
   end
 
   class InnerContext
-    DEFAULT_ON_CANCELLED = -> { raise RuntimeError, 'Polyglot::InnerContext was terminated forcefully' }
-    private_constant :DEFAULT_ON_CANCELLED
+    DEFAULT_ON_CLOSED = -> { raise RuntimeError, 'This Polyglot::InnerContext has been closed, cannot use it anymore' }
+    DEFAULT_ON_EXITED = -> exit_code {
+      raise RuntimeError, "This Polyglot::InnerContext has exited with exit code #{exit_code}, cannot use it anymore"
+    }
+    DEFAULT_ON_CANCELLED = -> { raise RuntimeError, 'This Polyglot::InnerContext was terminated forcefully, cannot use it anymore' }
+    private_constant :DEFAULT_ON_CLOSED, :DEFAULT_ON_EXITED, :DEFAULT_ON_CANCELLED
 
     # Create a new isolated inner context to eval code in any available public language
     # (those languages can be listed with +Polyglot.languages+).
     # Automatically closes the context when given a block.
-    def self.new(languages: [], language_options: {}, inherit_all_access: true, code_sharing: true, on_cancelled: DEFAULT_ON_CANCELLED)
+    def self.new(languages: [], language_options: {}, inherit_all_access: true, code_sharing: true,
+                 on_closed: DEFAULT_ON_CLOSED, on_exited: DEFAULT_ON_EXITED, on_cancelled: DEFAULT_ON_CANCELLED)
       languages = languages.map { |language| Primitive.convert_with_to_str(language) }
       language_options = language_options.flat_map { |k, v| [Primitive.convert_with_to_str(k), Primitive.convert_with_to_str(v)] }
       code_sharing = code_sharing == :inherit ? nil : Primitive.as_boolean(code_sharing)
 
-      inner_context = Primitive.inner_context_new(self, languages, language_options, inherit_all_access, code_sharing, on_cancelled)
+      inner_context = Primitive.inner_context_new(self, languages, language_options, inherit_all_access, code_sharing,
+        on_closed, on_exited, on_cancelled)
       if block_given?
         begin
           yield inner_context


### PR DESCRIPTION
* Fixes https://github.com/truffleruby/truffleruby/issues/4061

- [x] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
