### PR TITLE
Fix source location for `case in ... in ... end`

### DIFF
--- a/src/main/java/org/truffleruby/parser/YARPBaseTranslator.java
+++ b/src/main/java/org/truffleruby/parser/YARPBaseTranslator.java
@@ -188,12 +188,15 @@ public abstract class YARPBaseTranslator extends AbstractNodeVisitor<RubyNode> {
         return rubyNode;
     }
 
-    protected static void assignPositionOnly(Nodes.Node yarpNode, RubyNode rubyNode) {
+    /* TODO: this should never be called on a SequenceNode, otherwise the position might be lost when the SequenceNode
+     * is flattened in another SequenceNode. */
+    protected static RubyNode assignPositionOnly(Nodes.Node yarpNode, RubyNode rubyNode) {
         if (yarpNode.length == 0 && yarpNode.startOffset == 0) {
             // (0, 0) means unknown location, so do not set the source section and keep the node as !hasSource()
         } else {
             rubyNode.unsafeSetSourceSection(yarpNode.startOffset, yarpNode.length);
         }
+        return rubyNode;
     }
 
     // assign position based on a list of nodes (arguments list, exception classes list in a rescue section, etc)
@@ -206,6 +209,8 @@ public abstract class YARPBaseTranslator extends AbstractNodeVisitor<RubyNode> {
         rubyNode.unsafeSetSourceSection(first.startOffset, length);
     }
 
+    /* TODO: this should never be called on a SequenceNode, otherwise the position might be lost when the SequenceNode
+     * is flattened in another SequenceNode. */
     protected final void copyNewlineFlag(Nodes.Node yarpNode, RubyNode rubyNode) {
         if (yarpNode.hasNewLineFlag()) {
             if (parseEnvironment.isCoverageEnabled()) {

--- a/src/main/java/org/truffleruby/parser/YARPTranslator.java
+++ b/src/main/java/org/truffleruby/parser/YARPTranslator.java
@@ -424,8 +424,7 @@ public class YARPTranslator extends YARPBaseTranslator {
         // with ensure section
         if (node.ensure_clause != null && node.ensure_clause.statements != null) {
             final RubyNode ensureBlock = node.ensure_clause.accept(this);
-            rubyNode = EnsureNodeGen.create(rubyNode, ensureBlock);
-            assignPositionOnly(node, rubyNode);
+            rubyNode = assignPositionOnly(node, EnsureNodeGen.create(rubyNode, ensureBlock));
         }
 
         return rubyNode;
@@ -971,12 +970,10 @@ public class YARPTranslator extends YARPBaseTranslator {
             elseNode = ifNode;
         }
 
-        final RubyNode ifNode = elseNode;
+        final RubyNode ifNode = assignPositionAndFlags(node, elseNode);
 
         // A top-level block assigns the temp then runs the if
-        final RubyNode ret = sequence(writePredicateNode, ifNode);
-
-        return assignPositionAndFlags(node, ret);
+        return sequence(writePredicateNode, ifNode);
     }
 
     @Override


### PR DESCRIPTION
* Notably the implicit `else` would get the location of the SequenceNode which might have been flattened in another SequenceNode and e.g. return the first line of the method instead of the line of the `case`.

- [x] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
