### PR TITLE
Fix some StringIO specs

### DIFF
--- a/lib/truffle/stringio.rb
+++ b/lib/truffle/stringio.rb
@@ -29,9 +29,6 @@
 require 'truffle/cext'
 
 Truffle::CExt.rb_define_module_under(IO, 'generic_readable').module_eval do
-  # This is why we need undefined in Ruby
-  Undefined = Object.new
-
   def readchar
     raise EOFError, 'end of file reached' if eof?
     getc
@@ -41,7 +38,7 @@ Truffle::CExt.rb_define_module_under(IO, 'generic_readable').module_eval do
     readchar.getbyte(0)
   end
 
-  def readline(sep = $/, limit = ::Undefined, chomp: false)
+  def readline(sep = $/, limit = undefined, chomp: false)
     check_readable
     raise EOFError, 'end of file reached' if eof?
 
@@ -283,7 +280,7 @@ class StringIO
     self
   end
 
-  def each(sep = $/, limit = Undefined, chomp: false)
+  def each(sep = $/, limit = undefined, chomp: false)
     return to_enum :each, sep, limit, chomp: chomp unless block_given?
     check_readable
 
@@ -420,7 +417,7 @@ class StringIO
     end
   end
 
-  def gets(sep = $/, limit = Undefined, chomp: false)
+  def gets(sep = $/, limit = undefined, chomp: false)
     check_readable
 
     sep, limit = coerce_sep_and_limit(sep, limit, arg_error: false)
@@ -513,7 +510,7 @@ class StringIO
     end
   end
 
-  def readlines(sep = $/, limit = Undefined, chomp: false)
+  def readlines(sep = $/, limit = undefined, chomp: false)
     check_readable
     sep, limit = coerce_sep_and_limit(sep, limit, arg_error: true)
 
@@ -525,13 +522,13 @@ class StringIO
     ary
   end
 
-  def reopen(string = nil, mode = Undefined)
-    if string and not Primitive.is_a?(string, String) and Primitive.equal?(mode, Undefined)
+  def reopen(string = nil, mode = undefined)
+    if string and not Primitive.is_a?(string, String) and Primitive.undefined?(mode)
       stringio = Primitive.convert_type(string, StringIO, :to_strio)
 
       initialize_copy stringio
     else
-      mode = nil if Primitive.equal?(mode, Undefined)
+      mode = nil if Primitive.undefined?(mode)
       string = '' unless string
 
       initialize string, mode
@@ -730,10 +727,7 @@ class StringIO
   end
 
   private def coerce_sep_and_limit(sep, limit, arg_error:)
-    if limit != Undefined
-      limit = Primitive.convert_with_to_int limit if limit
-      sep = Primitive.convert_with_to_str sep if sep
-    else
+    if Primitive.undefined?(limit)
       limit = nil
 
       unless sep == $/ or Primitive.nil?(sep)
@@ -744,6 +738,9 @@ class StringIO
           sep = $/
         end
       end
+    else
+      limit = Primitive.convert_with_to_int limit if limit
+      sep = Primitive.convert_with_to_str sep if sep
     end
 
     raise ArgumentError if arg_error and limit == 0

--- a/lib/truffle/stringio.rb
+++ b/lib/truffle/stringio.rb
@@ -45,7 +45,8 @@ Truffle::CExt.rb_define_module_under(IO, 'generic_readable').module_eval do
     check_readable
     raise EOFError, 'end of file reached' if eof?
 
-    Primitive.io_last_line_set(Primitive.caller_special_variables, getline(false, sep, limit, chomp))
+    sep, limit = coerce_sep_and_limit(sep, limit, arg_error: false)
+    Primitive.io_last_line_set(Primitive.caller_special_variables, getline(sep, limit, chomp:))
   end
 
   def sysread(length = nil, buffer = nil)
@@ -141,7 +142,7 @@ class StringIO
 
   def initialize(string = nil, mode = nil, **options)
     if block_given?
-      warn 'StringIO::new() does not take block; use StringIO::open() instead'
+      warn 'StringIO::new() does not take block; use StringIO::open() instead', uplevel: 1
     end
 
     mode, _binary, _external, _internal, _autoclose, _perm = Truffle::IOOperations.normalize_options(mode, nil, options)
@@ -286,7 +287,8 @@ class StringIO
     return to_enum :each, sep, limit, chomp: chomp unless block_given?
     check_readable
 
-    while line = getline(true, sep, limit, chomp)
+    sep, limit = coerce_sep_and_limit(sep, limit, arg_error: true)
+    while line = getline(sep, limit, chomp:)
       yield line
     end
 
@@ -421,9 +423,10 @@ class StringIO
   def gets(sep = $/, limit = Undefined, chomp: false)
     check_readable
 
+    sep, limit = coerce_sep_and_limit(sep, limit, arg_error: false)
     # Truffle: $_ is thread and frame local, so we use a primitive to
     # set it in the caller's frame.
-    Primitive.io_last_line_set(Primitive.caller_special_variables, getline(false, sep, limit, chomp))
+    Primitive.io_last_line_set(Primitive.caller_special_variables, getline(sep, limit, chomp:))
   end
 
   def isatty
@@ -478,7 +481,7 @@ class StringIO
       # see https://bugs.ruby-lang.org/issues/20418
       if length
         length = Primitive.convert_with_to_int length
-        raise ArgumentError if length < 0
+        raise ArgumentError, "negative length #{length} given" if length < 0
 
         buffer = Primitive.convert_with_to_str(buffer) if buffer
 
@@ -512,9 +515,10 @@ class StringIO
 
   def readlines(sep = $/, limit = Undefined, chomp: false)
     check_readable
+    sep, limit = coerce_sep_and_limit(sep, limit, arg_error: true)
 
     ary = []
-    while line = getline(true, sep, limit, chomp)
+    while line = getline(sep, limit, chomp:)
       ary << line
     end
 
@@ -725,7 +729,7 @@ class StringIO
     @truncate = true if (mode & IO::TRUNC) != 0
   end
 
-  private def getline(arg_error, sep, limit, chomp = false)
+  private def coerce_sep_and_limit(sep, limit, arg_error:)
     if limit != Undefined
       limit = Primitive.convert_with_to_int limit if limit
       sep = Primitive.convert_with_to_str sep if sep
@@ -746,6 +750,10 @@ class StringIO
 
     limit = nil if limit && limit < 0
 
+    [sep, limit]
+  end
+
+  private def getline(sep, limit, chomp:)
     return nil if eof?
 
     line = nil

--- a/spec/tags/library/stringio/each_line_tags.txt
+++ b/spec/tags/library/stringio/each_line_tags.txt
@@ -1,3 +1,1 @@
 fails:StringIO#each_line when passed a separator yields each paragraph with all separation characters when passed an empty String as separator
-fails:StringIO#each when passed separator and limit tries to convert the passed separator to a String using #to_str
-fails:StringIO#each when passed separator and limit tries to convert the passed limit to an Integer using #to_int

--- a/spec/tags/library/stringio/new_tags.txt
+++ b/spec/tags/library/stringio/new_tags.txt
@@ -1,1 +1,0 @@
-fails:StringIO.new does not use the given block and warns to use StringIO::open

--- a/spec/tags/library/stringio/readpartial_tags.txt
+++ b/spec/tags/library/stringio/readpartial_tags.txt
@@ -1,2 +1,1 @@
-fails:StringIO#readpartial raises ArgumentError if the negative argument is provided
 fails:StringIO#readpartial reads after ungetc with multibyte characters in the buffer

--- a/src/main/java/org/truffleruby/parser/YARPTranslator.java
+++ b/src/main/java/org/truffleruby/parser/YARPTranslator.java
@@ -650,7 +650,7 @@ public class YARPTranslator extends YARPBaseTranslator {
         var argumentsAndBlock = translateArgumentsAndBlock(node.arguments, node.block, methodName, false);
         var translatedArguments = argumentsAndBlock.arguments;
 
-        if (parseEnvironment.inCore() && node.isVariableCall() && methodName.equals("undefined")) {
+        if (parseEnvironment.canUsePrivatePrimitives() && node.isVariableCall() && methodName.equals("undefined")) {
             // translate undefined
             final RubyNode rubyNode = new ObjectLiteralNode(NotProvided.INSTANCE);
             return assignPositionAndFlags(node, rubyNode);


### PR DESCRIPTION
* Fix warning message when passing a block to #initialize. Should include the path
* Don't call coerce multiple times in `each`. Should just happen once upfront
* Some error message update

And also use proper undefined.

- [ ] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
