### PR TITLE
Freeze the global input separator on assignment

### DIFF
--- a/spec/tags/language/predefined_tags.txt
+++ b/spec/tags/language/predefined_tags.txt
@@ -9,7 +9,3 @@ slow:Global variable $0 actually sets the program name
 fails:Predefined global $/ warns if assigned non-nil
 fails:Predefined global $-0 warns if assigned non-nil
 fails:Predefined global $\ warns if assigned non-nil
-fails:Predefined global $/ makes a new frozen String from the assigned String
-fails:Predefined global $/ makes a new frozen String if it's not frozen
-fails:Predefined global $-0 makes a new frozen String from the assigned String
-fails:Predefined global $-0 makes a new frozen String if it's not frozen

--- a/src/main/ruby/truffleruby/core/truffle/kernel_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/kernel_operations.rb
@@ -80,7 +80,7 @@ module Truffle
         if v && !Primitive.is_a?(v, String)
           raise TypeError, "value of #{name} must be String"
         end
-        Primitive.global_variable_set :$/, v
+        Primitive.global_variable_set :$/, v ? -v.to_s : v
       })
 
     $/ = "\n".freeze


### PR DESCRIPTION
It's hardly relevant since it's deprecated and it was done this way for ractors but very easy to remove a handful of tags.

The `to_s` is there to convert string subclasses to plain strings, which the test asserts against.

https://bugs.ruby-lang.org/issues/21109

- [ ] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
