### PR TITLE
Add array size recheck spec for `Array#find` and `Array#rfind`

### DIFF
--- a/spec/ruby/core/array/find_spec.rb
+++ b/spec/ruby/core/array/find_spec.rb
@@ -2,6 +2,10 @@ require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 require_relative '../enumerable/shared/enumeratorized'
 
+# Modifying a collection while the contents are being iterated
+# gives undefined behavior. See
+# https://blade.ruby-lang.org/ruby-core/23633
+
 ruby_version_is "4.0" do
   describe "Array#find" do
     it "returns the first element for which the block is not false" do
@@ -74,11 +78,12 @@ ruby_version_is "4.0" do
       multi.find { |e| e == [1, 2] }.should == [1, 2]
     end
 
-    # Modifying a collection while the contents are being iterated
-    # gives undefined behavior. See
-    # https://blade.ruby-lang.org/ruby-core/23633
-    # it "rechecks the array size during iteration" do
-    # end
+    it "rechecks the array size during iteration" do
+      ary = [4, 2, 1, 5, 1, 3]
+      seen = []
+      ary.find { |x| seen << x; ary.clear; false }
+      seen.should == [4]
+    end
 
     it_behaves_like :enumeratorized_with_unknown_size, :find, [1, 2, 3]
   end

--- a/spec/ruby/core/array/rfind_spec.rb
+++ b/spec/ruby/core/array/rfind_spec.rb
@@ -2,6 +2,10 @@ require_relative '../../spec_helper'
 require_relative 'fixtures/classes'
 require_relative '../enumerable/shared/enumeratorized'
 
+# Modifying a collection while the contents are being iterated
+# gives undefined behavior. See
+# https://blade.ruby-lang.org/ruby-core/23633
+
 ruby_version_is "4.0" do
   describe "Array#rfind" do
     it "returns the last element for which the block is not false" do
@@ -74,11 +78,12 @@ ruby_version_is "4.0" do
       multi.rfind { |e| e == [1, 2] }.should == [1, 2]
     end
 
-    # Modifying a collection while the contents are being iterated
-    # gives undefined behavior. See
-    # https://blade.ruby-lang.org/ruby-core/23633
-    # it "rechecks the array size during iteration" do
-    # end
+    it "rechecks the array size during iteration" do
+      ary = [4, 2, 1, 5, 1, 3]
+      seen = []
+      ary.rfind { |x| seen << x; ary.clear; false }
+      seen.should == [3]
+    end
 
     it_behaves_like :enumeratorized_with_unknown_size, :rfind, [1, 2, 3]
   end


### PR DESCRIPTION
Add extra specs for `Array#find` and `Array#rfind` following the discussion in: #4314

Issue: https://github.com/truffleruby/truffleruby/issues/4231

> Array#find has been added as a more efficient override of Enumerable#find [[Feature #21678](https://bugs.ruby-lang.org/issues/21678)]
> Array#rfind has been added as a more efficient alternative to array.reverse_each.find [[Feature #21678](https://bugs.ruby-lang.org/issues/21678)]

Related links:

* [Feature #21678](https://bugs.ruby-lang.org/issues/21678)
* https://github.com/ruby/ruby/pull/15189

- [X] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
