### PR TITLE
Fix `String#to_f` with excessive underscores

### DIFF
--- a/spec/ruby/core/kernel/Float_spec.rb
+++ b/spec/ruby/core/kernel/Float_spec.rb
@@ -222,6 +222,12 @@ describe :kernel_float, shared: true do
     it "raises an ArgumentError if there's a decimal point on the right side of the '#{e}'" do
       -> { @object.send(:Float, "20#{e}2.0") }.should.raise(ArgumentError)
     end
+
+    it "raises an ArgumentError if there's a trailing _ after '#{e}'" do
+      -> { @object.send(:Float, "20#{e}_") }.should.raise(ArgumentError)
+      -> { @object.send(:Float, "20#{e}+_") }.should.raise(ArgumentError)
+      -> { @object.send(:Float, "20#{e}-_") }.should.raise(ArgumentError)
+    end
   end
 
   context "for hexadecimal literals" do

--- a/spec/ruby/core/string/to_f_spec.rb
+++ b/spec/ruby/core/string/to_f_spec.rb
@@ -46,16 +46,39 @@ describe "String#to_f" do
     "_9".to_f.should == 0
   end
 
-  it "stops if the underscore is not followed or preceded by a number" do
+  it "stops if the underscore is not followed by a number" do
     "1__2".to_f.should == 1.0
-    "1_.2".to_f.should == 1.0
-    "1._2".to_f.should == 1.0
-    "1.2_e2".to_f.should == 1.2
-    "1.2e_2".to_f.should == 1.2
     "1_x2".to_f.should == 1.0
+
+    "1.2__3".to_f.should == 1.2
+    "1.2_x3".to_f.should == 1.2
+
+    "1.2e__3".to_f.should == 1.2
+    "1.2e_x3".to_f.should == 1.2
+  end
+
+  it "stops if the number contains invalid characters" do
     "1x_2".to_f.should == 1.0
+    "1.2x_3".to_f.should == 1.2
+    "1.2ex_3".to_f.should == 1.2
+  end
+
+  it "stops if +/- is not followed by a number" do
     "+_1".to_f.should == 0.0
     "-_1".to_f.should == 0.0
+    "+a1".to_f.should == 0.0
+
+    "1.1e+_1".to_f.should == 1.1
+    "1.1e-_1".to_f.should == 1.1
+    "1.1e-a1".to_f.should == 1.1
+  end
+
+  it "stops if the underscore appears at boundaries" do
+    "1_.2".to_f.should == 1.0
+    "1._2".to_f.should == 1.0
+
+    "1.2_e3".to_f.should == 1.2
+    "1.2e_3".to_f.should == 1.2
   end
 
   it "does not allow prefixes to autodetect the base" do

--- a/spec/tags/core/string/to_f_tags.txt
+++ b/spec/tags/core/string/to_f_tags.txt
@@ -1,2 +1,1 @@
-fails:String#to_f stops if the underscore is not followed or preceded by a number
 fails:String#to_f raises Encoding::CompatibilityError if String is in not ASCII-compatible encoding

--- a/src/main/java/org/truffleruby/core/string/DoubleConverter.java
+++ b/src/main/java/org/truffleruby/core/string/DoubleConverter.java
@@ -89,9 +89,8 @@ public final class DoubleConverter {
         return index >= endIndex;
     }
 
-    private boolean stopParsing() {
+    private void stopParsing() {
         index = endIndex;
-        return true;
     }
 
     private boolean isDigit(byte b) {
@@ -162,11 +161,9 @@ public final class DoubleConverter {
         }
     }
 
-    private boolean strictError() {
+    private void strictError() {
         if (isStrict) {
             throw new LightweightNumberFormatException("does not meet strict criteria");
-        } else {
-            return true; // means EOS for non-strict
         }
     }
 
@@ -175,10 +172,12 @@ public final class DoubleConverter {
     public double parse(AbstractTruffleString tstring, RubyEncoding encoding, boolean strict, boolean is19) {
         init(tstring, encoding, strict);
 
-        if (skipWhitespace()) {
+        skipWhitespace();
+        if (isEOS()) {
             return completeCalculation();
         }
-        if (parseOptionalSign()) {
+        parseOptionalSign();
+        if (isEOS()) {
             return completeCalculation();
         }
 
@@ -191,21 +190,18 @@ public final class DoubleConverter {
         return completeCalculation();
     }
 
-    /** Consume initial whitespace so that next character examined is not whitespace. Returns whether next position is
-     * at the end of the string or not. */
-    private boolean skipWhitespace() {
+    /** Consume initial whitespace so that next character examined is not whitespace. */
+    private void skipWhitespace() {
         while (!isEOS()) {
             if (isWhitespace(peek())) {
                 next();
                 continue;
             }
-            return false;
+            return;
         }
-
-        return true;
     }
 
-    private boolean parseOptionalSign() {
+    private void parseOptionalSign() {
         switch (peek()) {
             case '-':
                 addToResult((byte) '-');
@@ -215,11 +211,9 @@ public final class DoubleConverter {
                 next();
                 break;
         }
-
-        return isEOS();
     }
 
-    private boolean parseDigits() {
+    private void parseDigits() {
         if (!isEOS()) {
             byte value = next();
 
@@ -231,9 +225,11 @@ public final class DoubleConverter {
                 addToResult(value);
             } else if (value == '.') {
                 addToResult(value);
-                return parseDecimalDigits();
+                parseDecimalDigits();
+                return;
             } else {
-                return isEOS();
+                isEOS();
+                return;
             }
         } else {
             strictError();
@@ -254,27 +250,31 @@ public final class DoubleConverter {
                 }
             } else if (value == '.') {
                 addToResult(value);
-                return parseDecimalDigits();
+                parseDecimalDigits();
+                return;
             } else if (value == '_') {
                 verifyNumberAfterUnderscore();
             } else if (isExponent(value)) {
                 addToResult(value);
-                return parseExponent();
+                parseExponent();
+                return;
             } else if (isWhitespace(value)) {
-                return skipWhitespace();
+                skipWhitespace();
+                return;
             } else {
-                return strictError();
+                strictError();
+                return;
             }
 
         }
 
-        return true;
+        return;
     }
 
-    private boolean parseDecimalDigits() {
+    private void parseDecimalDigits() {
         // Allow decimal point with omitted fractional part (e.g., "1.")
         if (isEOS()) {
-            return true;
+            return;
         }
 
         byte value = next();
@@ -283,7 +283,7 @@ public final class DoubleConverter {
         if (value == '_') {
             strictError();
             if (isEOS()) {
-                return strictError();
+                return;
             }
             value = next();
         }
@@ -301,9 +301,11 @@ public final class DoubleConverter {
         } else if (isExponent(value)) {
             // Allow "1.e+0" (exponent immediately after decimal point)
             addToResult(value);
-            return parseExponent();
+            parseExponent();
+            return;
         } else {
-            return strictError();
+            strictError();
+            return;
         }
 
         while (!isEOS()) {
@@ -320,22 +322,25 @@ public final class DoubleConverter {
                 } // otherwise ignore it
             } else if (isExponent(value)) {
                 addToResult(value);
-                return parseExponent();
+                parseExponent();
+                return;
             } else if (value == '_') {
                 verifyNumberAfterUnderscore();
             } else if (isWhitespace(value)) {
-                return skipWhitespace();
+                skipWhitespace();
+                return;
             } else {
-                return strictError();
+                strictError();
+                return;
             }
         }
 
-        return true;
+        return;
     }
 
-    private boolean parseExponent() {
+    private void parseExponent() {
         if (eatUnderscores()) {
-            return isEOS();
+            return;
         }
 
         int exponent = 0;
@@ -363,7 +368,8 @@ public final class DoubleConverter {
                         exponent = 10 * exponent + (value - '0');
                     }
                 } else {
-                    return tooLargeExponent(chars[0] == '-', negative);
+                    tooLargeExponent(chars[0] == '-', negative);
+                    return;
                 }
             } else if (isWhitespace(value)) {
                 skipWhitespace();
@@ -386,13 +392,12 @@ public final class DoubleConverter {
         if (-MAX_EXPONENT <= exponent && exponent <= MAX_EXPONENT) {
             addExponentToResult(exponent);
             wroteExponent = true;
-            return isEOS(); // Exponent end of double...let's finish.
         } else {
-            return tooLargeExponent(chars[0] == '-', negative);
+            tooLargeExponent(chars[0] == '-', negative);
         }
     }
 
-    private boolean tooLargeExponent(boolean negativeFloat, boolean negativeExponent) {
+    private void tooLargeExponent(boolean negativeFloat, boolean negativeExponent) {
         if (negativeExponent) {
             if (negativeFloat) {
                 result = -0.0;
@@ -406,7 +411,7 @@ public final class DoubleConverter {
                 result = Double.POSITIVE_INFINITY;
             }
         }
-        return stopParsing();
+        stopParsing();
     }
 
     private void verifyNumberAfterUnderscore() {

--- a/src/main/java/org/truffleruby/core/string/DoubleConverter.java
+++ b/src/main/java/org/truffleruby/core/string/DoubleConverter.java
@@ -116,21 +116,6 @@ public final class DoubleConverter {
         }
     }
 
-    private boolean eatUnderscores() {
-        while (!isEOS()) {
-            byte value = peek();
-
-            if (value != '_') {
-                return isEOS();
-            } else if (isStrict) {
-                strictError();
-            }
-            next();
-        }
-
-        return true;
-    }
-
     private double completeCalculation() {
         if (charsIndex == 0 || (charsIndex == 1 && chars[0] == '-')) { // "" or "-"
             strictError(); // Strict requires at least one digit.
@@ -253,7 +238,7 @@ public final class DoubleConverter {
                 parseDecimalDigits();
                 return;
             } else if (value == '_') {
-                verifyNumberAfterUnderscore();
+                verifyNumber();
             } else if (isExponent(value)) {
                 addToResult(value);
                 parseExponent();
@@ -278,15 +263,6 @@ public final class DoubleConverter {
         }
 
         byte value = next();
-
-        // Wonky, but 12._2e2 is 1200.0 and 12.__e2 is 12.0
-        if (value == '_') {
-            strictError();
-            if (isEOS()) {
-                return;
-            }
-            value = next();
-        }
 
         if (isDigit(value)) {
             if (significantDigitsProcessed < SIGNIFICANT_DIGITS_LIMIT) {
@@ -325,7 +301,7 @@ public final class DoubleConverter {
                 parseExponent();
                 return;
             } else if (value == '_') {
-                verifyNumberAfterUnderscore();
+                verifyNumber();
             } else if (isWhitespace(value)) {
                 skipWhitespace();
                 return;
@@ -339,7 +315,8 @@ public final class DoubleConverter {
     }
 
     private void parseExponent() {
-        if (eatUnderscores()) {
+        if (isEOS()) {
+            strictError();
             return;
         }
 
@@ -356,6 +333,8 @@ public final class DoubleConverter {
                 next();
                 break;
         }
+
+        verifyNumber();
 
         while (!isEOS()) {
             byte value = next();
@@ -375,7 +354,7 @@ public final class DoubleConverter {
                 skipWhitespace();
                 break;
             } else if (value == '_') {
-                verifyNumberAfterUnderscore();
+                verifyNumber();
             } else {
                 strictError();
                 stopParsing();
@@ -414,9 +393,10 @@ public final class DoubleConverter {
         stopParsing();
     }
 
-    private void verifyNumberAfterUnderscore() {
-        if (isStrict && (isEOS() || !isDigit(bytes[index]))) {
+    private void verifyNumber() {
+        if (isEOS() || !isDigit(bytes[index])) {
             strictError();
+            stopParsing();
         }
     }
 }

--- a/src/main/java/org/truffleruby/core/string/DoubleConverter.java
+++ b/src/main/java/org/truffleruby/core/string/DoubleConverter.java
@@ -81,12 +81,8 @@ public final class DoubleConverter {
         return bytes[index++];
     }
 
-    /** Shift back to previous character in the incoming bytes
-     *
-     * @return false to indicate we are not in an EOS condition */
-    private boolean previous() {
-        index--;
-        return false;
+    private byte peek() {
+        return bytes[index];
     }
 
     private boolean isEOS() {
@@ -123,14 +119,14 @@ public final class DoubleConverter {
 
     private boolean eatUnderscores() {
         while (!isEOS()) {
-            byte value = next();
+            byte value = peek();
 
             if (value != '_') {
-                previous();
                 return isEOS();
             } else if (isStrict) {
                 strictError();
             }
+            next();
         }
 
         return true;
@@ -195,30 +191,29 @@ public final class DoubleConverter {
         return completeCalculation();
     }
 
-    /** Consume initial whitespace and underscores so that next character examined is not whitespace. 1.9 and strict do
-     * not allow leading underscores. Returns whether next position is at the end of the string or not.
-     * <p>
-     * Trivia: " _ _ _ _ 1".to_f == 1.0 in Ruby 1.8 */
+    /** Consume initial whitespace so that next character examined is not whitespace. Returns whether next position is
+     * at the end of the string or not. */
     private boolean skipWhitespace() {
         while (!isEOS()) {
-            byte value = next();
-
-            if (isWhitespace(value)) {
+            if (isWhitespace(peek())) {
+                next();
                 continue;
             }
-            return previous();
+            return false;
         }
 
         return true;
     }
 
     private boolean parseOptionalSign() {
-        byte sign = next();
-
-        if (sign == '-') {
-            addToResult(sign);
-        } else if (sign != '+') {
-            previous();  // backup...not a sign-char
+        switch (peek()) {
+            case '-':
+                addToResult((byte) '-');
+                next();
+                break;
+            case '+':
+                next();
+                break;
         }
 
         return isEOS();
@@ -343,20 +338,22 @@ public final class DoubleConverter {
             return isEOS();
         }
 
-        byte value = next();
-
         int exponent = 0;
         int digits = 0;
         boolean negative = false;
 
-        if (value == '-') {
-            negative = true;
-        } else if (value != '+') {
-            previous(); // backup...not a sign-char
+        switch (peek()) {
+            case '-':
+                negative = true;
+                next();
+                break;
+            case '+':
+                next();
+                break;
         }
 
         while (!isEOS()) {
-            value = next();
+            byte value = next();
 
             if (isDigit(value)) {
                 if (digits < EXPONENT_DIGITS_LIMIT) {


### PR DESCRIPTION
First two commits are a bit of a cleanup.

Second one makes a non-number after underscore stop in non-strict mode (`to_f`) and handles `123e_`.

- [ ] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
