### PR TITLE
Accept `Complex` with zero imaginary part in `Complex.{rect,polar}`

### DIFF
--- a/spec/ruby/core/complex/shared/rect.rb
+++ b/spec/ruby/core/complex/shared/rect.rb
@@ -85,6 +85,24 @@ describe :complex_rect_class, shared: true do
     end
   end
 
+  describe "when passed a Complex" do
+    it "raises a TypeError when the imaginary part is not zero" do
+      -> {
+        Complex.send(@method, 1.0+1i, 2)
+      }.should.raise(TypeError)
+
+      -> {
+        Complex.send(@method, 1.0, 2i)
+      }.should.raise(TypeError)
+    end
+
+    it "ignores the imaginary part if it is zero" do
+      result = Complex.send(@method, 1.0+0i, 2+0.0i)
+      result.real.should == 1.0
+      result.imag.should == 2
+    end
+  end
+
   describe "passed a non-Numeric" do
     it "raises TypeError" do
       -> { Complex.send(@method, :sym) }.should.raise(TypeError)

--- a/spec/tags/core/complex/polar_tags.txt
+++ b/spec/tags/core/complex/polar_tags.txt
@@ -1,1 +1,0 @@
-fails:Complex.polar computes the real values of the real & imaginary parts from the polar form

--- a/src/main/ruby/truffleruby/core/complex.rb
+++ b/src/main/ruby/truffleruby/core/complex.rb
@@ -56,13 +56,15 @@ class Complex < Numeric
   end
 
   def Complex.rect(real, imag = 0)
-    raise TypeError, 'not a real' unless Primitive.check_real?(real) && Primitive.check_real?(imag)
+    real = Truffle::ComplexOperations.extract_real(real)
+    imag = Truffle::ComplexOperations.extract_real(imag)
     new(real, imag)
   end
   class << self; alias_method :rectangular, :rect end
 
   def Complex.polar(r, theta = 0)
-    raise TypeError, 'not a real' unless Primitive.check_real?(r) && Primitive.check_real?(theta)
+    r = Truffle::ComplexOperations.extract_real(r)
+    theta = Truffle::ComplexOperations.extract_real(theta)
 
     Complex(r*Math.cos(theta), r*Math.sin(theta))
   end

--- a/src/main/ruby/truffleruby/core/truffle/complex_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/complex_operations.rb
@@ -64,5 +64,17 @@ module Truffle
 
       Complex.rect(real, imag)
     end
+
+    def self.extract_real(numeric)
+      case numeric
+      when Integer, Float, Rational
+        return numeric
+      when Complex
+        return numeric.real if numeric.imag.zero?
+      when Numeric
+        return numeric if numeric.real?
+      end
+      raise TypeError, 'not a real'
+    end
   end
 end


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/19004 added this spec (issue only somewhat related)

Removes `Primitive.check_real?` since it's now only used in one place. It was originally moved to a primitive in https://github.com/truffleruby/truffleruby/commit/ac50c7beb69a197f3fe46d09492150a3b22748b0. Seems fine but let me know if I should move that back.

- [ ] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
