### PR TITLE
Correctly implement `String#each_line` paragraph mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Compatibility:
 * `IO.select` now accepts `Float::INFINITY` as a timeout argument (#4252, @haukot)
 * Implement `Math.log1p` and `Math.expm1` (#4255, @haukot).
 * Accept `nil` as an argument to `Kernel#sleep` and `Mutex#sleep` (#4260, @earlopain).
+* Better compatibility for `String#each_line`/`String#lines` with an empty string argument (#4267, @earlopain).
 
 Performance:
 

--- a/spec/ruby/core/string/shared/each_line.rb
+++ b/spec/ruby/core/string/shared/each_line.rb
@@ -46,14 +46,36 @@ describe :string_each_line, shared: true do
     a.should == ["one\ntwo\r\nthree"]
   end
 
-  it "yields paragraphs (broken by 2 or more successive newlines) when passed '' and replaces multiple newlines with only two ones" do
-    a = []
-    "hello\nworld\n\n\nand\nuniverse\n\n\n\n\n".send(@method, '') { |s| a << s }
-    a.should == ["hello\nworld\n\n", "and\nuniverse\n\n"]
+  context "when passed '' (paragraph mode, broken by 2 or more successive newlines)" do
+    it "replaces multiple newlines with only two ones" do
+      a = []
+      "hello\nworld\n\n\nand\nuniverse\n\n\n\n\n".send(@method, '') { |s| a << s }
+      a.should == ["hello\nworld\n\n", "and\nuniverse\n\n"]
 
-    a = []
-    "hello\nworld\n\n\nand\nuniverse\n\n\n\n\ndog".send(@method, '') { |s| a << s }
-    a.should == ["hello\nworld\n\n", "and\nuniverse\n\n", "dog"]
+      a = []
+      "hello\nworld\n\n\nand\nuniverse\n\n\n\n\ndog".send(@method, '') { |s| a << s }
+      a.should == ["hello\nworld\n\n", "and\nuniverse\n\n", "dog"]
+    end
+
+    it 'handles \r\n-style newlines' do
+      a = []
+      "hello\nworld\r\n\r\n\nand\nuniverse\n\r\n\n\n\n".send(@method, '') { |s| a << s }
+      a.should == ["hello\nworld\r\n\r\n", "and\nuniverse\n\r\n"]
+
+      a = []
+      "hello\r\nworld\n\n\nand\nuniverse\n\n\n\r\n\r\ndog".send(@method, '') { |s| a << s }
+      a.should == ["hello\r\nworld\n\n", "and\nuniverse\n\n", "dog"]
+    end
+
+    it "removes trailing newlines with `chomp: true`" do
+      a = []
+      "hello\nworld\n\n\nand\nuniverse\n\n\n\n\n".send(@method, '', chomp: true) { |s| a << s }
+      a.should == ["hello\nworld", "and\nuniverse"]
+
+      a = []
+      "hello\nworld\n\n\nand\nuniverse\n\n\n\n\ndog".send(@method, '', chomp: true) { |s| a << s }
+      a.should == ["hello\nworld", "and\nuniverse", "dog"]
+    end
   end
 
   describe "uses $/" do

--- a/spec/tags/core/string/each_line_tags.txt
+++ b/spec/tags/core/string/each_line_tags.txt
@@ -1,1 +1,0 @@
-fails:String#each_line yields paragraphs (broken by 2 or more successive newlines) when passed '' and replaces multiple newlines with only two ones

--- a/spec/tags/core/string/lines_tags.txt
+++ b/spec/tags/core/string/lines_tags.txt
@@ -1,1 +1,0 @@
-fails:String#lines yields paragraphs (broken by 2 or more successive newlines) when passed '' and replaces multiple newlines with only two ones

--- a/src/main/ruby/truffleruby/core/string.rb
+++ b/src/main/ruby/truffleruby/core/string.rb
@@ -532,7 +532,7 @@ class String
       char = Primitive.string_chr_at(self, index)
 
       if char
-        index += inspect_char(enc, result_encoding, ascii, unicode, index, char, result)
+        index += Truffle::StringOperations.inspect_char(self, enc, result_encoding, ascii, unicode, index, char, result)
       else
         result << "\\x#{getbyte(index).to_s(16).upcase}"
         index += 1
@@ -542,84 +542,6 @@ class String
     result << '"'
 
     result.force_encoding(result_encoding)
-  end
-
-  private def inspect_char(enc, result_encoding, ascii, unicode, index, char, result)
-    consumed = char.bytesize
-    codepoint = char.ord
-
-    if (ascii or unicode) and (codepoint >= 7 and codepoint <= 92)
-      escaped = nil
-
-      case codepoint
-      when 7  # \a
-        escaped = '\a'
-      when 8  # \b
-        escaped = '\b'
-      when 9  # \t
-        escaped = '\t'
-      when 10 # \n
-        escaped = '\n'
-      when 11 # \v
-        escaped = '\v'
-      when 12 # \f
-        escaped = '\f'
-      when 13 # \r
-        escaped = '\r'
-      when 27 # \e
-        escaped = '\e'
-      when 34 # \"
-        escaped = '\"'
-      when 35 # #
-        case getbyte(index + 1)
-        when 36   # $
-          escaped = '\#$'
-          consumed += 1
-        when 64   # @
-          escaped = '\#@'
-          consumed += 1
-        when 123  # {
-          escaped = '\#{'
-          consumed += 1
-        end
-      when 92 # \\
-        escaped = '\\\\'
-      end
-
-      if escaped
-        result << escaped
-        return consumed
-      end
-    end
-
-    printable = Primitive.character_printable?(codepoint, enc)
-    if printable && (enc == result_encoding || (ascii && char.ascii_only?))
-      result << char
-    # < 0x7F from https://github.com/ruby/ruby/blob/12f7ba5ed4a07855d6a9429aa627211db3655ca7/string.c#L6049-L6050
-    # Exclude UTF-8 (unicode && ascii) because it was already checked just above
-    elsif printable && unicode && !ascii && codepoint < 0x7F
-      result << codepoint
-    else
-      escaped = codepoint.to_s(16).upcase
-
-      if unicode
-        if codepoint < 0x10000
-          pad = '0' * (4 - escaped.bytesize)
-          result << "\\u#{pad}#{escaped}"
-        else
-          result << "\\u{#{escaped}}"
-        end
-      else
-        if codepoint < 0x100
-          pad = '0' * (2 - escaped.bytesize)
-          result << "\\x#{pad}#{escaped}"
-        else
-          result << "\\x{#{escaped}}"
-        end
-      end
-    end
-
-    consumed
   end
 
   def prepend(*others)
@@ -861,11 +783,11 @@ class String
     # normal line breaking.
     if sep.empty?
       while pos < bytesize
-        nxt = index_after_consecutive_newlines(str, pos) || break
+        nxt = Truffle::StringOperations.index_after_consecutive_newlines(str, pos) || break
         match_size = nxt - pos
 
         while nxt < bytesize
-          nxt += newline_length(str, nxt) || break
+          nxt += Truffle::StringOperations.newline_length(str, nxt) || break
         end
 
         # string ends with \n's
@@ -901,30 +823,6 @@ class String
     end
 
     self
-  end
-
-  private def index_after_consecutive_newlines(str, index)
-    while true
-      # First newline
-      index = Primitive.find_string(str, "\n", index)
-      break unless index
-      index += 1
-      # Second newline
-      if (next_newline_length = newline_length(str, index))
-        return index + next_newline_length
-      end
-    end
-  end
-
-  private def newline_length(str, index)
-    case str.getbyte(index)
-    when 10
-      1
-    when 13
-      2 if str.getbyte(index + 1) == 10
-    else
-      nil
-    end
   end
 
   def lines(sep = $/, chomp: false, &block)

--- a/src/main/ruby/truffleruby/core/string.rb
+++ b/src/main/ruby/truffleruby/core/string.rb
@@ -860,17 +860,13 @@ class String
     # is used so infrequently, we'll handle it completely separately from
     # normal line breaking.
     if sep.empty?
-      sep = "\n\n"
-
       while pos < bytesize
-        nxt = Primitive.find_string(str, sep, pos)
-        break unless nxt
-
-        while Primitive.string_chr_at(str, nxt)&.ord == 10 and nxt < bytesize
-          nxt += 1
-        end
-
+        nxt = index_after_consecutive_newlines(str, pos) || break
         match_size = nxt - pos
+
+        while nxt < bytesize
+          nxt += newline_length(str, nxt) || break
+        end
 
         # string ends with \n's
         break if pos == bytesize
@@ -905,6 +901,30 @@ class String
     end
 
     self
+  end
+
+  private def index_after_consecutive_newlines(str, index)
+    while true
+      # First newline
+      index = Primitive.find_string(str, "\n", index)
+      break unless index
+      index += 1
+      # Second newline
+      if (next_newline_length = newline_length(str, index))
+        return index + next_newline_length
+      end
+    end
+  end
+
+  private def newline_length(str, index)
+    case str.getbyte(index)
+    when 10
+      1
+    when 13
+      2 if str.getbyte(index + 1) == 10
+    else
+      nil
+    end
   end
 
   def lines(sep = $/, chomp: false, &block)

--- a/src/main/ruby/truffleruby/core/string.rb
+++ b/src/main/ruby/truffleruby/core/string.rb
@@ -853,20 +853,20 @@ class String
 
     pos = 0
 
-    duped = dup
+    str = Primitive.dup_as_string_instance(self)
+    bytesize = str.bytesize
 
     # If the separator is empty, we're actually in paragraph mode. This
     # is used so infrequently, we'll handle it completely separately from
     # normal line breaking.
     if sep.empty?
       sep = "\n\n"
-      data = bytes
 
       while pos < bytesize
-        nxt = Primitive.find_string(self, sep, pos)
+        nxt = Primitive.find_string(str, sep, pos)
         break unless nxt
 
-        while data[nxt] == 10 and nxt < bytesize
+        while Primitive.string_chr_at(str, nxt)&.ord == 10 and nxt < bytesize
           nxt += 1
         end
 
@@ -875,38 +875,32 @@ class String
         # string ends with \n's
         break if pos == bytesize
 
-        str = byteslice pos, match_size
-        yield Primitive.dup_as_string_instance(maybe_chomp.call(str)) unless str.empty?
-
-        # detect mutation within the block
-        if duped != self
-          raise RuntimeError, 'string modified while iterating'
-        end
+        slice = str.byteslice pos, match_size
+        yield Primitive.dup_as_string_instance(maybe_chomp.call(slice)) unless slice.empty?
 
         pos = nxt
       end
 
       # No more separates, but we need to grab the last part still.
-      fin = byteslice pos, bytesize - pos
+      fin = str.byteslice pos, bytesize - pos
       yield Primitive.dup_as_string_instance(maybe_chomp.call(fin)) if fin and !fin.empty?
     else
       # This is the normal case.
       pat_size = sep.bytesize
-      unmodified_self = Primitive.dup_as_string_instance(self)
 
       while pos < bytesize
-        nxt = Primitive.find_string(unmodified_self, sep, pos)
+        nxt = Primitive.find_string(str, sep, pos)
         break unless nxt
 
         match_size = nxt - pos
-        str = unmodified_self.byteslice pos, match_size + pat_size
-        yield Primitive.dup_as_string_instance(maybe_chomp.call(str)) unless str.empty?
+        slice = str.byteslice pos, match_size + pat_size
+        yield Primitive.dup_as_string_instance(maybe_chomp.call(slice)) unless slice.empty?
 
         pos = nxt + pat_size
       end
 
       # No more separates, but we need to grab the last part still.
-      fin = unmodified_self.byteslice pos, bytesize - pos
+      fin = str.byteslice pos, bytesize - pos
       yield Primitive.dup_as_string_instance(maybe_chomp.call(fin)) unless fin.empty?
     end
 

--- a/src/main/ruby/truffleruby/core/truffle/string_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/string_operations.rb
@@ -438,5 +438,107 @@ module Truffle
 
       Primitive.string_splice(string, replacement, bi, bs, enc)
     end
+
+    def self.inspect_char(string, enc, result_encoding, ascii, unicode, index, char, result)
+      consumed = char.bytesize
+      codepoint = char.ord
+
+      if (ascii or unicode) and (codepoint >= 7 and codepoint <= 92)
+        escaped = nil
+
+        case codepoint
+        when 7  # \a
+          escaped = '\a'
+        when 8  # \b
+          escaped = '\b'
+        when 9  # \t
+          escaped = '\t'
+        when 10 # \n
+          escaped = '\n'
+        when 11 # \v
+          escaped = '\v'
+        when 12 # \f
+          escaped = '\f'
+        when 13 # \r
+          escaped = '\r'
+        when 27 # \e
+          escaped = '\e'
+        when 34 # \"
+          escaped = '\"'
+        when 35 # #
+          case string.getbyte(index + 1)
+          when 36   # $
+            escaped = '\#$'
+            consumed += 1
+          when 64   # @
+            escaped = '\#@'
+            consumed += 1
+          when 123  # {
+            escaped = '\#{'
+            consumed += 1
+          end
+        when 92 # \\
+          escaped = '\\\\'
+        end
+
+        if escaped
+          result << escaped
+          return consumed
+        end
+      end
+
+      printable = Primitive.character_printable?(codepoint, enc)
+      if printable && (enc == result_encoding || (ascii && char.ascii_only?))
+        result << char
+        # < 0x7F from https://github.com/ruby/ruby/blob/12f7ba5ed4a07855d6a9429aa627211db3655ca7/string.c#L6049-L6050
+        # Exclude UTF-8 (unicode && ascii) because it was already checked just above
+      elsif printable && unicode && !ascii && codepoint < 0x7F
+        result << codepoint
+      else
+        escaped = codepoint.to_s(16).upcase
+
+        if unicode
+          if codepoint < 0x10000
+            pad = '0' * (4 - escaped.bytesize)
+            result << "\\u#{pad}#{escaped}"
+          else
+            result << "\\u{#{escaped}}"
+          end
+        else
+          if codepoint < 0x100
+            pad = '0' * (2 - escaped.bytesize)
+            result << "\\x#{pad}#{escaped}"
+          else
+            result << "\\x{#{escaped}}"
+          end
+        end
+      end
+
+      consumed
+    end
+
+    def self.index_after_consecutive_newlines(str, index)
+      while true
+        # First newline
+        index = Primitive.find_string(str, "\n", index)
+        break unless index
+        index += 1
+        # Second newline
+        if (next_newline_length = newline_length(str, index))
+          return index + next_newline_length
+        end
+      end
+    end
+
+    def self.newline_length(str, index)
+      case str.getbyte(index)
+      when 10
+        1
+      when 13
+        2 if str.getbyte(index + 1) == 10
+      else
+        nil
+      end
+    end
   end
 end


### PR DESCRIPTION
First commit is a bit of a cleanup for destructive methods called during the block with some theoretical more correct behavior.
Second commit fixes the untagged specs and adds a few more specs.

- [x] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
