### PR TITLE
Remove usages of Gem::BUNDLED_GEMS.uplevel in stdlib

### DIFF
--- a/lib/mri/cgi.rb
+++ b/lib/mri/cgi.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 require "cgi/escape"
-warn <<-WARNING, uplevel: Gem::BUNDLED_GEMS.uplevel if $VERBOSE
+# TruffleRuby: do not rely on Gem::BUNDLED_GEMS in stdlib:
+# Gem might not exist (--disable-gems) and Gem::BUNDLED_GEMS is not loaded eagerly on TruffleRuby.
+warn <<-WARNING, uplevel: 1 if $VERBOSE
 CGI library is removed from Ruby 4.0. Please use cgi/escape instead for CGI.escape and CGI.unescape features.
 If you need to use the full features of CGI library, Please install cgi gem.
 WARNING

--- a/lib/mri/cgi/util.rb
+++ b/lib/mri/cgi/util.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 require "cgi/escape"
-warn <<-WARNING, uplevel: Gem::BUNDLED_GEMS.uplevel if $VERBOSE
+# TruffleRuby: do not rely on Gem::BUNDLED_GEMS in stdlib:
+# Gem might not exist (--disable-gems) and Gem::BUNDLED_GEMS is not loaded eagerly on TruffleRuby.
+warn <<-WARNING, uplevel: 1 if $VERBOSE
 CGI::Util is removed from Ruby 4.0. Please use cgi/escape instead for CGI.escape and CGI.unescape features.
 If you are using CGI.parse, please install and use the cgi gem instead.
 WARNING


### PR DESCRIPTION
* See https://github.com/truffleruby/truffleruby/issues/4231#issuecomment-4415246174
* Standard libraries should work fine with --disable-gems.

- [x] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
