### PR TITLE
Splatting nil no longer calls #to_a

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@ Bug fixes:
 Compatibility:
 
 * Support  `--vm.XstartOnFirstThread` on macOS, which is required for some UI libraries like `SDL` (#4228, @timfel).
-* Support `instance_variables_to_inspect` to control which variables to show in `inspect` output (#4239, @earlopain)
-* Add top-level `Ruby` module (#4240, @earlopain)
+* Support `instance_variables_to_inspect` to control which variables to show in `inspect` output (#4239, @earlopain).
+* Add top-level `Ruby` module (#4240, @earlopain).
+* Splatting `nil` no longer calls `#to_a` like Ruby 4.0 (#4240, @eregon).
 
 Performance:
 

--- a/spec/ruby/language/array_spec.rb
+++ b/spec/ruby/language/array_spec.rb
@@ -155,8 +155,12 @@ describe "The unpacking splat operator (*)" do
     b = [1, 0]
     [*a, 3, *a, *b].should == [1, 2, 3, 1, 2, 1, 0]
   end
-end
 
-describe "The packing splat operator (*)" do
-
+  ruby_version_is "4.0" do
+    it "does not call #to_a on nil" do
+      e = nil
+      e.should_not_receive(:to_a)
+      [*e].should == []
+    end
+  end
 end

--- a/spec/truffle/parsing/fixtures/array/array_with_preceding_elements_and_splat_operator.yaml
+++ b/spec/truffle/parsing/fixtures/array/array_with_preceding_elements_and_splat_operator.yaml
@@ -64,7 +64,7 @@ ast: |
                                   conversionMethod = :to_a
                                   copy = true
                                   flags = 0
-                                  nilBehavior = CONVERT
+                                  nilBehavior = EMPTY_ARRAY
                                   sourceCharIndex = 7
                                   sourceLength = 4
                               children:

--- a/spec/truffle/parsing/fixtures/array/array_with_splat_operator.yaml
+++ b/spec/truffle/parsing/fixtures/array/array_with_splat_operator.yaml
@@ -36,7 +36,7 @@ ast: |
                       conversionMethod = :to_a
                       copy = true
                       flags = 0
-                      nilBehavior = CONVERT
+                      nilBehavior = EMPTY_ARRAY
                       sourceCharIndex = 1
                       sourceLength = 4
                   children:

--- a/spec/truffle/parsing/fixtures/array/array_with_splat_operator_and_following_elements.yaml
+++ b/spec/truffle/parsing/fixtures/array/array_with_splat_operator_and_following_elements.yaml
@@ -43,7 +43,7 @@ ast: |
                                   conversionMethod = :to_a
                                   copy = true
                                   flags = 0
-                                  nilBehavior = CONVERT
+                                  nilBehavior = EMPTY_ARRAY
                                   sourceCharIndex = 1
                                   sourceLength = 4
                               children:

--- a/spec/truffle/parsing/fixtures/break/with_splat_operator.yaml
+++ b/spec/truffle/parsing/fixtures/break/with_splat_operator.yaml
@@ -20,7 +20,7 @@ ast: |
                       conversionMethod = :to_a
                       copy = true
                       flags = 0
-                      nilBehavior = CONVERT
+                      nilBehavior = EMPTY_ARRAY
                       sourceCharIndex = 19
                       sourceLength = 5
                   children:

--- a/spec/truffle/parsing/fixtures/break/with_splat_operator_and_following_argument.yaml
+++ b/spec/truffle/parsing/fixtures/break/with_splat_operator_and_following_argument.yaml
@@ -33,7 +33,7 @@ ast: |
                                   conversionMethod = :to_a
                                   copy = true
                                   flags = 0
-                                  nilBehavior = CONVERT
+                                  nilBehavior = EMPTY_ARRAY
                                   sourceCharIndex = 19
                                   sourceLength = 4
                               children:

--- a/spec/truffle/parsing/fixtures/break/with_splat_operator_and_following_arguments.yaml
+++ b/spec/truffle/parsing/fixtures/break/with_splat_operator_and_following_arguments.yaml
@@ -33,7 +33,7 @@ ast: |
                                   conversionMethod = :to_a
                                   copy = true
                                   flags = 0
-                                  nilBehavior = CONVERT
+                                  nilBehavior = EMPTY_ARRAY
                                   sourceCharIndex = 19
                                   sourceLength = 4
                               children:

--- a/spec/truffle/parsing/fixtures/break/with_splat_operator_and_preceding_and_following_arguments.yaml
+++ b/spec/truffle/parsing/fixtures/break/with_splat_operator_and_preceding_and_following_arguments.yaml
@@ -54,7 +54,7 @@ ast: |
                                   conversionMethod = :to_a
                                   copy = true
                                   flags = 0
-                                  nilBehavior = CONVERT
+                                  nilBehavior = EMPTY_ARRAY
                                   sourceCharIndex = 31
                                   sourceLength = 4
                               children:

--- a/spec/truffle/parsing/fixtures/break/with_splat_operator_and_preceding_argument.yaml
+++ b/spec/truffle/parsing/fixtures/break/with_splat_operator_and_preceding_argument.yaml
@@ -48,7 +48,7 @@ ast: |
                                   conversionMethod = :to_a
                                   copy = true
                                   flags = 0
-                                  nilBehavior = CONVERT
+                                  nilBehavior = EMPTY_ARRAY
                                   sourceCharIndex = 23
                                   sourceLength = 4
                               children:

--- a/spec/truffle/parsing/fixtures/break/with_splat_operator_and_preceding_arguments.yaml
+++ b/spec/truffle/parsing/fixtures/break/with_splat_operator_and_preceding_arguments.yaml
@@ -54,7 +54,7 @@ ast: |
                                   conversionMethod = :to_a
                                   copy = true
                                   flags = 0
-                                  nilBehavior = CONVERT
+                                  nilBehavior = EMPTY_ARRAY
                                   sourceCharIndex = 31
                                   sourceLength = 4
                               children:

--- a/spec/truffle/parsing/fixtures/case/with_expression_and_when/with_splat_operator.yaml
+++ b/spec/truffle/parsing/fixtures/case/with_expression_and_when/with_splat_operator.yaml
@@ -39,7 +39,7 @@ ast: |
                                   conversionMethod = :to_a
                                   copy = true
                                   flags = 0
-                                  nilBehavior = CONVERT
+                                  nilBehavior = EMPTY_ARRAY
                                   sourceCharIndex = 13
                                   sourceLength = 4
                               children:

--- a/spec/truffle/parsing/fixtures/case/with_expression_and_when/with_splat_operator_and_following_element.yaml
+++ b/spec/truffle/parsing/fixtures/case/with_expression_and_when/with_splat_operator_and_following_element.yaml
@@ -46,7 +46,7 @@ ast: |
                                               conversionMethod = :to_a
                                               copy = true
                                               flags = 0
-                                              nilBehavior = CONVERT
+                                              nilBehavior = EMPTY_ARRAY
                                               sourceCharIndex = 13
                                               sourceLength = 4
                                           children:

--- a/spec/truffle/parsing/fixtures/case/with_expression_and_when/with_splat_operator_and_following_elements.yaml
+++ b/spec/truffle/parsing/fixtures/case/with_expression_and_when/with_splat_operator_and_following_elements.yaml
@@ -46,7 +46,7 @@ ast: |
                                               conversionMethod = :to_a
                                               copy = true
                                               flags = 0
-                                              nilBehavior = CONVERT
+                                              nilBehavior = EMPTY_ARRAY
                                               sourceCharIndex = 13
                                               sourceLength = 4
                                           children:

--- a/spec/truffle/parsing/fixtures/case/with_expression_and_when/with_splat_operator_and_preceding_and_following_element.yaml
+++ b/spec/truffle/parsing/fixtures/case/with_expression_and_when/with_splat_operator_and_preceding_and_following_element.yaml
@@ -61,7 +61,7 @@ ast: |
                                               conversionMethod = :to_a
                                               copy = true
                                               flags = 0
-                                              nilBehavior = CONVERT
+                                              nilBehavior = EMPTY_ARRAY
                                               sourceCharIndex = 17
                                               sourceLength = 4
                                           children:

--- a/spec/truffle/parsing/fixtures/case/with_expression_and_when/with_splat_operator_and_preceding_and_following_elements.yaml
+++ b/spec/truffle/parsing/fixtures/case/with_expression_and_when/with_splat_operator_and_preceding_and_following_elements.yaml
@@ -67,7 +67,7 @@ ast: |
                                               conversionMethod = :to_a
                                               copy = true
                                               flags = 0
-                                              nilBehavior = CONVERT
+                                              nilBehavior = EMPTY_ARRAY
                                               sourceCharIndex = 25
                                               sourceLength = 4
                                           children:

--- a/spec/truffle/parsing/fixtures/case/with_expression_and_when/with_splat_operator_and_preceding_element.yaml
+++ b/spec/truffle/parsing/fixtures/case/with_expression_and_when/with_splat_operator_and_preceding_element.yaml
@@ -61,7 +61,7 @@ ast: |
                                               conversionMethod = :to_a
                                               copy = true
                                               flags = 0
-                                              nilBehavior = CONVERT
+                                              nilBehavior = EMPTY_ARRAY
                                               sourceCharIndex = 17
                                               sourceLength = 4
                                           children:

--- a/spec/truffle/parsing/fixtures/case/with_expression_and_when/with_splat_operator_and_preceding_elements.yaml
+++ b/spec/truffle/parsing/fixtures/case/with_expression_and_when/with_splat_operator_and_preceding_elements.yaml
@@ -67,7 +67,7 @@ ast: |
                                               conversionMethod = :to_a
                                               copy = true
                                               flags = 0
-                                              nilBehavior = CONVERT
+                                              nilBehavior = EMPTY_ARRAY
                                               sourceCharIndex = 25
                                               sourceLength = 4
                                           children:

--- a/spec/truffle/parsing/fixtures/case/without_expression_and_when/with_splat_operator.yaml
+++ b/spec/truffle/parsing/fixtures/case/without_expression_and_when/with_splat_operator.yaml
@@ -61,7 +61,7 @@ ast: |
                                               conversionMethod = :to_a
                                               copy = true
                                               flags = 0
-                                              nilBehavior = CONVERT
+                                              nilBehavior = EMPTY_ARRAY
                                               sourceCharIndex = 14
                                               sourceLength = 4
                                           children:

--- a/spec/truffle/parsing/fixtures/method_calls/arguments/with_positional_argument_and_splat_operator.yaml
+++ b/spec/truffle/parsing/fixtures/method_calls/arguments/with_positional_argument_and_splat_operator.yaml
@@ -68,7 +68,7 @@ ast: |
                                   conversionMethod = :to_a
                                   copy = true
                                   flags = 0
-                                  nilBehavior = CONVERT
+                                  nilBehavior = EMPTY_ARRAY
                                   sourceCharIndex = 9
                                   sourceLength = 4
                               children:

--- a/spec/truffle/parsing/fixtures/method_calls/arguments/with_splat_operator.yaml
+++ b/spec/truffle/parsing/fixtures/method_calls/arguments/with_splat_operator.yaml
@@ -31,7 +31,7 @@ ast: |
                       conversionMethod = :to_a
                       copy = false
                       flags = 0
-                      nilBehavior = CONVERT
+                      nilBehavior = EMPTY_ARRAY
                       sourceCharIndex = 4
                       sourceLength = 4
                   children:

--- a/spec/truffle/parsing/fixtures/method_calls/arguments/with_splat_operator_and_double_splat_operator.yaml
+++ b/spec/truffle/parsing/fixtures/method_calls/arguments/with_splat_operator_and_double_splat_operator.yaml
@@ -34,7 +34,7 @@ ast: |
                                   conversionMethod = :to_a
                                   copy = true
                                   flags = 0
-                                  nilBehavior = CONVERT
+                                  nilBehavior = EMPTY_ARRAY
                                   sourceCharIndex = 4
                                   sourceLength = 4
                               children:

--- a/spec/truffle/parsing/fixtures/method_calls/arguments/with_splat_operator_and_positional_arguments.yaml
+++ b/spec/truffle/parsing/fixtures/method_calls/arguments/with_splat_operator_and_positional_arguments.yaml
@@ -39,7 +39,7 @@ ast: |
                                   conversionMethod = :to_a
                                   copy = true
                                   flags = 0
-                                  nilBehavior = CONVERT
+                                  nilBehavior = EMPTY_ARRAY
                                   sourceCharIndex = 4
                                   sourceLength = 4
                               children:

--- a/spec/truffle/parsing/fixtures/method_calls/parameter_forwarding/forward_arguments.yaml
+++ b/spec/truffle/parsing/fixtures/method_calls/parameter_forwarding/forward_arguments.yaml
@@ -145,7 +145,7 @@ ast: |
                                                                   conversionMethod = :to_a
                                                                   copy = true
                                                                   flags = 0
-                                                                  nilBehavior = CONVERT
+                                                                  nilBehavior = EMPTY_ARRAY
                                                                   sourceCharIndex = -1
                                                                   sourceLength = 0
                                                               children:

--- a/spec/truffle/parsing/fixtures/next/with_splat_operator.yaml
+++ b/spec/truffle/parsing/fixtures/next/with_splat_operator.yaml
@@ -20,7 +20,7 @@ ast: |
                       conversionMethod = :to_a
                       copy = true
                       flags = 0
-                      nilBehavior = CONVERT
+                      nilBehavior = EMPTY_ARRAY
                       sourceCharIndex = 20
                       sourceLength = 5
                   children:

--- a/spec/truffle/parsing/fixtures/next/with_splat_operator_and_following_argument.yaml
+++ b/spec/truffle/parsing/fixtures/next/with_splat_operator_and_following_argument.yaml
@@ -31,7 +31,7 @@ ast: |
                                   conversionMethod = :to_a
                                   copy = true
                                   flags = 0
-                                  nilBehavior = CONVERT
+                                  nilBehavior = EMPTY_ARRAY
                                   sourceCharIndex = 20
                                   sourceLength = 4
                               children:

--- a/spec/truffle/parsing/fixtures/next/with_splat_operator_and_following_arguments.yaml
+++ b/spec/truffle/parsing/fixtures/next/with_splat_operator_and_following_arguments.yaml
@@ -31,7 +31,7 @@ ast: |
                                   conversionMethod = :to_a
                                   copy = true
                                   flags = 0
-                                  nilBehavior = CONVERT
+                                  nilBehavior = EMPTY_ARRAY
                                   sourceCharIndex = 20
                                   sourceLength = 4
                               children:

--- a/spec/truffle/parsing/fixtures/next/with_splat_operator_and_preceding_and_following_argument.yaml
+++ b/spec/truffle/parsing/fixtures/next/with_splat_operator_and_preceding_and_following_argument.yaml
@@ -46,7 +46,7 @@ ast: |
                                   conversionMethod = :to_a
                                   copy = true
                                   flags = 0
-                                  nilBehavior = CONVERT
+                                  nilBehavior = EMPTY_ARRAY
                                   sourceCharIndex = 24
                                   sourceLength = 4
                               children:

--- a/spec/truffle/parsing/fixtures/next/with_splat_operator_and_preceding_and_following_arguments.yaml
+++ b/spec/truffle/parsing/fixtures/next/with_splat_operator_and_preceding_and_following_arguments.yaml
@@ -52,7 +52,7 @@ ast: |
                                   conversionMethod = :to_a
                                   copy = true
                                   flags = 0
-                                  nilBehavior = CONVERT
+                                  nilBehavior = EMPTY_ARRAY
                                   sourceCharIndex = 32
                                   sourceLength = 4
                               children:

--- a/spec/truffle/parsing/fixtures/next/with_splat_operator_and_preceding_argument.yaml
+++ b/spec/truffle/parsing/fixtures/next/with_splat_operator_and_preceding_argument.yaml
@@ -46,7 +46,7 @@ ast: |
                                   conversionMethod = :to_a
                                   copy = true
                                   flags = 0
-                                  nilBehavior = CONVERT
+                                  nilBehavior = EMPTY_ARRAY
                                   sourceCharIndex = 24
                                   sourceLength = 4
                               children:

--- a/spec/truffle/parsing/fixtures/next/with_splat_operator_and_preceding_arguments.yaml
+++ b/spec/truffle/parsing/fixtures/next/with_splat_operator_and_preceding_arguments.yaml
@@ -52,7 +52,7 @@ ast: |
                                   conversionMethod = :to_a
                                   copy = true
                                   flags = 0
-                                  nilBehavior = CONVERT
+                                  nilBehavior = EMPTY_ARRAY
                                   sourceCharIndex = 32
                                   sourceLength = 4
                               children:

--- a/spec/truffle/parsing/fixtures/operators/&&=/reference_assignment_with_nested_splatted_argument.yaml
+++ b/spec/truffle/parsing/fixtures/operators/&&=/reference_assignment_with_nested_splatted_argument.yaml
@@ -61,7 +61,7 @@ ast: |
                                                           conversionMethod = :to_a
                                                           copy = true
                                                           flags = 0
-                                                          nilBehavior = CONVERT
+                                                          nilBehavior = EMPTY_ARRAY
                                                           sourceCharIndex = 6
                                                           sourceLength = 2
                                                       children:
@@ -150,7 +150,7 @@ ast: |
                                                                       conversionMethod = :to_a
                                                                       copy = false
                                                                       flags = 0
-                                                                      nilBehavior = CONVERT
+                                                                      nilBehavior = EMPTY_ARRAY
                                                                       sourceCharIndex = 4
                                                                       sourceLength = 5
                                                                   children:
@@ -202,7 +202,7 @@ ast: |
                                                                                   conversionMethod = :to_a
                                                                                   copy = true
                                                                                   flags = 0
-                                                                                  nilBehavior = CONVERT
+                                                                                  nilBehavior = EMPTY_ARRAY
                                                                                   sourceCharIndex = 4
                                                                                   sourceLength = 5
                                                                               children:

--- a/spec/truffle/parsing/fixtures/operators/&&=/reference_assignment_with_splatted_argument.yaml
+++ b/spec/truffle/parsing/fixtures/operators/&&=/reference_assignment_with_splatted_argument.yaml
@@ -148,7 +148,7 @@ ast: |
                                                                       conversionMethod = :to_a
                                                                       copy = false
                                                                       flags = 0
-                                                                      nilBehavior = CONVERT
+                                                                      nilBehavior = EMPTY_ARRAY
                                                                       sourceCharIndex = 4
                                                                       sourceLength = 2
                                                                   children:
@@ -200,7 +200,7 @@ ast: |
                                                                                   conversionMethod = :to_a
                                                                                   copy = true
                                                                                   flags = 0
-                                                                                  nilBehavior = CONVERT
+                                                                                  nilBehavior = EMPTY_ARRAY
                                                                                   sourceCharIndex = 4
                                                                                   sourceLength = 2
                                                                               children:

--- a/spec/truffle/parsing/fixtures/operators/+=/reference_assignment_with_nested_splatted_argument.yaml
+++ b/spec/truffle/parsing/fixtures/operators/+=/reference_assignment_with_nested_splatted_argument.yaml
@@ -61,7 +61,7 @@ ast: |
                                                           conversionMethod = :to_a
                                                           copy = true
                                                           flags = 0
-                                                          nilBehavior = CONVERT
+                                                          nilBehavior = EMPTY_ARRAY
                                                           sourceCharIndex = 6
                                                           sourceLength = 2
                                                       children:
@@ -150,7 +150,7 @@ ast: |
                                                                       conversionMethod = :to_a
                                                                       copy = true
                                                                       flags = 0
-                                                                      nilBehavior = CONVERT
+                                                                      nilBehavior = EMPTY_ARRAY
                                                                       sourceCharIndex = 4
                                                                       sourceLength = 5
                                                                   children:
@@ -202,7 +202,7 @@ ast: |
                                                                                                           conversionMethod = :to_a
                                                                                                           copy = false
                                                                                                           flags = 0
-                                                                                                          nilBehavior = CONVERT
+                                                                                                          nilBehavior = EMPTY_ARRAY
                                                                                                           sourceCharIndex = 4
                                                                                                           sourceLength = 5
                                                                                                       children:

--- a/spec/truffle/parsing/fixtures/operators/+=/reference_assignment_with_splatted_argument.yaml
+++ b/spec/truffle/parsing/fixtures/operators/+=/reference_assignment_with_splatted_argument.yaml
@@ -148,7 +148,7 @@ ast: |
                                                                       conversionMethod = :to_a
                                                                       copy = true
                                                                       flags = 0
-                                                                      nilBehavior = CONVERT
+                                                                      nilBehavior = EMPTY_ARRAY
                                                                       sourceCharIndex = 4
                                                                       sourceLength = 2
                                                                   children:
@@ -200,7 +200,7 @@ ast: |
                                                                                                           conversionMethod = :to_a
                                                                                                           copy = false
                                                                                                           flags = 0
-                                                                                                          nilBehavior = CONVERT
+                                                                                                          nilBehavior = EMPTY_ARRAY
                                                                                                           sourceCharIndex = 4
                                                                                                           sourceLength = 2
                                                                                                       children:

--- a/spec/truffle/parsing/fixtures/operators/||=/reference_assignment_with_nested_splatted_argument.yaml
+++ b/spec/truffle/parsing/fixtures/operators/||=/reference_assignment_with_nested_splatted_argument.yaml
@@ -61,7 +61,7 @@ ast: |
                                                           conversionMethod = :to_a
                                                           copy = true
                                                           flags = 0
-                                                          nilBehavior = CONVERT
+                                                          nilBehavior = EMPTY_ARRAY
                                                           sourceCharIndex = 6
                                                           sourceLength = 2
                                                       children:
@@ -151,7 +151,7 @@ ast: |
                                                                       conversionMethod = :to_a
                                                                       copy = false
                                                                       flags = 0
-                                                                      nilBehavior = CONVERT
+                                                                      nilBehavior = EMPTY_ARRAY
                                                                       sourceCharIndex = 4
                                                                       sourceLength = 5
                                                                   children:
@@ -203,7 +203,7 @@ ast: |
                                                                                   conversionMethod = :to_a
                                                                                   copy = true
                                                                                   flags = 0
-                                                                                  nilBehavior = CONVERT
+                                                                                  nilBehavior = EMPTY_ARRAY
                                                                                   sourceCharIndex = 4
                                                                                   sourceLength = 5
                                                                               children:

--- a/spec/truffle/parsing/fixtures/operators/||=/reference_assignment_with_splatted_argument.yaml
+++ b/spec/truffle/parsing/fixtures/operators/||=/reference_assignment_with_splatted_argument.yaml
@@ -149,7 +149,7 @@ ast: |
                                                                       conversionMethod = :to_a
                                                                       copy = false
                                                                       flags = 0
-                                                                      nilBehavior = CONVERT
+                                                                      nilBehavior = EMPTY_ARRAY
                                                                       sourceCharIndex = 4
                                                                       sourceLength = 2
                                                                   children:
@@ -201,7 +201,7 @@ ast: |
                                                                                   conversionMethod = :to_a
                                                                                   copy = true
                                                                                   flags = 0
-                                                                                  nilBehavior = CONVERT
+                                                                                  nilBehavior = EMPTY_ARRAY
                                                                                   sourceCharIndex = 4
                                                                                   sourceLength = 2
                                                                               children:

--- a/spec/truffle/parsing/fixtures/return/with_splat_operator.yaml
+++ b/spec/truffle/parsing/fixtures/return/with_splat_operator.yaml
@@ -19,7 +19,7 @@ ast: |
                       conversionMethod = :to_a
                       copy = true
                       flags = 0
-                      nilBehavior = CONVERT
+                      nilBehavior = EMPTY_ARRAY
                       sourceCharIndex = 7
                       sourceLength = 5
                   children:

--- a/spec/truffle/parsing/fixtures/warnings.yaml
+++ b/spec/truffle/parsing/fixtures/warnings.yaml
@@ -62,7 +62,7 @@ ast: |
                                   conversionMethod = :to_a
                                   copy = false
                                   flags = 0
-                                  nilBehavior = CONVERT
+                                  nilBehavior = EMPTY_ARRAY
                                   sourceCharIndex = 5
                                   sourceLength = 3
                               children:

--- a/spec/truffle/parsing/fixtures/yield/with_only_splat_operator.yaml
+++ b/spec/truffle/parsing/fixtures/yield/with_only_splat_operator.yaml
@@ -92,7 +92,7 @@ ast: |
                                                       conversionMethod = :to_a
                                                       copy = false
                                                       flags = 0
-                                                      nilBehavior = CONVERT
+                                                      nilBehavior = EMPTY_ARRAY
                                                       sourceCharIndex = 14
                                                       sourceLength = 4
                                                   children:

--- a/spec/truffle/parsing/fixtures/yield/with_splat_operator_and_multiple_following_arguments.yaml
+++ b/spec/truffle/parsing/fixtures/yield/with_splat_operator_and_multiple_following_arguments.yaml
@@ -114,7 +114,7 @@ ast: |
                                                                   conversionMethod = :to_a
                                                                   copy = true
                                                                   flags = 0
-                                                                  nilBehavior = CONVERT
+                                                                  nilBehavior = EMPTY_ARRAY
                                                                   sourceCharIndex = 14
                                                                   sourceLength = 4
                                                               children:

--- a/spec/truffle/parsing/fixtures/yield/with_splat_operator_and_multiple_preceding_and_following_positional_arguments.yaml
+++ b/spec/truffle/parsing/fixtures/yield/with_splat_operator_and_multiple_preceding_and_following_positional_arguments.yaml
@@ -175,7 +175,7 @@ ast: |
                                                                   conversionMethod = :to_a
                                                                   copy = true
                                                                   flags = 0
-                                                                  nilBehavior = CONVERT
+                                                                  nilBehavior = EMPTY_ARRAY
                                                                   sourceCharIndex = 24
                                                                   sourceLength = 7
                                                               children:

--- a/spec/truffle/parsing/fixtures/yield/with_splat_operator_and_multiple_preceding_arguments.yaml
+++ b/spec/truffle/parsing/fixtures/yield/with_splat_operator_and_multiple_preceding_arguments.yaml
@@ -168,7 +168,7 @@ ast: |
                                                                   conversionMethod = :to_a
                                                                   copy = true
                                                                   flags = 0
-                                                                  nilBehavior = CONVERT
+                                                                  nilBehavior = EMPTY_ARRAY
                                                                   sourceCharIndex = 24
                                                                   sourceLength = 4
                                                               children:

--- a/spec/truffle/parsing/fixtures/yield/with_splat_operator_and_single_following_argument.yaml
+++ b/spec/truffle/parsing/fixtures/yield/with_splat_operator_and_single_following_argument.yaml
@@ -110,7 +110,7 @@ ast: |
                                                                   conversionMethod = :to_a
                                                                   copy = true
                                                                   flags = 0
-                                                                  nilBehavior = CONVERT
+                                                                  nilBehavior = EMPTY_ARRAY
                                                                   sourceCharIndex = 14
                                                                   sourceLength = 4
                                                               children:

--- a/spec/truffle/parsing/fixtures/yield/with_splat_operator_and_single_preceding_and_following_positional_arguments.yaml
+++ b/spec/truffle/parsing/fixtures/yield/with_splat_operator_and_single_preceding_and_following_positional_arguments.yaml
@@ -144,7 +144,7 @@ ast: |
                                                                   conversionMethod = :to_a
                                                                   copy = true
                                                                   flags = 0
-                                                                  nilBehavior = CONVERT
+                                                                  nilBehavior = EMPTY_ARRAY
                                                                   sourceCharIndex = 19
                                                                   sourceLength = 4
                                                               children:

--- a/spec/truffle/parsing/fixtures/yield/with_splat_operator_and_single_preceding_argument.yaml
+++ b/spec/truffle/parsing/fixtures/yield/with_splat_operator_and_single_preceding_argument.yaml
@@ -142,7 +142,7 @@ ast: |
                                                                   conversionMethod = :to_a
                                                                   copy = true
                                                                   flags = 0
-                                                                  nilBehavior = CONVERT
+                                                                  nilBehavior = EMPTY_ARRAY
                                                                   sourceCharIndex = 19
                                                                   sourceLength = 4
                                                               children:

--- a/src/main/java/org/truffleruby/core/cast/SplatCastNode.java
+++ b/src/main/java/org/truffleruby/core/cast/SplatCastNode.java
@@ -35,8 +35,7 @@ public abstract class SplatCastNode extends RubyContextSourceNode {
     public enum NilBehavior {
         EMPTY_ARRAY,
         ARRAY_WITH_NIL,
-        NIL,
-        CONVERT
+        NIL
     }
 
     private final NilBehavior nilBehavior;
@@ -44,7 +43,6 @@ public abstract class SplatCastNode extends RubyContextSourceNode {
     @CompilationFinal private boolean copy = true;
 
     @Child private ArrayDupNode dup;
-    @Child private DispatchNode toA;
 
     public SplatCastNode(RubyLanguage language, NilBehavior nilBehavior, boolean useToAry) {
         this.nilBehavior = nilBehavior;
@@ -73,9 +71,6 @@ public abstract class SplatCastNode extends RubyContextSourceNode {
 
             case ARRAY_WITH_NIL:
                 return createArray(new Object[]{ nil });
-
-            case CONVERT:
-                return callToA(nil);
 
             case NIL:
                 return nil;
@@ -114,14 +109,6 @@ public abstract class SplatCastNode extends RubyContextSourceNode {
                 return (RubyArray) array;
             }
         }
-    }
-
-    private Object callToA(Object nil) {
-        if (toA == null) {
-            CompilerDirectives.transferToInterpreterAndInvalidate();
-            toA = insert(DispatchNode.create());
-        }
-        return toA.call(nil, "to_a");
     }
 
     private RubyArray executeDup(RubyArray array) {

--- a/src/main/java/org/truffleruby/parser/YARPTranslator.java
+++ b/src/main/java/org/truffleruby/parser/YARPTranslator.java
@@ -3154,7 +3154,7 @@ public class YARPTranslator extends YARPBaseTranslator {
 
         if (node.expression != null) {
             final RubyNode valueNode = node.expression.accept(this);
-            rubyNode = SplatCastNodeGen.create(language, SplatCastNode.NilBehavior.CONVERT, false,
+            rubyNode = SplatCastNodeGen.create(language, SplatCastNode.NilBehavior.EMPTY_ARRAY, false,
                     valueNode);
         } else {
             // forwarding * in a method call, e.g.
@@ -3414,7 +3414,7 @@ public class YARPTranslator extends YARPBaseTranslator {
                 }
                 // Relies on ... being only valid as a method parameter and not a block parameter
                 arraysToConcat.add(
-                        SplatCastNodeGen.create(language, SplatCastNode.NilBehavior.CONVERT, false,
+                        SplatCastNodeGen.create(language, SplatCastNode.NilBehavior.EMPTY_ARRAY, false,
                                 environment.readFromMethodFrameNode(FORWARDED_REST_NAME)));
 
                 current.add(HashCastNodeGen.HashCastASTNodeGen.create(


### PR DESCRIPTION
- [x] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
