### PR TITLE
Undefine `Refinement#{append,prepend}_features`

### DIFF
--- a/spec/tags/core/refinement/append_features_tags.txt
+++ b/spec/tags/core/refinement/append_features_tags.txt
@@ -1,1 +1,0 @@
-fails:Refinement#append_features is not defined

--- a/spec/tags/core/refinement/prepend_features_tags.txt
+++ b/spec/tags/core/refinement/prepend_features_tags.txt
@@ -1,1 +1,0 @@
-fails:Refinement#prepend_features is not defined

--- a/src/main/ruby/truffleruby/core/refinement.rb
+++ b/src/main/ruby/truffleruby/core/refinement.rb
@@ -11,6 +11,8 @@
 
 class Refinement < Module
 
+  undef_method :append_features
+  undef_method :prepend_features
   undef_method :extend_object
 
   def import_methods(*modules)


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/18270
`extend_object` was already done in https://github.com/truffleruby/truffleruby/commit/de83d7dabc7453db4d1ca22ee6c3770ee27a4ca5

- [ ] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
