### PR TITLE
Move the #to_class_name and #conversion_error_message helpers to Truffle::Type where they belong

### DIFF
--- a/lib/truffle/truffle/cext.rb
+++ b/lib/truffle/truffle/cext.rb
@@ -395,7 +395,7 @@ module Truffle::CExt
   def rb_check_type(value, type)
     value_type = rb_type(value)
     if value_type != type || (value_type == T_DATA && Primitive.object_hidden_var_defined?(value, DATA_TYPE))
-      raise TypeError, "wrong argument type #{Truffle::ExceptionOperations.to_class_name(value)} (expected #{BUILTIN_TYPES[type]})"
+      raise TypeError, "wrong argument type #{Truffle::Type.to_class_name(value)} (expected #{BUILTIN_TYPES[type]})"
     end
   end
 

--- a/src/main/ruby/truffleruby/core/hash.rb
+++ b/src/main/ruby/truffleruby/core/hash.rb
@@ -53,7 +53,7 @@ class Hash
     hash = new
     associate_array.each_with_index do |array, i|
       unless array.respond_to? :to_ary
-        type = Truffle::ExceptionOperations.to_class_name(array)
+        type = Truffle::Type.to_class_name(array)
         raise ArgumentError, "wrong element type #{type} at #{i} (expected array)"
       end
       array = array.to_ary

--- a/src/main/ruby/truffleruby/core/truffle/exception_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/exception_operations.rb
@@ -362,27 +362,6 @@ module Truffle
       message
     end
 
-    IMPLICIT_CONVERSION_METHODS = [:to_int, :to_ary, :to_str, :to_sym, :to_hash, :to_proc, :to_io]
-
-    def self.conversion_error_message(obj, cls, meth)
-      message = IMPLICIT_CONVERSION_METHODS.include?(meth) ? 'no implicit conversion of' : "can't convert"
-      type_name = to_class_name(obj)
-      "#{message} #{type_name} into #{cls}"
-    end
-
-    def self.to_class_name(val)
-      case val
-      when nil
-        'nil'
-      when true
-        'true'
-      when false
-        'false'
-      else
-        Primitive.class(val).name
-      end
-    end
-
     def self.get_formatted_backtrace(exception)
       full_message(exception, highlight: nil, order: :top)
     end

--- a/src/main/ruby/truffleruby/core/truffle/kernel_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/kernel_operations.rb
@@ -206,7 +206,7 @@ module Truffle
 
     def self.check_last_line(line)
       unless Primitive.is_a? line, String
-        raise TypeError, "$_ value need to be String (#{Truffle::ExceptionOperations.to_class_name(line)} given)"
+        raise TypeError, "$_ value need to be String (#{Truffle::Type.to_class_name(line)} given)"
       end
       line
     end

--- a/src/main/ruby/truffleruby/core/type.rb
+++ b/src/main/ruby/truffleruby/core/type.rb
@@ -223,16 +223,36 @@ module Truffle
     # MRI: Check_Type / rb_check_type
     def self.rb_check_type(obj, cls)
       unless Primitive.is_a?(obj, cls)
-        raise TypeError, "wrong argument type #{Primitive.class(obj)} (expected #{cls})"
+        raise TypeError, "wrong argument type #{to_class_name(obj)} (expected #{cls})"
       end
       obj
+    end
+
+    def self.to_class_name(object)
+      case object
+      when nil
+        'nil'
+      when true
+        'true'
+      when false
+        'false'
+      else
+        Primitive.class(object).name
+      end
+    end
+
+    IMPLICIT_CONVERSION_METHODS = [:to_int, :to_ary, :to_str, :to_sym, :to_hash, :to_proc, :to_io]
+
+    def self.conversion_error_message(obj, cls, meth)
+      message = IMPLICIT_CONVERSION_METHODS.include?(meth) ? 'no implicit conversion of' : "can't convert"
+      "#{message} #{to_class_name(obj)} into #{cls}"
     end
 
     def self.convert_type(obj, cls, meth, raise_on_error)
       r = check_funcall(obj, meth)
       if Primitive.undefined?(r)
         if raise_on_error
-          raise TypeError, Truffle::ExceptionOperations.conversion_error_message(obj, cls, meth)
+          raise TypeError, conversion_error_message(obj, cls, meth)
         else
           nil
         end
@@ -350,7 +370,7 @@ module Truffle
       when Numeric
         Primitive.convert_type obj, Float, :to_f
       else
-        raise TypeError, ExceptionOperations.conversion_error_message(obj, Float, :to_f)
+        raise TypeError, conversion_error_message(obj, Float, :to_f)
       end
     end
 


### PR DESCRIPTION
* Use #to_class_name for #rb_check_type.

Multiple times I searched for `to_class_name` in `type.rb`, it should just be there, that's where it's most used anyway.