### PR TITLE
Fix IPSocket#inspect on closed sockets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Compatibility:
 * Update `Proc#parameters` and return `[:opt]` instead of `[:opt, nil]` for destructured parameters (#4231, @andrykonchin).
 * Better compatibility for `Kernel#caller` with `Range` argument (#4295, @earlopain)
 * Support symbols as arguments for `IO#seek` and `IO#sysseek` (#4306, @earlopain)
+* Fix `IPSocket#inspect` to return `#<TCPSocket:(closed)>` for closed sockets like CRuby instead of raising `IOError` (#4312, @rubiii).
 
 Performance:
 

--- a/lib/truffle/socket/ip_socket.rb
+++ b/lib/truffle/socket/ip_socket.rb
@@ -73,6 +73,8 @@ class IPSocket < BasicSocket
   end
 
   def inspect
+    return "#<#{Primitive.class(self)}:(closed)>" if closed?
+
     family, port, _host, ip = addr
     "#<#{Primitive.class(self)}:fd #{fileno}, #{family}, #{ip}, #{port}>"
   end

--- a/spec/ruby/library/socket/ipsocket/inspect_spec.rb
+++ b/spec/ruby/library/socket/ipsocket/inspect_spec.rb
@@ -21,4 +21,22 @@ describe 'IPSocket#inspect' do
   ensure
     @socket&.close
   end
+
+  it 'returns a String marking the socket as closed for a closed TCPSocket' do
+    @server = TCPServer.new("127.0.0.1", 0)
+    @socket = TCPSocket.new("127.0.0.1", @server.addr[1])
+    @socket.close
+
+    @socket.inspect.should == "#<TCPSocket:(closed)>"
+  ensure
+    @server&.close
+  end
+
+  it 'returns a String marking the socket as closed for a closed UDPSocket' do
+    @socket = UDPSocket.new
+    @socket.bind('127.0.0.1', 0)
+    @socket.close
+
+    @socket.inspect.should == "#<UDPSocket:(closed)>"
+  end
 end


### PR DESCRIPTION
Hey people,

we encountered a problem with truffleruby-head in our integration test suite earlier today:
https://github.com/savonrb/savon/actions/runs/27293830858/job/80621200572

I figured it might be appropriate to follow CRuby in handling closed sockets on inspect.
Hope that change and the specs work for you. If not just let me know what needs to change.

- [x] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.