### PR TITLE
[Ruby 4.0] Don't expose numbered parameters in Binding local variable methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Compatibility:
 * Better compatibility for `Kernel#caller` with `Range` argument (#4295, @earlopain)
 * Support symbols as arguments for `IO#seek` and `IO#sysseek` (#4306, @earlopain)
 * Fix `IPSocket#inspect` to return `#<TCPSocket:(closed)>` for closed sockets like CRuby instead of raising `IOError` (#4312, @rubiii).
+* Don't expose numbered parameters in `Binding`'s local variable methods (#4231, @andrykonchin).
 
 Performance:
 

--- a/doc/contributor/how-to-guide.md
+++ b/doc/contributor/how-to-guide.md
@@ -14,7 +14,7 @@
   * [How to call Ruby method in Java](#how-to-call-ruby-method-in-java)
   * [How to declare an optional method argument in Ruby](#how-to-declare-an-optional-method-argument-in-ruby)
   * [How to accept keyword arguments in Core Method in Java](#how-to-accept-keyword-arguments-in-core-method-in-java)
-  * [How to create Ruby Array in Java](#how-to-create-ruby-array-in-java-)
+  * [How to create Ruby Array in Java](#how-to-create-ruby-array-in-java)
   * [How to call original class method in Ruby](#how-to-call-original-class-method-in-ruby)
   * [How to call original instance method in Ruby](#how-to-call-original-instance-method-in-ruby)
   * [How to get a list of all the Primitives](#how-to-get-a-list-of-all-the-primitives)
@@ -87,7 +87,7 @@ directory. File names follow the same pattern: `<RubyClass>Nodes`, e.g.
 represented by a Java class named after it, e.g.
 `StringNodes.SizeNode` implements Ruby `String#size` method.
 
-Let's consider and example - the implementation of the `Hash#clear` Core Method:
+Let's consider an example - the implementation of the `Hash#clear` Core Method:
 
 ```java
 // HashNodes.java
@@ -575,7 +575,7 @@ module.
 C extensions related *primitives* are located in
 `org/truffleruby/cext/CExtNodes.java` file.
 
-More details about writing a C extensions are provided in the [C Extensions Guide](cexts.md).
+More details about writing C extensions are provided in the [C Extensions Guide](cexts.md).
 
 ## How to define and expose a POSIX system call to Ruby code
 
@@ -1604,7 +1604,7 @@ whole suit pass successfully as well:
 If the new feature breaks existing behavior and some specs fail - disable them temporary (until TruffleRuby
 is switched to the next CRuby version completely) with tagging as failed (use `jt tag <path-to-spec-file>`)
 
-Look for additional details in [The "Running specs for the next Ruby version" section of the Contributor Workflow document](workflow.md#running-specs-for-ruby-40-features).
+Look for additional details in [The "Running specs for Ruby 4.1 features" section of the Contributor Workflow document](workflow.md#running-specs-for-ruby-41-features).
 
 ## How to use jt CLI tool
 

--- a/spec/ruby/core/binding/local_variable_defined_spec.rb
+++ b/spec/ruby/core/binding/local_variable_defined_spec.rb
@@ -43,4 +43,10 @@ describe 'Binding#local_variable_defined?' do
 
     binding.local_variable_defined?(name).should == true
   end
+
+  it 'raises a TypeError when given non-String/Symbol as the variable name' do
+    -> {
+      binding.local_variable_defined?(1)
+    }.should.raise(TypeError, '1 is not a symbol nor a string')
+  end
 end

--- a/spec/ruby/core/binding/local_variable_get_spec.rb
+++ b/spec/ruby/core/binding/local_variable_get_spec.rb
@@ -53,4 +53,10 @@ describe "Binding#local_variable_get" do
     -> { bind.local_variable_get(:$~) }.should.raise(NameError)
     -> { bind.local_variable_get(:$_) }.should.raise(NameError)
   end
+
+  it 'raises a TypeError when given non-String/Symbol as the variable name' do
+    -> {
+      binding.local_variable_get(1)
+    }.should.raise(TypeError, '1 is not a symbol nor a string')
+  end
 end

--- a/spec/ruby/core/binding/local_variable_set_spec.rb
+++ b/spec/ruby/core/binding/local_variable_set_spec.rb
@@ -68,4 +68,9 @@ describe "Binding#local_variable_set" do
     -> { bind.local_variable_set(:$_, "") }.should.raise(NameError)
   end
 
+  it 'raises a TypeError when given non-String/Symbol as the variable name' do
+    -> {
+      binding.local_variable_set(1, 2)
+    }.should.raise(TypeError, '1 is not a symbol nor a string')
+  end
 end

--- a/spec/ruby/language/numbered_parameters_spec.rb
+++ b/spec/ruby/language/numbered_parameters_spec.rb
@@ -118,19 +118,19 @@ describe "Numbered parameters" do
     it "does not affect binding local variables getting" do
       -> {
         -> { _1; binding.local_variable_get(:_1) }.call("a")
-      }.should.raise(NameError)
+      }.should.raise(NameError, "numbered parameter '_1' is not a local variable")
     end
 
     it "does not affect binding local variables setting" do
       -> {
         -> { _1; binding.local_variable_set(:_1, "b") }.call("a")
-      }.should.raise(NameError)
+      }.should.raise(NameError, "numbered parameter '_1' is not a local variable")
     end
 
     it "does not affect binding local variables definition check" do
       -> {
         -> { _1; binding.local_variable_defined?(:_1) }.call("a")
-      }.should.raise(NameError)
+      }.should.raise(NameError, "numbered parameter '_1' is not a local variable")
     end
   end
 

--- a/spec/ruby/language/numbered_parameters_spec.rb
+++ b/spec/ruby/language/numbered_parameters_spec.rb
@@ -95,12 +95,42 @@ describe "Numbered parameters" do
       -> { _1; binding.local_variables }.call("a").should == [:_1]
       -> { _2; binding.local_variables }.call("a", "b").should == [:_1, :_2]
     end
+
+    it "affects binding local variables getting" do
+      -> { _1; binding.local_variable_get(:_1) }.call("a").should == "a"
+    end
+
+    it "affects binding local variables setting" do
+      -> { _1; binding.local_variable_set(:_1, "b"); _1 }.call("a").should == "b"
+    end
+
+    it "affects binding local variables definition check" do
+      -> { _1; binding.local_variable_defined?(:_1) }.call("a").should == true
+    end
   end
 
   ruby_version_is "4.0" do
     it "does not affect binding local variables" do
       -> { _1; binding.local_variables }.call("a").should == []
       -> { _2; binding.local_variables }.call("a", "b").should == []
+    end
+
+    it "does not affect binding local variables getting" do
+      -> {
+        -> { _1; binding.local_variable_get(:_1) }.call("a")
+      }.should.raise(NameError)
+    end
+
+    it "does not affect binding local variables setting" do
+      -> {
+        -> { _1; binding.local_variable_set(:_1, "b") }.call("a")
+      }.should.raise(NameError)
+    end
+
+    it "does not affect binding local variables definition check" do
+      -> {
+        -> { _1; binding.local_variable_defined?(:_1) }.call("a")
+      }.should.raise(NameError)
     end
   end
 

--- a/spec/tags/core/proc/parameters_tags.txt
+++ b/spec/tags/core/proc/parameters_tags.txt
@@ -1,1 +1,0 @@
-fails:Proc#parameters handles the usage of `it` as a parameter

--- a/spec/tags/language/it_parameter_tags.txt
+++ b/spec/tags/language/it_parameter_tags.txt
@@ -1,1 +1,0 @@
-fails:The `it` parameter affects block parameters

--- a/spec/tags/language/numbered_parameters_tags.txt
+++ b/spec/tags/language/numbered_parameters_tags.txt
@@ -1,1 +1,0 @@
-fails:Numbered parameters does not affect binding local variables

--- a/src/main/java/org/truffleruby/core/binding/BindingNodes.java
+++ b/src/main/java/org/truffleruby/core/binding/BindingNodes.java
@@ -76,14 +76,6 @@ public abstract class BindingNodes {
                 sourceSection);
     }
 
-    @TruffleBoundary
-    public static FrameDescriptor newFrameDescriptor(FrameDescriptor parentDescriptor) {
-        var parentInfo = FrameDescriptorInfo.of(parentDescriptor);
-        var info = new FrameDescriptorInfo(parentDescriptor,
-                parentInfo.getSharedMethodInfo().addOneBlockDepthButKeepParseNameAndRuntimeName());
-        return TranslatorEnvironment.newFrameDescriptorBuilderForBlock(info).build();
-    }
-
     static final int NEW_VAR_INDEX = 1;
 
     @TruffleBoundary

--- a/src/main/java/org/truffleruby/core/binding/BindingNodes.java
+++ b/src/main/java/org/truffleruby/core/binding/BindingNodes.java
@@ -273,11 +273,19 @@ public abstract class BindingNodes {
         }
 
         @TruffleBoundary
-        @Specialization(guards = "isHiddenVariable(name) || isNumberedParameter(name)")
+        @Specialization(guards = "isHiddenVariable(name)")
         static boolean localVariableDefinedLastLine(Node node, RubyBinding binding, String name) {
             throw new RaiseException(
                     getContext(node),
                     coreExceptions(node).nameError("Bad local variable name", binding, name, node));
+        }
+
+        @TruffleBoundary
+        @Specialization(guards = "isNumberedParameter(name)")
+        static boolean numberedParameter(Node node, RubyBinding binding, String name) {
+            throw new RaiseException(
+                    getContext(node),
+                    coreExceptions(node).nameErrorNumberedParameterIsNotALocalVariable(name, node));
         }
 
         protected int getCacheLimit() {
@@ -322,12 +330,19 @@ public abstract class BindingNodes {
         }
 
         @TruffleBoundary
-        @Specialization(
-                guards = "isHiddenVariable(name) || isNumberedParameter(name)")
+        @Specialization(guards = "isHiddenVariable(name)")
         static Object localVariableGetLastLine(Node node, RubyBinding binding, String name) {
             throw new RaiseException(
                     getContext(node),
                     coreExceptions(node).nameError("Bad local variable name", binding, name, node));
+        }
+
+        @TruffleBoundary
+        @Specialization(guards = "isNumberedParameter(name)")
+        static Object numberedParameter(Node node, RubyBinding binding, String name) {
+            throw new RaiseException(
+                    getContext(node),
+                    coreExceptions(node).nameErrorNumberedParameterIsNotALocalVariable(name, node));
         }
 
     }
@@ -416,11 +431,19 @@ public abstract class BindingNodes {
         }
 
         @TruffleBoundary
-        @Specialization(guards = "isHiddenVariable(name) || isNumberedParameter(name)")
+        @Specialization(guards = "isHiddenVariable(name)")
         static Object localVariableSetLastLine(Node node, RubyBinding binding, String name, Object value) {
             throw new RaiseException(
                     getContext(node),
                     coreExceptions(node).nameError("Bad local variable name", binding, name, node));
+        }
+
+        @TruffleBoundary
+        @Specialization(guards = "isNumberedParameter(name)")
+        static Object numberedParameter(Node node, RubyBinding binding, String name, Object value) {
+            throw new RaiseException(
+                    getContext(node),
+                    coreExceptions(node).nameErrorNumberedParameterIsNotALocalVariable(name, node));
         }
 
         protected int getCacheLimit() {

--- a/src/main/java/org/truffleruby/core/binding/BindingNodes.java
+++ b/src/main/java/org/truffleruby/core/binding/BindingNodes.java
@@ -152,9 +152,9 @@ public abstract class BindingNodes {
         return false;
     }
 
-    public static boolean isHiddenVariable(Object name) {
-        if (name instanceof String) {
-            return isHiddenVariable((String) name);
+    public static boolean isHiddenVariable(Object object) {
+        if (object instanceof String name) {
+            return isHiddenVariable(name);
         } else {
             return true;
         }
@@ -166,6 +166,20 @@ public abstract class BindingNodes {
         final char first = name.charAt(0);
         return first == '$' /* Frame-local global variable */ ||
                 first == '%' /* temporary variable */;
+    }
+
+    @Idempotent
+    static boolean isNumberedParameter(String name) {
+        return name.length() == 2 && name.charAt(0) == '_' && name.charAt(1) >= '1' && name.charAt(1) <= '9';
+    }
+
+    @Idempotent
+    static boolean isNumberedParameter(Object object) {
+        if (!(object instanceof String name)) {
+            return false;
+        }
+
+        return isNumberedParameter(name);
     }
 
     @CoreMethod(names = { "dup", "clone" })
@@ -240,6 +254,7 @@ public abstract class BindingNodes {
                 guards = {
                         "name == cachedName",
                         "!isHiddenVariable(cachedName)",
+                        "!isNumberedParameter(cachedName)",
                         "getFrameDescriptor(binding) == descriptor" },
                 limit = "getCacheLimit()")
         static boolean localVariableDefinedCached(RubyBinding binding, String name,
@@ -250,13 +265,15 @@ public abstract class BindingNodes {
         }
 
         @TruffleBoundary
-        @Specialization(guards = "!isHiddenVariable(name)", replaces = "localVariableDefinedCached")
+        @Specialization(
+                guards = { "!isHiddenVariable(name)", "!isNumberedParameter(name)" },
+                replaces = "localVariableDefinedCached")
         static boolean localVariableDefinedUncached(RubyBinding binding, String name) {
             return FindDeclarationVariableNodes.findFrameSlotOrNull(name, binding.getFrame()) != null;
         }
 
         @TruffleBoundary
-        @Specialization(guards = "isHiddenVariable(name)")
+        @Specialization(guards = "isHiddenVariable(name) || isNumberedParameter(name)")
         static boolean localVariableDefinedLastLine(Node node, RubyBinding binding, String name) {
             throw new RaiseException(
                     getContext(node),
@@ -279,6 +296,7 @@ public abstract class BindingNodes {
             final var name = nameToJavaStringNode.execute(this, nameObject);
             return localVariableGetNode.execute(this, binding, name);
         }
+
     }
 
     @GenerateUncached
@@ -289,7 +307,8 @@ public abstract class BindingNodes {
 
         public abstract Object execute(Node node, RubyBinding binding, String name);
 
-        @Specialization(guards = "!isHiddenVariable(name)")
+        @Specialization(
+                guards = { "!isHiddenVariable(name)", "!isNumberedParameter(name)" })
         static Object localVariableGet(Node node, RubyBinding binding, String name,
                 @Cached FindAndReadDeclarationVariableNode readNode) {
             MaterializedFrame frame = binding.getFrame();
@@ -303,12 +322,14 @@ public abstract class BindingNodes {
         }
 
         @TruffleBoundary
-        @Specialization(guards = "isHiddenVariable(name)")
+        @Specialization(
+                guards = "isHiddenVariable(name) || isNumberedParameter(name)")
         static Object localVariableGetLastLine(Node node, RubyBinding binding, String name) {
             throw new RaiseException(
                     getContext(node),
                     coreExceptions(node).nameError("Bad local variable name", binding, name, node));
         }
+
     }
 
     @CoreMethod(names = "local_variable_set", required = 2)
@@ -337,6 +358,7 @@ public abstract class BindingNodes {
                 guards = {
                         "name == cachedName",
                         "!isHiddenVariable(cachedName)",
+                        "!isNumberedParameter(cachedName)",
                         "getFrameDescriptor(binding) == cachedFrameDescriptor",
                         "cachedFrameSlot != null" },
                 limit = "getCacheLimit()")
@@ -355,6 +377,7 @@ public abstract class BindingNodes {
                 guards = {
                         "name == cachedName",
                         "!isHiddenVariable(cachedName)",
+                        "!isNumberedParameter(cachedName)",
                         "getFrameDescriptor(binding) == cachedFrameDescriptor",
                         "cachedFrameSlot == null" },
                 limit = "getCacheLimit()")
@@ -372,7 +395,7 @@ public abstract class BindingNodes {
 
         @TruffleBoundary
         @Specialization(
-                guards = "!isHiddenVariable(name)",
+                guards = { "!isHiddenVariable(name)", "!isNumberedParameter(name)" },
                 replaces = { "localVariableSetCached", "localVariableSetNewCached" })
         static Object localVariableSetUncached(RubyBinding binding, String name, Object value) {
             MaterializedFrame frame = binding.getFrame();
@@ -393,7 +416,7 @@ public abstract class BindingNodes {
         }
 
         @TruffleBoundary
-        @Specialization(guards = "isHiddenVariable(name)")
+        @Specialization(guards = "isHiddenVariable(name) || isNumberedParameter(name)")
         static Object localVariableSetLastLine(Node node, RubyBinding binding, String name, Object value) {
             throw new RaiseException(
                     getContext(node),
@@ -433,7 +456,7 @@ public abstract class BindingNodes {
 
         private void addNamesFromFrame(Frame frame, Set<Object> names) {
             for (Object identifier : FrameDescriptorNamesIterator.iterate(frame.getFrameDescriptor())) {
-                if (!isHiddenVariable(identifier)) {
+                if (!isHiddenVariable(identifier) && !isNumberedParameter(identifier)) {
                     names.add(getSymbol((String) identifier));
                 }
             }

--- a/src/main/java/org/truffleruby/core/exception/CoreExceptions.java
+++ b/src/main/java/org/truffleruby/core/exception/CoreExceptions.java
@@ -797,6 +797,12 @@ public final class CoreExceptions {
     }
 
     @TruffleBoundary
+    public RubyNameError nameErrorNumberedParameterIsNotALocalVariable(String name, Node currentNode) {
+        return nameError(StringUtils.format("numbered parameter '%s' is not a local variable", name), null, name,
+                currentNode);
+    }
+
+    @TruffleBoundary
     public RubyNameError nameErrorUnknownIdentifierException(
             UnknownIdentifierException exception, Object receiver, Node currentNode) {
         return nameError(

--- a/src/main/java/org/truffleruby/language/arguments/ArgumentDescriptorUtils.java
+++ b/src/main/java/org/truffleruby/language/arguments/ArgumentDescriptorUtils.java
@@ -21,8 +21,11 @@ import org.truffleruby.parser.ArgumentDescriptor;
 import org.truffleruby.parser.ArgumentType;
 
 import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
+import org.truffleruby.parser.YARPTranslator;
 
 public final class ArgumentDescriptorUtils {
+
+    static final String IT_PARAMETER_NAME = YARPTranslator.IT_PARAMETER_NAME;
 
     @TruffleBoundary
     public static RubyArray argumentDescriptorsToParameters(RubyLanguage language, RubyContext context,
@@ -56,6 +59,8 @@ public final class ArgumentDescriptorUtils {
         } else if (argType == ArgumentType.anonblock) {
             store = new Object[]{ typeSymbol, language.coreSymbols.AMPERSAND };
         } else if (argType.anonymous || name == null) {
+            store = new Object[]{ typeSymbol };
+        } else if (name.equals(IT_PARAMETER_NAME)) {
             store = new Object[]{ typeSymbol };
         } else {
             store = new Object[]{ typeSymbol, language.getSymbol(name) };

--- a/src/main/java/org/truffleruby/parser/YARPTranslator.java
+++ b/src/main/java/org/truffleruby/parser/YARPTranslator.java
@@ -196,7 +196,7 @@ public class YARPTranslator extends YARPBaseTranslator {
             "_9"
     };
 
-    static final String IT_PARAMETER_NAME = "%it";
+    public static final String IT_PARAMETER_NAME = "%it";
 
     /** all the encountered BEGIN {} blocks; they will be added finally at the beginning of the program AST */
     private final ArrayList<RubyNode> beginBlocks = new ArrayList<>();

--- a/test/mri/excludes/TestProc.rb
+++ b/test/mri/excludes/TestProc.rb
@@ -20,7 +20,6 @@ exclude :test_implicit_parameters_for_numparams, "[NameError] exception expected
 exclude :test_localjump_error, "NoMethodError: undefined method `exit_value' for an instance of LocalJumpError"
 exclude :test_orphan_return, "LocalJumpError expected but nothing was raised."
 exclude :test_parameters, "<[[:opt, nil], [:block, :b]]> expected but was <[[:req], [:block, :b]]>."
-exclude :test_parameters_lambda, "<[[:req]]> expected but was <[[:req, :\"%it\"]]>."
 exclude :test_proc_args_opt_rest, "<[:a, :b, :c, []]> expected but was <[[], :b, :c, []]>."
 exclude :test_proc_autosplat, "<[[1, 2], [[1, 2, 3], 0], [[1, 2, 3], {}]]> expected but was <[[1, 2], [1, 2], [[1, 2, 3], {}]]>."
 exclude :test_proc_autosplat_with_multiple_args_with_ruby2_keywords_splat_bug_19759, "<[[:a, :b], nil]> expected but was <[:a, :b]>."

--- a/test/mri/excludes/TestProc.rb
+++ b/test/mri/excludes/TestProc.rb
@@ -18,7 +18,6 @@ exclude :test_implicit_parameters_for_it_and_numparams, "Test::Unit::ProxyError:
 exclude :test_implicit_parameters_for_it_complex, "Test::Unit::ProxyError: undefined method 'implicit_parameters' for an instance of Binding"
 exclude :test_implicit_parameters_for_numparams, "[NameError] exception expected, not #<NoMethodError: undefined method 'implicit_parameter_get' for an instance of Binding>."
 exclude :test_localjump_error, "NoMethodError: undefined method `exit_value' for an instance of LocalJumpError"
-exclude :test_numparam_is_not_local_variables, "<[]> expected but was <[:_1, :_2, :_3, :_4, :_5, :_6, :_7, :_8, :_9]>."
 exclude :test_orphan_return, "LocalJumpError expected but nothing was raised."
 exclude :test_parameters, "<[[:opt, nil], [:block, :b]]> expected but was <[[:req], [:block, :b]]>."
 exclude :test_parameters_lambda, "<[[:req]]> expected but was <[[:req, :\"%it\"]]>."


### PR DESCRIPTION
#4231

> Binding#local_variables does no longer include numbered parameters.
Also, Binding#local_variable_get, Binding#local_variable_set, and
Binding#local_variable_defined? reject to handle numbered parameters.
[[Bug #21049](https://bugs.ruby-lang.org/issues/21049)]

- [x] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
