### PR TITLE
TruffleRuby now passes over 98% of ruby/spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ We recommend that people trying TruffleRuby on their gems and applications [get 
 
 TruffleRuby runs Rails and is compatible with many gems, including C extensions.
 TruffleRuby is not 100% compatible with MRI 4.0 yet. Please [report](https://github.com/truffleruby/truffleruby/issues) any compatibility issues you might find.
-TruffleRuby [passes around 97% of ruby/spec](https://eregon.me/rubyspec-stats/),
+TruffleRuby [passes around 98% of ruby/spec](https://eregon.me/rubyspec-stats/),
 more than any other alternative Ruby implementation.
 
 Regarding performance, TruffleRuby is [by far](https://eregon.me/blog/2022/01/06/benchmarking-cruby-mjit-yjit-jruby-truffleruby.html)

--- a/doc/user/compatibility.md
+++ b/doc/user/compatibility.md
@@ -5,7 +5,7 @@ Ruby, MRI, version 4.0.2, [including C extensions](#c-extension-compatibility).
 TruffleRuby is still in development, so it is not 100% compatible yet.
 
 TruffleRuby can run Rails and is compatible with many gems, including C extensions.
-TruffleRuby [passes around 97% of ruby/spec](https://eregon.me/blog/2020/06/27/ruby-spec-compatibility-report.html),
+TruffleRuby [passes around 98% of ruby/spec](https://eregon.me/rubyspec-stats/),
 more than any other alternative Ruby implementation.
 
 Any incompatibility with MRI is considered a bug, except for rare cases detailed below.


### PR DESCRIPTION
<img width="819" height="1227" alt="Screenshot From 2026-06-07 18-14-21" src="https://github.com/user-attachments/assets/182a742a-bd8f-4a47-85bc-8cfaa99f82c7" />
