### PR TITLE
 Include original method name in method inspect output 

### DIFF
--- a/spec/tags/core/argf/inspect_tags.txt
+++ b/spec/tags/core/argf/inspect_tags.txt
@@ -1,1 +1,0 @@
-fails:ARGF.inspect is an alias of ARGF.to_s

--- a/spec/tags/core/method/inspect_tags.txt
+++ b/spec/tags/core/method/inspect_tags.txt
@@ -1,4 +1,1 @@
 fails:Method#inspect returns a String containing the Module containing the method if object has a singleton class but method is not defined in the singleton class
-fails:Method#inspect shows the original name in parentheses for an aliased method
-fails:Method#inspect shows the source UnboundMethod's name in parentheses for a define_method'd method
-fails:Method#inspect shows the source name when aliasing a define_method'd Kernel method

--- a/spec/tags/core/method/to_s_tags.txt
+++ b/spec/tags/core/method/to_s_tags.txt
@@ -1,4 +1,1 @@
 fails:Method#to_s returns a String containing the Module containing the method if object has a singleton class but method is not defined in the singleton class
-fails:Method#to_s shows the original name in parentheses for an aliased method
-fails:Method#to_s shows the source UnboundMethod's name in parentheses for a define_method'd method
-fails:Method#to_s shows the source name when aliasing a define_method'd Kernel method

--- a/spec/tags/core/unboundmethod/inspect_tags.txt
+++ b/spec/tags/core/unboundmethod/inspect_tags.txt
@@ -1,3 +1,0 @@
-fails:UnboundMethod#inspect shows the original name in parentheses for an aliased method
-fails:UnboundMethod#inspect shows the source UnboundMethod's name in parentheses for a define_method'd method
-fails:UnboundMethod#inspect shows the source name when aliasing a define_method'd Kernel method

--- a/spec/tags/core/unboundmethod/to_s_tags.txt
+++ b/spec/tags/core/unboundmethod/to_s_tags.txt
@@ -1,3 +1,0 @@
-fails:UnboundMethod#to_s shows the source UnboundMethod's name in parentheses for a define_method'd method
-fails:UnboundMethod#to_s shows the source name when aliasing a define_method'd Kernel method
-fails:UnboundMethod#to_s shows the original name in parentheses for an aliased method

--- a/src/main/ruby/truffleruby/core/argf.rb
+++ b/src/main/ruby/truffleruby/core/argf.rb
@@ -576,6 +576,7 @@ module Truffle
       +'ARGF'
     end
 
+    alias_method :inspect, :to_s
 
     # Internals
 

--- a/src/main/ruby/truffleruby/core/truffle/method_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/method_operations.rb
@@ -22,6 +22,9 @@ module Truffle
         end
       end
 
+      is_alias = meth.name != meth.original_name
+      meth_name = is_alias ? "#{meth.name}(#{meth.original_name})" : meth.name
+
       params = meth.parameters.map.with_index do |(type, name), i|
         case type
         when :req then "#{name || "param#{i+1}"}"
@@ -36,10 +39,10 @@ module Truffle
       end.join(', ').prepend('(') << ')'
 
       if !Primitive.undefined?(receiver) && owner.singleton_class?
-        "#<#{Primitive.class(meth)}: #{receiver.inspect}.#{meth.name}#{params}#{extra}>"
+        "#<#{Primitive.class(meth)}: #{receiver.inspect}.#{meth_name}#{params}#{extra}>"
       else
         origin_owner = origin == owner ? origin : "#{origin}(#{owner})"
-        "#<#{Primitive.class(meth)}: #{origin_owner}##{meth.name}#{params}#{extra}>"
+        "#<#{Primitive.class(meth)}: #{origin_owner}##{meth_name}#{params}#{extra}>"
       end
     end
   end


### PR DESCRIPTION
And also make `ARGF.inspect` and alias of `ARGF.to_s`

- [ ] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
