### PR TITLE
Support symbols for `IO#seek` and `IO#sysseek`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Compatibility:
 * Fix `Enumerable#chunk` to pack multi-argument source yields to match CRuby (0-arg yield → `nil`, 1-arg → value, multi-arg → `Array`) (#4286, @sampokuokkanen).
 * Update `Proc#parameters` and return `[:opt]` instead of `[:opt, nil]` for destructured parameters (#4231, @andrykonchin).
 * Better compatibility for `Kernel#caller` with `Range` argument (#4295, @earlopain)
+* Support symbols as arguments for `IO#seek` and `IO#sysseek` (#4306, @earlopain)
 
 Performance:
 

--- a/spec/ruby/core/io/seek_spec.rb
+++ b/spec/ruby/core/io/seek_spec.rb
@@ -24,6 +24,11 @@ describe "IO#seek" do
     @io.readline.should == "une.\n"
   end
 
+  it "accepts the symbol :CUR for SEEK_CUR" do
+    @io.seek(10, :CUR)
+    @io.readline.should == "igne une.\n"
+  end
+
   it "moves the read position relative to the start with SEEK_SET" do
     @io.seek(1)
     @io.pos.should == 1
@@ -34,11 +39,21 @@ describe "IO#seek" do
     @io.readline.should == " la ligne une.\n"
   end
 
+  it "accepts the symbol :SET for SEEK_SET" do
+    @io.seek(43, :SET)
+    @io.readline.should == "Aquí está la línea tres.\n"
+  end
+
   it "moves the read position relative to the end with SEEK_END" do
     @io.seek(0, IO::SEEK_END)
     @io.tell.should == 137
     @io.seek(-25, IO::SEEK_END)
     @io.readline.should == "cinco.\n"
+  end
+
+  it "accepts the symbol :END for SEEK_END" do
+    @io.seek(0, :END)
+    @io.tell.should == 137
   end
 
   it "moves the read position and clears EOF with SEEK_SET" do

--- a/spec/ruby/core/io/sysread_spec.rb
+++ b/spec/ruby/core/io/sysread_spec.rb
@@ -103,7 +103,7 @@ describe "IO#sysread on a file" do
 
   it "discards the existing buffer content upon error" do
     buffer = +"existing content"
-    @file.seek(0, :END)
+    @file.seek(0, IO::SEEK_END)
     -> { @file.sysread(1, buffer) }.should.raise(EOFError)
     buffer.should.empty?
   end

--- a/spec/ruby/core/io/sysseek_spec.rb
+++ b/spec/ruby/core/io/sysseek_spec.rb
@@ -21,6 +21,11 @@ describe "IO#sysseek" do
     @io.readline.should == "igne une.\n"
   end
 
+  it "accepts the symbol :CUR for SEEK_CUR" do
+    @io.sysseek(10, :CUR)
+    @io.readline.should == "igne une.\n"
+  end
+
   it "raises an error when called after buffered reads" do
     @io.readline
     -> { @io.sysseek(-5, IO::SEEK_CUR) }.should.raise(IOError)
@@ -36,6 +41,11 @@ describe "IO#sysseek" do
     @io.readline.should == "Aquí está la línea tres.\n"
   end
 
+  it "accepts the symbol :SET for SEEK_SET" do
+    @io.sysseek(43, :SET)
+    @io.readline.should == "Aquí está la línea tres.\n"
+  end
+
   it "moves the read position relative to the end with SEEK_END" do
     @io.sysseek(1, IO::SEEK_END)
 
@@ -44,6 +54,11 @@ describe "IO#sysseek" do
     -> { @io.sysread(1) }.should.raise(EOFError)
 
     @io.sysseek(-25, IO::SEEK_END)
+    @io.sysread(7).should == "cinco.\n"
+  end
+
+  it "accepts the symbol :END for SEEK_END" do
+    @io.sysseek(-25, :END)
     @io.sysread(7).should == "cinco.\n"
   end
 end

--- a/src/main/ruby/truffleruby/core/io.rb
+++ b/src/main/ruby/truffleruby/core/io.rb
@@ -2032,6 +2032,7 @@ class IO
     flush
     reset_buffering
 
+    whence = Truffle::IOOperations.parse_whence(whence)
     r = Truffle::POSIX.lseek(Primitive.io_fd(self), Primitive.rb_num2long(amount), whence)
     Errno.handle if r == -1
     0
@@ -2196,6 +2197,7 @@ class IO
     ensure_open
     raise IOError unless buffer_empty?
 
+    whence = Truffle::IOOperations.parse_whence(whence)
     r = Truffle::POSIX.lseek(Primitive.io_fd(self), Primitive.rb_num2long(amount), whence)
     Errno.handle if r == -1
     r

--- a/src/main/ruby/truffleruby/core/truffle/io_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/io_operations.rb
@@ -413,6 +413,16 @@ module Truffle
       ret
     end
 
+    def self.parse_whence(mode)
+      case mode
+      when :CUR then IO::SEEK_CUR
+      when :END then IO::SEEK_END
+      when :SET then IO::SEEK_SET
+      else
+        mode
+      end
+    end
+
     BOM = /\Abom\|/i
 
     def self.parse_external_enc(io, external, mode)


### PR DESCRIPTION
They are just aliases

- [x] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
