### PR TITLE
Ensure every RubyRootNode has a FrameDescriptor with a FrameDescriptorInfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ New features:
 Bug fixes:
 
 * Raise a `RuntimeError` when using an object from a `Polyglot::InnerContext` after it has been closed (#4061, @eregon).
+* Fix `object.method(:send).to_proc.call(some_method)` (#4299, @eregon).
 
 Compatibility:
 

--- a/spec/ruby/shared/basicobject/send.rb
+++ b/spec/ruby/shared/basicobject/send.rb
@@ -125,4 +125,10 @@ describe :basicobject_send, shared: true do
 
     c2.new.send(@method, :foo, *[[]]).should == %i[m1 m2]
   end
+
+  it "can be called reflectively" do
+    obj = Object.new
+    obj.method(@method).call(:itself).should.equal?(obj)
+    obj.method(@method).to_proc.call(:itself).should.equal?(obj)
+  end
 end

--- a/src/main/java/org/truffleruby/builtins/CoreMethodNodeManager.java
+++ b/src/main/java/org/truffleruby/builtins/CoreMethodNodeManager.java
@@ -347,10 +347,11 @@ public final class CoreMethodNodeManager {
                 throw new Error("Always-inlined methods do not support all @CoreMethod attributes for " + nodeClass);
             }
 
+            var frameDescriptor = TranslatorEnvironment.newFrameDescriptorBuilderForMethod(sharedMethodInfo).build();
             RubyRootNode reRaiseRootNode = new RubyRootNode(
                     language,
                     sharedMethodInfo.getSourceSection(),
-                    null,
+                    frameDescriptor,
                     sharedMethodInfo,
                     new ReRaiseInlinedExceptionNode(nodeFactory),
                     Split.NEVER,

--- a/src/main/java/org/truffleruby/core/module/ModuleNodes.java
+++ b/src/main/java/org/truffleruby/core/module/ModuleNodes.java
@@ -139,6 +139,7 @@ import com.oracle.truffle.api.nodes.IndirectCallNode;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.profiles.BranchProfile;
 import com.oracle.truffle.api.source.SourceSection;
+import org.truffleruby.parser.TranslatorEnvironment;
 
 import static org.truffleruby.builtins.PrimitiveNode.FAILURE;
 import static org.truffleruby.core.module.ModuleNodes.GenerateAccessorNode.Accessor.BOTH;
@@ -525,10 +526,11 @@ public abstract class ModuleNodes {
                     ? ModuleNodesFactory.GeneratedReaderNodeFactory.getInstance()
                     : ModuleNodesFactory.GeneratedWriterNodeFactory.getInstance();
 
+            var frameDescriptor = TranslatorEnvironment.newFrameDescriptorBuilderForMethod(sharedMethodInfo).build();
             final RubyRootNode reRaiseRootNode = new RubyRootNode(
                     getLanguage(),
                     sourceSection,
-                    null,
+                    frameDescriptor,
                     sharedMethodInfo,
                     new ReRaiseInlinedExceptionNode(alwaysInlinedNodeFactory),
                     Split.NEVER,

--- a/src/main/java/org/truffleruby/language/RubyBaseRootNode.java
+++ b/src/main/java/org/truffleruby/language/RubyBaseRootNode.java
@@ -18,12 +18,15 @@ import org.truffleruby.RubyContext;
 import org.truffleruby.RubyLanguage;
 import org.truffleruby.core.CoreLibrary;
 
+import java.util.Objects;
+
 public abstract class RubyBaseRootNode extends RootNode {
 
     private final SourceSection sourceSection;
 
     public RubyBaseRootNode(TruffleLanguage<?> language, FrameDescriptor frameDescriptor, SourceSection sourceSection) {
-        super(language, frameDescriptor);
+        // We always want an explicit descriptor, the default of `new FrameDescriptor(null) is no good for Ruby
+        super(language, Objects.requireNonNull(frameDescriptor));
         this.sourceSection = sourceSection;
     }
 

--- a/src/main/java/org/truffleruby/language/RubyEvalInteractiveRootNode.java
+++ b/src/main/java/org/truffleruby/language/RubyEvalInteractiveRootNode.java
@@ -28,7 +28,7 @@ public final class RubyEvalInteractiveRootNode extends RubyBaseRootNode implemen
     @Child DispatchNode callEvalNode = DispatchNode.create();
 
     public RubyEvalInteractiveRootNode(RubyLanguage language, Source source) {
-        super(language, null, null);
+        super(language, language.EMPTY_DECLARATION_DESCRIPTOR, null);
         this.sourceString = TStringUtils.utf8TString(source.getCharacters().toString());
     }
 

--- a/src/main/java/org/truffleruby/language/RubyParsingRequestNode.java
+++ b/src/main/java/org/truffleruby/language/RubyParsingRequestNode.java
@@ -39,7 +39,7 @@ public final class RubyParsingRequestNode extends RubyBaseRootNode implements In
     @Child private DirectCallNode callNode;
 
     public RubyParsingRequestNode(RubyLanguage language, RubyContext context, Source source, String[] argumentNames) {
-        super(language, null, null);
+        super(language, language.EMPTY_DECLARATION_DESCRIPTOR, null);
 
         final RubySource rubySource = new RubySource(source, RubyLanguage.getPath(source));
 

--- a/src/main/java/org/truffleruby/language/RubyRootNode.java
+++ b/src/main/java/org/truffleruby/language/RubyRootNode.java
@@ -53,6 +53,7 @@ public class RubyRootNode extends RubyBaseRootNode {
             Split split,
             ReturnID returnID) {
         super(language, frameDescriptor, sourceSection);
+        assert frameDescriptor != null && FrameDescriptorInfo.of(frameDescriptor) != null;
         assert sourceSection != null;
         assert body != null;
 


### PR DESCRIPTION
* Fixes https://github.com/truffleruby/truffleruby/issues/4299

- [x] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
