### PR TITLE
Fix Enumerator::Lazy value packing of source yields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Compatibility:
 * Better compatibility for `String#each_line`/`String#lines` with an empty string argument (#4267, @earlopain).
 * Remove `..` from `Dir.glob` when `File::FNM_DOTMATCH` is given (#4269, @earlopain).
 * Better compatibility for `Data#initialize` and `Data#deconstruct_keys` with convertable keys (#4251, @earlopain)
+* Fix `Enumerator::Lazy` value packing of source yields to match CRuby (0-arg yield → `nil`, multi-arg → `Array`) (#4272, @sampokuokkanen).
 
 Performance:
 

--- a/src/main/ruby/truffleruby/core/enumerator.rb
+++ b/src/main/ruby/truffleruby/core/enumerator.rb
@@ -358,6 +358,9 @@ class Enumerator
     end
     private(*aliases)
 
+    alias_method :_enumerable_each, :each
+    private :_enumerable_each
+
     class StopLazyError < Exception # rubocop:disable Lint/InheritException
     end
 
@@ -367,7 +370,7 @@ class Enumerator
 
       super(size) do |yielder, *each_args|
         begin
-          receiver.each(*each_args) do |*args|
+          iterate_chain(receiver, *each_args) do |*args|
             yield yielder, *args
           end
         rescue StopLazyError
@@ -376,6 +379,32 @@ class Enumerator
       end
 
       self
+    end
+
+    # Pack source args for the consumer (rb_enum_values_pack in enum.c):
+    # 0 -> nil, 1 -> value, N -> Array.
+    # Prepended so it doesn't appear in Lazy.public_instance_methods(false)
+    # Chain-internal stages bypass via iterate_chain.
+    module ConsumerPacking
+      def each(*args, **kwargs, &user_block)
+        return super unless user_block
+
+        super(*args, **kwargs) do
+          user_block.call(Primitive.single_block_arg)
+        end
+      end
+    end
+    private_constant :ConsumerPacking
+    prepend ConsumerPacking
+
+    # For Lazy receivers, use _enumerable_each so stage blocks see raw args
+    # (CRuby equivalent: lazyenum_yield_values unpacking LAZY_MEMO_PACKED in enumerator.c).
+    private def iterate_chain(receiver, *args, **kwargs, &block)
+      if Primitive.is_a?(receiver, Lazy)
+        receiver.__send__(:_enumerable_each, *args, **kwargs, &block)
+      else
+        receiver.each(*args, **kwargs, &block)
+      end
     end
 
     def to_enum(method_name = :each, *method_args, **method_kwargs, &block)


### PR DESCRIPTION
Apply CRuby's rb_enum_values_pack rule at the consumer boundary (0 args -> nil, 1 arg -> value, N args -> Array) via Primitive.single_block_arg. The override lives on a prepended ConsumerPacking module so Lazy.public_instance_methods(false) still matches MRI, which defines no Lazy#each.

Chained stages bypass via a private iterate_chain helper that routes through a pre-override _enumerable_each alias, so stage user blocks still see raw args, matching CRuby's LAZY_MEMO_PACKED unpacking in enumerator.c.

Specced via Enumerable#take / Enumerator::Lazy#take shared examples in https://github.com/ruby/spec/pull/1363.

- [x] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
