### PR TITLE
Fix Process.spawn and raise Errno::ENOENT when called with chdir option and a directory doesn't exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Compatibility:
 * Fix `Range#max` for Integer beginless ranges with excluded end and return a proper maximum value instead of raising `TypeError` (#4231, @andrykonchin).
 * Adjust `Range#{max,min}` and support Integer argument (#4231, @andrykonchin).
 * Fix `StringIO#ungetc` for multibyte strings (#4340, @earlopain).
+* Fix `Process.spawn` and raise `Errno::ENOENT` when called with `chdir` option and a directory doesn't exist (#3825, @andrykonchin).
 
 Performance:
 

--- a/spec/ruby/core/process/spawn_spec.rb
+++ b/spec/ruby/core/process/spawn_spec.rb
@@ -413,6 +413,12 @@ describe "Process.spawn" do
         Process.wait Process.spawn(ruby_cmd("print Dir.pwd"), chdir: dir)
       end.should output_to_fd(@dir)
     end
+
+    it "raises an Errno::ENOENT when a given path doesn't exist" do
+      -> do
+        Process.wait Process.spawn(ruby_cmd("print Dir.pwd"), chdir: "nonexistent")
+      end.should.raise(Errno::ENOENT, "No such file or directory - nonexistent")
+    end
   end
 
   # chdir

--- a/spec/tags/core/process/spawn_tags.txt
+++ b/spec/tags/core/process/spawn_tags.txt
@@ -81,3 +81,4 @@ slow:Process.spawn closes STDERR in the child if :err => :close
 slow:Process.spawn returns the process ID of the new process as an Integer
 slow:Process.spawn redirects non-default file descriptor to itself
 slow:Process.spawn redirects default file descriptor to itself
+slow:Process.spawn when passed :chdir raises an Errno::ENOENT when a given path doesn't exist

--- a/src/main/ruby/truffleruby/core/truffle/process_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/process_operations.rb
@@ -297,7 +297,9 @@ module Truffle
             end
             @options[key] = value
           when :chdir
-            @options[key] = Truffle::Type.coerce_to_path(value)
+            path = Truffle::Type.coerce_to_path(value)
+            raise Errno::ENOENT, path unless Dir.exist?(path)
+            @options[key] = path
           when :umask
             @options[key] = value
           when :close_others


### PR DESCRIPTION
Close #3825

- [x] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
