### PR TITLE
Fix TruffleRuby::AtomicReference#compare_and_set to work with NaN values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Bug fixes:
 
 * Raise a `RuntimeError` when using an object from a `Polyglot::InnerContext` after it has been closed (#4061, @eregon).
 * Fix `object.method(:send).to_proc.call(some_method)` (#4299, @eregon).
+* Fix `TruffleRuby::AtomicReference#compare_and_set` to work with NaN values like `Float::NAN` (@eregon).
 
 Compatibility:
 

--- a/spec/truffle/truffleruby/atomic_reference_spec.rb
+++ b/spec/truffle/truffleruby/atomic_reference_spec.rb
@@ -44,7 +44,7 @@ describe "TruffleRuby::AtomicReference" do
       r.get.should.equal? v2
     end
 
-    it "comparing numeric objects with equality " do
+    it "comparing numeric objects with equality" do
       [-> { 1 },
        -> { 1.1 },
        -> { 1000 }
@@ -60,6 +60,23 @@ describe "TruffleRuby::AtomicReference" do
         r.compare_and_set(numeric_source.call, v2).should == true
         r.get.should.equal? v2
       end
+    end
+
+    it "handles NaN correctly" do
+      r = TruffleRuby::AtomicReference.new Float::NAN
+      r.compare_and_set(0.0, 1.0).should == false
+      r.get.should.equal? Float::NAN
+
+
+      r.compare_and_set(Float::NAN, 42.0).should == true
+      r.get.should == 42.0
+
+      r.set Float::NAN
+
+      another_nan = 0.0 / 0.0
+      [another_nan].pack('D').should_not.equal?([Float::NAN].pack('D')) # different bit pattern
+      r.compare_and_set(another_nan, 43.0).should == true
+      r.get.should == 43.0
     end
   end
 

--- a/src/main/java/org/truffleruby/extra/AtomicReferenceNodes.java
+++ b/src/main/java/org/truffleruby/extra/AtomicReferenceNodes.java
@@ -91,6 +91,8 @@ public abstract class AtomicReferenceNodes {
         }
     }
 
+    // Note that concurrent-ruby uses this directly:
+    // https://github.com/ruby-concurrency/concurrent-ruby/blob/4c8fc28ab6/lib/concurrent-ruby/concurrent/atomic/atomic_reference.rb#L38
     @CoreMethod(names = "compare_and_set_reference", required = 2, visibility = Visibility.PRIVATE)
     public abstract static class CompareAndSetReferenceNode extends CoreMethodArrayArgumentsNode {
 

--- a/src/main/ruby/truffleruby/core/truffle/truffleruby.rb
+++ b/src/main/ruby/truffleruby/core/truffle/truffleruby.rb
@@ -17,19 +17,24 @@ module TruffleRuby
 
   class AtomicReference
 
+    # Same logic as https://github.com/ruby-concurrency/concurrent-ruby/blob/4c8fc28ab6/lib/concurrent-ruby/concurrent/atomic_reference/numeric_cas_wrapper.rb
+    # We handle the Numeric case here so TruffleRuby::AtomicReference can be used without needing concurrent-ruby
     def compare_and_set(expected_value, new_value)
       if Primitive.is_a?(expected_value, Numeric)
-        loop do
-          current_value = get
+        # NaN is never == to itself, so match it explicitly
+        expected_nan = Primitive.is_a?(expected_value, Float) && expected_value.nan?
 
-          if Primitive.is_a?(current_value, Numeric) && current_value == expected_value
-            if compare_and_set_reference(current_value, new_value)
-              return true
-            end
+        begin
+          current_value = get
+          return false unless Primitive.is_a?(current_value, Numeric)
+
+          if expected_nan
+            return false unless Primitive.is_a?(current_value, Float) && current_value.nan?
           else
-            return false
+            return false unless current_value == expected_value
           end
-        end
+        end until compare_and_set_reference(current_value, new_value)
+        true
       else
         compare_and_set_reference(expected_value, new_value)
       end


### PR DESCRIPTION
- [x] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
