### PR TITLE
Revise Range methods

### DIFF
--- a/spec/ruby/core/range/fixtures/classes.rb
+++ b/spec/ruby/core/range/fixtures/classes.rb
@@ -111,6 +111,28 @@ module RangeSpecs
     undef_method :coerce
   end
 
+  # supports only interface required by Range#cover? + #succ
+  class CoverElementWithSucc
+    attr_reader :n
+
+    def initialize(n)
+      @n = n
+    end
+
+    def <=>(other)
+      return nil unless other.is_a?(CoverElementWithSucc)
+      @n <=> other.n
+    end
+
+    def succ
+      CoverElementWithSucc.new(@n + 1)
+    end
+
+    def inspect
+      "CoverElementWithSucc(#{@n})"
+    end
+  end
+
   class Xs < Custom # represent a string of 'x's
     def succ
       Xs.new(@length + 1)

--- a/spec/ruby/core/range/fixtures/classes.rb
+++ b/spec/ruby/core/range/fixtures/classes.rb
@@ -58,8 +58,57 @@ module RangeSpecs
     end
 
     def <=>(other)
+      return nil unless other.is_a?(WithoutSucc)
       @n <=> other.n
     end
+  end
+
+  class WithSucc
+    attr_reader :value
+
+    def initialize(value)
+      @value = value
+    end
+
+    def <=>(other)
+      return nil unless other.is_a?(WithSucc)
+      @value <=> other.value
+    end
+
+    def succ
+      WithSucc.new(@value + 1)
+    end
+
+    def ==(other)
+      return false unless other.is_a?(WithSucc)
+      @value == other.value
+    end
+  end
+
+  class Number < Numeric
+    attr_reader :value
+
+    def initialize(value)
+      @value = value
+    end
+
+    def <=>(other)
+      return nil unless other.is_a?(Number)
+      @value <=> other.value
+    end
+
+    def +(other)
+      raise "supported Integer only" unless other.is_a?(Integer)
+      Number.new(@value + other)
+    end
+
+    def ==(other)
+      return false unless other.is_a?(Number)
+      @value == other.value
+    end
+
+    # to prevent type conversion
+    undef_method :coerce
   end
 
   class Xs < Custom # represent a string of 'x's

--- a/spec/ruby/core/range/include_spec.rb
+++ b/spec/ruby/core/range/include_spec.rb
@@ -16,6 +16,76 @@ describe "Range#include?" do
       ('a'..'c').include?('bc').should == false
       ('a'...'c').include?('bc').should == false
     end
+
+    it "returns whether object is an element of self using #== to compare" do
+      range = 'a'..'ab'
+      range.include?('b').should == true
+      range.include?('aa').should == true
+      range.include?('ac').should == false
+    end
+
+    it "ignores self.end if excluded end" do
+      range = 'a'...'aa'
+      range.include?('aa').should == false
+    end
+
+    it "returns false if backward range" do
+      range = 'aa'..'a'
+      range.include?('b').should == false
+    end
+
+    it "returns false if empty range" do
+      range = 'aa'...'aa'
+      range.include?('aa').should == false
+    end
+
+    it "raises TypeError for beginningless ranges" do
+      -> { (..'aa').include?('a') }.should.raise(TypeError)
+      -> { (..'aa').include?(Object.new) }.should.raise(TypeError)
+    end
+
+    it "raises TypeError for endless ranges" do
+      -> {
+        ('aa'..).include?(Object.new)
+      }.should.raise(TypeError)
+      -> {
+        ('aa'..).include?('a')
+      }.should.raise(TypeError)
+    end
+
+    it "returns false if an argument isn't comparable with range boundaries" do
+      range = 'a'..'aa'
+      range.include?(Object.new).should == false
+    end
+
+    it "returns false if an argument is empty" do
+      range = 'a'..'aa'
+      range.include?('').should == false
+    end
+
+    describe "argument conversion to String" do
+      it "converts the passed argument to a String using #to_str" do
+        range = 'a'..'aa'
+        object = Object.new
+        def object.to_str; 'b'; end
+        range.include?(object).should == true
+      end
+
+      it "returns false if the passed argument does not respond to #to_str" do
+        range = 'a'..'aa'
+        range.include?(nil).should == false
+        range.include?([]).should == false
+      end
+
+      it "raises a TypeError if the passed argument responds to #to_str but it returns non-String value" do
+        range = 'a'..'aa'
+        object = Object.new
+        def object.to_str; 1; end
+        -> {
+          range.include?(object)
+        }.should.raise(TypeError)
+      end
+    end
   end
 
   describe "with weird succ" do
@@ -94,5 +164,229 @@ describe "Range#include?" do
 
   it "does not include U+9995 in the range U+0999..U+9999" do
     ("\u{999}".."\u{9999}").include?("\u{9995}").should == false
+  end
+
+  describe "with custom Comparable objects (with #succ)" do
+    it "returns whether object is an element of self using #== to compare" do
+      range = RangeSpecs::WithSucc.new(1)..RangeSpecs::WithSucc.new(4)
+      range.include?(RangeSpecs::WithSucc.new(2)).should == true
+      range.include?(RangeSpecs::WithSucc.new(5)).should == false
+    end
+
+    it "ignores self.end if excluded end" do
+      range = RangeSpecs::WithSucc.new(1)...RangeSpecs::WithSucc.new(4)
+      range.include?(RangeSpecs::WithSucc.new(4)).should == false
+    end
+
+    it "returns false if backward range" do
+      range = RangeSpecs::WithSucc.new(4)..RangeSpecs::WithSucc.new(1)
+      range.include?(RangeSpecs::WithSucc.new(2)).should == false
+    end
+
+    it "returns false if empty range" do
+      range = RangeSpecs::WithSucc.new(1)...RangeSpecs::WithSucc.new(1)
+      range.include?(RangeSpecs::WithSucc.new(1)).should == false
+    end
+
+    it "returns false if an argument isn't comparable with range boundaries" do
+      range = RangeSpecs::WithSucc.new(0)..RangeSpecs::WithSucc.new(6)
+      range.include?(Object.new).should == false
+    end
+
+    it "raises TypeError for beginningless ranges" do
+      -> {
+        (..RangeSpecs::WithSucc.new(10)).include?(RangeSpecs::WithSucc.new(5))
+      }.should.raise(TypeError)
+    end
+
+    it "raises TypeError for endless ranges" do
+      -> {
+        (RangeSpecs::WithSucc.new(0)..).include?(RangeSpecs::WithSucc.new(5))
+      }.should.raise(TypeError)
+    end
+  end
+
+  describe "with custom Comparable objects (without #succ)" do
+    it "raises TypeError for beginningless ranges" do
+      -> {
+        (..RangeSpecs::WithoutSucc.new(10)).include?(RangeSpecs::WithoutSucc.new(5))
+      }.should.raise(TypeError)
+
+      -> {
+        (..RangeSpecs::WithoutSucc.new(10)).include?(Object.new)
+      }.should.raise(TypeError)
+    end
+
+    it "raises TypeError for endless ranges" do
+      -> {
+        (RangeSpecs::WithoutSucc.new(0)..).include?(RangeSpecs::WithoutSucc.new(5))
+      }.should.raise(TypeError)
+
+      -> {
+        (RangeSpecs::WithoutSucc.new(0)..).include?(Object.new)
+      }.should.raise(TypeError)
+    end
+
+    it "raises TypeError for (nil..nil)" do
+      -> {
+        (nil..nil).include?(Object.new)
+      }.should.raise(TypeError)
+    end
+  end
+
+  describe "with Numeric subclass elements" do
+    it "returns true if object is between self.begin and self.end" do
+      range = RangeSpecs::Number.new(0)..RangeSpecs::Number.new(6)
+      range.include?(RangeSpecs::Number.new(5)).should == true
+    end
+
+    it "returns false if object is smaller than self.begin" do
+      range = RangeSpecs::Number.new(0)..RangeSpecs::Number.new(6)
+      range.include?(RangeSpecs::Number.new(-5)).should == false
+    end
+
+    it "returns false if object is greater than self.end" do
+      range = RangeSpecs::Number.new(0)..RangeSpecs::Number.new(6)
+      range.include?(RangeSpecs::Number.new(10)).should == false
+    end
+
+    it "ignores end if excluded end" do
+      range = RangeSpecs::Number.new(0)...RangeSpecs::Number.new(6)
+      range.include?(RangeSpecs::Number.new(6)).should == false
+    end
+
+    it "returns true if argument is a single element in the range" do
+      range = RangeSpecs::Number.new(0)..RangeSpecs::Number.new(0)
+      range.include?(RangeSpecs::Number.new(0)).should == true
+    end
+
+    it "returns false if range is empty" do
+      range = RangeSpecs::Number.new(0)...RangeSpecs::Number.new(0)
+      range.include?(RangeSpecs::Number.new(0)).should == false
+    end
+
+    it "returns false if an argument isn't comparable with range boundaries" do
+      range = RangeSpecs::Number.new(0)..RangeSpecs::Number.new(6)
+      range.include?(Object.new).should == false
+    end
+
+    describe "beginningless range" do
+      it "returns false if object is greater than self.end" do
+        range = ..RangeSpecs::Number.new(6)
+        range.include?(RangeSpecs::Number.new(10)).should == false
+      end
+
+      it "returns true if object is smaller than self.end" do
+        range = ..RangeSpecs::Number.new(6)
+        range.include?(RangeSpecs::Number.new(0)).should == true
+      end
+    end
+
+    describe "endless range" do
+      it "returns true if object is greater than self.begin" do
+        range = (RangeSpecs::Number.new(0)..)
+        range.include?(RangeSpecs::Number.new(10)).should == true
+      end
+
+      it "returns false if object is smaller than self.begin" do
+        range = (RangeSpecs::Number.new(0)..)
+        range.include?(RangeSpecs::Number.new(-10)).should == false
+      end
+    end
+
+    it "returns false if object isn't comparable with self.begin and self.end (that's #<=> returns nil)" do
+      range = RangeSpecs::Number.new(0)..RangeSpecs::Number.new(6)
+      object = Object.new
+      def object.<=>(other); nil; end
+      range.include?(object).should == false
+    end
+  end
+
+  describe "with Time elements" do
+    it "returns true if object is between self.begin and self.end" do
+      range = Time.at(1_700_000_000)..Time.at(1_700_000_000 + 6)
+      range.include?(Time.at(1_700_000_000 + 5)).should == true
+    end
+
+    it "returns false if object is smaller than self.begin" do
+      range = Time.at(1_700_000_000)..Time.at(1_700_000_000 + 6)
+      range.include?(Time.at(1_700_000_000 - 5)).should == false
+    end
+
+    it "returns false if object is greater than self.end" do
+      range = Time.at(1_700_000_000)..Time.at(1_700_000_000 + 6)
+      range.include?(Time.at(1_700_000_000 + 10)).should == false
+    end
+
+    it "ignores end if excluded end" do
+      range = Time.at(1_700_000_000)...Time.at(1_700_000_000 + 6)
+      range.include?(Time.at(1_700_000_000 + 6)).should == false
+    end
+
+    it "returns true if argument is a single element in the range" do
+      range = Time.at(1_700_000_000)..Time.at(1_700_000_000)
+      range.include?(Time.at(1_700_000_000)).should == true
+    end
+
+    it "returns false if range is empty" do
+      range = Time.at(1_700_000_000)...Time.at(1_700_000_000)
+      range.include?(Time.at(1_700_000_000)).should == false
+    end
+
+    it "returns false if an argument isn't comparable with range boundaries" do
+      range = Time.at(1_700_000_000)..Time.at(1_700_000_000 + 6)
+      range.include?(Object.new).should == false
+    end
+
+    describe "beginningless range" do
+      it "returns false if object is greater than self.end" do
+        range = ..Time.at(1_700_000_000 + 6)
+        range.include?(Time.at(1_700_000_000 + 10)).should == false
+      end
+
+      it "returns true if object is smaller than self.end" do
+        range = ..Time.at(1_700_000_000 + 6)
+        range.include?(Time.at(1_700_000_000)).should == true
+      end
+    end
+
+    describe "endless range" do
+      it "returns true if object is greater than self.begin" do
+        range = (Time.at(1_700_000_000)..)
+        range.include?(Time.at(1_700_000_000 + 10)).should == true
+      end
+
+      it "returns false if object is smaller than self.begin" do
+        range = (Time.at(1_700_000_000 + 10)..)
+        range.include?(Time.at(1_700_000_000)).should == false
+      end
+    end
+
+    it "returns false if object isn't comparable with self.begin and self.end (that's #<=> returns nil)" do
+      range = Time.at(1_700_000_000)..Time.at(1_700_000_000 + 6)
+      object = Object.new
+      def object.<=>(other); nil; end
+      range.include?(object).should == false
+    end
+  end
+
+  describe 'with beginless and endless range' do
+    it "return true for any Numeric value" do
+      (nil..nil).include?(1).should == true
+      (nil..nil).include?(1.0).should == true
+      (nil..nil).include?(1r).should == true
+      (nil..nil).include?(Complex(1)).should == true
+      (nil..nil).include?(RangeSpecs::Number.new(1)).should == true
+    end
+
+    it "return true for any Time value" do
+      (nil..nil).include?(Time.now).should == true
+    end
+
+    it "raises TypeError for non-Numeric/Time values" do
+      -> { (nil..nil).include?("a") }.should.raise(TypeError)
+      -> { (nil..nil).include?(:a) }.should.raise(TypeError)
+      -> { (nil..nil).include?([]) }.should.raise(TypeError)
+    end
   end
 end

--- a/spec/ruby/core/range/overlap_spec.rb
+++ b/spec/ruby/core/range/overlap_spec.rb
@@ -9,6 +9,9 @@ describe "Range#overlap?" do
     (1..2).overlap?(0..3).should == true
 
     ('a'..'c').overlap?('b'..'d').should == true
+
+    (0..4).overlap?(4..10).should == true
+    (4..10).overlap?(0..10).should == true
   end
 
   it "returns false if other Range does not overlap self" do
@@ -43,6 +46,20 @@ describe "Range#overlap?" do
 
     (0..).overlap?(2..).should == true
     (..0).overlap?(..2).should == true
+
+    (nil..nil).overlap?(4..6).should == true
+    (4..6).overlap?(nil..nil).should == true
+
+    ruby_version_is "4.0" do
+      (nil..nil).overlap?(..6).should == true
+      (..6).overlap?(nil..nil).should == true
+    end
+
+    (nil..nil).overlap?(4..).should == true
+    (4..).overlap?(nil..nil).should == true
+
+    (..10).overlap?(10..).should == true
+    (10..).overlap?(..10).should == true
   end
 
   it "returns false when beginningless and endless Ranges do not overlap" do
@@ -51,6 +68,8 @@ describe "Range#overlap?" do
 
     (..-1).overlap?(0..2).should == false
     (3..).overlap?(0..2).should == false
+
+    (..0).overlap?(10..).should == false
   end
 
   it "returns false when Ranges are not compatible" do
@@ -83,5 +102,14 @@ describe "Range#overlap?" do
 
     ('a'...'c').overlap?('c'..'e').should == false
     ('c'..'e').overlap?('a'...'c').should == false
+
+    (0...10).overlap?(6..10).should == true
+    (nil...6).overlap?(4..6).should == true
+    (nil...10).overlap?(nil..10).should == true
+
+    (nil...4).overlap?(4..10).should == false
+    (nil...10).overlap?(10..).should == false
+    (10..).overlap?(nil...10).should == false
+    (6..).overlap?(0...6).should == false
   end
 end

--- a/spec/ruby/core/range/shared/cover.rb
+++ b/spec/ruby/core/range/shared/cover.rb
@@ -463,5 +463,17 @@ describe :range_cover_subrange, shared: true do
         end
       end
     end
+
+    context "when other range is partially interleaved" do
+      context "when a range cannot be iterated (that's it does not responds to #succ)" do
+        it "returns false if self.begin < other.begin, self.end < other.end but other.exclude_end? is true and the rightmost other value < self.end" do
+          (0..10.0).send(@method, 5...11.0).should == false
+        end
+
+        it "returns false if self is beginless and self.end < other.end but other.exclude_end? is true and the rightmost other value < self.end" do
+          (..10.0).send(@method, ...11.0).should == false
+        end
+      end
+    end
   end
 end

--- a/spec/ruby/core/range/shared/cover.rb
+++ b/spec/ruby/core/range/shared/cover.rb
@@ -90,6 +90,48 @@ describe :range_cover, shared: true do
       end
     end
   end
+
+  describe "with non-Range argument" do
+    it "returns false if the object is smaller than self.begin" do
+      (0..6).send(@method, -5).should == false
+    end
+
+    it "returns false if the object is greater than self.end" do
+      (0..6).send(@method, 10).should == false
+    end
+
+    it "returns false if the range is empty" do
+      (0...0).send(@method, 0).should == false
+    end
+
+    it "returns false if the argument is not comparable with the range elements (returns nil from <=>)" do
+      (0..6).send(@method, Object.new).should == false
+    end
+
+    it "returns false if the argument is greater than self.end on a beginless range" do
+      (...6).send(@method, 10).should == false
+    end
+
+    it "returns true if the argument is smaller than self.end on a beginless range" do
+      (...6).send(@method, 0).should == true
+    end
+
+    it "returns true if the argument is greater than self.begin on an endless range" do
+      (0..).send(@method, 10).should == true
+    end
+
+    it "returns false if the argument is smaller than self.begin on an endless range" do
+      (0..).send(@method, -10).should == false
+    end
+
+    it "returns true on any value for (nil..nil)" do
+      (nil..nil).send(@method, Object.new).should == true
+    end
+
+    it "returns true on any value for (nil...nil)" do
+      (nil...nil).send(@method, Object.new).should == true
+    end
+  end
 end
 
 describe :range_cover_subrange, shared: true do
@@ -149,45 +191,260 @@ describe :range_cover_subrange, shared: true do
       (0...11.1).send(@method, (0..10.1)).should == true
       (0..10.1).send(@method, (0...11.1)).should == false
     end
-  end
 
-  it "allows self to be a beginless range" do
-    (...10).send(@method, (3..7)).should == true
-    (...10).send(@method, (3..15)).should == false
+    context "when other range is completely inside self" do
+      it "returns true if self.begin < other.begin and self.end > other.end" do
+        (0..10).send(@method, 4..6).should == true
+      end
 
-    (..7.9).send(@method, (2.5..6.5)).should == true
-    (..7.9).send(@method, (2.5..8.5)).should == false
+      it "returns true if self.begin == other.begin and self.end > other.end" do
+        (0..10).send(@method, 0..6).should == true
+      end
 
-    (..'i').send(@method, ('d'..'f')).should == true
-    (..'i').send(@method, ('d'..'z')).should == false
-  end
+      it "returns true if self.begin < other.begin and self.end == other.end" do
+        (0..10).send(@method, 4..10).should == true
+      end
 
-  it "allows self to be a endless range" do
-    eval("(0...)").send(@method, (3..7)).should == true
-    eval("(5...)").send(@method, (3..15)).should == false
+      it "returns true if self.begin < other.begin and self.end < other.end but other.exclude_end? is true and the rightmost other value <= self.end" do
+        (0..10).send(@method, 4...11).should == true
+      end
 
-    eval("(1.1..)").send(@method, (2.5..6.5)).should == true
-    eval("(3.3..)").send(@method, (2.5..8.5)).should == false
+      it "returns true if self.begin == other.begin and self.end == other.end" do
+        (0..10).send(@method, 0..10).should == true
+      end
 
-    eval("('a'..)").send(@method, ('d'..'f')).should == true
-    eval("('p'..)").send(@method, ('d'..'z')).should == false
-  end
+      it "returns true if self.begin == other.begin and self.end == other.end and self.exclude_end? is true and other.exclude_end? is true" do
+        (0...10).send(@method, 0...10).should == true
+      end
 
-  it "accepts beginless range argument" do
-    (..10).send(@method, (...10)).should == true
-    (0..10).send(@method, (...10)).should == false
+      it "returns true if self is beginless and self.end > other.end" do
+        (...10).send(@method, 4..6).should == true
+      end
 
-    (1.1..7.9).send(@method, (...10.5)).should == false
+      it "returns true if self is beginless and self.end == other.end" do
+        (..10).send(@method, 4..10).should == true
+      end
 
-    ('c'..'i').send(@method, (..'i')).should == false
-  end
+      it "returns true if self is beginless and self.end == other.end and self.exclude_end? is true and other.exclude_end? is true" do
+        (...10).send(@method, 4...10).should == true
+      end
 
-  it "accepts endless range argument" do
-    eval("(0..)").send(@method, eval("(0...)")).should == true
-    (0..10).send(@method, eval("(0...)")).should == false
+      it "returns true if self and other are beginless and self.end > other.end" do
+        (...10).send(@method, (...6)).should == true
+      end
 
-    (1.1..7.9).send(@method, eval("(0.8...)")).should == false
+      it "returns true if self and other are beginless and self.end == other.end and self.exclude_end? is true and other.exclude_end? is true" do
+        (...10).send(@method, (...10)).should == true
+      end
 
-    ('c'..'i').send(@method, eval("('a'..)")).should == false
+      it "returns true if self is beginless and self.end < other.end but other.exclude_end? is true and the rightmost other value <= self.end" do
+        (..10).send(@method, 4...11).should == true
+      end
+
+      it "returns true if self is endless and self.begin < other.begin" do
+        (0..).send(@method, 4..6).should == true
+      end
+
+      it "returns true if self is endless and self.begin == other.begin" do
+        (0..).send(@method, 0..6).should == true
+      end
+
+      it "returns true if self and other are endless and self.begin < other.begin" do
+        (0..).send(@method, (4..)).should == true
+      end
+
+      it "returns true if self and other are endless and self.begin == other.begin" do
+        (0..).send(@method, (0..)).should == true
+      end
+
+      it "returns true if self and other are endless and self.begin < other.begin and self.exclude_end? is true and other.exclude_end? is true" do
+        (0...).send(@method, (4...)).should == true
+      end
+
+      it "returns true if self and other are endless and self.begin == other.begin and self.exclude_end? is true and other.exclude_end? is true" do
+        (0...).send(@method, (0...)).should == true
+      end
+
+      it "returns true if self is (nil..nil) and other is finite" do
+        (nil..nil).send(@method, 4..6).should == true
+      end
+
+      it "returns true if self is (nil..nil) and other is beginless" do
+        (nil..nil).send(@method, (...6)).should == true
+      end
+
+      it "returns true if self is (nil..nil) and other is endless" do
+        (nil..nil).send(@method, (4..)).should == true
+      end
+
+      it "returns true if self is (nil...nil) and other is finite" do
+        (nil...nil).send(@method, 4..6).should == true
+      end
+
+      it "returns true if self is (nil...nil) and other is beginless" do
+        (nil...nil).send(@method, (...6)).should == true
+      end
+
+      it "returns true if self is (nil...nil) and other is endless and other.exclude_end? is true" do
+        (nil...nil).send(@method, (4...)).should == true
+      end
+    end
+
+    context "when other range is partially interleaved" do
+      it "returns false if self.begin > other.begin, self.begin < other.end and self.end > other.end" do
+        (4..10).send(@method, 0..6).should == false
+      end
+
+      it "returns false if self.begin > other.begin, self.begin < other.end and self.end == other.end" do
+        (4..10).send(@method, 0..10).should == false
+      end
+
+      it "returns false if self.begin > other.begin, self.begin < other.end and self.end < other.end" do
+        (4..6).send(@method, 0..10).should == false
+      end
+
+      it "returns false if self.begin < other.begin and self.end > other.begin, self.end < other.end" do
+        (0..6).send(@method, 4..10).should == false
+      end
+
+      it "returns false if self.begin < other.begin and self.end == other.end and self.exclude_end? is true" do
+        (0...10).send(@method, 6..10).should == false
+      end
+
+      it "returns false if self.begin < other.begin and self.end == other.begin" do
+        (0..4).send(@method, 4..10).should == false
+      end
+
+      it "returns false if self is beginless and self.end > other.begin but self.end < other.end" do
+        (...6).send(@method, 4..10).should == false
+      end
+
+      it "returns false if self is beginless and self.end == other.end but self.exclude_end? is true" do
+        (...6).send(@method, 4..6).should == false
+      end
+
+      it "returns false if self and other are beginless but self.end < other.end" do
+        (...6).send(@method, (...10)).should == false
+      end
+
+      it "returns false if self and other are beginless and self.end == other.end but self.exclude_end? is true" do
+        (...10).send(@method, (..10)).should == false
+      end
+
+      it "returns false if self is endless and self.begin > other.begin" do
+        (4..).send(@method, 0..6).should == false
+      end
+
+      it "returns false if self and other are endless and self.begin > other.begin" do
+        (4..).send(@method, (0..)).should == false
+      end
+
+      it "returns false if self and other are endless and self.begin == other.begin but self.exclude_end? is true" do
+        (0...).send(@method, (0..)).should == false
+      end
+
+      it "returns false if self and other are endless and self.begin < other.begin but self.exclude_end? is true" do
+        (0...).send(@method, (4..)).should == false
+      end
+
+      it "returns false if self is (nil...nil) and other is endless" do
+        (nil...nil).send(@method, (4..)).should == false
+      end
+
+      it "returns false if self is beginless and other is endless and self.end == other.begin" do
+        (..10).send(@method, (10..)).should == false
+      end
+
+      it "returns false if other is beginless and self is endless and other.end == self.begin" do
+        (10..).send(@method, (..10)).should == false
+      end
+
+      it "returns false if self is finite and other is beginless and they overlap" do
+        (0..10).send(@method, ...10).should == false
+      end
+
+      it "returns false if self is finite and other is endless and they overlap" do
+        (0..10).send(@method, 0..).should == false
+      end
+    end
+
+    context "when other range does not interleave" do
+      it "returns false if self.begin > other.end" do
+        (6..10).send(@method, 0..4).should == false
+      end
+
+      it "returns false if self.end < other.begin" do
+        (0..4).send(@method, 6..10).should == false
+      end
+
+      it "returns false if self is beginless but self.end < other.begin" do
+        (...4).send(@method, 6..10).should == false
+      end
+
+      it "returns false if self is beginless and self.end == other.begin but self.exclude_end? is true" do
+        (...4).send(@method, 4..10).should == false
+      end
+
+      it "returns false if self is beginless and other is endless but self.end < other.begin" do
+        (...0).send(@method, (10..)).should == false
+      end
+
+      it "returns false if self is beginless and other is endless and self.end == other.begin but self.exclude_end? is true" do
+        (...10).send(@method, (10..)).should == false
+      end
+
+      it "returns false if self is endless but self.begin > other.end" do
+        (10..).send(@method, 0..6).should == false
+      end
+
+      it "returns false if self is endless but self.begin == other.end but other.exclude_end? is true" do
+        (6..).send(@method, (0...6)).should == false
+      end
+
+      it "returns false if other is beginless but self.begin > other.end" do
+        (4..10).send(@method, (...0)).should == false
+      end
+
+      it "returns false if other is beginless and self.begin == other.end but other.exclude_end? is true" do
+        (6..10).send(@method, (...6)).should == false
+      end
+
+      it "returns false if other is beginless and self is endless and other.end == self.begin but other.exclude_end? is true" do
+        (10..).send(@method, (...10)).should == false
+      end
+
+      it "returns false if other is endless but self.end < other.begin" do
+        (0..4).send(@method, (10..)).should == false
+      end
+
+      it "returns false if other is endless and self.end == other.begin but self.exclude_end? is true" do
+        (0...10).send(@method, (10..)).should == false
+      end
+    end
+
+    context "when comparing with backward ranges" do
+      it "returns false if other is backward and fits into self" do
+        (0..10).send(@method, 6..4).should == false
+      end
+
+      it "returns false if self is backward and other fits into self" do
+        (10..0).send(@method, 4..6).should == false
+      end
+    end
+
+    context "when comparing with empty ranges" do
+      it "returns false if other is empty and fits into self" do
+        (0..10).send(@method, 4...4).should == false
+      end
+
+      it "returns false if self is empty and equals other" do
+        (0...0).send(@method, 0...0).should == false
+      end
+    end
+
+    it "returns false if other boundaries are not comparable with self boundaries" do
+      (0..10).send(@method, ("a".."z")).should == false
+    end
+
   end
 end

--- a/spec/ruby/core/range/shared/cover.rb
+++ b/spec/ruby/core/range/shared/cover.rb
@@ -135,63 +135,63 @@ describe :range_cover, shared: true do
 end
 
 describe :range_cover_subrange, shared: true do
-  context "range argument" do
-    it "accepts range argument" do
-      (0..10).send(@method, (3..7)).should == true
-      (0..10).send(@method, (3..15)).should == false
-      (0..10).send(@method, (-2..7)).should == false
+  it "accepts range argument" do
+    (0..10).send(@method, (3..7)).should == true
+    (0..10).send(@method, (3..15)).should == false
+    (0..10).send(@method, (-2..7)).should == false
 
-      (1.1..7.9).send(@method, (2.5..6.5)).should == true
-      (1.1..7.9).send(@method, (2.5..8.5)).should == false
-      (1.1..7.9).send(@method, (0.5..6.5)).should == false
+    (1.1..7.9).send(@method, (2.5..6.5)).should == true
+    (1.1..7.9).send(@method, (2.5..8.5)).should == false
+    (1.1..7.9).send(@method, (0.5..6.5)).should == false
 
-      ('c'..'i').send(@method, ('d'..'f')).should == true
-      ('c'..'i').send(@method, ('d'..'z')).should == false
-      ('c'..'i').send(@method, ('a'..'f')).should == false
+    ('c'..'i').send(@method, ('d'..'f')).should == true
+    ('c'..'i').send(@method, ('d'..'z')).should == false
+    ('c'..'i').send(@method, ('a'..'f')).should == false
 
-      range_10_100 = RangeSpecs::TenfoldSucc.new(10)..RangeSpecs::TenfoldSucc.new(100)
-      range_20_90 = RangeSpecs::TenfoldSucc.new(20)..RangeSpecs::TenfoldSucc.new(90)
-      range_20_110 = RangeSpecs::TenfoldSucc.new(20)..RangeSpecs::TenfoldSucc.new(110)
-      range_0_90 = RangeSpecs::TenfoldSucc.new(0)..RangeSpecs::TenfoldSucc.new(90)
+    range_10_100 = RangeSpecs::TenfoldSucc.new(10)..RangeSpecs::TenfoldSucc.new(100)
+    range_20_90 = RangeSpecs::TenfoldSucc.new(20)..RangeSpecs::TenfoldSucc.new(90)
+    range_20_110 = RangeSpecs::TenfoldSucc.new(20)..RangeSpecs::TenfoldSucc.new(110)
+    range_0_90 = RangeSpecs::TenfoldSucc.new(0)..RangeSpecs::TenfoldSucc.new(90)
 
-      range_10_100.send(@method, range_20_90).should == true
-      range_10_100.send(@method, range_20_110).should == false
-      range_10_100.send(@method, range_0_90).should == false
-    end
+    range_10_100.send(@method, range_20_90).should == true
+    range_10_100.send(@method, range_20_110).should == false
+    range_10_100.send(@method, range_0_90).should == false
+  end
 
-    it "supports boundaries of different comparable types" do
-      (0..10).send(@method, (3.1..7.9)).should == true
-      (0..10).send(@method, (3.1..15.9)).should == false
-      (0..10).send(@method, (-2.1..7.9)).should == false
-    end
+  it "supports boundaries of different comparable types" do
+    (0..10).send(@method, (3.1..7.9)).should == true
+    (0..10).send(@method, (3.1..15.9)).should == false
+    (0..10).send(@method, (-2.1..7.9)).should == false
+  end
 
-    it "returns false if types are not comparable" do
-      (0..10).send(@method, ('a'..'z')).should == false
-      (0..10).send(@method, (RangeSpecs::TenfoldSucc.new(0)..RangeSpecs::TenfoldSucc.new(100))).should == false
-    end
+  it "returns false if types are not comparable" do
+    (0..10).send(@method, ('a'..'z')).should == false
+    (0..10).send(@method, (RangeSpecs::TenfoldSucc.new(0)..RangeSpecs::TenfoldSucc.new(100))).should == false
+  end
 
-    it "honors exclusion of right boundary (:exclude_end option)" do
-      # Integer
-      (0..10).send(@method, (0..10)).should == true
-      (0...10).send(@method, (0...10)).should == true
+  it "honors exclusion of right boundary (:exclude_end option)" do
+    # Integer
+    (0..10).send(@method, (0..10)).should == true
+    (0...10).send(@method, (0...10)).should == true
 
-      (0..10).send(@method, (0...10)).should == true
-      (0...10).send(@method, (0..10)).should == false
+    (0..10).send(@method, (0...10)).should == true
+    (0...10).send(@method, (0..10)).should == false
 
-      (0...11).send(@method, (0..10)).should == true
-      (0..10).send(@method, (0...11)).should == true
+    (0...11).send(@method, (0..10)).should == true
+    (0..10).send(@method, (0...11)).should == true
 
-      # Float
-      (0..10.1).send(@method, (0..10.1)).should == true
-      (0...10.1).send(@method, (0...10.1)).should == true
+    # Float
+    (0..10.1).send(@method, (0..10.1)).should == true
+    (0...10.1).send(@method, (0...10.1)).should == true
 
-      (0..10.1).send(@method, (0...10.1)).should == true
-      (0...10.1).send(@method, (0..10.1)).should == false
+    (0..10.1).send(@method, (0...10.1)).should == true
+    (0...10.1).send(@method, (0..10.1)).should == false
 
-      (0...11.1).send(@method, (0..10.1)).should == true
-      (0..10.1).send(@method, (0...11.1)).should == false
-    end
+    (0...11.1).send(@method, (0..10.1)).should == true
+    (0..10.1).send(@method, (0...11.1)).should == false
+  end
 
+  context "range argument with Integer boundaries" do
     context "when other range is completely inside self" do
       it "returns true if self.begin < other.begin and self.end > other.end" do
         (0..10).send(@method, 4..6).should == true
@@ -445,6 +445,23 @@ describe :range_cover_subrange, shared: true do
     it "returns false if other boundaries are not comparable with self boundaries" do
       (0..10).send(@method, ("a".."z")).should == false
     end
+  end
 
+  context "range argument with boundaries of generic type (that implements only #<=>)" do
+    context "when other range is completely inside self" do
+      context "when a range can be iterated (that's it responds to #succ)" do
+        it "returns true if self.begin < other.begin and self.end < other.end but other.exclude_end? is true and the rightmost other value <= self.end" do
+          a = RangeSpecs::CoverElementWithSucc.new(0)..RangeSpecs::CoverElementWithSucc.new(10)
+          b = RangeSpecs::CoverElementWithSucc.new(4)...RangeSpecs::CoverElementWithSucc.new(11)
+          (a).send(@method, b).should == true
+        end
+
+        it "returns true if self is beginless and self.end < other.end but other.exclude_end? is true and the rightmost other value <= self.end" do
+          a = ..RangeSpecs::CoverElementWithSucc.new(10)
+          b = RangeSpecs::CoverElementWithSucc.new(4)...RangeSpecs::CoverElementWithSucc.new(11)
+          (a).send(@method, b).should == true
+        end
+      end
+    end
   end
 end

--- a/spec/ruby/core/range/shared/cover_and_include.rb
+++ b/spec/ruby/core/range/shared/cover_and_include.rb
@@ -83,4 +83,14 @@ describe :range_cover_and_include, shared: true do
     ('A'..'C').send(@method, 20.9).should == false
     ('A'...'C').send(@method, 'C').should == false
   end
+
+  it "returns false if other is not an element of self for endless ranges" do
+    (1..).send(@method, 0.4).should == false
+    (0.5...).send(@method, 0.4).should == false
+  end
+
+  it "returns false if other is not an element of self for beginless ranges" do
+    (..10).send(@method, 12.4).should == false
+    (...10.5).send(@method, 12.4).should == false
+  end
 end

--- a/src/main/ruby/truffleruby/core/comparable.rb
+++ b/src/main/ruby/truffleruby/core/comparable.rb
@@ -98,7 +98,7 @@ module Comparable
     self
   end
 
-  # A version of MRI's rb_cmpint (sort of)
+  # A version of MRI's rb_cmpint (sort of, not raising ArgumentError)
   def self.compare_int(int)
     return int if Primitive.is_a?(int, Integer)
 

--- a/src/main/ruby/truffleruby/core/range.rb
+++ b/src/main/ruby/truffleruby/core/range.rb
@@ -352,10 +352,8 @@ class Range
   end
 
   def include?(value)
-    if Primitive.is_a?(self.begin, Numeric) ||
-       Primitive.is_a?(self.end, Numeric) ||
-       Primitive.is_a?(self.begin, Time) ||
-       Primitive.is_a?(self.end, Time) ||
+    if Truffle::RangeOperations.linear?(self.begin) ||
+       Truffle::RangeOperations.linear?(self.end) ||
        Truffle::Type.rb_check_to_integer(self.begin, :to_int) ||
        Truffle::Type.rb_check_to_integer(self.end, :to_int)
       return cover?(value)
@@ -368,8 +366,9 @@ class Range
       return super(value)
     end
 
+    # MRI: range_include_fallback
     if Primitive.nil?(self.begin) && Primitive.nil?(self.end) &&
-       (Primitive.is_a?(value, Numeric) || Primitive.is_a?(value, Time) || Truffle::Type.rb_check_to_integer(value, :to_int))
+       Truffle::RangeOperations.linear?(value)
       return true
     end
 

--- a/src/main/ruby/truffleruby/core/range.rb
+++ b/src/main/ruby/truffleruby/core/range.rb
@@ -352,16 +352,32 @@ class Range
   end
 
   def include?(value)
-    if self.begin.respond_to?(:to_int) ||
-        self.end.respond_to?(:to_int) ||
-        Primitive.is_a?(self.begin, Numeric) ||
-        Primitive.is_a?(self.end, Numeric) ||
-        Primitive.is_a?(self.begin, Time) ||
-        Primitive.is_a?(self.end, Time)
-      cover? value
-    else
-      super
+    if Primitive.is_a?(self.begin, Numeric) ||
+       Primitive.is_a?(self.end, Numeric) ||
+       Primitive.is_a?(self.begin, Time) ||
+       Primitive.is_a?(self.end, Time) ||
+       Truffle::Type.rb_check_to_integer(self.begin, :to_int) ||
+       Truffle::Type.rb_check_to_integer(self.end, :to_int)
+      return cover?(value)
     end
+
+    if Primitive.is_a?(self.begin, String) && Primitive.is_a?(self.end, String)
+      value = Truffle::Type.rb_check_convert_type(value, String, :to_str)
+      return false if Primitive.nil?(value)
+      return false if self.begin > self.end || (self.exclude_end? && self.begin == self.end)
+      return super(value)
+    end
+
+    if Primitive.nil?(self.begin) && Primitive.nil?(self.end) &&
+       (Primitive.is_a?(value, Numeric) || Primitive.is_a?(value, Time) || Truffle::Type.rb_check_to_integer(value, :to_int))
+      return true
+    end
+
+    if Primitive.nil?(self.begin) || Primitive.nil?(self.end)
+      raise TypeError, 'cannot determine inclusion in beginless/endless ranges'
+    end
+
+    super
   end
   alias_method :member?, :include?
 

--- a/src/main/ruby/truffleruby/core/truffle/range_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/range_operations.rb
@@ -177,36 +177,60 @@ module Truffle
       end
     end
 
-    # MRI: r_cover_range_p
-    def self.range_cover?(range, other)
-      b1 = range.begin
-      b2 = other.begin
-      e1 = range.end
-      e2 = other.end
-
-      return false if Primitive.nil?(b2) && !Primitive.nil?(b1)
-      return false if Primitive.nil?(e2) && !Primitive.nil?(e1)
-      # other is empty or backward
-      return false if !Primitive.nil?(b2) && !Primitive.nil?(e2) &&
-                      (other.exclude_end? ? (b2 <=> e2) >= 0 : (b2 <=> e2) > 0)
-      return false unless Primitive.nil?(b2) || cover?(range, b2)
-
-      # here we know that other.begin is covered by range and if other is endless
-      # then range is endless too
-      return true if Primitive.nil?(e2) && !range.exclude_end?
-
-      if (e1 <=> e2) == 0
-        !(range.exclude_end? && !other.exclude_end?)
-      else
-        if Primitive.is_a?(e2, Integer) && other.exclude_end?
-          cover?(range, e2 - 1)
-        else
-          cover?(range, e2)
-        end
-      end
+    # MRI: r_less
+    def self.r_less(a, b)
+      cmp = (a <=> b)
+      return 1 if Primitive.nil?(cmp)
+      Comparable.compare_int(cmp)
     end
 
-    # # MRI: r_cover_p
+    # MRI: r_cover_range_p
+    def self.range_cover?(range, other)
+      range_begin = range.begin
+      range_end = range.end
+      other_begin = other.begin
+      other_end = other.end
+
+      return false if !Primitive.nil?(range_end) && Primitive.nil?(other_end)
+      return false if !Primitive.nil?(range_begin) && Primitive.nil?(other_begin)
+
+      if !Primitive.nil?(other_begin) && !Primitive.nil?(other_end)
+        if r_less(other_begin, other_end) > (other.exclude_end? ? -1 : 0)
+          return false
+        end
+      end
+
+      if !Primitive.nil?(other_begin) && !cover?(range, other_begin)
+        return false
+      end
+
+      if !Primitive.nil?(other_end) && !Primitive.nil?(range_end)
+        r_cmp_end = (range_end <=> other_end)
+        return false if Primitive.nil?(r_cmp_end)
+        cmp_end = Comparable.compare_int(r_cmp_end)
+      else
+        cmp_end = r_less(range_end, other_end)
+      end
+
+      if range.exclude_end? == other.exclude_end?
+        return cmp_end >= 0
+      elsif range.exclude_end?
+        return cmp_end > 0
+      elsif cmp_end >= 0
+        return true
+      end
+
+      begin
+        other_max = other.max
+      rescue TypeError
+        other_max = nil
+      end
+      return false if Primitive.nil?(other_max)
+
+      r_less(range_end, other_max) >= 0
+    end
+
+    # MRI: r_cover_p
     def self.cover?(range, value)
       # Check lower bound.
       if !Primitive.nil?(range.begin)

--- a/src/main/ruby/truffleruby/core/truffle/range_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/range_operations.rb
@@ -191,35 +191,47 @@ module Truffle
       other_begin = other.begin
       other_end = other.end
 
+      # finite end cannot cover endless end: (a..b).cover?(c..) is false
+      # finite begin cannot cover beginless begin: (a..b).cover?(..c) is false
       return false if !Primitive.nil?(range_end) && Primitive.nil?(other_end)
       return false if !Primitive.nil?(range_begin) && Primitive.nil?(other_begin)
 
+      # cannot cover an empty or backward range (e.g., 5...5 or 5..0)
       if !Primitive.nil?(other_begin) && !Primitive.nil?(other_end)
         if r_less(other_begin, other_end) > (other.exclude_end? ? -1 : 0)
           return false
         end
       end
 
+      # must cover other's begin value
       if !Primitive.nil?(other_begin) && !cover?(range, other_begin)
         return false
       end
 
+      # compare end values
       if !Primitive.nil?(other_end) && !Primitive.nil?(range_end)
         r_cmp_end = (range_end <=> other_end)
         return false if Primitive.nil?(r_cmp_end)
         cmp_end = Comparable.compare_int(r_cmp_end)
       else
+        # end is nil, other.end is either nil or finite so could return immediately `true`,
+        # but there is an edge cases with exclusive range and inclusive other,
+        # e.g. (a...).cover?(a..) => false
         cmp_end = r_less(range_end, other_end)
       end
 
       if range.exclude_end? == other.exclude_end?
         return cmp_end >= 0
       elsif range.exclude_end?
+        # exclusive range (a...b) covers inclusive (c..d) if end > other.end
         return cmp_end > 0
       elsif cmp_end >= 0
+        # inclusive range (a..b) covers exclusive (c...d) if end >= other.end
         return true
       end
 
+      # edge case: (a..b).cover?(c...d) where b < d;
+      # compare range.end with other.max to handle non-numeric types.
       begin
         other_max = other.max
       rescue TypeError
@@ -232,15 +244,14 @@ module Truffle
 
     # MRI: r_cover_p
     def self.cover?(range, value)
-      # Check lower bound.
+      # Check lower bound
       if !Primitive.nil?(range.begin)
-        # MRI uses <=> to compare, so must we.
         cmp = (range.begin <=> value)
         return false if Primitive.nil?(cmp)
         return false if Comparable.compare_int(cmp) > 0
       end
 
-      # Check upper bound.
+      # Check upper bound
       if !Primitive.nil?(range.end)
         cmp = (value <=> range.end)
         return false if Primitive.nil?(cmp)

--- a/src/main/ruby/truffleruby/core/truffle/range_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/range_operations.rb
@@ -231,6 +231,11 @@ module Truffle
       true
     end
 
+    # MRI: linear_object_p
+    def self.linear?(object)
+      Primitive.is_a?(object, Numeric) || Primitive.is_a?(object, Time)
+    end
+
     # MRI: empty_region_p
     def self.greater_than?(from, to, to_exclusive)
       return false if Primitive.nil?(from)

--- a/src/main/ruby/truffleruby/core/truffle/range_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/range_operations.rb
@@ -186,12 +186,16 @@ module Truffle
 
       return false if Primitive.nil?(b2) && !Primitive.nil?(b1)
       return false if Primitive.nil?(e2) && !Primitive.nil?(e1)
+      # other is empty or backward
+      return false if !Primitive.nil?(b2) && !Primitive.nil?(e2) &&
+                      (other.exclude_end? ? (b2 <=> e2) >= 0 : (b2 <=> e2) > 0)
+      return false unless Primitive.nil?(b2) || cover?(range, b2)
 
-      return false unless (Primitive.nil?(b2) || cover?(range, b2))
+      # here we know that other.begin is covered by range and if other is endless
+      # then range is endless too
+      return true if Primitive.nil?(e2) && !range.exclude_end?
 
-      return true if Primitive.nil?(e2)
-
-      if e1 == e2
+      if (e1 <=> e2) == 0
         !(range.exclude_end? && !other.exclude_end?)
       else
         if Primitive.is_a?(e2, Integer) && other.exclude_end?

--- a/src/main/ruby/truffleruby/core/truffle/range_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/range_operations.rb
@@ -210,9 +210,9 @@ module Truffle
 
       # compare end values
       if !Primitive.nil?(other_end) && !Primitive.nil?(range_end)
-        r_cmp_end = (range_end <=> other_end)
-        return false if Primitive.nil?(r_cmp_end)
-        cmp_end = Comparable.compare_int(r_cmp_end)
+        cmp_end = (range_end <=> other_end)
+        return false if Primitive.nil?(cmp_end)
+        cmp_end = Comparable.compare_int(cmp_end)
       else
         # end is nil, other.end is either nil or finite so could return immediately `true`,
         # but there is an edge cases with exclusive range and inclusive other,


### PR DESCRIPTION
- [x] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.

## Fixed issues

### `Range#include?`

Failed examples:
- Range#include? on string elements argument conversion to String converts the passed argument to a String using #to_str FAILED
- Range#include? on string elements argument conversion to String raises a TypeError if the passed argument responds to #to_str but it returns non-String value FAILED
- Range#include? with beginless and endless range return true for any Numeric value ERROR
- Range#include? with beginless and endless range return true for any Time value ERROR

Hung examples:
- Range#include? on string elements raises TypeError for endless ranges

### `Range#cover?`

Failed examples:
- Range#cover? range argument when other range is partially interleaved returns false if self and other are endless and self.begin == other.begin but self.exclude_end? is true FAILED
- Range#cover? range argument when other range is partially interleaved returns false if self and other are endless and self.begin < other.begin but self.exclude_end? is true FAILED
- Range#cover? range argument when other range is partially interleaved returns false if self is (nil...nil) and other is endless FAILED
- Range#cover? range argument when comparing with backward ranges returns false if other is backward and fits into self FAILED
- Range#cover? range argument when comparing with empty ranges returns false if other is empty and fits into self FAILED
