### PR TITLE
Call inspect for real/imaginary on `Complex#inspect`

### DIFF
--- a/spec/tags/core/complex/inspect_tags.txt
+++ b/spec/tags/core/complex/inspect_tags.txt
@@ -1,2 +1,0 @@
-fails:Complex#inspect calls #inspect on real and imaginary
-fails:Complex#inspect adds an `*' before the `i' if the last character of the imaginary part is not numeric

--- a/src/main/ruby/truffleruby/core/complex.rb
+++ b/src/main/ruby/truffleruby/core/complex.rb
@@ -270,7 +270,7 @@ class Complex < Numeric
   end
 
   private def stringify(real_str, imag_abs_str)
-    result = real_str
+    result = real_str.dup
 
     if imag < 0 || Primitive.equal?(imag, -0.0)
       result << '-'

--- a/src/main/ruby/truffleruby/core/complex.rb
+++ b/src/main/ruby/truffleruby/core/complex.rb
@@ -266,7 +266,11 @@ class Complex < Numeric
   end
 
   def to_s
-    result = real.to_s
+    stringify(real.to_s, imag.abs.to_s)
+  end
+
+  private def stringify(real_s, imag_s)
+    result = real_s
 
     if imag < 0 || Primitive.equal?(imag, -0.0)
       result << '-'
@@ -274,7 +278,6 @@ class Complex < Numeric
       result << '+'
     end
 
-    imag_s = imag.abs.to_s
     result << imag_s
 
     unless imag_s[-1] =~ /\d/
@@ -301,7 +304,7 @@ class Complex < Numeric
   end
 
   def inspect
-    "(#{self})"
+    "(#{stringify(real.inspect, imag.abs.inspect)})"
   end
 
   def fdiv(other)

--- a/src/main/ruby/truffleruby/core/complex.rb
+++ b/src/main/ruby/truffleruby/core/complex.rb
@@ -269,8 +269,8 @@ class Complex < Numeric
     stringify(real.to_s, imag.abs.to_s)
   end
 
-  private def stringify(real_s, imag_s)
-    result = real_s
+  private def stringify(real_str, imag_abs_str)
+    result = real_str
 
     if imag < 0 || Primitive.equal?(imag, -0.0)
       result << '-'
@@ -278,9 +278,9 @@ class Complex < Numeric
       result << '+'
     end
 
-    result << imag_s
+    result << imag_abs_str
 
-    unless imag_s[-1] =~ /\d/
+    unless imag_abs_str[-1] =~ /\d/
       result << '*'
     end
 


### PR DESCRIPTION
The implementation for `to_s`/`inspect` are identical, apart from from difference between `to_s`/`inspect` on the individual parts.

https://github.com/ruby/spec/commit/d3100d21f71d6aa18f8011eec2718b887adba161

- [ ] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
