### PR TITLE
Remove special handling for `Range#each` with `Time`

### DIFF
--- a/spec/tags/core/range/each_tags.txt
+++ b/spec/tags/core/range/each_tags.txt
@@ -1,1 +1,0 @@
-fails:Range#each supports Time objects that respond to #succ

--- a/src/main/ruby/truffleruby/core/range.rb
+++ b/src/main/ruby/truffleruby/core/range.rb
@@ -280,7 +280,7 @@ class Range
     return to_enum { size } unless block_given?
     first, last = self.begin, self.end
 
-    unless first.respond_to?(:succ) && !Primitive.is_a?(first, Time)
+    unless first.respond_to?(:succ)
       raise TypeError, "can't iterate from #{Primitive.class(first)}"
     end
 


### PR DESCRIPTION
Not sure about the history of why this is here in the first place. I guess it implemented `succ` but it was not what people were expecting

https://bugs.ruby-lang.org/issues/18237

- [ ] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
