### PR TITLE
Make `BasicSocket.do_not_reverse_lookup` shared between subclasses

### DIFF
--- a/lib/truffle/socket/basic_socket.rb
+++ b/lib/truffle/socket/basic_socket.rb
@@ -30,6 +30,8 @@
 class BasicSocket < IO
   undef_method :initialize
 
+  @do_not_reverse_lookup = true
+
   def self.for_fd(fd)
     sock = allocate
 
@@ -43,12 +45,11 @@ class BasicSocket < IO
   end
 
   def self.do_not_reverse_lookup=(setting)
-    @no_reverse_lookup = setting
+    BasicSocket.instance_variable_set(:@do_not_reverse_lookup, setting)
   end
 
   def self.do_not_reverse_lookup
-    @no_reverse_lookup = true unless defined?(@no_reverse_lookup)
-    @no_reverse_lookup
+    BasicSocket.instance_variable_get(:@do_not_reverse_lookup)
   end
 
   def do_not_reverse_lookup=(setting)

--- a/lib/truffle/socket/tcp_socket.rb
+++ b/lib/truffle/socket/tcp_socket.rb
@@ -54,7 +54,7 @@ class TCPSocket < IPSocket
     socket.autoclose = false
     socket.close
 
-    @no_reverse_lookup = Primitive.class(self).do_not_reverse_lookup
+    @no_reverse_lookup = BasicSocket.do_not_reverse_lookup
     setup(fd, nil, true)
     binmode
   end

--- a/lib/truffle/socket/udp_socket.rb
+++ b/lib/truffle/socket/udp_socket.rb
@@ -29,7 +29,7 @@
 
 class UDPSocket < IPSocket
   def initialize(family = Socket::AF_INET)
-    @no_reverse_lookup = Primitive.class(self).do_not_reverse_lookup
+    @no_reverse_lookup = BasicSocket.do_not_reverse_lookup
     @family            = Truffle::Socket.address_family(family)
 
     descriptor = Truffle::Socket::Foreign

--- a/spec/tags/library/socket/basicsocket/do_not_reverse_lookup_tags.txt
+++ b/spec/tags/library/socket/basicsocket/do_not_reverse_lookup_tags.txt
@@ -1,2 +1,0 @@
-fails:BasicSocket#do_not_reverse_lookup for an TCPSocket.new socket is false when BasicSocket.do_not_reverse_lookup is false
-fails:BasicSocket#do_not_reverse_lookup for an TCPServer#accept socket is false when BasicSocket.do_not_reverse_lookup is false


### PR DESCRIPTION
It's what CRuby does.

The change to replace self with `BasicSocket` is not really necessary but there's also no point in doing it the other way.

- [ ] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
