### PR TITLE
Fix "too many arguments for format string" warning for *printf

### DIFF
--- a/spec/tags/core/kernel/printf_tags.txt
+++ b/spec/tags/core/kernel/printf_tags.txt
@@ -1,2 +1,0 @@
-fails(the cache does not re-emit warnings):Kernel.printf formatting io is specified when $VERBOSE is true warns if too many arguments are passed
-fails(the cache does not re-emit warnings):Kernel.printf formatting io is not specified when $VERBOSE is true warns if too many arguments are passed

--- a/spec/tags/core/kernel/sprintf_tags.txt
+++ b/spec/tags/core/kernel/sprintf_tags.txt
@@ -2,5 +2,3 @@ fails:Kernel#sprintf returns a String in the argument's encoding if format encod
 fails:Kernel#sprintf raises Encoding::CompatibilityError if both encodings are ASCII compatible and there are not ASCII characters
 fails:Kernel.sprintf returns a String in the argument's encoding if format encoding is more restrictive
 fails:Kernel.sprintf raises Encoding::CompatibilityError if both encodings are ASCII compatible and there are not ASCII characters
-fails(the cache does not re-emit warnings):Kernel#sprintf when $VERBOSE is true warns if too many arguments are passed
-fails(the cache does not re-emit warnings):Kernel.sprintf when $VERBOSE is true warns if too many arguments are passed

--- a/spec/tags/core/string/modulo_tags.txt
+++ b/spec/tags/core/string/modulo_tags.txt
@@ -4,4 +4,3 @@ fails:String#% returns a String in the argument's encoding if format encoding is
 fails:String#% raises Encoding::CompatibilityError if both encodings are ASCII compatible and there are not ASCII characters
 fails:String#% raises an ArgumentError if % is not followed by a conversion specifier
 fails:String#% raises an ArgumentError if absolute argument specifier is followed by a conversion specifier
-fails(the cache does not re-emit warnings):String#% when $VERBOSE is true warns if too many arguments are passed

--- a/spec/tags/library/stringio/printf_tags.txt
+++ b/spec/tags/library/stringio/printf_tags.txt
@@ -1,1 +1,0 @@
-fails(the cache does not re-emit warnings):StringIO#printf formatting when $VERBOSE is true warns if too many arguments are passed

--- a/src/main/.checkstyle_checks.xml
+++ b/src/main/.checkstyle_checks.xml
@@ -327,7 +327,7 @@
     <property name="message" value="Lazily initialized child nodes must be explicitly inserted into the AST."/>
   </module>
   <module name="RegexpHeader">
-    <property name="header" value='/\*\n (\* Copyright \(c\) (20[0-9][0-9]-)?20[0-9][0-9] TruffleRuby contributors\.|\*\*\*\*\* BEGIN LICENSE BLOCK \*\*\*\*\*)\n (\* Copyright \(c\) (20[0-9][0-9]-)?20[0-9][0-9] Oracle and/or its affiliates\.|\* Version: EPL 2\.0/GPL 2\.0/LGPL 2\.1)\n (\* This code is released under a tri EPL/GPL/LGPL license\.|\*)\n (\* You can use it, redistribute it and/or modify it under the terms of the:|\* The contents of this file are subject to the Eclipse Public)\n (\*|\* License Version 2\.0 \(the "License"\); you may not use this file)\n (\* Eclipse Public License version 2\.0|\* except in compliance with the License\. You may obtain a copy of)\n (\* GNU General Public License version 2|\* the License at http://www.eclipse.org/legal/epl-v20.html)\n (\* GNU Lesser General Public License version 2\.1|\*)\n (\*/|\*|\* Software distributed under the License is distributed on an "AS)\n'/>
+    <property name="header" value='/\*\n(\* Copyright \(c\) (20(2[6-9]|[3-9][0-9])-)?20(2[6-9]|[3-9][0-9]) TruffleRuby contributors\.|\* Copyright \(c\) (20([0-1][0-9]|2[0-5])-)?20([0-1][0-9]|2[0-5]) Oracle and/or its affiliates\.|\*\*\*\*\* BEGIN LICENSE BLOCK \*\*\*\*\*)\n'/>
     <property name="fileExtensions" value="java"/>
   </module>
   <module name="FileTabCharacter">

--- a/src/main/java/org/truffleruby/core/format/printf/CheckTooManyArgumentsNode.java
+++ b/src/main/java/org/truffleruby/core/format/printf/CheckTooManyArgumentsNode.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026 TruffleRuby contributors.
+ * This code is released under a tri EPL/GPL/LGPL license.
+ * You can use it, redistribute it and/or modify it under the terms of the:
+ *
+ * Eclipse Public License version 2.0, or
+ * GNU General Public License version 2, or
+ * GNU Lesser General Public License version 2.1.
+ */
+package org.truffleruby.core.format.printf;
+
+import org.truffleruby.core.format.FormatFrameDescriptor;
+import org.truffleruby.core.format.FormatNode;
+
+import com.oracle.truffle.api.frame.VirtualFrame;
+import org.truffleruby.core.hash.RubyHash;
+import org.truffleruby.language.WarningNode;
+
+public final class CheckTooManyArgumentsNode extends FormatNode {
+
+    private final int expectedArguments;
+    @Child FormatNode child;
+    @Child WarningNode warningNode = WarningNode.create();
+
+    public CheckTooManyArgumentsNode(int expectedArguments, FormatNode child) {
+        this.expectedArguments = expectedArguments;
+        this.child = child;
+    }
+
+    private void checkTooManyArguments(Object[] arguments) {
+        // don't warn if arguments are passed as a Hash:
+        //   format("%<foo>d : %<bar>f", { :foo => 1, :bar => 2 })
+        if (arguments.length == 1 && arguments[0] instanceof RubyHash) {
+            return;
+        }
+
+        if (expectedArguments < arguments.length) {
+            warningNode.warningMessage(
+                    getContext().getCallStack().getTopMostUserSourceSection(),
+                    "too many arguments for format string");
+        }
+    }
+
+    @Override
+    public Object execute(VirtualFrame frame) {
+        if (expectedArguments >= 0 && warningNode.shouldWarn()) {
+            Object[] arguments = (Object[]) frame.getObject(FormatFrameDescriptor.SOURCE_SLOT);
+            checkTooManyArguments(arguments);
+        }
+        return child.execute(frame);
+    }
+
+}

--- a/src/main/java/org/truffleruby/core/format/printf/PrintfSimpleTreeBuilder.java
+++ b/src/main/java/org/truffleruby/core/format/printf/PrintfSimpleTreeBuilder.java
@@ -260,10 +260,27 @@ public final class PrintfSimpleTreeBuilder {
 
     }
 
+    private int expectedArguments() {
+        int modifiersCount = 0;
+        for (var config : configs) {
+            if (config.getAbsoluteArgumentIndex() != null) {
+                return -1; // no warnings if there is an absolute argument index
+            }
+            if (!config.isLiteral()) {
+                modifiersCount++;
+                if (config.isWidthStar() || config.isPrecisionStar()) {
+                    modifiersCount++;
+                }
+            }
+        }
+        return modifiersCount;
+    }
 
     public FormatNode getNode() {
         buildTree();
-        return SharedTreeBuilder.createSequence(sequence.toArray(FormatNode.EMPTY_ARRAY));
+
+        return new CheckTooManyArgumentsNode(expectedArguments(),
+                SharedTreeBuilder.createSequence(sequence.toArray(FormatNode.EMPTY_ARRAY)));
     }
 
 }

--- a/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
+++ b/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
@@ -112,7 +112,6 @@ import org.truffleruby.language.RubyGuards;
 import org.truffleruby.language.RubyNode;
 import org.truffleruby.language.RubyRootNode;
 import org.truffleruby.language.WarnNode;
-import org.truffleruby.language.WarningNode;
 import org.truffleruby.language.arguments.RubyArguments;
 import org.truffleruby.language.backtrace.Backtrace;
 import org.truffleruby.language.backtrace.BacktraceFormatter;
@@ -1676,12 +1675,11 @@ public abstract class KernelNodes {
                 limit = "3")
         static BytesResult formatCached(
                 Node node, AbstractTruffleString format, RubyEncoding encoding, Object[] arguments, boolean isDebug,
-                @Cached(inline = false) @Shared WarningNode warnNode,
                 @Cached("isDebug") boolean cachedIsDebug,
                 @Cached("format.asTruffleStringUncached(encoding.tencoding)") TruffleString cachedFormat,
                 @Cached("encoding") RubyEncoding cachedEncoding,
                 @Cached("arguments.length") int cachedArgumentsLength,
-                @Cached(value = "create(compileFormat(cachedFormat, cachedEncoding, arguments, isDebug, warnNode, node))",
+                @Cached(value = "create(compileFormat(cachedFormat, cachedEncoding, arguments, isDebug, node))",
                         inline = false) DirectCallNode callPackNode,
                 @Cached StringHelperNodes.EqualSameEncodingNode equalNode) {
             return (BytesResult) callPackNode.call(new Object[]{ arguments, arguments.length, null });
@@ -1690,16 +1688,15 @@ public abstract class KernelNodes {
         @Specialization(replaces = "formatCached")
         static BytesResult formatUncached(
                 Node node, AbstractTruffleString format, RubyEncoding encoding, Object[] arguments, boolean isDebug,
-                @Cached(inline = false) @Shared WarningNode warnNode,
                 @Cached(inline = false) IndirectCallNode callPackNode) {
             return (BytesResult) callPackNode.call(
-                    compileFormat(format, encoding, arguments, isDebug, warnNode, node),
+                    compileFormat(format, encoding, arguments, isDebug, node),
                     new Object[]{ arguments, arguments.length, null });
         }
 
         @TruffleBoundary
         static RootCallTarget compileFormat(AbstractTruffleString tstring, RubyEncoding encoding, Object[] arguments,
-                boolean isDebug, WarningNode warnNode, Node node) {
+                boolean isDebug, Node node) {
             try {
                 var byteArray = tstring.getInternalByteArrayUncached(encoding.tencoding);
 
@@ -1710,10 +1707,6 @@ public abstract class KernelNodes {
                 final PrintfSimpleTreeBuilder builder = new PrintfSimpleTreeBuilder(getLanguage(node), configs,
                         encoding);
 
-                if (warnNode.shouldWarn()) {
-                    warn(configs, arguments, warnNode, node);
-                }
-
                 return new FormatRootNode(
                         getLanguage(node),
                         node.getEncapsulatingSourceSection(),
@@ -1723,33 +1716,6 @@ public abstract class KernelNodes {
                         false).getCallTarget();
             } catch (InvalidFormatException e) {
                 throw new RaiseException(getContext(node), coreExceptions(node).argumentError(e.getMessage(), node));
-            }
-        }
-
-        private static void warn(List<SprintfConfig> configs, Object[] arguments, WarningNode warnNode, Node node) {
-            // don't warn if arguments are passed as a Hash:
-            //   format("%<foo>d : %<bar>f", { :foo => 1, :bar => 2 })
-            if (arguments.length == 1 && arguments[0] instanceof RubyHash) {
-                return;
-            }
-
-            int modifiersCount = 0;
-            for (var config : configs) {
-                if (config.getAbsoluteArgumentIndex() != null) {
-                    return; // no warnings if there is an absolute argument index
-                }
-                if (!config.isLiteral()) {
-                    modifiersCount++;
-                    if (config.isWidthStar() || config.isPrecisionStar()) {
-                        modifiersCount++;
-                    }
-                }
-            }
-
-            if (modifiersCount < arguments.length) {
-                warnNode.warningMessage(
-                        RubyContext.get(node).getCallStack().getTopMostUserSourceSection(),
-                        "too many arguments for format string");
             }
         }
     }


### PR DESCRIPTION
* They were only emitted once and then not anymore when the format was inline-cached.

- [x] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
