### PR TITLE
Fix `Enumerator::Lazy` methods to pack multi-argument source yields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Compatibility:
 * Fix precedence between `RUBYOPT` and CLI switches (#4342, @earlopain).
 * Fix `FFI::DynamicLibrary.open` and raise `LoadError` instead of `RuntimeError` with adjusted message (#4345, @andrykonchin).
 * Fix `Enumerator::Lazy#{drop,drop_while,take,uniq,zip}` when doing multiple enumerations (#4357, @earlopain).
+* Fix `Enumerator::Lazy` methods and `Enumerable#take_while` to pack multi-argument source yields like CRuby (0-arg yield → `nil`, 1-arg → value, multi-arg → `Array`) (#4310, @sampokuokkanen).
 
 Performance:
 

--- a/spec/ruby/core/enumerable/compact_spec.rb
+++ b/spec/ruby/core/enumerable/compact_spec.rb
@@ -2,6 +2,18 @@ require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 
 describe "Enumerable#compact" do
+  describe "value packing of source yields" do
+    it "packs a multi-argument source yield into an Array" do
+      e = Enumerator.new { |y| y.yield 1, 2 }
+      e.compact.should == [[1, 2]]
+    end
+
+    it "removes a zero-argument source yield like nil" do
+      e = Enumerator.new { |y| y.yield; y.yield :v }
+      e.compact.should == [:v]
+    end
+  end
+
   it 'returns array without nil elements' do
     arr = EnumerableSpecs::Numerous.new(nil, 1, 2, nil, true)
     arr.compact.should == [1, 2, true]

--- a/spec/ruby/core/enumerable/drop_spec.rb
+++ b/spec/ruby/core/enumerable/drop_spec.rb
@@ -1,7 +1,15 @@
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
+require_relative 'shared/value_packing'
 
 describe "Enumerable#drop" do
+  describe "value packing of source yields" do
+    before :each do
+      @take = -> e { e.drop(0) }
+    end
+    it_behaves_like :enumerable_value_packing, nil
+  end
+
   before :each do
     @enum = EnumerableSpecs::Numerous.new(3, 2, 1, :go)
   end

--- a/spec/ruby/core/enumerable/drop_while_spec.rb
+++ b/spec/ruby/core/enumerable/drop_while_spec.rb
@@ -1,8 +1,16 @@
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 require_relative 'shared/enumerable_enumeratorized'
+require_relative 'shared/value_packing'
 
 describe "Enumerable#drop_while" do
+  describe "value packing of source yields" do
+    before :each do
+      @take = -> e { e.drop_while { false } }
+    end
+    it_behaves_like :enumerable_value_packing, nil
+  end
+
   before :each do
     @enum = EnumerableSpecs::Numerous.new(3, 2, 1, :go)
   end

--- a/spec/ruby/core/enumerable/reject_spec.rb
+++ b/spec/ruby/core/enumerable/reject_spec.rb
@@ -1,8 +1,16 @@
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 require_relative 'shared/enumerable_enumeratorized'
+require_relative 'shared/value_packing'
 
 describe "Enumerable#reject" do
+  describe "value packing of source yields" do
+    before :each do
+      @take = -> e { e.reject { false } }
+    end
+    it_behaves_like :enumerable_value_packing, nil
+  end
+
   it "returns an array of the elements for which block is false" do
     EnumerableSpecs::Numerous.new.reject { |i| i > 3 }.should == [2, 3, 1]
     entries = (1..10).to_a

--- a/spec/ruby/core/enumerable/select_spec.rb
+++ b/spec/ruby/core/enumerable/select_spec.rb
@@ -1,8 +1,16 @@
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 require_relative 'shared/enumerable_enumeratorized'
+require_relative 'shared/value_packing'
 
 describe "Enumerable#select" do
+  describe "value packing of source yields" do
+    before :each do
+      @take = -> e { e.select { true } }
+    end
+    it_behaves_like :enumerable_value_packing, nil
+  end
+
   before :each do
     ScratchPad.record []
     @elements = (1..10).to_a

--- a/spec/ruby/core/enumerable/take_while_spec.rb
+++ b/spec/ruby/core/enumerable/take_while_spec.rb
@@ -1,8 +1,16 @@
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 require_relative 'shared/enumerable_enumeratorized'
+require_relative 'shared/value_packing'
 
 describe "Enumerable#take_while" do
+  describe "value packing of source yields" do
+    before :each do
+      @take = -> e { e.take_while { true } }
+    end
+    it_behaves_like :enumerable_value_packing, nil
+  end
+
   before :each do
     @enum = EnumerableSpecs::Numerous.new(3, 2, 1, :go)
   end

--- a/spec/ruby/core/enumerable/uniq_spec.rb
+++ b/spec/ruby/core/enumerable/uniq_spec.rb
@@ -1,7 +1,15 @@
 require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
+require_relative 'shared/value_packing'
 
 describe 'Enumerable#uniq' do
+  describe "value packing of source yields" do
+    before :each do
+      @take = -> e { e.uniq }
+    end
+    it_behaves_like :enumerable_value_packing, nil
+  end
+
   it 'returns an array that contains only unique elements' do
     [0, 1, 2, 3].to_enum.uniq { |n| n.even? }.should == [0, 1]
   end

--- a/spec/ruby/core/enumerator/lazy/compact_spec.rb
+++ b/spec/ruby/core/enumerator/lazy/compact_spec.rb
@@ -2,6 +2,23 @@ require_relative '../../../spec_helper'
 require_relative 'fixtures/classes'
 
 describe "Enumerator::Lazy#compact" do
+  # Cannot use shared/value_packing.rb examples: the packed nil is removed by #compact.
+  describe "value packing of source yields" do
+    it "packs a multi-argument source yield into an Array" do
+      e = Enumerator.new { |y| y.yield 1, 2 }
+      args = nil
+      e.lazy.compact.each { |*a| args = a }
+      args.should == [[1, 2]]
+    end
+
+    it "removes a zero-argument source yield like nil" do
+      e = Enumerator.new { |y| y.yield; y.yield :v }
+      collected = []
+      e.lazy.compact.each { |*a| collected << a }
+      collected.should == [[:v]]
+    end
+  end
+
   it 'returns array without nil elements' do
     arr = [1, nil, 3, false, 5].to_enum.lazy.compact
     arr.should.instance_of?(Enumerator::Lazy)

--- a/spec/ruby/core/enumerator/lazy/drop_spec.rb
+++ b/spec/ruby/core/enumerator/lazy/drop_spec.rb
@@ -2,8 +2,16 @@
 
 require_relative '../../../spec_helper'
 require_relative 'fixtures/classes'
+require_relative '../../enumerable/shared/value_packing'
 
 describe "Enumerator::Lazy#drop" do
+  describe "value packing of source yields (matches Enumerable#drop)" do
+    before :each do
+      @take = -> e { e.lazy.drop(0) }
+    end
+    it_behaves_like :enumerable_value_packing, nil
+  end
+
   before :each do
     @yieldsmixed = EnumeratorLazySpecs::YieldsMixed.new.to_enum.lazy
     @eventsmixed = EnumeratorLazySpecs::EventsMixed.new.to_enum.lazy

--- a/spec/ruby/core/enumerator/lazy/drop_while_spec.rb
+++ b/spec/ruby/core/enumerator/lazy/drop_while_spec.rb
@@ -2,8 +2,16 @@
 
 require_relative '../../../spec_helper'
 require_relative 'fixtures/classes'
+require_relative '../../enumerable/shared/value_packing'
 
 describe "Enumerator::Lazy#drop_while" do
+  describe "value packing of source yields (matches Enumerable#drop_while)" do
+    before :each do
+      @take = -> e { e.lazy.drop_while { false } }
+    end
+    it_behaves_like :enumerable_value_packing, nil
+  end
+
   before :each do
     @yieldsmixed = EnumeratorLazySpecs::YieldsMixed.new.to_enum.lazy
     @eventsmixed = EnumeratorLazySpecs::EventsMixed.new.to_enum.lazy

--- a/spec/ruby/core/enumerator/lazy/reject_spec.rb
+++ b/spec/ruby/core/enumerator/lazy/reject_spec.rb
@@ -2,8 +2,16 @@
 
 require_relative '../../../spec_helper'
 require_relative 'fixtures/classes'
+require_relative '../../enumerable/shared/value_packing'
 
 describe "Enumerator::Lazy#reject" do
+  describe "value packing of source yields (matches Enumerable#reject)" do
+    before :each do
+      @take = -> e { e.lazy.reject { false } }
+    end
+    it_behaves_like :enumerable_value_packing, nil
+  end
+
   before :each do
     @yieldsmixed = EnumeratorLazySpecs::YieldsMixed.new.to_enum.lazy
     @eventsmixed = EnumeratorLazySpecs::EventsMixed.new.to_enum.lazy

--- a/spec/ruby/core/enumerator/lazy/select_spec.rb
+++ b/spec/ruby/core/enumerator/lazy/select_spec.rb
@@ -1,7 +1,15 @@
 require_relative '../../../spec_helper'
 require_relative 'fixtures/classes'
+require_relative '../../enumerable/shared/value_packing'
 
 describe "Enumerator::Lazy#select" do
+  describe "value packing of source yields (matches Enumerable#select)" do
+    before :each do
+      @take = -> e { e.lazy.select { true } }
+    end
+    it_behaves_like :enumerable_value_packing, nil
+  end
+
   before :each do
     @yieldsmixed = EnumeratorLazySpecs::YieldsMixed.new.to_enum.lazy
     @eventsmixed = EnumeratorLazySpecs::EventsMixed.new.to_enum.lazy

--- a/spec/ruby/core/enumerator/lazy/take_while_spec.rb
+++ b/spec/ruby/core/enumerator/lazy/take_while_spec.rb
@@ -2,8 +2,16 @@
 
 require_relative '../../../spec_helper'
 require_relative 'fixtures/classes'
+require_relative '../../enumerable/shared/value_packing'
 
 describe "Enumerator::Lazy#take_while" do
+  describe "value packing of source yields (matches Enumerable#take_while)" do
+    before :each do
+      @take = -> e { e.lazy.take_while { true } }
+    end
+    it_behaves_like :enumerable_value_packing, nil
+  end
+
   before :each do
     @yieldsmixed = EnumeratorLazySpecs::YieldsMixed.new.to_enum.lazy
     @eventsmixed = EnumeratorLazySpecs::EventsMixed.new.to_enum.lazy

--- a/spec/ruby/core/enumerator/lazy/uniq_spec.rb
+++ b/spec/ruby/core/enumerator/lazy/uniq_spec.rb
@@ -1,7 +1,15 @@
 require_relative '../../../spec_helper'
 require_relative 'fixtures/classes'
+require_relative '../../enumerable/shared/value_packing'
 
 describe 'Enumerator::Lazy#uniq' do
+  describe "value packing of source yields (matches Enumerable#uniq)" do
+    before :each do
+      @take = -> e { e.lazy.uniq }
+    end
+    it_behaves_like :enumerable_value_packing, nil
+  end
+
   context 'without block' do
     before :each do
       @lazy = [0, 1, 0, 1].to_enum.lazy.uniq

--- a/spec/ruby/core/enumerator/lazy/with_index_spec.rb
+++ b/spec/ruby/core/enumerator/lazy/with_index_spec.rb
@@ -4,6 +4,29 @@ require_relative '../../../spec_helper'
 require_relative 'fixtures/classes'
 
 describe "Enumerator::Lazy#with_index" do
+  describe "value packing of source yields" do
+    it "pairs a packed Array with the index for a multi-argument source yield" do
+      e = Enumerator.new { |y| y.yield 1, 2 }
+      args = nil
+      e.lazy.with_index.each { |*a| args = a }
+      args.should == [[[1, 2], 0]]
+    end
+
+    it "pairs nil with the index for a zero-argument source yield" do
+      e = Enumerator.new { |y| y.yield }
+      args = nil
+      e.lazy.with_index.each { |*a| args = a }
+      args.should == [[nil, 0]]
+    end
+
+    it "calls the block with the packed value and the index" do
+      e = Enumerator.new { |y| y.yield 1, 2 }
+      seen = []
+      e.lazy.with_index { |v, i| seen << [v, i] }.force
+      seen.should == [[[1, 2], 0]]
+    end
+  end
+
   it "enumerates with an index" do
     (0..Float::INFINITY).lazy.with_index.map { |i, idx| [i, idx] }.first(3).should == [[0, 0], [1, 1], [2, 2]]
   end

--- a/spec/tags/core/enumerator/lazy/take_tags.txt
+++ b/spec/tags/core/enumerator/lazy/take_tags.txt
@@ -1,2 +1,0 @@
-fails:Enumerator::Lazy#take value packing of source yields (matches Enumerable#take) yields a single nil for a zero-argument source yield
-fails:Enumerator::Lazy#take value packing of source yields (matches Enumerable#take) yields a packed Array for a multi-argument source yield

--- a/src/main/ruby/truffleruby/core/enumerable.rb
+++ b/src/main/ruby/truffleruby/core/enumerable.rb
@@ -1037,9 +1037,9 @@ module Enumerable
     return to_enum(:take_while) unless block_given?
 
     array = []
-    each do |elem|
-      return array unless yield(elem)
-      array << elem
+    each do |*args|
+      return array unless yield(*args)
+      array << Truffle::EnumerableOperations.pack_values(args)
     end
 
     array

--- a/src/main/ruby/truffleruby/core/enumerator.rb
+++ b/src/main/ruby/truffleruby/core/enumerator.rb
@@ -398,7 +398,7 @@ class Enumerator
       Lazy.new(self, set_size) do |yielder, *args|
         taken = yielder.memo || 0
         if taken < n
-          yielder.yield(*args)
+          yielder.yield(Truffle::EnumerableOperations.pack_values(args))
           taken += 1
           yielder.memo = taken
           raise StopLazyError unless taken < n
@@ -424,7 +424,7 @@ class Enumerator
         if dropped < n
           yielder.memo = dropped + 1
         else
-          yielder.yield(*args)
+          yielder.yield(Truffle::EnumerableOperations.pack_values(args))
         end
       end
     end
@@ -434,7 +434,7 @@ class Enumerator
 
       Lazy.new(self, nil) do |yielder, *args|
         if yield(*args)
-          yielder.yield(*args)
+          yielder.yield(Truffle::EnumerableOperations.pack_values(args))
         else
           raise StopLazyError
         end
@@ -449,10 +449,10 @@ class Enumerator
         if succeeding
           unless yield(*args)
             yielder.memo = false
-            yielder.yield(*args)
+            yielder.yield(Truffle::EnumerableOperations.pack_values(args))
           end
         else
-          yielder.yield(*args)
+          yielder.yield(Truffle::EnumerableOperations.pack_values(args))
         end
       end
     end
@@ -470,8 +470,8 @@ class Enumerator
       raise ArgumentError, 'Lazy#{select,find_all} requires a block' unless block_given?
 
       Lazy.new(self, nil) do |yielder, *args|
-        val = args.length >= 2 ? args : args.first
-        yielder.yield(*args) if yield(val)
+        val = Truffle::EnumerableOperations.pack_values(args)
+        yielder.yield(val) if yield(val)
       end
     end
     alias_method :find_all, :select
@@ -481,8 +481,8 @@ class Enumerator
       raise ArgumentError, 'Lazy#reject requires a block' unless block_given?
 
       Lazy.new(self, nil) do |yielder, *args|
-        val = args.length >= 2 ? args : args.first
-        yielder.yield(*args) unless yield(val)
+        val = Truffle::EnumerableOperations.pack_values(args)
+        yielder.yield(val) unless yield(val)
       end
     end
 
@@ -491,7 +491,7 @@ class Enumerator
 
       Lazy.new(self, nil) do |yielder, *args|
         Primitive.share_special_variables(sv)
-        val = args.length >= 2 ? args : args.first
+        val = Truffle::EnumerableOperations.pack_values(args)
         matches = pattern === val
 
         if matches
@@ -508,7 +508,7 @@ class Enumerator
       s = block ? Primitive.proc_special_variables(block) : Primitive.caller_special_variables
 
       Lazy.new(self, nil) do |yielder, *args|
-        val = args.length >= 2 ? args : args.first
+        val = Truffle::EnumerableOperations.pack_values(args)
         matches = pattern === val
         Primitive.regexp_last_match_set(s, $~)
 
@@ -565,10 +565,11 @@ class Enumerator
 
       Lazy.new(self, enumerator_size) do |yielder, *args|
         memo = yielder.memo || offset
+        val = Truffle::EnumerableOperations.pack_values(args)
         if block
-          yielder.yield yield(*args, memo)
+          yielder.yield yield(val, memo)
         else
-          yielder.yield(*args, memo)
+          yielder.yield [val, memo]
         end
         yielder.memo = Primitive.rb_num2long(memo) + 1
       end
@@ -592,7 +593,7 @@ class Enumerator
 
       Lazy.new(self, enumerator_size) do |yielder, *args|
         index = yielder.memo || 0
-        val = args.length >= 2 ? args : args.first
+        val = Truffle::EnumerableOperations.pack_values(args)
         rests = lists.map do |list|
           case list
           when Array
@@ -619,8 +620,9 @@ class Enumerator
     end
 
     def compact
-      Lazy.new(self, nil) do |yielder, e|
-        yielder.yield(e) unless Primitive.nil?(e)
+      Lazy.new(self, nil) do |yielder, *args|
+        val = Truffle::EnumerableOperations.pack_values(args)
+        yielder.yield(val) unless Primitive.nil?(val)
       end
     end
 
@@ -641,9 +643,9 @@ class Enumerator
         Lazy.new(self, nil) do |yielder, *args|
           memo = yielder.memo || Set.new
 
-          val = args.length >= 2 ? args : args.first
+          val = Truffle::EnumerableOperations.pack_values(args)
           comp = yield(val)
-          yielder.yield(*args) if memo.add?(comp)
+          yielder.yield(val) if memo.add?(comp)
 
           yielder.memo = memo
         end
@@ -651,8 +653,8 @@ class Enumerator
         Lazy.new(self, nil) do |yielder, *args|
           memo = yielder.memo || Set.new
 
-          val = args.length >= 2 ? args : args.first
-          yielder.yield(*args) if memo.add?(val)
+          val = Truffle::EnumerableOperations.pack_values(args)
+          yielder.yield(val) if memo.add?(val)
 
           yielder.memo = memo
         end

--- a/src/main/ruby/truffleruby/core/truffle/enumerable_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/enumerable_operations.rb
@@ -28,6 +28,12 @@
 
 module Truffle
   module EnumerableOperations
+    # Packs values yielded by a source like rb_enum_values_pack() in CRuby:
+    # no values -> nil, a single value -> the value, multiple values -> an Array.
+    def self.pack_values(values)
+      values.size >= 2 ? values : values.first
+    end
+
     def self.cycle_size(enum_size, many)
       if many
         many = Primitive.rb_num2int many


### PR DESCRIPTION
Apply CRuby's `rb_enum_values_pack` rule where `Enumerator::Lazy` stages yield to the consumer: a multi-argument source yield is packed into one value (0 args -> `nil`, 1 -> the value, N -> an `Array`). Follow-up to #4286 (`Enumerable#chunk`), implemented at the per-method layer as discussed in #4272.

## Examples

A source whose `each` yields 0, 1, and 2 values:

```ruby
e = Enumerator.new { |y| y.yield; y.yield 1; y.yield 2, 3 }
```

CRuby packs each multi-argument source yield at the consumer boundary via `rb_enum_values_pack`. TruffleRuby did not, so the extra values were unpacked or dropped:

```ruby
# consumer boundary — collect with a splat block
e.lazy.take(9).to_a       # before: [nil, 1, 2]        after: [nil, 1, [2, 3]]

# data loss: #compact and eager #take_while dropped the second value
e.lazy.compact.to_a       # before: [1, 2]   after: [1, [2, 3]]
e.take_while { true }     # before: [nil, 1, 2]        after: [nil, 1, [2, 3]]

# #with_index pairs the packed value with the index
e.lazy.with_index.to_a    # before: [[0], [1, 1], [2, 3, 2]]
                          # after:  [[nil, 0], [1, 1], [[2, 3], 2]]
```

All "after" values match CRuby 3.4. User blocks still receive the raw arguments by ordinary block arity (`map`/`take_while`/`flat_map` etc.), matching CRuby's `rb_yield_values2`.

## Changes

* Apply the `rb_enum_values_pack` rule (0 args -> nil, 1 -> value, N -> Array) where lazy stages yield to the consumer, matching CRuby. Extracted as `Truffle::EnumerableOperations.pack_values`.
* Also fix `Enumerable#take_while`, which dropped extra values of a multi-argument yield.
* Specs copied from ruby/spec PR https://github.com/ruby/spec/pull/1375 and deleted the exclusion file `spec/tags/core/enumerator/lazy/take_tags.txt`.

## Known remaining divergence

We still cannot fully match CRuby, because CRuby tracks packed-ness with a `LAZY_MEMO_PACKED` flag on the internal value (`enumerator.c`) and splats it back into user blocks at later stages. 

```ruby
e2 = Enumerator.new { |y| y.yield 1, 2 }
e2.lazy.select { true }.map { |x| x }.force   # CRuby: [1]  | TruffleRuby master: [1], this branch: [[1, 2]]
```

This bit was introduced in the procs-array performance rewrite in Ruby 2.4 (ruby/ruby@856afbe, [Feature #6183]); the rule that block-replacing stages clear it was a later fix (ruby/ruby@51982c8, [Bug #13648]). Before 2.4, CRuby seems to have used a design much like TruffleRuby's, and appears to behave like this branch on these cases. I confirmed this partially by running 2.3, though the setup was fragile so I couldn't test everything.

The problem above happens when a pass-through stage (take/drop/select/reject/uniq/compact) feeds a splat-consuming block (map/flat_map/take_while…) using |x|/|*x|. No values are lost (grouped, not dropped), and |a, b| blocks destructure as before. Master, by contrast, did drop values elsewhere, e.g. e.lazy.compact.to_a was [1, 2] on master vs [1, [2, 3]] here and in CRuby.

The next step is a follow-up that restructures `Lazy` to carry a packed flag like CRuby's `LAZY_MEMO_PACKED`, which would also close this gap. If we have this flag, it would then be possible to strip it in `map` like CRuby. 

This divergence is not covered by ruby/spec. Probably should be though. 

- [x] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
