### PR TITLE
Convert to a MutableTruffleString and write inplace for String#bytesplice when writing the same number of bytes as the value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Compatibility:
 
 Performance:
 
+* Convert to a `MutableTruffleString` and write inplace for `String#bytesplice` when writing the same number of bytes as the value (#2336, #2599, @eregon).
 
 Incompatible Changes:
 

--- a/src/main/java/org/truffleruby/core/string/StringHelperNodes.java
+++ b/src/main/java/org/truffleruby/core/string/StringHelperNodes.java
@@ -29,6 +29,7 @@ import com.oracle.truffle.api.profiles.InlinedBranchProfile;
 import com.oracle.truffle.api.profiles.InlinedConditionProfile;
 import com.oracle.truffle.api.strings.AbstractTruffleString;
 import com.oracle.truffle.api.strings.InternalByteArray;
+import com.oracle.truffle.api.strings.MutableTruffleString;
 import com.oracle.truffle.api.strings.TruffleString;
 import com.oracle.truffle.api.strings.TruffleString.ErrorHandling;
 import com.oracle.truffle.api.strings.TruffleStringIterator;
@@ -647,6 +648,29 @@ public abstract class StringHelperNodes {
             TruffleString tstring = asTruffleStringNode.execute(string.tstring, libString.getTEncoding(node, string));
             string.setTString(tstring);
             return tstring;
+        }
+    }
+
+    @GenerateInline
+    @GenerateCached(false)
+    public abstract static class ToMutableTruffleStringNode extends RubyBaseNode {
+
+        public abstract MutableTruffleString execute(Node node, RubyString string);
+
+        @Specialization
+        static MutableTruffleString toMutable(Node node, RubyString string,
+                @Cached RubyStringLibrary libString,
+                @Cached InlinedConditionProfile isMutableProfile,
+                @Cached(inline = false) MutableTruffleString.AsMutableTruffleStringNode asMutableTruffleStringNode) {
+            var tstring = string.tstring;
+            if (isMutableProfile.profile(node, tstring instanceof MutableTruffleString)) {
+                return (MutableTruffleString) tstring;
+            } else {
+                MutableTruffleString mutable = asMutableTruffleStringNode.execute(tstring,
+                        libString.getTEncoding(node, string));
+                string.setTString(mutable);
+                return mutable;
+            }
         }
     }
 

--- a/src/main/java/org/truffleruby/core/string/StringNodes.java
+++ b/src/main/java/org/truffleruby/core/string/StringNodes.java
@@ -115,6 +115,7 @@ import org.truffleruby.core.range.RangeNodes;
 import org.truffleruby.core.regexp.RubyRegexp;
 import org.truffleruby.core.string.StringHelperNodes.DeleteBangStringsNode;
 import org.truffleruby.core.string.StringHelperNodes.SingleByteOptimizableNode;
+import org.truffleruby.core.string.StringHelperNodes.ToMutableTruffleStringNode;
 import org.truffleruby.extra.ffi.Pointer;
 import org.truffleruby.interop.ToJavaStringNode;
 import org.truffleruby.language.Nil;
@@ -1714,32 +1715,18 @@ public abstract class StringNodes {
 
         public abstract int execute(Node node, RubyString string, int index, int value);
 
-        @Specialization(guards = "tstring.isMutable()")
-        static int mutable(Node node, RubyString string, int index, int value,
-                @Cached @Shared StringHelperNodes.CheckIndexNode checkIndexNode,
-                @Cached @Shared RubyStringLibrary libString,
+        @Specialization
+        static int setByte(Node node, RubyString string, int index, int value,
+                @Cached StringHelperNodes.CheckIndexNode checkIndexNode,
+                @Cached RubyStringLibrary libString,
                 @Bind("string.tstring") AbstractTruffleString tstring,
-                @Cached(inline = false) @Shared MutableTruffleString.WriteByteNode writeByteNode) {
+                @Cached ToMutableTruffleStringNode toMutableTruffleStringNode,
+                @Cached(inline = false) MutableTruffleString.WriteByteNode writeByteNode) {
             var tencoding = libString.getTEncoding(node, string);
             final int normalizedIndex = checkIndexNode.execute(node, index, tstring.byteLength(tencoding));
 
-            writeByteNode.execute((MutableTruffleString) tstring, normalizedIndex, (byte) value, tencoding);
-            return value;
-        }
-
-        @Specialization(guards = "!tstring.isMutable()")
-        static int immutable(Node node, RubyString string, int index, int value,
-                @Cached @Shared StringHelperNodes.CheckIndexNode checkIndexNode,
-                @Cached @Shared RubyStringLibrary libString,
-                @Bind("string.tstring") AbstractTruffleString tstring,
-                @Cached(inline = false) MutableTruffleString.AsMutableTruffleStringNode asMutableTruffleStringNode,
-                @Cached(inline = false) @Shared MutableTruffleString.WriteByteNode writeByteNode) {
-            var tencoding = libString.getTEncoding(node, string);
-            final int normalizedIndex = checkIndexNode.execute(node, index, tstring.byteLength(tencoding));
-
-            MutableTruffleString mutableTString = asMutableTruffleStringNode.execute(tstring, tencoding);
-            writeByteNode.execute(mutableTString, normalizedIndex, (byte) value, tencoding);
-            string.setTString(mutableTString);
+            MutableTruffleString mutable = toMutableTruffleStringNode.execute(node, string);
+            writeByteNode.execute(mutable, normalizedIndex, (byte) value, tencoding);
             return value;
         }
     }

--- a/src/main/java/org/truffleruby/core/string/StringPrimitiveNodes.java
+++ b/src/main/java/org/truffleruby/core/string/StringPrimitiveNodes.java
@@ -86,6 +86,7 @@ import com.oracle.truffle.api.profiles.InlinedLoopConditionProfile;
 import com.oracle.truffle.api.profiles.LoopConditionProfile;
 import com.oracle.truffle.api.strings.AbstractTruffleString;
 import com.oracle.truffle.api.strings.InternalByteArray;
+import com.oracle.truffle.api.strings.MutableTruffleString;
 import com.oracle.truffle.api.strings.TruffleString;
 import com.oracle.truffle.api.strings.TruffleString.AsTruffleStringNode;
 import com.oracle.truffle.api.strings.TruffleString.CodePointLengthNode;
@@ -116,6 +117,7 @@ import org.truffleruby.core.format.unpack.ArrayResult;
 import org.truffleruby.core.format.unpack.UnpackCompiler;
 import org.truffleruby.core.proc.RubyProc;
 import org.truffleruby.core.string.StringHelperNodes.SingleByteOptimizableNode;
+import org.truffleruby.core.string.StringHelperNodes.ToMutableTruffleStringNode;
 import org.truffleruby.core.support.RubyByteArray;
 import org.truffleruby.core.symbol.RubySymbol;
 import org.truffleruby.interop.ToJavaStringNode;
@@ -2123,16 +2125,52 @@ public abstract class StringPrimitiveNodes {
     @ImportStatic(StringGuards.class)
     public abstract static class StringSplicePrimitiveNode extends PrimitiveArrayArgumentsNode {
 
-        @Specialization(guards = "spliceByteIndex == 0")
-        Object splicePrepend(
+        @Specialization(guards = "byteCountToReplace == otherByteLength", limit = "1")
+        static RubyString spliceSameNumberOfBytes(
                 RubyString string, Object other, int spliceByteIndex, int byteCountToReplace, RubyEncoding rubyEncoding,
+                @Bind Node node,
                 @Cached @Exclusive RubyStringLibrary libString,
                 @Cached @Exclusive RubyStringLibrary libOther,
+                @Cached @Exclusive RubyStringLibrary profileEncoding,
+                @Bind("libOther.byteLength(node, other)") int otherByteLength,
+                @Cached ToMutableTruffleStringNode toMutableTruffleStringNode,
+                @Cached MutableTruffleString.ForceEncodingNode forceEncodingNode,
+                @Cached TruffleString.MaterializeNode materializeNode,
+                @Cached TruffleString.ReadByteNode readByteNode,
+                @Cached MutableTruffleString.WriteByteNode writeByteNode) {
+            var resultEncoding = profileEncoding.profileEncoding(node, rubyEncoding);
+
+            var originalTEncoding = libString.getTEncoding(node, string);
+            MutableTruffleString mutable = toMutableTruffleStringNode.execute(node, string);
+            if (originalTEncoding != resultEncoding.tencoding) {
+                mutable = forceEncodingNode.execute(mutable, originalTEncoding, resultEncoding.tencoding);
+                string.setTString(mutable, resultEncoding);
+            }
+
+            var otherTString = libOther.getTString(node, other);
+            var otherTEncoding = libOther.getTEncoding(node, other);
+
+            materializeNode.execute(otherTString, otherTEncoding);
+            for (int i = 0; i < byteCountToReplace; i++) {
+                byte value = (byte) readByteNode.execute(otherTString, i, otherTEncoding);
+                writeByteNode.execute(mutable, spliceByteIndex + i, value, resultEncoding.tencoding);
+            }
+
+            return string;
+        }
+
+        @Specialization(guards = { "byteCountToReplace != otherByteLength", "spliceByteIndex == 0" }, limit = "1")
+        static RubyString splicePrepend(
+                RubyString string, Object other, int spliceByteIndex, int byteCountToReplace, RubyEncoding rubyEncoding,
+                @Bind Node node,
+                @Cached @Exclusive RubyStringLibrary libString,
+                @Cached @Exclusive RubyStringLibrary libOther,
+                @Bind("libOther.byteLength(node, other)") int otherByteLength,
                 @Cached @Exclusive TruffleString.SubstringByteIndexNode prependSubstringNode,
                 @Cached @Shared TruffleString.ConcatNode concatNode) {
             var original = string.tstring;
-            var originalTEncoding = libString.getTEncoding(this, string);
-            var left = libOther.getTString(this, other);
+            var originalTEncoding = libString.getTEncoding(node, string);
+            var left = libOther.getTString(node, other);
             var right = prependSubstringNode.execute(original, byteCountToReplace,
                     original.byteLength(originalTEncoding) - byteCountToReplace, originalTEncoding, true);
 
@@ -2142,14 +2180,16 @@ public abstract class StringPrimitiveNodes {
             return string;
         }
 
-        @Specialization(guards = "spliceByteIndex == byteLength", limit = "1")
-        static Object spliceAppend(
+        @Specialization(guards = { "byteCountToReplace != otherByteLength", "spliceByteIndex == byteLength" },
+                limit = "1")
+        static RubyString spliceAppend(
                 RubyString string, Object other, int spliceByteIndex, int byteCountToReplace, RubyEncoding rubyEncoding,
                 @Bind Node node,
                 @Cached @Exclusive RubyStringLibrary libString,
                 @Cached @Exclusive RubyStringLibrary libOther,
-                @Cached @Shared TruffleString.ConcatNode concatNode,
-                @Bind("libString.byteLength(node, string)") int byteLength) {
+                @Bind("libString.byteLength(node, string)") int byteLength,
+                @Bind("libOther.byteLength(node, other)") int otherByteLength,
+                @Cached @Shared TruffleString.ConcatNode concatNode) {
             var left = string.tstring;
             var right = libOther.getTString(node, other);
 
@@ -2159,19 +2199,23 @@ public abstract class StringPrimitiveNodes {
             return string;
         }
 
-        @Specialization(guards = { "spliceByteIndex != 0", "spliceByteIndex != byteLength" }, limit = "1")
+        @Specialization(guards = {
+                "byteCountToReplace != otherByteLength",
+                "spliceByteIndex != 0",
+                "spliceByteIndex != byteLength" }, limit = "1")
         static RubyString splice(
                 RubyString string, Object other, int spliceByteIndex, int byteCountToReplace, RubyEncoding rubyEncoding,
+                @Bind Node node,
                 @Cached @Exclusive RubyStringLibrary libString,
                 @Cached @Exclusive RubyStringLibrary libOther,
+                @Bind("libString.byteLength(node, string)") int byteLength,
+                @Bind("libOther.byteLength(node, other)") int otherByteLength,
                 @Cached InlinedConditionProfile insertStringIsEmptyProfile,
                 @Cached InlinedConditionProfile splitRightIsEmptyProfile,
                 @Cached @Exclusive TruffleString.SubstringByteIndexNode leftSubstringNode,
                 @Cached @Exclusive TruffleString.SubstringByteIndexNode rightSubstringNode,
                 @Cached @Shared TruffleString.ConcatNode concatNode,
-                @Cached TruffleString.ForceEncodingNode forceEncodingNode,
-                @Bind("libString.byteLength($node, string)") int byteLength,
-                @Bind Node node) {
+                @Cached TruffleString.ForceEncodingNode forceEncodingNode) {
             var sourceTEncoding = libString.getTEncoding(node, string);
             var resultTEncoding = rubyEncoding.tencoding;
             var source = string.tstring;


### PR DESCRIPTION
* Fixes https://github.com/truffleruby/truffleruby/issues/2336.
* Fixes https://github.com/truffleruby/truffleruby/issues/2599.
* Also necessary for IO::Buffer.

- [x] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
