### PR TITLE
IO.select accepts Float::INFINITY as a timeout argument.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Compatibility:
 * `Enumerator.produce` now accepts the optional `size` keyword parameter (#4246, @earlopain)
 * Fix `Enumerator.product` size for empty enumerators (#4249, @earlopain)
 * Consistent coercion error messages (#4250, @earlopain)
+* `IO.select` now accepts `Float::INFINITY` as a timeout argument (#4252, @haukot)
 
 Performance:
 

--- a/spec/tags/core/io/select_tags.txt
+++ b/spec/tags/core/io/select_tags.txt
@@ -1,4 +1,3 @@
 fails:IO.select raises an ArgumentError when passed a negative timeout
 fails:IO.select raises an RangeError when passed NaN as timeout
 fails:IO.select raises an ArgumentError when passed negative infinity as timeout
-fails:IO.select when passed Float::INFINITY for timeout sleeps forever and sets the thread status to 'sleep'

--- a/src/main/ruby/truffleruby/core/io.rb
+++ b/src/main/ruby/truffleruby/core/io.rb
@@ -716,8 +716,8 @@ class IO
   # A +timeout+ of 0 indicates that each descriptor should be
   # checked once only, effectively polling the sets.
   #
-  # Leaving the +timeout+ to +nil+ causes +select+ to block
-  # infinitely until an event transpires.
+  # Leaving the +timeout+ to +nil+ or passing +Float::INFINITY+ causes
+  # +select+ to block infinitely until an event transpires.
   #
   # If the timeout expires without events, +nil+ is returned.
   # Otherwise, an [readable, writable, errors] Array of Arrays
@@ -727,6 +727,8 @@ class IO
   #                 Rubinius does not.
   #
   def self.select(readables = nil, writables = nil, errorables = nil, timeout = nil)
+    timeout = nil if timeout == Float::INFINITY
+
     if timeout
       unless Primitive.is_a? timeout, Numeric
         raise TypeError, 'Timeout must be numeric'


### PR DESCRIPTION
https://github.com/truffleruby/truffleruby/issues/4231 / https://bugs.ruby-lang.org/issues/20610

- [x] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
