### PR TITLE
Avoid unnecessary writes when building to not escape the sandbox

### DIFF
--- a/tool/jt.rb
+++ b/tool/jt.rb
@@ -257,7 +257,9 @@ module Utilities
 
     if mx = which('mx')
       mx_repo = File.dirname(mx)
-      sh 'git', 'checkout', '--quiet', @mx_version, chdir: mx_repo
+      unless git_tag(mx_repo) == @mx_version
+        sh 'git', 'checkout', '--quiet', @mx_version, chdir: mx_repo
+      end
       'mx'
     else
       mx_repo = find_or_clone_repo('https://github.com/graalvm/mx.git', @mx_version)
@@ -390,6 +392,10 @@ module Utilities
 
   def git_branch
     @git_branch ||= `GIT_DIR="#{TRUFFLERUBY_DIR}/.git" git rev-parse --abbrev-ref HEAD`.strip
+  end
+
+  def git_tag(repo = TRUFFLERUBY_DIR)
+    `GIT_DIR="#{repo}/.git" git describe --tags --exact-match HEAD 2>/dev/null`.strip
   end
 
   def no_gem_vars_env

--- a/tool/jt.rb
+++ b/tool/jt.rb
@@ -2616,13 +2616,15 @@ module Commands
         next if File.exist?(link)
         target = File.readlink(link)
         next unless target.start_with?("#{TRUFFLERUBY_DIR}/mxbuild")
+        puts "Deleting broken link: #{link} -> #{target}"
         File.delete link
-        puts "Deleted broken link: #{link} -> #{target}"
       end
 
       link_path = "#{rubies_dir}/#{name}"
-      File.delete link_path if File.symlink? link_path or File.exist? link_path
-      File.symlink dest, link_path
+      unless File.symlink?(link_path) and File.readlink(link_path) == dest
+        File.delete(link_path) if File.symlink?(link_path) or File.exist?(link_path)
+        File.symlink(dest, link_path)
+      end
     end
   end
 


### PR DESCRIPTION
The next issue is:
```
$ BOOTSTRAP_GRAALVM=/home/eregon/.mx/jdks/graalvm-jdk-25e1-25.0.3-ea.32 mx --java-home labsjdk-ce-latest-25.0.3+9-jvmci-25.1-b18 --env jvm build
Exception in thread "main" java.net.SocketException: Operation not permitted
	at java.base/sun.nio.ch.Net.socket0(Native Method)
	at java.base/sun.nio.ch.Net.serverSocket(Net.java:501)
	at java.base/sun.nio.ch.Net.serverSocket(Net.java:495)
	at java.base/sun.nio.ch.NioSocketImpl.create(NioSocketImpl.java:471)
	at java.base/java.net.ServerSocket.getImpl(ServerSocket.java:255)
	at java.base/java.net.ServerSocket.bind(ServerSocket.java:325)
	at java.base/java.net.ServerSocket.<init>(ServerSocket.java:222)
	at com.oracle.mxtool.compilerserver.CompilerDaemon.run(CompilerDaemon.java:91)
	at com.oracle.mxtool.compilerserver.JavacDaemon.main(JavacDaemon.java:70)
```
And it seems hard to configure Codex to allow this unfortunately.