### PR TITLE
Better compatibility for `Data#initialize` and `Data#deconstruct_keys` with convertable keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Compatibility:
 * Accept `nil` as an argument to `Kernel#sleep` and `Mutex#sleep` (#4260, @earlopain).
 * Better compatibility for `String#each_line`/`String#lines` with an empty string argument (#4267, @earlopain).
 * Remove `..` from `Dir.glob` when `File::FNM_DOTMATCH` is given (#4269, @earlopain).
+* Better compatibility for `Data#initialize` and `Data#deconstruct_keys` with convertable keys (#4251, @earlopain)
 
 Performance:
 

--- a/spec/ruby/core/data/deconstruct_keys_spec.rb
+++ b/spec/ruby/core/data/deconstruct_keys_spec.rb
@@ -56,7 +56,7 @@ describe "Data#deconstruct_keys" do
     d.deconstruct_keys(nil).should == {x: 1, y: 2}
   end
 
-  ruby_bug "Bug #21844", ""..."4.1" do
+  ruby_version_is "4.0" do # https://bugs.ruby-lang.org/issues/21844
     it "tries to convert a key with #to_str if index is not a String nor a Symbol, but responds to #to_str" do
       klass = Data.define(:x, :y)
       d = klass.new(1, 2)

--- a/spec/ruby/core/data/initialize_spec.rb
+++ b/spec/ruby/core/data/initialize_spec.rb
@@ -47,6 +47,12 @@ describe "Data#initialize" do
     data.unit.should == "km"
   end
 
+  it "accepts the last entry when a keyword is given as both String and Symbol" do
+    data = DataSpecs::Single.new("value" => -1, value: 42)
+
+    data.value.should == 42
+  end
+
   it "accepts positional arguments with empty keyword arguments" do
     data = DataSpecs::Single.new(42, **{})
 
@@ -74,12 +80,54 @@ describe "Data#initialize" do
     }
   end
 
+  ruby_version_is "4.0" do # https://bugs.ruby-lang.org/issues/21844
+    it "raises ArgumentError if at least one argument is missing and other is provided as both String and Symbol" do
+      -> {
+        DataSpecs::Measure.new(unit: "km", "unit" => "km")
+      }.should.raise(ArgumentError) { |e|
+        e.message.should.include?("missing keyword: :amount")
+      }
+    end
+  end
+
   it "raises ArgumentError if unknown keyword is given" do
     -> {
       DataSpecs::Measure.new(amount: 42, unit: "km", system: "metric")
     }.should.raise(ArgumentError) { |e|
       e.message.should.include?("unknown keyword: :system")
     }
+  end
+
+  ruby_version_is "4.0" do # https://bugs.ruby-lang.org/issues/21844
+    it "raises ArgumentError if unknown keyword is given which is convertable to String" do
+      key = mock("to_str")
+      key.should_receive(:to_str).and_return("system")
+
+      -> {
+        DataSpecs::Measure.new(amount: 42, unit: "km", key => "metric")
+      }.should.raise(ArgumentError) { |e|
+        e.message.should.include?('unknown keyword: "system"')
+      }
+    end
+
+    it "raises TypeError when the keyword is not convertable to String" do
+      -> {
+        DataSpecs::Measure.new(1 => 2)
+      }.should.raise(TypeError) { |e|
+        e.message.should == "1 is not a symbol nor a string"
+      }
+    end
+
+    it "raises TypeError if the conversion with #to_str does not return a String" do
+      klass = Data.define(:x, :y)
+
+      key = mock("to_str")
+      key.should_receive(:to_str).and_return(0)
+
+      -> {
+        klass.new(key => 2)
+      }.should raise_consistent_error(TypeError, /can't convert MockObject into String/)
+    end
   end
 
   it "supports super from a subclass" do

--- a/spec/tags/core/data/deconstruct_keys_tags.txt
+++ b/spec/tags/core/data/deconstruct_keys_tags.txt
@@ -1,6 +1,0 @@
-fails:Data#deconstruct_keys raises a TypeError if the conversion with #to_int does not return an Integer
-fails:Data#deconstruct_keys tries to convert a key with #to_str if index is not a String nor a Symbol, but responds to #to_str
-fails:Data#deconstruct_keys raise an error on argument position number
-fails:Data#deconstruct_keys raises a TypeError if the conversion with #to_str does not return a String
-fails:Data#deconstruct_keys raises TypeError if index is not a Symbol and not convertible to String 
-fails:Data#deconstruct_keys raises TypeError if index is not a Symbol and not convertible to String

--- a/src/main/ruby/truffleruby/core/data.rb
+++ b/src/main/ruby/truffleruby/core/data.rb
@@ -11,14 +11,12 @@
 
 module Truffle
   module DataOperations
-    def self.unknown_keywords_message(given, object)
-      unknowns = given - Primitive.class(object)::CLASS_MEMBERS
+    def self.unknown_keywords_message(unknowns)
       s = 's' if unknowns.size > 1
       "unknown keyword#{s}: #{unknowns.map(&:inspect).join ', '}"
     end
 
-    def self.missing_keywords_message(given, object)
-      missing = Primitive.class(object)::CLASS_MEMBERS - given
+    def self.missing_keywords_message(missing)
       s = 's' if missing.size > 1
       "missing keyword#{s}: #{missing.map(&:inspect).join ', '}"
     end
@@ -30,17 +28,40 @@ class Data
   # Keep in sync with #initialize below
   def initialize(**kwargs)
     members_hash = Primitive.class(self)::CLASS_MEMBERS_HASH
+    coerced_args = nil
+    unknown_args = nil
+
     kwargs.each do |member, value|
-      member = member.to_sym
-      if members_hash.include?(member)
-        Primitive.object_hidden_var_set(self, member, value)
+      if Primitive.is_a?(member, Symbol)
+        coerced_member = member
       else
-        raise ArgumentError, Truffle::DataOperations.unknown_keywords_message(kwargs.keys, self)
+        coerced_args ||= Set.new
+        coerced_member = Truffle::Type.coerce_to_symbol(member)
+        coerced_args << coerced_member
+      end
+
+      if members_hash.include?(coerced_member)
+        Primitive.object_hidden_var_set(self, coerced_member, value)
+      else
+        unknown_args ||= Set.new
+        case member
+        when String, Symbol
+          unknown_args << member
+        else
+          unknown_args << coerced_member.name
+        end
       end
     end
 
-    if kwargs.size < members_hash.size
-      raise ArgumentError, Truffle::DataOperations.missing_keywords_message(kwargs.keys, self)
+    if unknown_args&.any?
+      raise ArgumentError, Truffle::DataOperations.unknown_keywords_message(unknown_args)
+    end
+    if kwargs.size != members_hash.size || coerced_args&.any?
+      missing_args = members_hash.keys - kwargs.keys
+      missing_args -= coerced_args.to_a if coerced_args
+      if missing_args.any?
+        raise ArgumentError, Truffle::DataOperations.missing_keywords_message(missing_args)
+      end
     end
     Primitive.freeze(self)
   end
@@ -121,17 +142,40 @@ class Data
       # Keep in sync with #initialize above
       def initialize(**kwargs)
         members_hash = Primitive.class(self)::CLASS_MEMBERS_HASH
+        coerced_args = nil
+        unknown_args = nil
+
         kwargs.each do |member, value|
-          member = member.to_sym
-          if members_hash.include?(member)
-            Primitive.object_hidden_var_set(self, member, value)
+          if Primitive.is_a?(member, Symbol)
+            coerced_member = member
           else
-            raise ArgumentError, Truffle::DataOperations.unknown_keywords_message(kwargs.keys, self)
+            coerced_args ||= Set.new
+            coerced_member = Truffle::Type.coerce_to_symbol(member)
+            coerced_args << coerced_member
+          end
+
+          if members_hash.include?(coerced_member)
+            Primitive.object_hidden_var_set(self, coerced_member, value)
+          else
+            unknown_args ||= Set.new
+            case member
+            when String, Symbol
+              unknown_args << member
+            else
+              unknown_args << coerced_member.name
+            end
           end
         end
 
-        if kwargs.size < members_hash.size
-          raise ArgumentError, Truffle::DataOperations.missing_keywords_message(kwargs.keys, self)
+        if unknown_args&.any?
+          raise ArgumentError, Truffle::DataOperations.unknown_keywords_message(unknown_args)
+        end
+        if kwargs.size != members_hash.size || coerced_args&.any?
+          missing_args = members_hash.keys - kwargs.keys
+          missing_args -= coerced_args.to_a if coerced_args
+          if missing_args.any?
+            raise ArgumentError, Truffle::DataOperations.missing_keywords_message(missing_args)
+          end
         end
         Primitive.freeze(self)
       end
@@ -195,7 +239,6 @@ class Data
         return {} if members_hash.size < keys.size
 
         h = {}
-        members = Primitive.class(self)::CLASS_MEMBERS
         keys.each do |requested_key|
           case requested_key
           when Symbol
@@ -203,10 +246,11 @@ class Data
           when String
             symbolized_key = requested_key.to_sym
           else
-            symbolized_key = members[requested_key]
+            symbolized_key = Truffle::Type.coerce_to_symbol(requested_key)
+            requested_key = symbolized_key.name
           end
 
-          if symbolized_key && members_hash.include?(symbolized_key)
+          if members_hash.include?(symbolized_key)
             h[requested_key] = Primitive.object_hidden_var_get(self, symbolized_key)
           else
             return h

--- a/src/main/ruby/truffleruby/core/data.rb
+++ b/src/main/ruby/truffleruby/core/data.rb
@@ -11,14 +11,29 @@
 
 module Truffle
   module DataOperations
-    def self.unknown_keywords_message(unknowns)
+    def self.unknown_keywords(members_hash, kwargs, unknown_member, unknown_coerced_member)
+      unknowns = kwargs.keys.filter_map do |member|
+        if Primitive.equal?(member, unknown_member)
+          coerced_member = unknown_coerced_member
+        else
+          coerced_member = Truffle::Type.coerce_to_symbol(member)
+        end
+        unless members_hash.include?(coerced_member)
+          (Primitive.is_a?(member, Symbol) || Primitive.is_a?(member, String)) ? member : coerced_member.name
+        end
+      end
+
       s = 's' if unknowns.size > 1
-      "unknown keyword#{s}: #{unknowns.map(&:inspect).join ', '}"
+      raise ArgumentError, "unknown keyword#{s}: #{unknowns.map(&:inspect).join ', '}"
     end
 
-    def self.missing_keywords_message(missing)
-      s = 's' if missing.size > 1
-      "missing keyword#{s}: #{missing.map(&:inspect).join ', '}"
+    def self.check_missing_keywords(members_hash, kwargs, coerced_args)
+      missing_args = members_hash.keys - kwargs.keys
+      missing_args -= coerced_args if coerced_args
+      unless missing_args.empty?
+        s = 's' if missing_args.size > 1
+        raise ArgumentError, "missing keyword#{s}: #{missing_args.map(&:inspect).join ', '}"
+      end
     end
   end
 end
@@ -29,39 +44,25 @@ class Data
   def initialize(**kwargs)
     members_hash = Primitive.class(self)::CLASS_MEMBERS_HASH
     coerced_args = nil
-    unknown_args = nil
 
     kwargs.each do |member, value|
       if Primitive.is_a?(member, Symbol)
         coerced_member = member
       else
-        coerced_args ||= Set.new
         coerced_member = Truffle::Type.coerce_to_symbol(member)
+        coerced_args ||= []
         coerced_args << coerced_member
       end
 
       if members_hash.include?(coerced_member)
         Primitive.object_hidden_var_set(self, coerced_member, value)
       else
-        unknown_args ||= Set.new
-        case member
-        when String, Symbol
-          unknown_args << member
-        else
-          unknown_args << coerced_member.name
-        end
+        Truffle::DataOperations.unknown_keywords(members_hash, kwargs, member, coerced_member)
       end
     end
 
-    if unknown_args&.any?
-      raise ArgumentError, Truffle::DataOperations.unknown_keywords_message(unknown_args)
-    end
-    if kwargs.size != members_hash.size || coerced_args&.any?
-      missing_args = members_hash.keys - kwargs.keys
-      missing_args -= coerced_args.to_a if coerced_args
-      if missing_args.any?
-        raise ArgumentError, Truffle::DataOperations.missing_keywords_message(missing_args)
-      end
+    if kwargs.size != members_hash.size || coerced_args
+      Truffle::DataOperations.check_missing_keywords(members_hash, kwargs, coerced_args)
     end
     Primitive.freeze(self)
   end
@@ -143,39 +144,25 @@ class Data
       def initialize(**kwargs)
         members_hash = Primitive.class(self)::CLASS_MEMBERS_HASH
         coerced_args = nil
-        unknown_args = nil
 
         kwargs.each do |member, value|
           if Primitive.is_a?(member, Symbol)
             coerced_member = member
           else
-            coerced_args ||= Set.new
             coerced_member = Truffle::Type.coerce_to_symbol(member)
+            coerced_args ||= []
             coerced_args << coerced_member
           end
 
           if members_hash.include?(coerced_member)
             Primitive.object_hidden_var_set(self, coerced_member, value)
           else
-            unknown_args ||= Set.new
-            case member
-            when String, Symbol
-              unknown_args << member
-            else
-              unknown_args << coerced_member.name
-            end
+            Truffle::DataOperations.unknown_keywords(members_hash, kwargs, member, coerced_member)
           end
         end
 
-        if unknown_args&.any?
-          raise ArgumentError, Truffle::DataOperations.unknown_keywords_message(unknown_args)
-        end
-        if kwargs.size != members_hash.size || coerced_args&.any?
-          missing_args = members_hash.keys - kwargs.keys
-          missing_args -= coerced_args.to_a if coerced_args
-          if missing_args.any?
-            raise ArgumentError, Truffle::DataOperations.missing_keywords_message(missing_args)
-          end
+        if kwargs.size != members_hash.size || coerced_args
+          Truffle::DataOperations.check_missing_keywords(members_hash, kwargs, coerced_args)
         end
         Primitive.freeze(self)
       end

--- a/test/mri/excludes/URI/TestMailTo.rb
+++ b/test/mri/excludes/URI/TestMailTo.rb
@@ -1,0 +1,1 @@
+exclude :test_email_regexp, "transient: Test::Unit::ProxyError: [100]: in 0.19060160000066162s (tmin: 0.00166138399998772, tmax: 0.00190601600000662, tbase: 0.01906016000006616)"


### PR DESCRIPTION
Started out as just https://bugs.ruby-lang.org/issues/21844 but stumbled across a few other things

All in all:
* Reject non-convertible keys (not symbol, string, or to_str)
* Raise error when keyword is missing and other keyword given as both string and symbol
* Show the converted string in error messages instead of the raw object

- [x] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
