### PR TITLE
Reject `%` format specifier followed by `\n`/`\0`

### DIFF
--- a/spec/ruby/core/kernel/shared/sprintf.rb
+++ b/spec/ruby/core/kernel/shared/sprintf.rb
@@ -460,6 +460,51 @@ describe :kernel_sprintf, shared: true do
         }.should.raise(ArgumentError)
       end
 
+      ruby_version_is ""..."3.4" do
+        it "formats single % character before a newline as literal %" do
+          @method.call("%\n").should == "%\n"
+          @method.call("foo%\n").should == "foo%\n"
+          @method.call("%\n.3f").should == "%\n.3f"
+        end
+
+        it "formats single % character before a NUL as literal %" do
+          @method.call("%\0").should == "%\0"
+          @method.call("foo%\0").should == "foo%\0"
+          @method.call("%\0.3f").should == "%\0.3f"
+        end
+
+        it "raises an error if single % appears anywhere else" do
+          -> { @method.call(" % ") }.should.raise(ArgumentError)
+          -> { @method.call("foo%quux") }.should.raise(ArgumentError)
+        end
+
+        it "raises an error if NULL or \\n appear anywhere else in the format string" do
+          begin
+            old_debug, $DEBUG = $DEBUG, false
+
+            -> { @method.call("%.\n3f", 1.2) }.should.raise(ArgumentError)
+            -> { @method.call("%.3\nf", 1.2) }.should.raise(ArgumentError)
+            -> { @method.call("%.\03f", 1.2) }.should.raise(ArgumentError)
+            -> { @method.call("%.3\0f", 1.2) }.should.raise(ArgumentError)
+          ensure
+            $DEBUG = old_debug
+          end
+        end
+      end
+
+      ruby_version_is "3.4" do
+        it "raises ArgumentError if not followed by a conversion specifier" do
+          -> { @method.call("%") }.should.raise(ArgumentError, /incomplete format specifier/)
+          -> { @method.call("%\n") }.should.raise(ArgumentError, /malformed format string/)
+          -> { @method.call("%\0") }.should.raise(ArgumentError, /malformed format string/)
+          -> { @method.call(" % ") }.should.raise(ArgumentError, /malformed format string/)
+          -> { @method.call("%.\n3f") }.should.raise(ArgumentError, /malformed format string/)
+          -> { @method.call("%.3\nf") }.should.raise(ArgumentError, /malformed format string/)
+          -> { @method.call("%.\03f") }.should.raise(ArgumentError, /malformed format string/)
+          -> { @method.call("%.3\0f") }.should.raise(ArgumentError, /malformed format string/)
+        end
+      end
+
       it "is escaped by %" do
         @method.call("%%").should == "%"
         @method.call("%%d").should == "%d"
@@ -843,6 +888,18 @@ describe :kernel_sprintf, shared: true do
         -> {
           @method.call("%*10d", 10, 112)
         }.should.raise(ArgumentError)
+      end
+
+      ruby_version_is ""..."3.4" do
+        it "replaces trailing absolute argument specifier without type with percent sign" do
+          @method.call("hello %1$", "foo").should == "hello %"
+        end
+      end
+
+      ruby_version_is "3.4" do
+        it "raises ArgumentError if absolute argument specifier is followed by a conversion specifier" do
+          -> { @method.call("hello %1$", "foo") }.should.raise(ArgumentError, /malformed format string/)
+        end
       end
     end
   end

--- a/spec/ruby/core/string/modulo_spec.rb
+++ b/spec/ruby/core/string/modulo_spec.rb
@@ -55,51 +55,6 @@ describe "String#%" do
     -> { ("foo%" % [])}.should.raise(ArgumentError)
   end
 
-  ruby_version_is ""..."3.4" do
-    it "formats single % character before a newline as literal %" do
-      ("%\n" % []).should == "%\n"
-      ("foo%\n" % []).should == "foo%\n"
-      ("%\n.3f" % 1.2).should == "%\n.3f"
-    end
-
-    it "formats single % character before a NUL as literal %" do
-      ("%\0" % []).should == "%\0"
-      ("foo%\0" % []).should == "foo%\0"
-      ("%\0.3f" % 1.2).should == "%\0.3f"
-    end
-
-    it "raises an error if single % appears anywhere else" do
-      -> { (" % " % []) }.should.raise(ArgumentError)
-      -> { ("foo%quux" % []) }.should.raise(ArgumentError)
-    end
-
-    it "raises an error if NULL or \\n appear anywhere else in the format string" do
-      begin
-        old_debug, $DEBUG = $DEBUG, false
-
-        -> { "%.\n3f" % 1.2 }.should.raise(ArgumentError)
-        -> { "%.3\nf" % 1.2 }.should.raise(ArgumentError)
-        -> { "%.\03f" % 1.2 }.should.raise(ArgumentError)
-        -> { "%.3\0f" % 1.2 }.should.raise(ArgumentError)
-      ensure
-        $DEBUG = old_debug
-      end
-    end
-  end
-
-  ruby_version_is "3.4" do
-    it "raises an ArgumentError if % is not followed by a conversion specifier" do
-      -> { "%" % [] }.should.raise(ArgumentError)
-      -> { "%\n" % [] }.should.raise(ArgumentError)
-      -> { "%\0" % [] }.should.raise(ArgumentError)
-      -> { " % " % [] }.should.raise(ArgumentError)
-      -> { "%.\n3f" % 1.2 }.should.raise(ArgumentError)
-      -> { "%.3\nf" % 1.2 }.should.raise(ArgumentError)
-      -> { "%.\03f" % 1.2 }.should.raise(ArgumentError)
-      -> { "%.3\0f" % 1.2 }.should.raise(ArgumentError)
-    end
-  end
-
   it "ignores unused arguments when $DEBUG is false" do
     begin
       old_debug = $DEBUG
@@ -137,18 +92,6 @@ describe "String#%" do
       ("%2$s" % [1, 2, 3]).should == "2"
     ensure
       $DEBUG = old_debug
-    end
-  end
-
-  ruby_version_is ""..."3.4" do
-    it "replaces trailing absolute argument specifier without type with percent sign" do
-      ("hello %1$" % "foo").should == "hello %"
-    end
-  end
-
-  ruby_version_is "3.4" do
-    it "raises an ArgumentError if absolute argument specifier is followed by a conversion specifier" do
-      -> { "hello %1$" % "foo" }.should.raise(ArgumentError)
     end
   end
 

--- a/spec/tags/core/string/modulo_tags.txt
+++ b/spec/tags/core/string/modulo_tags.txt
@@ -2,5 +2,3 @@ fails:String#% output's encoding negotiates a compatible encoding if necessary
 fails:String#% output's encoding raises if a compatible encoding can't be found
 fails:String#% returns a String in the argument's encoding if format encoding is more restrictive
 fails:String#% raises Encoding::CompatibilityError if both encodings are ASCII compatible and there are not ASCII characters
-fails:String#% raises an ArgumentError if % is not followed by a conversion specifier
-fails:String#% raises an ArgumentError if absolute argument specifier is followed by a conversion specifier

--- a/src/main/java/org/truffleruby/core/format/printf/PrintfSimpleParser.java
+++ b/src/main/java/org/truffleruby/core/format/printf/PrintfSimpleParser.java
@@ -63,13 +63,13 @@ public final class PrintfSimpleParser {
             boolean finished = false;
             boolean argTypeSet = false;
 
-            while (!finished) {
-                /* MRI's parser will accept a format specifier such as %1$ even though it doesn't actually include a
-                 * type, but will raise an exception for a format specifier such as %1. */
-                if (i >= this.source.length && config.getAbsoluteArgumentIndex() == null) {
-                    throw new InvalidFormatException("incomplete format specifier; use %% (double %) instead");
-                }
+            /* MRI's parser will accept a format specifier such as %1$ even though it doesn't actually include a type,
+             * but will raise an exception for a format specifier such as %1. */
+            if (i >= this.source.length && config.getAbsoluteArgumentIndex() == null) {
+                throw new InvalidFormatException("incomplete format specifier; use %% (double %) instead");
+            }
 
+            while (!finished) {
                 char p = i >= this.source.length ? '\0' : this.source[i];
 
                 switch (p) {
@@ -198,8 +198,6 @@ public final class PrintfSimpleParser {
                         config.setPrecision(re.getNumber() == null ? 0 : re.getNumber());
                         i = re.getNextI();
                         break;
-                    case '\n':
-                    case '\0':
                     case '%':
                         if (config.hasFlags()) {
                             throw new InvalidFormatException("invalid format character - %");


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/20438
http://github.com/ruby/ruby/commit/31c9a3a1d330606493e5e70aec3cd1a36d8c61a0

Move the spec out of `String#%`, it applies to all format specifier methods.

Also test against the error message. ArgumentError could just as well be from not passing enough arguments for the format string.

As a result, move the check for "incomplete format specifier" out of the loop, it should only be raised with that message when `%` was the last character.

- [ ] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
