### PR TITLE
Raise for `Enumerator.new` without block

### DIFF
--- a/spec/tags/core/enumerator/new_tags.txt
+++ b/spec/tags/core/enumerator/new_tags.txt
@@ -1,1 +1,0 @@
-fails:Enumerator.new no block given raises

--- a/src/main/ruby/truffleruby/core/enumerator.rb
+++ b/src/main/ruby/truffleruby/core/enumerator.rb
@@ -29,10 +29,10 @@
 class Enumerator
   include Enumerable
 
-  attr_writer :args, :kwargs, :size
-  private :args=, :kwargs=, :size=
+  attr_writer :args, :kwargs
+  private :args=, :kwargs=
 
-  private def initialize_enumerator(receiver, size, method_name, *method_args, **method_kwargs)
+  private def initialize_internal(receiver, size, method_name, *method_args, **method_kwargs)
     @object = receiver
     @size = size
     @iter = method_name
@@ -45,27 +45,9 @@ class Enumerator
     self
   end
 
-  private def initialize(receiver_or_size = undefined, method_name = :each, *method_args, **method_kwargs, &block)
-    size = nil
-
-    if block_given?
-      unless Primitive.undefined? receiver_or_size
-        size = receiver_or_size
-      end
-
-      receiver = Generator.new(&block)
-    else
-      if Primitive.undefined? receiver_or_size
-        raise ArgumentError, 'Enumerator#initialize requires a block when called without arguments'
-      end
-
-      receiver = receiver_or_size
-    end
-
-    method_name = Primitive.convert_type method_name, Symbol, :to_sym
-
-    initialize_enumerator receiver, size, method_name, *method_args, **method_kwargs
-
+  private def initialize(size = nil, &block)
+    raise ArgumentError, 'tried to create Proc object without a block' unless block
+    initialize_internal(Generator.new(&block), size, :each)
     self
   end
 
@@ -383,7 +365,7 @@ class Enumerator
       ret = Lazy.allocate
       method_name = Truffle::EnumeratorOperations.lazy_method(method_name)
 
-      ret.__send__ :initialize_enumerator, self, size, method_name, *method_args, **method_kwargs
+      ret.__send__(:initialize_internal, self, size, method_name, *method_args, **method_kwargs)
 
       ret
     end
@@ -720,13 +702,12 @@ class Enumerator
 end
 
 class Enumerator::ArithmeticSequence < Enumerator
-
-  def initialize(obj, method_name, enum_begin, enum_end, step, exclude_end)
+  private def initialize_internal(obj, method_name, enum_begin, enum_end, step, exclude_end)
     @begin = enum_begin
     @end =  enum_end
     @step = step
     @exclude_end = exclude_end
-    super(obj, method_name)
+    super(obj, nil, method_name)
   end
 
   attr_reader :begin, :end, :step

--- a/src/main/ruby/truffleruby/core/kernel.rb
+++ b/src/main/ruby/truffleruby/core/kernel.rb
@@ -568,9 +568,9 @@ module Kernel
   module_function :test
 
   def to_enum(method = :each, *args, **kwargs, &block)
-    Enumerator.new(self, method, *args, **kwargs).tap do |enum|
-      enum.__send__ :size=, block if block_given?
-    end
+    method = Primitive.convert_type method, Symbol, :to_sym
+    enum = Enumerator.allocate
+    enum.__send__(:initialize_internal, self, block, method, *args, **kwargs)
   end
   alias_method :enum_for, :to_enum
 

--- a/src/main/ruby/truffleruby/core/truffle/numeric_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/numeric_operations.rb
@@ -41,7 +41,8 @@ module Truffle
       step = 1 if Primitive.nil?(step)
 
       if (Primitive.undefined?(to) || Primitive.nil?(to) || Primitive.is_a?(to, Numeric)) && Primitive.is_a?(step, Numeric)
-        return Enumerator::ArithmeticSequence.new(from, :step, from, limit, step, false)
+        enum = Enumerator::ArithmeticSequence.allocate
+        return enum.__send__(:initialize_internal, from, :step, from, limit, step, false)
       end
 
       kwargs = {}

--- a/src/main/ruby/truffleruby/core/truffle/range_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/range_operations.rb
@@ -151,7 +151,8 @@ module Truffle
         check_step_zero(step_size) if Primitive.is_a?(from, Numeric)
 
         if arithmetic_range?(from, to)
-          return Enumerator::ArithmeticSequence.new(range, :step, from, to, step_size, range.exclude_end?)
+          enum = Enumerator::ArithmeticSequence.allocate
+          return enum.send(:initialize_internal, range, :step, from, to, step_size, range.exclude_end?)
         end
       end
 


### PR DESCRIPTION
By extracting the internal initialize logic and calling it where needed.

- [ ] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
