### PR TITLE
Implement `rb_io_get_io`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Compatibility:
 * Fix `IPSocket#inspect` to return `#<TCPSocket:(closed)>` for closed sockets like CRuby instead of raising `IOError` (#4312, @rubiii).
 * Don't expose numbered parameters in `Binding`'s local variable methods (#4231, @andrykonchin).
 * Add methods `Binding#{implicit_parameters,implicit_parameter_defined?,implicit_parameter_get}` (#4231, @andrykonchin).
+* Implement `rb_io_get_io` (@nirvdrum).
 
 Performance:
 

--- a/lib/cext/include/truffleruby/truffleruby-abi-version.h
+++ b/lib/cext/include/truffleruby/truffleruby-abi-version.h
@@ -26,6 +26,6 @@
 // and cannot reach the same version while having different ABI
 // ($TRUFFLERUBY_VERSION is never the same as $RUBY_VERSION).
 
-#define TRUFFLERUBY_ABI_VERSION "4.0.2.2"
+#define TRUFFLERUBY_ABI_VERSION "4.0.2.3"
 
 #endif

--- a/lib/truffle/truffle/cext.rb
+++ b/lib/truffle/truffle/cext.rb
@@ -1484,6 +1484,10 @@ module Truffle::CExt
     Primitive.io_fd(io)
   end
 
+  def rb_io_get_io(io)
+    Primitive.convert_type(io, IO, :to_io)
+  end
+
   def rb_equal(a, b)
     Primitive.same_or_equal?(a, b)
   end

--- a/spec/ruby/optional/capi/ext/io_spec.c
+++ b/spec/ruby/optional/capi/ext/io_spec.c
@@ -35,6 +35,10 @@ VALUE io_spec_GetOpenFile_fd(VALUE self, VALUE io) {
   return INT2NUM(io_spec_get_fd(io));
 }
 
+VALUE io_spec_rb_io_get_io(VALUE self, VALUE io) {
+  return rb_io_get_io(io);
+}
+
 VALUE io_spec_rb_io_addstr(VALUE self, VALUE io, VALUE str) {
   return rb_io_addstr(io, str);
 }
@@ -379,6 +383,7 @@ void Init_io_spec(void) {
   rb_define_method(cls, "rb_io_check_readable", io_spec_rb_io_check_readable, 1);
   rb_define_method(cls, "rb_io_check_writable", io_spec_rb_io_check_writable, 1);
   rb_define_method(cls, "rb_io_check_closed", io_spec_rb_io_check_closed, 1);
+  rb_define_method(cls, "rb_io_get_io", io_spec_rb_io_get_io, 1);
   rb_define_method(cls, "rb_io_set_nonblock", io_spec_rb_io_set_nonblock, 1);
   rb_define_method(cls, "rb_io_taint_check", io_spec_rb_io_taint_check, 1);
   rb_define_method(cls, "rb_io_wait_readable", io_spec_rb_io_wait_readable, 2);

--- a/spec/ruby/optional/capi/io_spec.rb
+++ b/spec/ruby/optional/capi/io_spec.rb
@@ -190,6 +190,45 @@ describe "C-API IO function" do
     end
   end
 
+  describe "rb_io_get_io" do
+    it "returns the passed object and does not call #to_io if the object is already an IO" do
+      @io.should_not_receive(:to_io)
+
+      @o.rb_io_get_io(@io).should equal(@io)
+    end
+
+    it "returns the passed object and does not call #to_io if the object is a subclass of IO" do
+      file = File.open(@name)
+
+      begin
+        file.should_not_receive(:to_io)
+
+        @o.rb_io_get_io(file).should equal(file)
+      ensure
+        file.close
+      end
+    end
+
+    it "calls #to_io to convert the object to an IO" do
+      wrapper = Object.new
+      io = @io
+      wrapper.define_singleton_method(:to_io) { io }
+
+      @o.rb_io_get_io(wrapper).should equal(@io)
+    end
+
+    it "raises a TypeError if #to_io does not return an IO" do
+      wrapper = Object.new
+      wrapper.define_singleton_method(:to_io) { Object.new }
+
+      -> { @o.rb_io_get_io(wrapper) }.should.raise(TypeError)
+    end
+
+    it "raises a TypeError if the object does not respond to #to_io" do
+      -> { @o.rb_io_get_io(Object.new) }.should.raise(TypeError)
+    end
+  end
+
   describe "rb_io_binmode" do
     it "returns self" do
       @o.rb_io_binmode(@io).should == @io

--- a/src/main/c/cext/io.c
+++ b/src/main/c/cext/io.c
@@ -74,6 +74,10 @@ VALUE rb_io_closed_p(VALUE io) {
   return RUBY_INVOKE(io, "closed?");
 }
 
+VALUE rb_io_get_io(VALUE io) {
+  return RUBY_CEXT_INVOKE("rb_io_get_io", io);
+}
+
 static RFile_and_rb_io_t* get_RFile_and_rb_io_t(VALUE io) {
   RFile_and_rb_io_t* pointer = RUBY_CEXT_INVOKE_NO_WRAP("rb_tr_io_pointer", io);
   if (!polyglot_is_null(pointer)) {


### PR DESCRIPTION
`rb_io_get_io` is used by the _trilogy_ gem. Without it, the native extension crashes.