### PR TITLE
Simplify SharedMethodInfo constructors by always setting identity after creation

### DIFF
--- a/src/main/java/org/truffleruby/RubyLanguage.java
+++ b/src/main/java/org/truffleruby/RubyLanguage.java
@@ -361,7 +361,6 @@ public final class RubyLanguage extends TruffleLanguage<RubyContext> {
             "<empty-declaration-descriptor>",
             "<empty-declaration-descriptor>",
             null,
-            null,
             null);
 
     private static final SharedMethodInfo EMPTY_BINDING_SHARED_METHOD_INFO = SharedMethodInfo.forMethod(
@@ -370,7 +369,6 @@ public final class RubyLanguage extends TruffleLanguage<RubyContext> {
             Arity.MODULE_BODY, // Primitive.create_empty_binding is only used in module-body methods
             "<empty-binding>",
             "<empty-binding>",
-            null,
             null,
             null);
 

--- a/src/main/java/org/truffleruby/builtins/CoreMethodNodeManager.java
+++ b/src/main/java/org/truffleruby/builtins/CoreMethodNodeManager.java
@@ -264,8 +264,7 @@ public final class CoreMethodNodeManager {
                     moduleName,
                     onSingleton,
                     name,
-                    arity,
-                    arity /* use the Arity object as the identity */);
+                    arity);
 
             final RootCallTarget callTarget;
             final CachedLazyCallTargetSupplier callTargetSupplier;
@@ -304,7 +303,7 @@ public final class CoreMethodNodeManager {
     }
 
     private static SharedMethodInfo makeSharedMethodInfo(String moduleName, boolean onSingleton, String name,
-            Arity arity, Object identity) {
+            Arity arity) {
         final String parseName;
         if (onSingleton || moduleName.equals("main")) {
             parseName = moduleName + "." + name;
@@ -312,15 +311,18 @@ public final class CoreMethodNodeManager {
             parseName = moduleName + "#" + name;
         }
 
-        return SharedMethodInfo.forMethod(
+        var sharedMethodInfo = SharedMethodInfo.forMethod(
                 CoreLibrary.JAVA_CORE_SOURCE_SECTION,
                 LexicalScope.IGNORE,
                 arity,
                 name,
                 parseName,
                 "builtin",
-                identity,
                 null);
+        // Use the Arity object as the identity, so @CoreMethod aliases like String#size and String#length are UnboundMethod#==,
+        // even though they have different CallTarget, InternalMethod and SharedMethodInfo
+        sharedMethodInfo.setIdentity(arity);
+        return sharedMethodInfo;
     }
 
     public static RootCallTarget createCoreMethodCallTarget(NodeFactory<? extends RubyBaseNode> nodeFactory,

--- a/src/main/java/org/truffleruby/core/module/ModuleNodes.java
+++ b/src/main/java/org/truffleruby/core/module/ModuleNodes.java
@@ -519,7 +519,6 @@ public abstract class ModuleNodes {
                     accessorName,
                     parseName,
                     ivar, // notes
-                    null,
                     null);
 
             final NodeFactory<? extends RubyBaseNode> alwaysInlinedNodeFactory = accessor == READER

--- a/src/main/java/org/truffleruby/core/symbol/SymbolNodes.java
+++ b/src/main/java/org/truffleruby/core/symbol/SymbolNodes.java
@@ -223,7 +223,6 @@ public abstract class SymbolNodes {
                     symbol.getString(),
                     "&:" + symbol.getString(),
                     "Symbol#to_proc",
-                    null,
                     ArgumentDescriptor.AT_LEAST_ONE_UNNAMED);
 
             // ModuleNodes.DefineMethodNode relies on the lambda CallTarget to always use a RubyLambdaRootNode,

--- a/src/main/java/org/truffleruby/language/methods/SharedMethodInfo.java
+++ b/src/main/java/org/truffleruby/language/methods/SharedMethodInfo.java
@@ -55,9 +55,7 @@ public final class SharedMethodInfo implements DetailedInspectingSupport {
     private final SharedMethodInfo methodSharedMethodInfo;
     /** Extra information. If blockDepth > 0 then it is the name of the method containing this block. */
     private final String notes;
-    /** An optional object to make two different SharedMethodInfo considered equal for Method#==. Notably used
-     * for @CoreMethod aliases to be == such as String#size and String#length, even though they have different
-     * CallTarget, InternalMethod and SharedMethodInfo. */
+    /** An optional object to make two different SharedMethodInfo considered equal for UnboundMethod#== */
     private Object identity;
     private final ArgumentDescriptor[] argumentDescriptors;
 
@@ -68,9 +66,8 @@ public final class SharedMethodInfo implements DetailedInspectingSupport {
             String methodName,
             String parseName,
             String notes,
-            Object identity,
             ArgumentDescriptor[] argumentDescriptors) {
-        return new SharedMethodInfo(sourceSection, staticLexicalScope, arity, methodName, parseName, notes, identity,
+        return new SharedMethodInfo(sourceSection, staticLexicalScope, arity, methodName, parseName, notes,
                 0, null, argumentDescriptors);
     }
 
@@ -84,7 +81,7 @@ public final class SharedMethodInfo implements DetailedInspectingSupport {
             int blockDepth,
             SharedMethodInfo methodSharedMethodInfo,
             ArgumentDescriptor[] argumentDescriptors) {
-        return new SharedMethodInfo(sourceSection, staticLexicalScope, arity, methodName, parseName, notes, null,
+        return new SharedMethodInfo(sourceSection, staticLexicalScope, arity, methodName, parseName, notes,
                 blockDepth, methodSharedMethodInfo, argumentDescriptors);
     }
 
@@ -95,7 +92,6 @@ public final class SharedMethodInfo implements DetailedInspectingSupport {
             String methodName,
             String parseName,
             String notes,
-            Object identity,
             int blockDepth,
             SharedMethodInfo methodSharedMethodInfo,
             ArgumentDescriptor[] argumentDescriptors) {
@@ -109,20 +105,20 @@ public final class SharedMethodInfo implements DetailedInspectingSupport {
         this.blockDepth = blockDepth;
         this.methodSharedMethodInfo = methodSharedMethodInfo;
         this.argumentDescriptors = argumentDescriptors;
-        setIdentity(identity);
     }
 
     public SharedMethodInfo forDefineMethod(RubyModule declaringModule, String methodName, RubyProc proc) {
         // no longer a block
-        return forMethod(
+        var sharedMethodInfo = forMethod(
                 sourceSection,
                 staticLexicalScope,
                 proc.arity,
                 methodName,
                 moduleAndMethodNameIfModuleIsFullyNamed(declaringModule, methodName, proc.arity),
                 null,
-                identity,
                 proc.argumentDescriptors);
+        sharedMethodInfo.setIdentity(identity);
+        return sharedMethodInfo;
     }
 
     public SharedMethodInfo convertMethodMissingToMethod(RubyModule declaringModule, String methodName) {
@@ -134,7 +130,6 @@ public final class SharedMethodInfo implements DetailedInspectingSupport {
                 methodName,
                 moduleAndMethodNameIfModuleIsFullyNamed(declaringModule, methodName, effectiveArity),
                 notes,
-                identity,
                 ArgumentDescriptor.ANY_UNNAMED);
     }
 

--- a/src/main/java/org/truffleruby/parser/YARPTranslator.java
+++ b/src/main/java/org/truffleruby/parser/YARPTranslator.java
@@ -214,7 +214,7 @@ public class YARPTranslator extends YARPBaseTranslator {
         var body = node.accept(this);
         var sourceSection = CoreLibrary.JAVA_CORE_SOURCE_SECTION;
         var sharedMethodInfo = SharedMethodInfo.forMethod(sourceSection, null, Arity.MODULE_BODY, "<main>", "<main>",
-                null, null, null);
+                null, null);
         var frameDescriptor = TranslatorEnvironment.newFrameDescriptorBuilderForMethod(sharedMethodInfo).build();
         return new RubyTopLevelRootNode(language, sourceSection, frameDescriptor, sharedMethodInfo, body,
                 Split.HEURISTIC, null, Arity.MODULE_BODY);
@@ -1515,7 +1515,6 @@ public class YARPTranslator extends YARPBaseTranslator {
                 arity,
                 node.name,
                 parseName,
-                null,
                 null,
                 argumentDescriptors);
 
@@ -3507,7 +3506,6 @@ public class YARPTranslator extends YARPBaseTranslator {
                 Arity.MODULE_BODY,
                 methodName,
                 methodName,
-                null,
                 null,
                 null);
 

--- a/src/main/java/org/truffleruby/parser/YARPTranslatorDriver.java
+++ b/src/main/java/org/truffleruby/parser/YARPTranslatorDriver.java
@@ -200,7 +200,6 @@ public final class YARPTranslatorDriver {
                     methodName,
                     methodName,
                     null,
-                    null,
                     null);
         } else {
             sharedMethodInfo = SharedMethodInfo.forBlock(


### PR DESCRIPTION
* Also a few places were keeping the identity but that does not seem correct.