### PR TITLE
`Thread#inspect` encoding should be binary

### DIFF
--- a/spec/tags/core/thread/to_s_tags.txt
+++ b/spec/tags/core/thread/to_s_tags.txt
@@ -1,1 +1,0 @@
-fails:Thread#to_s has a binary encoding

--- a/src/main/ruby/truffleruby/core/thread.rb
+++ b/src/main/ruby/truffleruby/core/thread.rb
@@ -178,8 +178,9 @@ class Thread
   end
 
   def inspect
+    result = ''.b
     loc = Primitive.thread_source_location(self)
-    "#{super.delete_suffix('>')} #{loc} #{status || 'dead'}>"
+    result << "#{super.delete_suffix('>')} #{loc} #{status || 'dead'}>"
   end
   alias_method :to_s, :inspect
 


### PR DESCRIPTION
Just a trivial spec to pass

- [ ] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
