### PR TITLE
Even more consistent coercion messages

### DIFF
--- a/spec/tags/core/queue/deq_tags.txt
+++ b/spec/tags/core/queue/deq_tags.txt
@@ -1,3 +1,0 @@
-fails:Queue#deq with a timeout raise TypeError if timeout is not a valid numeric
-fails:Queue operations with timeout fails if string is provided
-fails:Queue operations with timeout fails if boolean is provided

--- a/spec/tags/core/queue/pop_tags.txt
+++ b/spec/tags/core/queue/pop_tags.txt
@@ -1,3 +1,0 @@
-fails:Queue#pop with a timeout raise TypeError if timeout is not a valid numeric
-fails:Queue operations with timeout fails if string is provided
-fails:Queue operations with timeout fails if boolean is provided

--- a/spec/tags/core/queue/shift_tags.txt
+++ b/spec/tags/core/queue/shift_tags.txt
@@ -1,3 +1,0 @@
-fails:Queue#shift with a timeout raise TypeError if timeout is not a valid numeric
-fails:Queue operations with timeout fails if string is provided
-fails:Queue operations with timeout fails if boolean is provided

--- a/spec/tags/core/sizedqueue/append_tags.txt
+++ b/spec/tags/core/sizedqueue/append_tags.txt
@@ -1,3 +1,0 @@
-fails:SizedQueue#<< with a timeout raise TypeError if timeout is not a valid numeric
-fails:SizedQueue operations with timeout fails if string is provided
-fails:SizedQueue operations with timeout fails if boolean is provided

--- a/spec/tags/core/sizedqueue/deq_tags.txt
+++ b/spec/tags/core/sizedqueue/deq_tags.txt
@@ -1,3 +1,0 @@
-fails:SizedQueue#deq with a timeout raise TypeError if timeout is not a valid numeric
-fails:SizedQueue operations with timeout fails if string is provided
-fails:SizedQueue operations with timeout fails if boolean is provided

--- a/spec/tags/core/sizedqueue/enq_tags.txt
+++ b/spec/tags/core/sizedqueue/enq_tags.txt
@@ -1,3 +1,0 @@
-fails:SizedQueue#enq with a timeout raise TypeError if timeout is not a valid numeric
-fails:SizedQueue operations with timeout fails if string is provided
-fails:SizedQueue operations with timeout fails if boolean is provided

--- a/spec/tags/core/sizedqueue/pop_tags.txt
+++ b/spec/tags/core/sizedqueue/pop_tags.txt
@@ -1,3 +1,0 @@
-fails:SizedQueue#pop with a timeout raise TypeError if timeout is not a valid numeric
-fails:SizedQueue operations with timeout fails if string is provided
-fails:SizedQueue operations with timeout fails if boolean is provided

--- a/spec/tags/core/sizedqueue/push_tags.txt
+++ b/spec/tags/core/sizedqueue/push_tags.txt
@@ -1,3 +1,0 @@
-fails:SizedQueue#push with a timeout raise TypeError if timeout is not a valid numeric
-fails:SizedQueue operations with timeout fails if string is provided
-fails:SizedQueue operations with timeout fails if boolean is provided

--- a/spec/tags/core/sizedqueue/shift_tags.txt
+++ b/spec/tags/core/sizedqueue/shift_tags.txt
@@ -1,3 +1,0 @@
-fails:SizedQueue#shift with a timeout raise TypeError if timeout is not a valid numeric
-fails:SizedQueue operations with timeout fails if string is provided
-fails:SizedQueue operations with timeout fails if boolean is provided

--- a/src/main/ruby/truffleruby/core/type.rb
+++ b/src/main/ruby/truffleruby/core/type.rb
@@ -83,7 +83,7 @@ module Truffle
     end
 
     def self.rb_num2ulong(val)
-      raise TypeError, 'no implicit conversion from nil into Integer' if Primitive.nil? val
+      raise TypeError, 'no implicit conversion of nil into Integer' if Primitive.nil? val
 
       if Primitive.is_a?(val, Integer)
         if Primitive.integer_fits_into_long?(val)
@@ -100,7 +100,7 @@ module Truffle
     end
 
     def self.rb_num2dbl(val)
-      raise TypeError, 'no implicit conversion from nil into Float' if Primitive.nil? val
+      raise TypeError, 'no implicit conversion of nil into Float' if Primitive.nil? val
 
       if Primitive.is_a?(val, Float)
         val
@@ -108,12 +108,8 @@ module Truffle
         val.to_f
       elsif Primitive.is_a?(val, Rational)
         val.to_f
-      elsif Primitive.true?(val)
-        raise TypeError, 'no implicit conversion to float from true'
-      elsif Primitive.false?(val)
-        raise TypeError, 'no implicit conversion to float from false'
-      elsif Primitive.is_a?(val, String)
-        raise TypeError, 'no implicit conversion to float from string'
+      elsif Primitive.true?(val) || Primitive.false?(val) || Primitive.is_a?(val, String)
+        raise TypeError, "no implicit conversion of #{to_class_name(val)} into Float"
       else
         rb_num2dbl(rb_to_f(val))
       end


### PR DESCRIPTION
Followup to https://github.com/truffleruby/truffleruby/pull/4250

I missed some and wrote two wrong (from -> of)

- [ ] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
