### PR TITLE
Fix `IO#each` with `nil` separator

### DIFF
--- a/spec/ruby/core/io/ungetc_spec.rb
+++ b/spec/ruby/core/io/ungetc_spec.rb
@@ -105,7 +105,7 @@ describe "IO#ungetc" do
 
   it "raises TypeError if passed nil" do
     @io.getc.should == ?V
-    proc{@io.ungetc(nil)}.should.raise(TypeError)
+    proc{@io.ungetc(nil)}.should raise_consistent_error(TypeError, /no implicit conversion of nil into String/)
   end
 
   it "puts one or more characters back in the stream" do

--- a/spec/tags/core/io/close_read_tags.txt
+++ b/spec/tags/core/io/close_read_tags.txt
@@ -1,2 +1,0 @@
-fails:IO#close_read does nothing on subsequent invocations
-fails:IO#close_read does nothing on closed stream

--- a/spec/tags/core/io/close_write_tags.txt
+++ b/spec/tags/core/io/close_write_tags.txt
@@ -1,2 +1,0 @@
-fails:IO#close_write does nothing on subsequent invocations
-fails:IO#close_write does nothing on closed stream

--- a/spec/tags/core/io/each_line_tags.txt
+++ b/spec/tags/core/io/each_line_tags.txt
@@ -1,1 +1,0 @@
-fails:IO#each_line when passed chomp and nil as a separator yields self's content

--- a/spec/tags/core/io/external_encoding_tags.txt
+++ b/spec/tags/core/io/external_encoding_tags.txt
@@ -1,1 +1,0 @@
-fails:IO#external_encoding can be retrieved from a closed stream

--- a/spec/tags/core/io/internal_encoding_tags.txt
+++ b/spec/tags/core/io/internal_encoding_tags.txt
@@ -1,1 +1,0 @@
-fails:IO#internal_encoding can be retrieved from a closed stream

--- a/spec/tags/core/io/print_tags.txt
+++ b/spec/tags/core/io/print_tags.txt
@@ -1,1 +1,0 @@
-fails:IO#print writes each obj.to_s to the stream separated by $, (if any) and appends $\ (if any) given multiple objects

--- a/spec/tags/core/io/ungetc_tags.txt
+++ b/spec/tags/core/io/ungetc_tags.txt
@@ -1,1 +1,0 @@
-fails:IO#ungetc raises TypeError if passed nil

--- a/src/main/ruby/truffleruby/core/io.rb
+++ b/src/main/ruby/truffleruby/core/io.rb
@@ -1348,7 +1348,6 @@ class IO
   end
 
   def external_encoding
-    ensure_open
     if @mode.anybits?(FMODE_WRITABLE)
       @external
     else
@@ -1382,7 +1381,6 @@ class IO
   end
 
   def internal_encoding
-    ensure_open
     @internal
   end
 
@@ -2424,12 +2422,10 @@ class IO::BidirectionalPipe < IO
   end
 
   def close_read
-    raise IOError, 'closed stream' if closed?
     close
   end
 
   def close_write
-    raise IOError, 'closed stream' if @write.closed?
     @write.close
   end
 

--- a/src/main/ruby/truffleruby/core/io.rb
+++ b/src/main/ruby/truffleruby/core/io.rb
@@ -2252,8 +2252,6 @@ class IO
       str = obj
     when Integer
       str = obj.chr(external_encoding || Encoding.default_external)
-    when nil
-      return
     else
       str = Primitive.convert_with_to_str(obj)
     end

--- a/src/main/ruby/truffleruby/core/io.rb
+++ b/src/main/ruby/truffleruby/core/io.rb
@@ -1122,7 +1122,6 @@ class IO
       end
 
       str << @buffer.shift
-      str.chomp!(@separator) if @chomp
       yield prepare_read_string(str) unless str.empty?
     end
 
@@ -1176,7 +1175,6 @@ class IO
         str << tmp_str
       end
 
-      str.chomp!(DEFAULT_RECORD_SEPARATOR) if @chomp
       yield prepare_read_string(str) unless str.empty?
     end
 

--- a/src/main/ruby/truffleruby/core/truffle/io_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/io_operations.rb
@@ -33,7 +33,10 @@ module Truffle
         raise 'last_line_binding is required' if Primitive.nil? last_line_storage
         io.write Primitive.io_last_line_get(last_line_storage).to_s
       else
-        args.each { |o| io.write o.to_s }
+        args.each_with_index do |o, index|
+          io.write o.to_s
+          io.write $,.to_s unless index == args.length - 1
+        end
       end
 
       io.write $\.to_s


### PR DESCRIPTION
There are a few codepaths this can take, and it only affects `nil` sep with no further arguments.

in `read_all` it chomps with `DEFAULT_RECORD_SEPARATOR`, regardless of what was actaully passed. More specifically, in that codepath it can only ever be falsy.

But `prepare_read_string` already does the chomp (after negotiating encoding), so we can just remove that call alltogether

- [ ] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
