### PR TITLE
Remove some leftover methods

### DIFF
--- a/spec/tags/core/method/private_tags.txt
+++ b/spec/tags/core/method/private_tags.txt
@@ -1,1 +1,0 @@
-fails:Method#private? has been removed

--- a/spec/tags/core/method/protected_tags.txt
+++ b/spec/tags/core/method/protected_tags.txt
@@ -1,1 +1,0 @@
-fails:Method#protected? has been removed

--- a/spec/tags/core/method/public_tags.txt
+++ b/spec/tags/core/method/public_tags.txt
@@ -1,1 +1,0 @@
-fails:Method#public? has been removed

--- a/spec/tags/core/unboundmethod/private_tags.txt
+++ b/spec/tags/core/unboundmethod/private_tags.txt
@@ -1,1 +1,0 @@
-fails:UnboundMethod#private? has been removed

--- a/spec/tags/core/unboundmethod/protected_tags.txt
+++ b/spec/tags/core/unboundmethod/protected_tags.txt
@@ -1,1 +1,0 @@
-fails:UnboundMethod#protected? has been removed

--- a/spec/tags/core/unboundmethod/public_tags.txt
+++ b/spec/tags/core/unboundmethod/public_tags.txt
@@ -1,1 +1,0 @@
-fails:UnboundMethod#public? has been removed

--- a/src/main/java/org/truffleruby/core/method/MethodNodes.java
+++ b/src/main/java/org/truffleruby/core/method/MethodNodes.java
@@ -209,30 +209,6 @@ public abstract class MethodNodes {
 
     }
 
-    @CoreMethod(names = "private?")
-    public abstract static class IsPrivateNode extends CoreMethodArrayArgumentsNode {
-        @Specialization
-        boolean isPrivate(RubyMethod method) {
-            return method.method.isPrivate();
-        }
-    }
-
-    @CoreMethod(names = "protected?")
-    public abstract static class IsProtectedNode extends CoreMethodArrayArgumentsNode {
-        @Specialization
-        boolean isProtected(RubyMethod method) {
-            return method.method.isProtected();
-        }
-    }
-
-    @CoreMethod(names = "public?")
-    public abstract static class IsPublicNode extends CoreMethodArrayArgumentsNode {
-        @Specialization
-        boolean isPublic(RubyMethod method) {
-            return method.method.isPublic();
-        }
-    }
-
     @CoreMethod(names = "receiver")
     public abstract static class ReceiverNode extends CoreMethodArrayArgumentsNode {
 

--- a/src/main/java/org/truffleruby/core/method/UnboundMethodNodes.java
+++ b/src/main/java/org/truffleruby/core/method/UnboundMethodNodes.java
@@ -172,30 +172,6 @@ public abstract class UnboundMethodNodes {
 
     }
 
-    @CoreMethod(names = "private?")
-    public abstract static class IsPrivateNode extends CoreMethodArrayArgumentsNode {
-        @Specialization
-        boolean isPrivate(RubyUnboundMethod unboundMethod) {
-            return unboundMethod.method.isPrivate();
-        }
-    }
-
-    @CoreMethod(names = "protected?")
-    public abstract static class IsProtectedNode extends CoreMethodArrayArgumentsNode {
-        @Specialization
-        boolean isProtected(RubyUnboundMethod unboundMethod) {
-            return unboundMethod.method.isProtected();
-        }
-    }
-
-    @CoreMethod(names = "public?")
-    public abstract static class IsPublicNode extends CoreMethodArrayArgumentsNode {
-        @Specialization
-        boolean isPublic(RubyUnboundMethod unboundMethod) {
-            return unboundMethod.method.isPublic();
-        }
-    }
-
     @CoreMethod(names = "source_location")
     public abstract static class SourceLocationNode extends CoreMethodArrayArgumentsNode {
 

--- a/src/main/java/org/truffleruby/language/methods/InternalMethod.java
+++ b/src/main/java/org/truffleruby/language/methods/InternalMethod.java
@@ -489,18 +489,6 @@ public final class InternalMethod implements ObjectGraphNode {
         return false;
     }
 
-    public boolean isPublic() {
-        return visibility == Visibility.PUBLIC;
-    }
-
-    public boolean isPrivate() {
-        return visibility == Visibility.PRIVATE;
-    }
-
-    public boolean isProtected() {
-        return visibility == Visibility.PROTECTED;
-    }
-
     @Override
     public String toString() {
         return sharedMethodInfo.toString();

--- a/src/main/ruby/truffleruby/core/struct.rb
+++ b/src/main/ruby/truffleruby/core/struct.rb
@@ -99,10 +99,6 @@ class Struct
     klass
   end
 
-  def self.make_struct(name, attrs)
-    new name, *attrs
-  end
-
   private def _attrs # :nodoc:
     Primitive.class(self)::STRUCT_ATTRS
   end

--- a/src/main/ruby/truffleruby/core/thread.rb
+++ b/src/main/ruby/truffleruby/core/thread.rb
@@ -78,12 +78,6 @@ class Thread
     nil
   end
 
-  MUTEX_FOR_THREAD_EXCLUSIVE = Mutex.new
-
-  def self.exclusive
-    MUTEX_FOR_THREAD_EXCLUSIVE.synchronize { yield }
-  end
-
   def self.handle_interrupt(config, &block)
     unless Primitive.is_a?(config, Hash)
       raise ArgumentError, 'unknown mask signature'


### PR DESCRIPTION
* https://bugs.ruby-lang.org/issues/11689
* https://bugs.ruby-lang.org/issues/17125
* And some obsolete `Struct` implementation detail

The other two I found by comparing public methods but that's pretty noisy so I didn't look to closely

- [ ] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
