### PR TITLE
Fix `Kernel#caller` for Ranges with negative end size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Compatibility:
 * Implement `IO::Buffer` (#4248, @eregon).
 * Fix `Enumerable#chunk` to pack multi-argument source yields to match CRuby (0-arg yield → `nil`, 1-arg → value, multi-arg → `Array`) (#4286, @sampokuokkanen).
 * Update `Proc#parameters` and return `[:opt]` instead of `[:opt, nil]` for destructured parameters (#4231, @andrykonchin).
+* Better compatibility for `Kernel#caller` with `Range` argument (#4295, @earlopain)
 
 Performance:
 

--- a/spec/ruby/core/kernel/caller_locations_spec.rb
+++ b/spec/ruby/core/kernel/caller_locations_spec.rb
@@ -22,6 +22,18 @@ describe 'Kernel#caller_locations' do
     locations.length.should == 1
   end
 
+  it "raises for negative start" do
+    -> { caller_locations(-1) }.should.raise(ArgumentError, "negative level (-1)")
+  end
+
+  it "raises for negative length" do
+    -> { caller_locations(0, -1) }.should.raise(ArgumentError, "negative size (-1)")
+  end
+
+  it "can be called with `nil` length" do
+    caller_locations(0, nil).map(&:to_s).should == caller_locations(0).map(&:to_s)
+  end
+
   it "can be called with a range" do
     locations1 = caller_locations(0)
     locations2 = caller_locations(2..4)
@@ -68,6 +80,11 @@ describe 'Kernel#caller_locations' do
 
   it "must return the same locations when called with 1..-1 and when called with no arguments" do
     caller_locations.map(&:to_s).should == caller_locations(1..-1).map(&:to_s)
+  end
+
+  it "coerces the arguments to integers" do
+    caller_locations(1.1, 1.1).map(&:to_s).should == caller(1, 1).map(&:to_s)
+    caller_locations(1.1..1.1).map(&:to_s).should == caller(1..1).map(&:to_s)
   end
 
   guard -> { Kernel.instance_method(:tap).source_location } do

--- a/spec/ruby/core/kernel/caller_spec.rb
+++ b/spec/ruby/core/kernel/caller_spec.rb
@@ -43,6 +43,18 @@ describe 'Kernel#caller' do
     lines[1].should =~ /\A#{path}:2:in [`']block in <main>'\n\z/
   end
 
+  it "raises for negative start" do
+    -> { caller(-1) }.should.raise(ArgumentError, "negative level (-1)")
+  end
+
+  it "raises for negative length" do
+    -> { caller(0, -1) }.should.raise(ArgumentError, "negative size (-1)")
+  end
+
+  it "can be called with `nil` length" do
+    caller(0, nil).should == caller(0)
+  end
+
   it "can be called with a range" do
     locations1 = caller(0)
     locations2 = caller(2..4)
@@ -81,6 +93,11 @@ describe 'Kernel#caller' do
 
   it "must return the same locations when called with 1..-1 and when called with no arguments" do
     caller.should == caller(1..-1)
+  end
+
+  it "coerces the arguments to integers" do
+    caller(1.1, 1.1).should == caller(1, 1)
+    caller(1.1..1.1).should == caller(1..1)
   end
 
   guard -> { Kernel.instance_method(:tap).source_location } do

--- a/spec/ruby/core/thread/backtrace_locations_spec.rb
+++ b/spec/ruby/core/thread/backtrace_locations_spec.rb
@@ -32,6 +32,18 @@ describe "Thread#backtrace_locations" do
     locations2.map(&:to_s).should == locations1[2..4].map(&:to_s)
   end
 
+  it "raises for negative start" do
+    -> { Thread.current.backtrace_locations(-1) }.should.raise(ArgumentError, "negative level (-1)")
+  end
+
+  it "raises for negative length" do
+    -> { Thread.current.backtrace_locations(0, -1) }.should.raise(ArgumentError, "negative size (-1)")
+  end
+
+  it "can be called with `nil` length" do
+    Thread.current.backtrace_locations(0, nil).map(&:to_s).should == Thread.current.backtrace_locations(0).map(&:to_s)
+  end
+
   it "can be called with a range" do
     locations1 = Thread.current.backtrace_locations
     locations2 = Thread.current.backtrace_locations(2..4)
@@ -75,5 +87,10 @@ describe "Thread#backtrace_locations" do
 
   it "[1..-1] is the same as #caller_locations(0..-1) for Thread.current" do
     Thread.current.backtrace_locations(1..-1).map(&:to_s).should == caller_locations(0..-1).map(&:to_s)
+  end
+
+  it "coerces the arguments to integers" do
+    Thread.current.backtrace_locations(1.1, 1.1).map(&:to_s).should == Thread.current.backtrace_locations(1, 1).map(&:to_s)
+    Thread.current.backtrace_locations(1.1..1.1).map(&:to_s).should == Thread.current.backtrace_locations(1..1).map(&:to_s)
   end
 end

--- a/spec/ruby/core/thread/backtrace_spec.rb
+++ b/spec/ruby/core/thread/backtrace_spec.rb
@@ -46,6 +46,19 @@ describe "Thread#backtrace" do
     locations1[2..4].map(&:to_s).should == locations2.map(&:to_s)
   end
 
+  it "raises for negative start" do
+    -> { Thread.current.backtrace(-1) }.should.raise(ArgumentError, "negative level (-1)")
+  end
+
+  it "raises for negative length" do
+    -> { Thread.current.backtrace(0, -1) }.should.raise(ArgumentError, "negative size (-1)")
+  end
+
+
+  it "can be called with `nil` length" do
+    Thread.current.backtrace(0, nil).should == Thread.current.backtrace(0)
+  end
+
   it "can be called with a range" do
     locations1 = Thread.current.backtrace
     locations2 = Thread.current.backtrace(2..4)
@@ -65,5 +78,10 @@ describe "Thread#backtrace" do
   it "returns [] if omitting exactly the number of locations available" do
     omit = Thread.current.backtrace.length
     Thread.current.backtrace(omit).should == []
+  end
+
+  it "coerces the arguments to integers" do
+    Thread.current.backtrace(1.1, 1.1).should == Thread.current.backtrace(1, 1)
+    Thread.current.backtrace(1.1..1.1).should == Thread.current.backtrace(1..1)
   end
 end

--- a/spec/tags/core/kernel/caller_tags.txt
+++ b/spec/tags/core/kernel/caller_tags.txt
@@ -1,4 +1,2 @@
 slow:Kernel#caller returns an Array with the block given to #at_exit at the base of the stack
-fails:Kernel#caller can be called with a range whose end is negative
 fails:Kernel#caller must return nil if omitting more locations than available
-fails:Kernel#caller must return the same locations when called with 1..-1 and when called with no arguments

--- a/spec/tags/core/kernel/caller_tags.txt
+++ b/spec/tags/core/kernel/caller_tags.txt
@@ -1,2 +1,1 @@
 slow:Kernel#caller returns an Array with the block given to #at_exit at the base of the stack
-fails:Kernel#caller must return nil if omitting more locations than available

--- a/src/main/ruby/truffleruby/core/kernel.rb
+++ b/src/main/ruby/truffleruby/core/kernel.rb
@@ -726,25 +726,9 @@ module Kernel
     pp(*args)
   end
 
-  def caller(start = 1, limit = nil)
-    args =  if Primitive.is_a?(start, Range)
-              if Primitive.nil?(start.begin) and Primitive.nil?(start.end)
-                [1]
-              elsif Primitive.nil? start.begin
-                size = start.end + 1
-                size -= 1 if start.exclude_end?
-                [1, size]
-              elsif Primitive.nil? start.end
-                [start.begin + 1]
-              else
-                [start.begin + 1, start.size]
-              end
-            elsif Primitive.nil? limit
-              [start + 1]
-            else
-              [start + 1, limit]
-            end
-    Kernel.caller_locations(*args).map(&:to_s)
+  def caller(start = 1, length = undefined)
+    start, length = Truffle::KernelOperations.normalize_backtrace_args(start, length)
+    Primitive.kernel_caller_locations(start, length).map(&:to_s)
   end
   module_function :caller
 

--- a/src/main/ruby/truffleruby/core/kernel.rb
+++ b/src/main/ruby/truffleruby/core/kernel.rb
@@ -728,7 +728,7 @@ module Kernel
 
   def caller(start = 1, length = undefined)
     start, length = Truffle::KernelOperations.normalize_backtrace_args(start, length)
-    Primitive.kernel_caller_locations(start, length).map(&:to_s)
+    Primitive.kernel_caller_locations(start, length)&.map(&:to_s)
   end
   module_function :caller
 

--- a/src/main/ruby/truffleruby/core/truffle/kernel_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/kernel_operations.rb
@@ -213,10 +213,7 @@ module Truffle
 
     # Will throw an exception if the arguments are invalid, and potentially convert a range to [omit, length] format.
     def self.normalize_backtrace_args(omit, length)
-      if Primitive.is_a?(length, Integer) && length < 0
-        raise ArgumentError, "negative size (#{length})"
-      end
-      if Primitive.is_a?(omit, Range)
+      if Primitive.is_a?(omit, Range) && Primitive.undefined?(length)
         range = omit
         if Primitive.nil? range.begin
           omit = 0
@@ -231,6 +228,16 @@ module Truffle
             end_index += (range.exclude_end? ? 0 : 1)
             length = omit > end_index ? 0 : end_index - omit
           end
+        end
+      else
+        omit = Primitive.convert_with_to_int(omit)
+        length = undefined if Primitive.nil?(length)
+        length = Primitive.convert_with_to_int(length) unless Primitive.undefined?(length)
+        if Primitive.is_a?(omit, Integer) && omit < 0
+          raise ArgumentError, "negative level (#{omit})"
+        end
+        if Primitive.is_a?(length, Integer) && length < 0
+          raise ArgumentError, "negative size (#{length})"
         end
       end
       [omit, length]


### PR DESCRIPTION
In CRuby it means to exclude that many entries. There already exists a method that computes this, just use it.

It's overall more correct (raises for negative length, coerces floats to ints with to_int). Apart from that, I didn't check `normalize_backtrace_args` in detail and am just assuming it does the right thing.

- [x] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
