### PR TITLE
Update `Kernel#Integer` coercion

### DIFF
--- a/spec/ruby/core/kernel/Integer_spec.rb
+++ b/spec/ruby/core/kernel/Integer_spec.rb
@@ -14,7 +14,9 @@ describe :kernel_integer, shared: true do
     obj = mock("object")
     obj.should_receive(:to_int).and_return("1")
     obj.should_receive(:to_i).and_return(nil)
-    -> { Integer(obj) }.should.raise(TypeError)
+    -> {
+      Integer(obj)
+    }.should raise_consistent_error(TypeError, "can't convert MockObject into Integer (MockObject#to_i gives nil)")
   end
 
   it "return a result of to_i when to_int does not return an Integer" do
@@ -24,8 +26,31 @@ describe :kernel_integer, shared: true do
     Integer(obj).should == 42
   end
 
+  it "returns a result of to_str" do
+    obj = mock("obj")
+    obj.should_receive(:to_str).and_return("1")
+
+    Integer(obj).should == 1
+  end
+
+  it "returns a result of to_int when both to_int and to_str are defined" do
+    obj = mock("obj")
+    obj.should_receive(:to_int).and_return(1)
+    obj.should_not_receive(:to_str)
+
+    Integer(obj).should == 1
+  end
+
+  it "returns a result of to_str when both to_str and to_i are defined" do
+    obj = mock("obj")
+    obj.should_receive(:to_str).and_return("1")
+    obj.should_not_receive(:to_i)
+
+    Integer(obj).should == 1
+  end
+
   it "raises a TypeError when passed nil" do
-    -> { Integer(nil) }.should.raise(TypeError)
+    -> { Integer(nil) }.should.raise(TypeError, "can't convert nil into Integer")
   end
 
   it "returns an Integer object" do
@@ -67,18 +92,24 @@ describe :kernel_integer, shared: true do
   it "raises a TypeError if to_i returns a value that is not an Integer" do
     obj = mock("object")
     obj.should_receive(:to_i).and_return("1")
-    -> { Integer(obj) }.should.raise(TypeError)
+    -> {
+      Integer(obj)
+    }.should raise_consistent_error(TypeError, "can't convert MockObject into Integer (MockObject#to_i gives String)")
   end
 
   it "raises a TypeError if no to_int or to_i methods exist" do
     obj = mock("object")
-    -> { Integer(obj) }.should.raise(TypeError)
+    -> {
+      Integer(obj)
+    }.should.raise(TypeError, "can't convert MockObject into Integer")
   end
 
   it "raises a TypeError if to_int returns nil and no to_i exists" do
     obj = mock("object")
     obj.should_receive(:to_i).and_return(nil)
-    -> { Integer(obj) }.should.raise(TypeError)
+    -> {
+      Integer(obj)
+    }.should raise_consistent_error(TypeError, "can't convert MockObject into Integer (MockObject#to_i gives nil)")
   end
 
   it "raises a FloatDomainError when passed NaN" do
@@ -576,7 +607,7 @@ describe :kernel_integer_string_base, shared: true do
   end
 
   it "raises an ArgumentError if a base is given for a non-String value" do
-    -> { Integer(98, 15) }.should.raise(ArgumentError)
+    -> { Integer(98, 15) }.should.raise(ArgumentError, "base specified for non string value")
   end
 
   it "tries to convert the base to an integer using to_int" do

--- a/spec/tags/core/kernel/Integer_tags.txt
+++ b/spec/tags/core/kernel/Integer_tags.txt
@@ -1,2 +1,0 @@
-fails:Kernel.Integer raises a TypeError if it is not an integer and does not respond to #to_i
-fails:Kernel#Integer raises a TypeError if it is not an integer and does not respond to #to_i

--- a/src/main/ruby/truffleruby/core/kernel.rb
+++ b/src/main/ruby/truffleruby/core/kernel.rb
@@ -103,8 +103,7 @@ module Kernel
 
   def Integer(obj, base = 0, exception: true)
     obj = Truffle::Interop.unbox_if_needed(obj)
-    converted_base = Truffle::Type.rb_check_to_integer(base, :to_int)
-    base = Primitive.nil?(converted_base) ? 0 : converted_base
+    base = Primitive.convert_with_to_int(base)
     raise_exception = !Primitive.false?(exception)
 
     if Primitive.is_a?(obj, String)
@@ -113,7 +112,7 @@ module Kernel
       bad_base_check = Proc.new do
         if base != 0
           return nil unless raise_exception
-          raise ArgumentError, 'base is only valid for String values'
+          raise ArgumentError, 'base specified for non string value'
         end
       end
       case obj
@@ -132,17 +131,23 @@ module Kernel
         return nil unless raise_exception
         raise TypeError, "can't convert nil into Integer"
       else
-        if base != 0
-          converted_to_str_obj = Truffle::Type.rb_check_convert_type(obj, String, :to_str)
-          return Primitive.string_to_inum(converted_to_str_obj, base, true, raise_exception) unless Primitive.nil? converted_to_str_obj
-          return nil unless raise_exception
-          raise ArgumentError, 'base is only valid for String values'
-        end
         converted_to_int_obj = Truffle::Type.rb_check_to_integer(obj, :to_int)
-        return converted_to_int_obj unless Primitive.nil? converted_to_int_obj
+        unless Primitive.nil? converted_to_int_obj
+          bad_base_check.call
+          return converted_to_int_obj
+        end
 
-        return Truffle::Type.rb_check_to_integer(obj, :to_i) unless raise_exception
-        Primitive.convert_type(obj, Integer, :to_i)
+        converted_to_str_obj = Truffle::Type.rb_check_convert_type(obj, String, :to_str)
+        unless Primitive.nil? converted_to_str_obj
+          return Primitive.string_to_inum(converted_to_str_obj, base, true, raise_exception)
+        end
+
+        bad_base_check.call
+        if raise_exception
+          Primitive.convert_type(obj, Integer, :to_i)
+        else
+          Truffle::Type.rb_check_to_integer(obj, :to_i)
+        end
       end
     end
   end

--- a/src/main/ruby/truffleruby/core/type.rb
+++ b/src/main/ruby/truffleruby/core/type.rb
@@ -143,7 +143,7 @@ module Truffle
 
     def self.conversion_mismatch(obj, cls, meth, res)
       oc = Primitive.class(obj)
-      raise TypeError, "can't convert #{oc} into #{cls} (#{oc}##{meth} gives #{Primitive.class(res)})"
+      raise TypeError, "can't convert #{oc} into #{cls} (#{oc}##{meth} gives #{to_class_name(res)})"
     end
 
     def self.fits_into_int?(val)

--- a/test/mri/excludes/TestInteger.rb
+++ b/test/mri/excludes/TestInteger.rb
@@ -1,6 +1,4 @@
 exclude :test_Integer, "[Encoding::CompatibilityError] exception expected, not #<ArgumentError: invalid value for Integer(): 0>."
-exclude :test_Integer_when_to_str, "TypeError: can't convert Object into Integer"
-exclude :test_Integer_with_base, "TypeError expected but nothing was raised."
 exclude :test_Integer_with_exception_keyword, "RuntimeError: "
 exclude :test_Integer_with_invalid_exception, "ArgumentError expected but nothing was raised."
 exclude :test_bitwise_and_with_integer_coercion, "TypeError: #<Class:0x4c8> can't be coerced into Integer"


### PR DESCRIPTION
* Coerce base https://bugs.ruby-lang.org/issues/19349
* Coerce with to_str https://bugs.ruby-lang.org/issues/18998

Currently to_str raises when it doesn't return a string, which is inconsistent. I openend https://bugs.ruby-lang.org/issues/22080 for that

- [ ] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
