### PR TITLE
Fix `Enumerable#chunk` to pack multi-argument source yields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Compatibility:
 * Better compatibility for `Data#initialize` and `Data#deconstruct_keys` with convertable keys (#4251, @earlopain)
 * Tolerate uninitialized variables for `RB_GC_GUARD()` (#4274, @eregon).
 * Implement `IO::Buffer` (#4248, @eregon).
+* Fix `Enumerable#chunk` to pack multi-argument source yields to match CRuby (0-arg yield → `nil`, 1-arg → value, multi-arg → `Array`) (#4286, @sampokuokkanen).
 
 Performance:
 

--- a/spec/tags/core/enumerator/lazy/chunk_tags.txt
+++ b/spec/tags/core/enumerator/lazy/chunk_tags.txt
@@ -1,2 +1,0 @@
-fails:Enumerator::Lazy#chunk calls the block with gathered values when yield with multiple arguments
-fails:Enumerator::Lazy#chunk returns an Enumerator if called without a block

--- a/src/main/ruby/truffleruby/core/enumerable.rb
+++ b/src/main/ruby/truffleruby/core/enumerable.rb
@@ -47,7 +47,8 @@ module Enumerable
         duplicated_initial_state = initial_state.dup
         block = Proc.new { |val| original_block.yield(val, duplicated_initial_state) }
       end
-      each do |val|
+      each do
+        val = Primitive.single_block_arg
         key = block.yield(val)
         if Primitive.nil?(key) || (Primitive.is_a?(key, Symbol) && key.to_s[0, 1] == '_')
           yielder.yield [previous, accumulate] unless accumulate.empty?


### PR DESCRIPTION
Match CRuby (0-arg yield → `nil`, 1-arg → value, multi-arg → `Array`. Previously `each do |val|` took only the first value of a multi-argument yield.

Tested by removing spec/tags/core/enumerator/lazy/chunk_tags.txt exclusions. (Though there seem to be no non-lazy chunk tests in ruby/spec, should those tests be shared between normal and lazy?)

Sample:
```ruby
Enumerator.new { |y| y.yield; y.yield 1; y.yield 2, 3 }.chunk { true }.to_a
```
Before:
```ruby
=> [[true, [nil, 1, 2]]]
```
After: 
```ruby
=> [[true, [nil, 1, [2, 3]]]]
```


- [x] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
