### PR TITLE
Add Array#find and Array#rfind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 New features:
 
 * Updated to Ruby 4.0.2 (#4231, @eregon).
+* Add `Array#find` and `Array#detect` as faster overrides of `Enumerable#find` (#4231, @komarovb).
+* Add `Array#rfind` as a more efficient alternative to `array.reverse_each.find` (#4231, @komarovb).
 
 Bug fixes:
 

--- a/spec/ruby/core/array/detect_spec.rb
+++ b/spec/ruby/core/array/detect_spec.rb
@@ -1,0 +1,9 @@
+require_relative '../../spec_helper'
+
+ruby_version_is "4.0" do
+  describe "Array#detect" do
+    it "is an alias of Array#find" do
+      Array.instance_method(:detect).should == Array.instance_method(:find)
+    end
+  end
+end

--- a/spec/ruby/core/array/find_spec.rb
+++ b/spec/ruby/core/array/find_spec.rb
@@ -41,6 +41,18 @@ ruby_version_is "4.0" do
       -> { [1, 2, 3].find(42) { |x| false } }.should.raise(NoMethodError)
     end
 
+    it "iterates elements in forward order" do
+      visited = []
+      [1, 2, 3].find { |element| visited << element; false }
+      visited.should == [1, 2, 3]
+    end
+
+    it "passes through the values yielded by #each_with_index" do
+      ScratchPad.record []
+      [:a, :b].each_with_index.to_a.find { |x, i| ScratchPad << [x, i]; nil }
+      ScratchPad.recorded.should == [[:a, 0], [:b, 1]]
+    end
+
     it "stops iterating as soon as an element is found" do
       visited = []
       [1, 2, 3, 4, 5].find { |x| visited << x; x == 3 }
@@ -52,10 +64,21 @@ ruby_version_is "4.0" do
     end
 
     it "passes the ifnone proc to the enumerator" do
-      times = 0
-      fail_proc = -> { times += 1; raise if times > 1; "cheeseburgers" }
-      [1, 2, 3].find(fail_proc).each { |x| false }.should == "cheeseburgers"
+      fail_proc = -> { "cheeseburgers" }
+      enum = [1, 2, 3].find(fail_proc)
+      enum.each { |x| false }.should == "cheeseburgers"
     end
+
+    it "does not destructure elements" do
+      multi = [[1, 2], [3, 4, 5], [6, 7, 8, 9]]
+      multi.find { |e| e == [1, 2] }.should == [1, 2]
+    end
+
+    # Modifying a collection while the contents are being iterated
+    # gives undefined behavior. See
+    # https://blade.ruby-lang.org/ruby-core/23633
+    # it "rechecks the array size during iteration" do
+    # end
 
     it_behaves_like :enumeratorized_with_unknown_size, :find, [1, 2, 3]
   end

--- a/spec/ruby/core/array/find_spec.rb
+++ b/spec/ruby/core/array/find_spec.rb
@@ -1,0 +1,40 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+require_relative '../enumerable/shared/enumeratorized'
+
+describe "Array#find" do
+  it "returns the first element for which the block returns a truthy value" do
+    [1, 2, 3, 4, 5].find { |x| x % 2 == 0 }.should == 2
+  end
+
+  it "returns nil when no element matches and no ifnone proc is given" do
+    [1, 2, 3].find { |x| false }.should == nil
+  end
+
+  it "calls the ifnone proc and returns its value when no element matches" do
+    fail_proc = -> { "cheeseburgers" }
+    [1, 2, 3].find(fail_proc) { |x| false }.should == "cheeseburgers"
+  end
+
+  it "does not call the ifnone proc when an element is found" do
+    fail_proc = -> { raise "This shouldn't have been called" }
+    [1, 2, 3].find(fail_proc) { |x| x == 1 }.should == 1
+  end
+
+  it "stops iterating as soon as an element is found" do
+    visited = []
+    [1, 2, 3, 4, 5].find { |x| visited << x; x == 3 }
+    visited.should == [1, 2, 3]
+  end
+
+  it "returns an Enumerator when no block is given" do
+    [1, 2, 3].find.should.instance_of?(Enumerator)
+  end
+
+  it "is also available as #detect using the Array-specific implementation" do
+    [].method(:detect).owner.should == Array
+    [1, 2, 3].detect { |x| x % 2 == 0 }.should == 2
+  end
+
+  it_behaves_like :enumeratorized_with_unknown_size, :find, [1, 2, 3]
+end

--- a/spec/ruby/core/array/find_spec.rb
+++ b/spec/ruby/core/array/find_spec.rb
@@ -38,7 +38,7 @@ ruby_version_is "4.0" do
     end
 
     it "raises a NoMethodError if the ifnone argument does not respond to #call and no element is found" do
-      -> { [1, 2, 3].find(42) { |x| false } }.should raise_error(NoMethodError)
+      -> { [1, 2, 3].find(42) { |x| false } }.should.raise(NoMethodError)
     end
 
     it "stops iterating as soon as an element is found" do

--- a/spec/ruby/core/array/find_spec.rb
+++ b/spec/ruby/core/array/find_spec.rb
@@ -2,39 +2,41 @@ require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 require_relative '../enumerable/shared/enumeratorized'
 
-describe "Array#find" do
-  it "returns the first element for which the block returns a truthy value" do
-    [1, 2, 3, 4, 5].find { |x| x % 2 == 0 }.should == 2
-  end
+ruby_version_is "4.0" do
+  describe "Array#find" do
+    it "returns the first element for which the block returns a truthy value" do
+      [1, 2, 3, 4, 5].find { |x| x % 2 == 0 }.should == 2
+    end
 
-  it "returns nil when no element matches and no ifnone proc is given" do
-    [1, 2, 3].find { |x| false }.should == nil
-  end
+    it "returns nil when no element matches and no ifnone proc is given" do
+      [1, 2, 3].find { |x| false }.should == nil
+    end
 
-  it "calls the ifnone proc and returns its value when no element matches" do
-    fail_proc = -> { "cheeseburgers" }
-    [1, 2, 3].find(fail_proc) { |x| false }.should == "cheeseburgers"
-  end
+    it "calls the ifnone proc and returns its value when no element matches" do
+      fail_proc = -> { "cheeseburgers" }
+      [1, 2, 3].find(fail_proc) { |x| false }.should == "cheeseburgers"
+    end
 
-  it "does not call the ifnone proc when an element is found" do
-    fail_proc = -> { raise "This shouldn't have been called" }
-    [1, 2, 3].find(fail_proc) { |x| x == 1 }.should == 1
-  end
+    it "does not call the ifnone proc when an element is found" do
+      fail_proc = -> { raise "This shouldn't have been called" }
+      [1, 2, 3].find(fail_proc) { |x| x == 1 }.should == 1
+    end
 
-  it "stops iterating as soon as an element is found" do
-    visited = []
-    [1, 2, 3, 4, 5].find { |x| visited << x; x == 3 }
-    visited.should == [1, 2, 3]
-  end
+    it "stops iterating as soon as an element is found" do
+      visited = []
+      [1, 2, 3, 4, 5].find { |x| visited << x; x == 3 }
+      visited.should == [1, 2, 3]
+    end
 
-  it "returns an Enumerator when no block is given" do
-    [1, 2, 3].find.should.instance_of?(Enumerator)
-  end
+    it "returns an Enumerator when no block is given" do
+      [1, 2, 3].find.should.instance_of?(Enumerator)
+    end
 
-  it "is also available as #detect using the Array-specific implementation" do
-    [].method(:detect).owner.should == Array
-    [1, 2, 3].detect { |x| x % 2 == 0 }.should == 2
-  end
+    it "is also available as #detect using the Array-specific implementation" do
+      [].method(:detect).owner.should == Array
+      [1, 2, 3].detect { |x| x % 2 == 0 }.should == 2
+    end
 
-  it_behaves_like :enumeratorized_with_unknown_size, :find, [1, 2, 3]
+    it_behaves_like :enumeratorized_with_unknown_size, :find, [1, 2, 3]
+  end
 end

--- a/spec/ruby/core/array/find_spec.rb
+++ b/spec/ruby/core/array/find_spec.rb
@@ -4,22 +4,41 @@ require_relative '../enumerable/shared/enumeratorized'
 
 ruby_version_is "4.0" do
   describe "Array#find" do
-    it "returns the first element for which the block returns a truthy value" do
+    it "returns the first element for which the block is not false" do
       [1, 2, 3, 4, 5].find { |x| x % 2 == 0 }.should == 2
     end
 
-    it "returns nil when no element matches and no ifnone proc is given" do
+    it "returns nil when the block is false and there is no ifnone proc given" do
       [1, 2, 3].find { |x| false }.should == nil
     end
 
-    it "calls the ifnone proc and returns its value when no element matches" do
+    it "returns the value of the ifnone proc if the block is false" do
       fail_proc = -> { "cheeseburgers" }
       [1, 2, 3].find(fail_proc) { |x| false }.should == "cheeseburgers"
     end
 
-    it "does not call the ifnone proc when an element is found" do
+    it "doesn't call the ifnone proc if an element is found" do
       fail_proc = -> { raise "This shouldn't have been called" }
       [1, 2, 3].find(fail_proc) { |x| x == 1 }.should == 1
+    end
+
+    it "calls the ifnone proc only once when the block is false" do
+      times = 0
+      fail_proc = -> { times += 1; raise if times > 1; "cheeseburgers" }
+      [1, 2, 3].find(fail_proc) { |x| false }.should == "cheeseburgers"
+    end
+
+    it "calls the ifnone proc when there are no elements" do
+      fail_proc = -> { "yay" }
+      [].find(fail_proc) { |x| true }.should == "yay"
+    end
+
+    it "ignores the ifnone argument when nil" do
+      [1, 2, 3].find(nil) { |x| false }.should == nil
+    end
+
+    it "raises a NoMethodError if the ifnone argument does not respond to #call and no element is found" do
+      -> { [1, 2, 3].find(42) { |x| false } }.should raise_error(NoMethodError)
     end
 
     it "stops iterating as soon as an element is found" do
@@ -28,13 +47,14 @@ ruby_version_is "4.0" do
       visited.should == [1, 2, 3]
     end
 
-    it "returns an Enumerator when no block is given" do
+    it "returns an enumerator when no block given" do
       [1, 2, 3].find.should.instance_of?(Enumerator)
     end
 
-    it "is also available as #detect using the Array-specific implementation" do
-      [].method(:detect).owner.should == Array
-      [1, 2, 3].detect { |x| x % 2 == 0 }.should == 2
+    it "passes the ifnone proc to the enumerator" do
+      times = 0
+      fail_proc = -> { times += 1; raise if times > 1; "cheeseburgers" }
+      [1, 2, 3].find(fail_proc).each { |x| false }.should == "cheeseburgers"
     end
 
     it_behaves_like :enumeratorized_with_unknown_size, :find, [1, 2, 3]

--- a/spec/ruby/core/array/rfind_spec.rb
+++ b/spec/ruby/core/array/rfind_spec.rb
@@ -42,7 +42,7 @@ ruby_version_is "4.0" do
     end
 
     it "raises a NoMethodError if the ifnone argument does not respond to #call and no element is found" do
-      -> { [1, 2, 3].rfind(42) { |x| false } }.should raise_error(NoMethodError)
+      -> { [1, 2, 3].rfind(42) { |x| false } }.should.raise(NoMethodError)
     end
 
     it "iterates elements in reverse order" do

--- a/spec/ruby/core/array/rfind_spec.rb
+++ b/spec/ruby/core/array/rfind_spec.rb
@@ -6,47 +6,49 @@ require_relative '../enumerable/shared/enumeratorized'
 # gives undefined behavior. See
 # https://blade.ruby-lang.org/ruby-core/23633
 
-describe "Array#rfind" do
-  it "returns the last element for which the block returns a truthy value" do
-    [1, 2, 3, 4, 5].rfind { |x| x % 2 == 0 }.should == 4
-  end
+ruby_version_is "4.0" do
+  describe "Array#rfind" do
+    it "returns the last element for which the block returns a truthy value" do
+      [1, 2, 3, 4, 5].rfind { |x| x % 2 == 0 }.should == 4
+    end
 
-  it "returns nil when no element matches and no ifnone proc is given" do
-    [1, 2, 3].rfind { |x| false }.should == nil
-  end
+    it "returns nil when no element matches and no ifnone proc is given" do
+      [1, 2, 3].rfind { |x| false }.should == nil
+    end
 
-  it "calls the ifnone proc and returns its value when no element matches" do
-    fail_proc = -> { "cheeseburgers" }
-    [1, 2, 3].rfind(fail_proc) { |x| false }.should == "cheeseburgers"
-  end
+    it "calls the ifnone proc and returns its value when no element matches" do
+      fail_proc = -> { "cheeseburgers" }
+      [1, 2, 3].rfind(fail_proc) { |x| false }.should == "cheeseburgers"
+    end
 
-  it "does not call the ifnone proc when an element is found" do
-    fail_proc = -> { raise "This shouldn't have been called" }
-    [1, 2, 3].rfind(fail_proc) { |x| x == 3 }.should == 3
-  end
+    it "does not call the ifnone proc when an element is found" do
+      fail_proc = -> { raise "This shouldn't have been called" }
+      [1, 2, 3].rfind(fail_proc) { |x| x == 3 }.should == 3
+    end
 
-  it "iterates elements in reverse order" do
-    visited = []
-    [1, 2, 3].rfind { |x| visited << x; false }
-    visited.should == [3, 2, 1]
-  end
+    it "iterates elements in reverse order" do
+      visited = []
+      [1, 2, 3].rfind { |x| visited << x; false }
+      visited.should == [3, 2, 1]
+    end
 
-  it "stops iterating as soon as a matching element is found from the end" do
-    visited = []
-    [1, 2, 3, 4, 5].rfind { |x| visited << x; x == 3 }
-    visited.should == [5, 4, 3]
-  end
+    it "stops iterating as soon as a matching element is found from the end" do
+      visited = []
+      [1, 2, 3, 4, 5].rfind { |x| visited << x; x == 3 }
+      visited.should == [5, 4, 3]
+    end
 
-  it "returns an Enumerator when no block is given" do
-    [1, 2, 3].rfind.should.instance_of?(Enumerator)
-  end
+    it "returns an Enumerator when no block is given" do
+      [1, 2, 3].rfind.should.instance_of?(Enumerator)
+    end
 
-  it "rechecks the array size during iteration" do
-    ary = [4, 2, 1, 5, 1, 3]
-    seen = []
-    ary.rfind { |x| seen << x; ary.clear; false }
-    seen.should == [3]
-  end
+    it "rechecks the array size during iteration" do
+      ary = [4, 2, 1, 5, 1, 3]
+      seen = []
+      ary.rfind { |x| seen << x; ary.clear; false }
+      seen.should == [3]
+    end
 
-  it_behaves_like :enumeratorized_with_unknown_size, :rfind, [1, 2, 3]
+    it_behaves_like :enumeratorized_with_unknown_size, :rfind, [1, 2, 3]
+  end
 end

--- a/spec/ruby/core/array/rfind_spec.rb
+++ b/spec/ruby/core/array/rfind_spec.rb
@@ -8,22 +8,41 @@ require_relative '../enumerable/shared/enumeratorized'
 
 ruby_version_is "4.0" do
   describe "Array#rfind" do
-    it "returns the last element for which the block returns a truthy value" do
+    it "returns the last element for which the block is not false" do
       [1, 2, 3, 4, 5].rfind { |x| x % 2 == 0 }.should == 4
     end
 
-    it "returns nil when no element matches and no ifnone proc is given" do
+    it "returns nil when the block is false and there is no ifnone proc given" do
       [1, 2, 3].rfind { |x| false }.should == nil
     end
 
-    it "calls the ifnone proc and returns its value when no element matches" do
+    it "returns the value of the ifnone proc if the block is false" do
       fail_proc = -> { "cheeseburgers" }
       [1, 2, 3].rfind(fail_proc) { |x| false }.should == "cheeseburgers"
     end
 
-    it "does not call the ifnone proc when an element is found" do
+    it "doesn't call the ifnone proc if an element is found" do
       fail_proc = -> { raise "This shouldn't have been called" }
       [1, 2, 3].rfind(fail_proc) { |x| x == 3 }.should == 3
+    end
+
+    it "calls the ifnone proc only once when the block is false" do
+      times = 0
+      fail_proc = -> { times += 1; raise if times > 1; "cheeseburgers" }
+      [1, 2, 3].rfind(fail_proc) { |x| false }.should == "cheeseburgers"
+    end
+
+    it "calls the ifnone proc when there are no elements" do
+      fail_proc = -> { "yay" }
+      [].rfind(fail_proc) { |x| true }.should == "yay"
+    end
+
+    it "ignores the ifnone argument when nil" do
+      [1, 2, 3].rfind(nil) { |x| false }.should == nil
+    end
+
+    it "raises a NoMethodError if the ifnone argument does not respond to #call and no element is found" do
+      -> { [1, 2, 3].rfind(42) { |x| false } }.should raise_error(NoMethodError)
     end
 
     it "iterates elements in reverse order" do
@@ -38,8 +57,14 @@ ruby_version_is "4.0" do
       visited.should == [5, 4, 3]
     end
 
-    it "returns an Enumerator when no block is given" do
+    it "returns an enumerator when no block given" do
       [1, 2, 3].rfind.should.instance_of?(Enumerator)
+    end
+
+    it "passes the ifnone proc to the enumerator" do
+      times = 0
+      fail_proc = -> { times += 1; raise if times > 1; "cheeseburgers" }
+      [1, 2, 3].rfind(fail_proc).each { |x| false }.should == "cheeseburgers"
     end
 
     it "rechecks the array size during iteration" do

--- a/spec/ruby/core/array/rfind_spec.rb
+++ b/spec/ruby/core/array/rfind_spec.rb
@@ -1,0 +1,52 @@
+require_relative '../../spec_helper'
+require_relative 'fixtures/classes'
+require_relative '../enumerable/shared/enumeratorized'
+
+# Modifying a collection while the contents are being iterated
+# gives undefined behavior. See
+# https://blade.ruby-lang.org/ruby-core/23633
+
+describe "Array#rfind" do
+  it "returns the last element for which the block returns a truthy value" do
+    [1, 2, 3, 4, 5].rfind { |x| x % 2 == 0 }.should == 4
+  end
+
+  it "returns nil when no element matches and no ifnone proc is given" do
+    [1, 2, 3].rfind { |x| false }.should == nil
+  end
+
+  it "calls the ifnone proc and returns its value when no element matches" do
+    fail_proc = -> { "cheeseburgers" }
+    [1, 2, 3].rfind(fail_proc) { |x| false }.should == "cheeseburgers"
+  end
+
+  it "does not call the ifnone proc when an element is found" do
+    fail_proc = -> { raise "This shouldn't have been called" }
+    [1, 2, 3].rfind(fail_proc) { |x| x == 3 }.should == 3
+  end
+
+  it "iterates elements in reverse order" do
+    visited = []
+    [1, 2, 3].rfind { |x| visited << x; false }
+    visited.should == [3, 2, 1]
+  end
+
+  it "stops iterating as soon as a matching element is found from the end" do
+    visited = []
+    [1, 2, 3, 4, 5].rfind { |x| visited << x; x == 3 }
+    visited.should == [5, 4, 3]
+  end
+
+  it "returns an Enumerator when no block is given" do
+    [1, 2, 3].rfind.should.instance_of?(Enumerator)
+  end
+
+  it "rechecks the array size during iteration" do
+    ary = [4, 2, 1, 5, 1, 3]
+    seen = []
+    ary.rfind { |x| seen << x; ary.clear; false }
+    seen.should == [3]
+  end
+
+  it_behaves_like :enumeratorized_with_unknown_size, :rfind, [1, 2, 3]
+end

--- a/spec/ruby/core/array/rfind_spec.rb
+++ b/spec/ruby/core/array/rfind_spec.rb
@@ -2,10 +2,6 @@ require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 require_relative '../enumerable/shared/enumeratorized'
 
-# Modifying a collection while the contents are being iterated
-# gives undefined behavior. See
-# https://blade.ruby-lang.org/ruby-core/23633
-
 ruby_version_is "4.0" do
   describe "Array#rfind" do
     it "returns the last element for which the block is not false" do
@@ -51,6 +47,12 @@ ruby_version_is "4.0" do
       visited.should == [3, 2, 1]
     end
 
+    it "passes through the values yielded by #each_with_index" do
+      ScratchPad.record []
+      [:a, :b].each_with_index.to_a.rfind { |x, i| ScratchPad << [x, i]; nil }
+      ScratchPad.recorded.should == [[:b, 1], [:a, 0]]
+    end
+
     it "stops iterating as soon as a matching element is found from the end" do
       visited = []
       [1, 2, 3, 4, 5].rfind { |x| visited << x; x == 3 }
@@ -62,17 +64,21 @@ ruby_version_is "4.0" do
     end
 
     it "passes the ifnone proc to the enumerator" do
-      times = 0
-      fail_proc = -> { times += 1; raise if times > 1; "cheeseburgers" }
-      [1, 2, 3].rfind(fail_proc).each { |x| false }.should == "cheeseburgers"
+      fail_proc = -> { "cheeseburgers" }
+      enum = [1, 2, 3].rfind(fail_proc)
+      enum.each { |x| false }.should == "cheeseburgers"
     end
 
-    it "rechecks the array size during iteration" do
-      ary = [4, 2, 1, 5, 1, 3]
-      seen = []
-      ary.rfind { |x| seen << x; ary.clear; false }
-      seen.should == [3]
+    it "does not destructure elements" do
+      multi = [[1, 2], [3, 4, 5], [6, 7, 8, 9]]
+      multi.rfind { |e| e == [1, 2] }.should == [1, 2]
     end
+
+    # Modifying a collection while the contents are being iterated
+    # gives undefined behavior. See
+    # https://blade.ruby-lang.org/ruby-core/23633
+    # it "rechecks the array size during iteration" do
+    # end
 
     it_behaves_like :enumeratorized_with_unknown_size, :rfind, [1, 2, 3]
   end

--- a/spec/ruby/core/enumerable/find_spec.rb
+++ b/spec/ruby/core/enumerable/find_spec.rb
@@ -55,7 +55,7 @@ describe "Enumerable#find" do
   end
 
   it "raises a NoMethodError if the ifnone argument does not respond to #call and no element is found" do
-    -> { @numerous.find(42) {|e| false } }.should raise_error(NoMethodError)
+    -> { @numerous.find(42) {|e| false } }.should.raise(NoMethodError)
   end
 
   it "passes through the values yielded by #each_with_index" do

--- a/spec/ruby/core/enumerable/find_spec.rb
+++ b/spec/ruby/core/enumerable/find_spec.rb
@@ -10,23 +10,14 @@ describe "Enumerable#find" do
     @empty = []
   end
 
-  it "passes each entry in enum to block while block when block is false" do
-    visited_elements = []
-    @numerous.find do |element|
-      visited_elements << element
-      false
-    end
-    visited_elements.should == @elements
-  end
-
-  it "returns nil when the block is false and there is no ifnone proc given" do
-    @numerous.find {|e| false }.should == nil
-  end
-
   it "returns the first element for which the block is not false" do
     @elements.each do |element|
       @numerous.find {|e| e > element - 1 }.should == element
     end
+  end
+
+  it "returns nil when the block is false and there is no ifnone proc given" do
+    @numerous.find {|e| false }.should == nil
   end
 
   it "returns the value of the ifnone proc if the block is false" do
@@ -58,9 +49,21 @@ describe "Enumerable#find" do
     -> { @numerous.find(42) {|e| false } }.should.raise(NoMethodError)
   end
 
+  it "iterates elements in forward order" do
+    visited = []
+    @numerous.find { |element| visited << element; false }
+    visited.should == @elements
+  end
+
   it "passes through the values yielded by #each_with_index" do
     [:a, :b].each_with_index.find { |x, i| ScratchPad << [x, i]; nil }
     ScratchPad.recorded.should == [[:a, 0], [:b, 1]]
+  end
+
+  it "stops iterating as soon as an element is found" do
+    visited = []
+    @numerous.find { |x| visited << x; x == 6 }
+    visited.should == [2, 4, 6]
   end
 
   it "returns an enumerator when no block given" do
@@ -68,9 +71,9 @@ describe "Enumerable#find" do
   end
 
   it "passes the ifnone proc to the enumerator" do
-    times = 0
-    fail_proc = -> { times += 1; raise if times > 1; "cheeseburgers" }
-    @numerous.find(fail_proc).each {|e| false }.should == "cheeseburgers"
+    fail_proc = -> { "cheeseburgers" }
+    enum = @numerous.find(fail_proc)
+    enum.each { |e| false }.should == "cheeseburgers"
   end
 
   it "gathers whole arrays as elements when each yields multiple" do

--- a/spec/ruby/core/enumerable/find_spec.rb
+++ b/spec/ruby/core/enumerable/find_spec.rb
@@ -54,6 +54,10 @@ describe "Enumerable#find" do
     @numerous.find(nil) {|e| false }.should == nil
   end
 
+  it "raises a NoMethodError if the ifnone argument does not respond to #call and no element is found" do
+    -> { @numerous.find(42) {|e| false } }.should raise_error(NoMethodError)
+  end
+
   it "passes through the values yielded by #each_with_index" do
     [:a, :b].each_with_index.find { |x, i| ScratchPad << [x, i]; nil }
     ScratchPad.recorded.should == [[:a, 0], [:b, 1]]

--- a/src/main/ruby/truffleruby/core/array.rb
+++ b/src/main/ruby/truffleruby/core/array.rb
@@ -576,6 +576,20 @@ class Array
   end
   Primitive.always_split self, :hash
 
+  def find(ifnone = nil)
+    return to_enum(:find, ifnone) unless block_given?
+
+    i = 0
+    while i < size
+      elem = at(i)
+      return elem if yield(elem)
+      i += 1
+    end
+
+    ifnone.call if ifnone
+  end
+  alias_method :detect, :find
+
   def find_index(obj = undefined)
     super
   end
@@ -1014,6 +1028,23 @@ class Array
       i -= 1
     end
     self
+  end
+
+  def rfind(ifnone = nil)
+    return to_enum(:rfind, ifnone) unless block_given?
+
+    i = size - 1
+    while i >= 0
+      elem = at(i)
+      return elem if yield(elem)
+
+      # Compensate for the array being modified by the block during iteration
+      i = size if i > size
+
+      i -= 1
+    end
+
+    ifnone.call if ifnone
   end
 
   def rindex(obj = undefined)

--- a/src/main/ruby/truffleruby/core/truffle/versioned_array.rb
+++ b/src/main/ruby/truffleruby/core/truffle/versioned_array.rb
@@ -561,6 +561,11 @@ class Truffle::VersionedArray < Array
     copy.reverse_each(*args, &block)
   end
 
+  def rfind(*args, &block)
+    copy = TruffleRuby.synchronized(@lock) { Array.new self }
+    copy.rfind(*args, &block)
+  end
+
   def rindex(*args, &block)
     copy = TruffleRuby.synchronized(@lock) { Array.new self }
     copy.rindex(*args, &block)


### PR DESCRIPTION
Issue: [#4231](https://github.com/truffleruby/truffleruby/issues/4231)

> Array#find has been added as a more efficient override of Enumerable#find [[Feature #21678](https://bugs.ruby-lang.org/issues/21678)]
> Array#rfind has been added as a more efficient alternative to array.reverse_each.find [[Feature #21678](https://bugs.ruby-lang.org/issues/21678)]

Related links:

- [Feature #21678](https://bugs.ruby-lang.org/issues/21678)
- https://github.com/ruby/ruby/pull/15189


- [x] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.