### PR TITLE
Make IO.select argument checks aligned with CRuby

### DIFF
--- a/spec/tags/core/io/select_tags.txt
+++ b/spec/tags/core/io/select_tags.txt
@@ -1,3 +1,0 @@
-fails:IO.select raises an ArgumentError when passed a negative timeout
-fails:IO.select raises an RangeError when passed NaN as timeout
-fails:IO.select raises an ArgumentError when passed negative infinity as timeout

--- a/src/main/ruby/truffleruby/core/io.rb
+++ b/src/main/ruby/truffleruby/core/io.rb
@@ -734,7 +734,8 @@ class IO
         raise TypeError, 'Timeout must be numeric'
       end
 
-      raise ArgumentError, 'timeout must be positive' if timeout < 0
+      raise ArgumentError, 'time interval must not be negative' if timeout < 0
+      raise RangeError, "#{timeout} out of Time range" if Primitive.is_a?(timeout, Float) && timeout.nan?
 
       # Milliseconds, rounded down
       timeout = Integer(timeout * 1_000)

--- a/test/mri/excludes/TestIO.rb
+++ b/test/mri/excludes/TestIO.rb
@@ -66,7 +66,6 @@ exclude :test_seek, "NameError: uninitialized constant TestIO::Bug" if RUBY_PLAT
 exclude :test_seek_symwhence, "TypeError: unsupported type [:SET]"
 exclude :test_select_exceptfds, "Truffle::IOOperations.poll(acc, Truffle::IOOperations::POLLIN_SET | Truffle::IOOperations::POLLEX_SET, nil) returns POLLRDNORM|POLLPRI|POLLIN on Linux (correct) but POLLRDNORM|POLLIN on macOS (bug). With events=POLLPRI it hangs on macOS. It seems a bug of macOS poll() not handling TCP MSG_OOB. MSG_OOB is poorly supported across platforms anyway." if RUBY_PLATFORM.include?('darwin')
 exclude :test_select_memory_leak, "hangs"
-exclude :test_select_timeout, "[RangeError] exception expected, not #<FloatDomainError: NaN>."
 exclude :test_sysread_locktmp, "Exception(RuntimeError) with message matches to /can't modify string; temporarily locked/."
 exclude :test_sysread_with_negative_length, "[ArgumentError] exception expected, not #<Errno::EFAULT: Bad address>."
 exclude :test_ungetbyte, "Errno::EINVAL: Invalid argument"


### PR DESCRIPTION
This is a small cleanup of IO.select error messages, so we can untag the last tests of IO.select.

I didn't add an entry in ChangeLog as it seems to be a small change.

- [x] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
