### PR TITLE
Cherry-pick ruby/spec@8fcc960b to fix CI

### DIFF
--- a/spec/ruby/security/cve_2019_8322_spec.rb
+++ b/spec/ruby/security/cve_2019_8322_spec.rb
@@ -1,6 +1,6 @@
 require_relative '../spec_helper'
 
-ruby_version_is ""..."4.1" do
+ruby_version_is ""..."4.0" do
 
   require 'yaml'
   require 'rubygems'


### PR DESCRIPTION
* The newly-released Ruby 4.0.4 fails that spec otherwise.