### PR TITLE
[Ruby 4.0] Fix Range#max

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Compatibility:
 * Implement `rb_io_get_io` (@nirvdrum).
 * Implement `File.birthtime`, `File#birthtime`, and `File::Stat#birthtime` (@andrykonchin, @eregon).
 * Fix `Range#max` for Integer beginless ranges with excluded end and return a proper maximum value instead of raising `TypeError` (#4231, @andrykonchin).
+* Adjust `Range#max` and support Integer argument (#4231, @andrykonchin).
 
 Performance:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Compatibility:
 * Add methods `Binding#{implicit_parameters,implicit_parameter_defined?,implicit_parameter_get}` (#4231, @andrykonchin).
 * Implement `rb_io_get_io` (@nirvdrum).
 * Implement `File.birthtime`, `File#birthtime`, and `File::Stat#birthtime` (@andrykonchin, @eregon).
+* Fix `Range#max` for Integer beginless ranges with excluded end and return a proper maximum value instead of raising `TypeError` (#4231, @andrykonchin).
 
 Performance:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ Compatibility:
 * Implement `rb_io_get_io` (@nirvdrum).
 * Implement `File.birthtime`, `File#birthtime`, and `File::Stat#birthtime` (@andrykonchin, @eregon).
 * Fix `Range#max` for Integer beginless ranges with excluded end and return a proper maximum value instead of raising `TypeError` (#4231, @andrykonchin).
-* Adjust `Range#max` and support Integer argument (#4231, @andrykonchin).
+* Adjust `Range#{max,min}` and support Integer argument (#4231, @andrykonchin).
 
 Performance:
 

--- a/spec/ruby/core/range/max_spec.rb
+++ b/spec/ruby/core/range/max_spec.rb
@@ -1,7 +1,7 @@
 require_relative '../../spec_helper'
 
 describe "Range#max" do
-  it "returns the maximum value in the range when called with no arguments" do
+  it "returns the maximum value in the range" do
     (1..10).max.should == 10
     (1...10).max.should == 9
     (0...2**64).max.should == 18446744073709551615
@@ -9,7 +9,7 @@ describe "Range#max" do
     ('a'...'f').max.should == 'e'
   end
 
-  it "returns the maximum value in the Float range when called with no arguments" do
+  it "returns the maximum value in the Float range" do
     (303.20..908.1111).max.should == 908.1111
   end
 
@@ -47,7 +47,7 @@ describe "Range#max" do
   end
 
   it "raises RangeError when called on an endless range" do
-    -> { eval("(1..)").max }.should.raise(RangeError)
+    -> { (1..).max }.should.raise(RangeError)
   end
 
   it "returns the end point for beginless ranges" do
@@ -73,6 +73,97 @@ describe "Range#max" do
     -> {
       (...1.0).max
     }.should.raise(TypeError, 'cannot exclude non Integer end value')
+  end
+end
+
+describe "Range#max given an integer argument" do
+  it "returns the n maximum values in the range" do
+    (1..10).max(2).should == [10, 9]
+    (1...10).max(2).should == [9, 8]
+    ('f'..'l').max(2).should == ['l', 'k']
+    ('a'...'f').max(2).should == ['e', 'd']
+  end
+
+  ruby_version_is "4.0" do
+    it "returns the n maximum values in a very large Integer range" do
+      (0...2**64).max(2).should == [18446744073709551615, 18446744073709551615-1]
+    end
+  end
+
+  it "raise a TypeError for non Integer ranges" do
+    -> { (303.20..908.1111).max(2) }.should.raise(TypeError)
+    -> { (303.20...908.1111).max(2) }.should.raise(TypeError)
+
+    -> { (['a']..['f']).max(2) }.should.raise(TypeError)
+    -> { (['a']...['f']).max(2) }.should.raise(TypeError)
+
+    -> { (Time.now..Time.now).max(2) }.should.raise(TypeError)
+    -> { (Time.now...Time.now).max(2) }.should.raise(TypeError)
+  end
+
+  it "returns [] when the endpoint is less than the start point" do
+    (100..10).max(2).should == []
+    ('z'..'l').max(2).should == []
+  end
+
+  it "returns [] when the endpoint equals the start point and the Integer range is exclusive" do
+    (5...5).max(2).should == []
+  end
+
+  it "returns the endpoint when the endpoint equals the start point and the Integer range is inclusive" do
+    (5..5).max(2).should == [5]
+  end
+
+  it "returns all the elements in the range when given n larger that elements count" do
+    (1..3).max(10).should == [3, 2, 1]
+    (1...3).max(10).should == [2, 1]
+  end
+
+  it "raises RangeError when called on an endless range" do
+    -> { (1..).max(2) }.should.raise(RangeError)
+  end
+
+  ruby_version_is "4.0" do
+    it "returns the n maximum values for beginless Integer ranges" do
+      (..1).max(2).should == [1, 0]
+    end
+
+    it "returns the n maximum values (except the end point) for exclusive beginless Integer ranges" do
+      (...1).max(2).should == [0, -1]
+    end
+  end
+
+  ruby_version_is ""..."4.0" do
+    it "raises a RangeError for an beginless non-Integer range" do
+      -> { (..1.0).max(2) }.should.raise(RangeError)
+      -> { (..'f').max(2) }.should.raise(RangeError)
+    end
+  end
+
+  ruby_version_is "4.0" do
+    it "raises a TypeError for an beginless non-Integer range" do
+      -> { (..1.0).max(2) }.should.raise(TypeError)
+      -> { (..'f').max(2) }.should.raise(TypeError)
+    end
+  end
+
+  it "raises an ArgumentError when given negative value" do
+    -> { (0..2).max(-1) }.should.raise(ArgumentError)
+  end
+
+  it "converts the passed argument to an Integer using #to_int'" do
+    obj = mock_int(2)
+    (1..10).max(obj).should == [10, 9]
+  end
+
+  it "raises a TypeError if the passed argument does not respond to #to_int" do
+    -> { (0..2).max(Object.new) }.should.raise(TypeError)
+  end
+
+  it "raises a TypeError if #to_int does not return an Integer" do
+    obj = mock("to_int")
+    obj.should_receive(:to_int).and_return("1")
+    -> { (0..2).max(obj) }.should.raise(TypeError)
   end
 end
 
@@ -111,5 +202,11 @@ describe "Range#max given a block" do
 
   it "raises RangeError when called with custom comparison method on an beginless range" do
     -> { (..1).max {|a, b| a} }.should.raise(RangeError)
+  end
+end
+
+describe "Range#max given a block and an integer argument" do
+  it "returns n elements the block determines to be the maximum" do
+    (1..10).max(2) {|a,b| a <=> b }.should == [10, 9]
   end
 end

--- a/spec/ruby/core/range/min_spec.rb
+++ b/spec/ruby/core/range/min_spec.rb
@@ -1,12 +1,12 @@
 require_relative '../../spec_helper'
 
 describe "Range#min" do
-  it "returns the minimum value in the range when called with no arguments" do
+  it "returns the minimum value in the range" do
     (1..10).min.should == 1
     ('f'..'l').min.should == 'f'
   end
 
-  it "returns the minimum value in the Float range when called with no arguments" do
+  it "returns the minimum value in the Float range" do
     (303.20..908.1111).min.should == 303.20
   end
 
@@ -40,12 +40,84 @@ describe "Range#min" do
   end
 
   it "returns the start point for endless ranges" do
-    eval("(1..)").min.should == 1
-    eval("(1.0...)").min.should == 1.0
+    (1..).min.should == 1
+    (1.0...).min.should == 1.0
   end
 
   it "raises RangeError when called on an beginless range" do
     -> { (..1).min }.should.raise(RangeError)
+  end
+end
+
+describe "Range#min given an integer argument" do
+  it "returns the n minimum values in the range" do
+    (1..10).min(2).should == [1, 2]
+    (1...10).min(2).should == [1, 2]
+    (0...2**64).min(2).should == [0, 1]
+    ('f'..'l').min(2).should == ['f', 'g']
+    ('a'...'f').min(2).should == ['a', 'b']
+  end
+
+  it "raise a TypeError for non Integer ranges" do
+    -> { (303.20..908.1111).min(2) }.should.raise(TypeError)
+    -> { (303.20...908.1111).min(2) }.should.raise(TypeError)
+
+    -> { (['a']..['f']).min(2) }.should.raise(TypeError)
+    -> { (['a']...['f']).min(2) }.should.raise(TypeError)
+
+    -> { (Time.now..Time.now).min(2) }.should.raise(TypeError)
+    -> { (Time.now...Time.now).min(2) }.should.raise(TypeError)
+  end
+
+  it "returns [] when the endpoint is less than the start point" do
+    (100..10).min(2).should == []
+    ('z'..'l').min(2).should == []
+  end
+
+  it "returns [] when the endpoint equals the start point and the Integer range is exclusive" do
+    (5...5).min(2).should == []
+  end
+
+  it "returns the endpoint when the endpoint equals the start point and the Integer range is inclusive" do
+    (5..5).min(2).should == [5]
+  end
+
+  it "returns all the elements in the range when given n larger that elements count" do
+    (1..3).min(10).should == [1, 2, 3]
+    (1...3).min(10).should == [1, 2]
+  end
+
+  it "raises RangeError when called on a beginless range" do
+    -> { (..1).min(2) }.should.raise(RangeError)
+    -> { (...1).min(2) }.should.raise(RangeError)
+  end
+
+  it "returns the n minimum values for endless Integer ranges" do
+    (1..).min(2).should == [1, 2]
+    (1...).min(2).should == [1, 2]
+  end
+
+  it "raises a TypeError for an endless non-Integer range" do
+    -> { (1.0..).min(2) }.should.raise(TypeError)
+  end
+
+  it "raises an ArgumentError when given negative value" do
+    -> { (0..2).min(-1) }.should.raise(ArgumentError)
+  end
+
+  it "converts the passed argument to an Integer using #to_int" do
+    obj = mock_int(2)
+    (1..10).min(obj).should == [1, 2]
+  end
+
+  it "raises a TypeError if the passed argument does not respond to #to_int" do
+    -> { (0..2).min(Object.new) }.should.raise(TypeError)
+  end
+
+  it "raises a TypeError if #to_int does not return an Integer" do
+    obj = mock("to_int")
+    obj.should_receive(:to_int).and_return("1")
+    -> { (0..2).min(obj) }.should.raise(TypeError)
   end
 end
 
@@ -83,6 +155,12 @@ describe "Range#min given a block" do
   end
 
   it "raises RangeError when called with custom comparison method on an endless range" do
-    -> { eval("(1..)").min {|a, b| a} }.should.raise(RangeError)
+    -> { (1..).min {|a, b| a} }.should.raise(RangeError)
+  end
+end
+
+describe "Range#max given a block and an integer argument" do
+  it "returns n elements the block determines to be the minimum" do
+    (1..10).min(2) { |a,b| a <=> b }.should == [1, 2]
   end
 end

--- a/spec/tags/core/range/max_tags.txt
+++ b/spec/tags/core/range/max_tags.txt
@@ -1,1 +1,0 @@
-fails:Range#max returns the end point for exclusive beginless Integer ranges

--- a/src/main/ruby/truffleruby/core/range.rb
+++ b/src/main/ruby/truffleruby/core/range.rb
@@ -419,13 +419,28 @@ class Range
     end
   end
 
-  def min
+  def min(n = undefined)
     raise RangeError, 'cannot get the minimum of beginless range' if Primitive.nil? self.begin
+
+    if block_given?
+      if Primitive.nil? self.end
+        raise RangeError, 'cannot get the minimum of endless range with custom comparison method'
+      end
+
+      return super
+    end
+
+    unless Primitive.undefined?(n)
+      n = Primitive.convert_with_to_int(n)
+      raise ArgumentError, "negative size #{n}" if n < 0
+
+      return take(n)
+    end
+
     if Primitive.nil? self.end
-      raise RangeError, 'cannot get the minimum of endless range with custom comparison method' if block_given?
       return self.begin
     end
-    return super if block_given?
+
     if Comparable.compare_int(self.end <=> self.begin) < 0
       return nil
     elsif exclude_end? && self.end == self.begin

--- a/src/main/ruby/truffleruby/core/range.rb
+++ b/src/main/ruby/truffleruby/core/range.rb
@@ -385,7 +385,7 @@ class Range
     to_a.last(n)
   end
 
-  def max
+  def max(n = undefined)
     raise RangeError, 'cannot get the maximum of endless range' if Primitive.nil? self.end
 
     if block_given? || (exclude_end? && !Primitive.is_a?(self.end, Numeric))
@@ -394,6 +394,13 @@ class Range
       end
 
       return super
+    end
+
+    unless Primitive.undefined?(n)
+      n = Primitive.convert_with_to_int(n)
+      raise ArgumentError, "negative size #{n}" if n < 0
+
+      return reverse_each.take(n)
     end
 
     if exclude_end?

--- a/src/main/ruby/truffleruby/core/range.rb
+++ b/src/main/ruby/truffleruby/core/range.rb
@@ -399,9 +399,9 @@ class Range
     if exclude_end?
       if !Primitive.is_a?(self.end, Integer)
         raise TypeError, 'cannot exclude non Integer end value'
-      elsif !Primitive.is_a?(self.begin, Integer)
+      elsif !Primitive.nil?(self.begin) && !Primitive.is_a?(self.begin, Integer)
         raise TypeError, 'cannot exclude end value with non Integer begin value'
-      elsif self.end <= self.begin
+      elsif !Primitive.nil?(self.begin) && self.end <= self.begin
         return nil
       end
 


### PR DESCRIPTION
#4231

> Range#max behavior on beginless integer ranges has been fixed.
[[Bug #21174](https://bugs.ruby-lang.org/issues/21174)] [[Bug #21175](https://bugs.ruby-lang.org/issues/21175)]

- [x] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
