### PR TITLE
[Ruby 4.0] Fix Proc#parameters for anonymous optional parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Compatibility:
 * Tolerate uninitialized variables for `RB_GC_GUARD()` (#4274, @eregon).
 * Implement `IO::Buffer` (#4248, @eregon).
 * Fix `Enumerable#chunk` to pack multi-argument source yields to match CRuby (0-arg yield → `nil`, 1-arg → value, multi-arg → `Array`) (#4286, @sampokuokkanen).
+* Update `Proc#parameters` and return `[:opt]` instead of `[:opt, nil]` for destructured parameters (#4231, @andrykonchin).
 
 Performance:
 

--- a/doc/contributor/workflow.md
+++ b/doc/contributor/workflow.md
@@ -67,13 +67,15 @@ It is also possible to use a `pre-push` hook instead (`cp tool/hooks/lint-check.
 That way the lint check runs only before `git push`.
 However, that might result in extra "Fix style" commits, which sometimes can be `git rebase -i` away, but sometimes not.
 
+One of the checks requires installing `shellcheck` in advance (https://www.shellcheck.net/).
+
 ## Building
 
 ```bash
 jt build
 ```
 
-By default the `jt build` command builds a small JVM-only (no native images)
+By default, the `jt build` command builds a small JVM-only (no native images)
 GraalVM containing only the Ruby language. The built GraalVM can be found in the
 `mxbuild/truffleruby-jvm` directory.
 

--- a/spec/ruby/core/proc/parameters_spec.rb
+++ b/spec/ruby/core/proc/parameters_spec.rb
@@ -180,4 +180,20 @@ describe "Proc#parameters" do
       RUBY
     end
   end
+
+  ruby_version_is ""..."4.0" do
+    it "regards a destructured parameter in proc as an optional one" do
+      proc { |(a)| }.parameters.should == [[:opt, nil]]
+    end
+  end
+
+  ruby_version_is "4.0" do
+    it "regards a destructured parameter in proc as an optional one" do
+      proc { |(a)| }.parameters.should == [[:opt]]
+    end
+  end
+
+  it "regards a destructured parameter in lambda as an required" do
+    -> ((a)) { }.parameters.should == [[:req]]
+  end
 end

--- a/src/main/java/org/truffleruby/language/arguments/ArgumentDescriptorUtils.java
+++ b/src/main/java/org/truffleruby/language/arguments/ArgumentDescriptorUtils.java
@@ -38,6 +38,8 @@ public final class ArgumentDescriptorUtils {
             boolean isLambda) {
         if ((argDesc.type == ArgumentType.req) && !isLambda) {
             return toArray(language, context, ArgumentType.opt, argDesc.name);
+        } else if ((argDesc.type == ArgumentType.anonreq) && !isLambda) {
+            return toArray(language, context, ArgumentType.anonopt, argDesc.name);
         }
 
         return toArray(language, context, argDesc.type, argDesc.name);

--- a/src/main/java/org/truffleruby/parser/ArgumentType.java
+++ b/src/main/java/org/truffleruby/parser/ArgumentType.java
@@ -47,8 +47,10 @@ public enum ArgumentType {
     req("req", false),
 
     /* Parameters declared in a method/proc explicitly without name, e.g. anonymous *, ** , and &. Required parameter
-     * can be anonymous only in case of parameters nesting (e.g. `def foo(a, (b, c)) end`) */
+     * can be anonymous only in case of parameters nesting (e.g. `def foo(a, (b, c)) end`). Similarly, an optional
+     * parameter can be anonymous only in case of parameter nesting in a proc (e.g. proc {|a, (b)|}) */
     anonreq("req", true),
+    anonopt("opt", true),
     anonrest("rest", true),
     anonkeyrest("keyrest", true),
     anonblock("block", true),


### PR DESCRIPTION
Issue #4231
> Proc#parameters now shows anonymous optional parameters as [:opt] instead of [:opt, nil], making the output consistent with when the anonymous parameter is required. [[Bug #20974](https://bugs.ruby-lang.org/issues/20974)]

Related links:
- https://bugs.ruby-lang.org/issues/20974
- https://github.com/ruby/ruby/commit/6637aa4682ef64134e05af949a9beee260dab937

---

- [x] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
