### PR TITLE
Fix `StringIO#ungetc` for multibyte strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Compatibility:
 * Implement `File.birthtime`, `File#birthtime`, and `File::Stat#birthtime` (@andrykonchin, @eregon).
 * Fix `Range#max` for Integer beginless ranges with excluded end and return a proper maximum value instead of raising `TypeError` (#4231, @andrykonchin).
 * Adjust `Range#{max,min}` and support Integer argument (#4231, @andrykonchin).
+* Fix `StringIO#ungetc` for multibyte strings (#4340, @earlopain).
 
 Performance:
 

--- a/lib/truffle/stringio.rb
+++ b/lib/truffle/stringio.rb
@@ -630,13 +630,11 @@ class StringIO
       bytesize = string.bytesize
 
       if pos > bytesize
-        string[bytesize..pos] = "\000" * (pos - bytesize)
-        d.pos -= 1
-        string[d.pos] = char
-      elsif pos > 0
-        d.pos -= 1
-        string[d.pos] = char
+        string << "\000" * (pos - bytesize)
       end
+
+      d.pos = (d.pos - char.bytesize).clamp(0..)
+      string.bytesplice((d.pos...pos), char)
     end
 
     nil

--- a/spec/ruby/library/stringio/ungetc_spec.rb
+++ b/spec/ruby/library/stringio/ungetc_spec.rb
@@ -12,6 +12,18 @@ describe "StringIO#ungetc when passed [char]" do
     @io.string.should == 'A234'
   end
 
+  it "writes the passed string before the current position" do
+    @io.pos = 3
+    @io.ungetc("foo")
+    @io.string.should == 'foo4'
+  end
+
+  it "writes the passed string at the start if the current position is 0" do
+    @io.pos = 0
+    @io.ungetc("A")
+    @io.string.should == 'A1234'
+  end
+
   it "returns nil" do
     @io.pos = 1
     @io.ungetc(?A).should == nil
@@ -23,10 +35,32 @@ describe "StringIO#ungetc when passed [char]" do
     @io.pos.should.eql?(1)
   end
 
+  it "decreases the current position by the size of a multibyte character" do
+    @io.pos = 2
+    @io.ungetc("φ")
+    @io.pos.should == 0
+    @io.string.should == "φ34"
+  end
+
+  it "writes the given string completely when the current position does not have enough space" do
+    @io.pos = 2
+    @io.ungetc("foo")
+    @io.pos.should == 0
+    @io.string.should == "foo34"
+  end
+
   it "pads with \\000 when the current position is after the end" do
     @io.pos = 15
     @io.ungetc(?A)
     @io.string.should == "1234\000\000\000\000\000\000\000\000\000\000A"
+    @io.pos.should == 14
+  end
+
+  it "pads with \\000 when the current position is after the end for a multibyte character" do
+    @io.pos = 15
+    @io.ungetc("φ")
+    @io.string.should == "1234\000\000\000\000\000\000\000\000\000φ"
+    @io.pos.should == 13
   end
 
   it "tries to convert the passed argument to an String using #to_str" do

--- a/spec/tags/library/stringio/readpartial_tags.txt
+++ b/spec/tags/library/stringio/readpartial_tags.txt
@@ -1,1 +1,0 @@
-fails:StringIO#readpartial reads after ungetc with multibyte characters in the buffer


### PR DESCRIPTION
Added specs for that behaviour. The `readpartial` specs passes because it uses multibyte characters like this.

`StringIO#pos` is in bytes, so it works out nicely.

Also add some other specs around strings (not single chars) and how it behaves when it would go off to the left. StringIO documentation say it is for a character but `IO#ungetc` is documented for strings.

- [ ] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
