### PR TITLE
Raise when encoding is specified multiple times on CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Compatibility:
 * Fix `Range#max` for Integer beginless ranges with excluded end and return a proper maximum value instead of raising `TypeError` (#4231, @andrykonchin).
 * Adjust `Range#{max,min}` and support Integer argument (#4231, @andrykonchin).
 * Fix `StringIO#ungetc` for multibyte strings (#4340, @earlopain).
+* Fix precedence between `RUBYOPT` and CLI switches (#4342, @earlopain).
 
 Performance:
 

--- a/spec/ruby/command_line/dash_upper_e_spec.rb
+++ b/spec/ruby/command_line/dash_upper_e_spec.rb
@@ -32,6 +32,11 @@ describe "ruby -E" do
     ruby_exe("p 1",
              options: '-Eascii:ascii -U',
              args: '2>&1',
-             exit_status: 1).should =~ /RuntimeError/
+             exit_status: 1).should =~ /already set to ascii \(RuntimeError\)/
+  end
+
+  it "doesn't raise a RuntimeError if used with -U in RUBYOPT" do
+    ruby_exe("puts Encoding.default_external, Encoding.default_internal", options: '-E ascii:ascii', env: { 'RUBYOPT' => '-U' }).
+      should == "US-ASCII\nUS-ASCII\n"
   end
 end

--- a/spec/ruby/command_line/rubyopt_spec.rb
+++ b/spec/ruby/command_line/rubyopt_spec.rb
@@ -59,6 +59,11 @@ describe "Processing RUBYOPT" do
     ruby_exe("p $VERBOSE").chomp.should == "true"
   end
 
+  it "is overwritten by a cli switch" do
+    ENV["RUBYOPT"] = "-W2"
+    ruby_exe("p $VERBOSE", options: "-W0").chomp.should == "nil"
+  end
+
   it "suppresses deprecation warnings for '-W:no-deprecated'" do
     ENV["RUBYOPT"] = '-W:no-deprecated'
     result = ruby_exe('$; = ""', args: '2>&1')

--- a/spec/tags/command_line/dash_upper_e_tags.txt
+++ b/spec/tags/command_line/dash_upper_e_tags.txt
@@ -1,6 +1,7 @@
-fails:ruby -E raises a RuntimeError if used with -U
+slow:ruby -E raises a RuntimeError if used with -U
 slow:ruby -E sets the external encoding with '-E external'
 slow:ruby -E also sets the filesystem encoding with '-E external'
 slow:ruby -E sets the external encoding with '-E external:'
 slow:ruby -E sets the internal encoding with '-E :internal'
 slow:ruby -E sets the external and internal encodings with '-E external:internal'
+slow:ruby -E doesn't raise a RuntimeError if used with -U in RUBYOPT

--- a/spec/tags/command_line/dash_upper_u_tags.txt
+++ b/spec/tags/command_line/dash_upper_u_tags.txt
@@ -1,5 +1,5 @@
-fails:ruby -U raises a RuntimeError if used with -Eext:int
-fails:ruby -U raises a RuntimeError if used with -E:int
+slow:ruby -U raises a RuntimeError if used with -Eext:int
+slow:ruby -U raises a RuntimeError if used with -E:int
 slow:ruby -U sets Encoding.default_internal to UTF-8
 slow:ruby -U does nothing different if specified multiple times
 slow:ruby -U is overruled by Encoding.default_internal=

--- a/spec/tags/command_line/rubyopt_tags.txt
+++ b/spec/tags/command_line/rubyopt_tags.txt
@@ -6,6 +6,7 @@ slow:Processing RUBYOPT sets $VERBOSE to true for '-W'
 slow:Processing RUBYOPT sets $VERBOSE to nil for '-W0'
 slow:Processing RUBYOPT sets $VERBOSE to false for '-W1'
 slow:Processing RUBYOPT sets $VERBOSE to true for '-W2'
+slow:Processing RUBYOPT is overwritten by a cli switch
 slow:Processing RUBYOPT requires the file for '-r'
 slow:Processing RUBYOPT raises a RuntimeError for '-a'
 slow:Processing RUBYOPT raises a RuntimeError for '-p'

--- a/spec/truffle/pre_initialization_spec.rb
+++ b/spec/truffle/pre_initialization_spec.rb
@@ -44,13 +44,10 @@ guard -> { TruffleRuby.native? } do
 
     it "is used when $VERBOSE changes" do
       code = "p [$VERBOSE, Truffle::Boot.was_preinitialized?]"
-      # -w/-W in RUBYOPT overrides -w on the command-line, like in MRI,
-      # so unset the RUBYOPT and TRUFFLERUBYOPT env vars
-      env = { "RUBYOPT" => nil, "TRUFFLERUBYOPT" => nil }
-      ruby_exe(code, env: env).should == "[false, true]\n"
-      ruby_exe(code, options: "-w", env: env).should == "[true, true]\n"
-      ruby_exe(code, options: "-W0", env: env).should == "[nil, true]\n"
-      ruby_exe(code, options: "-v", env: env).should.include? "[true, true]\n"
+      ruby_exe(code).should == "[false, true]\n"
+      ruby_exe(code, options: "-w").should == "[true, true]\n"
+      ruby_exe(code, options: "-W0").should == "[nil, true]\n"
+      ruby_exe(code, options: "-v").should.include? "[true, true]\n"
     end
 
     it "is used with --disable-gems so startup with --disable-gems is not slower" do

--- a/src/launcher/java/org/truffleruby/launcher/CommandLineOptions.java
+++ b/src/launcher/java/org/truffleruby/launcher/CommandLineOptions.java
@@ -107,6 +107,10 @@ public class CommandLineOptions {
                 RubyOptionTypes.valueToString(descriptor.getKey().getDefaultValue()));
     }
 
+    public boolean containsOption(OptionDescriptor descriptor) {
+        return options.containsKey(descriptor.getName());
+    }
+
     public String[] getArguments() {
         return arguments;
     }

--- a/src/launcher/java/org/truffleruby/launcher/CommandLineParser.java
+++ b/src/launcher/java/org/truffleruby/launcher/CommandLineParser.java
@@ -48,6 +48,7 @@ import java.util.logging.Logger;
 
 import org.graalvm.options.OptionDescriptor;
 import org.truffleruby.shared.options.OptionsCatalog;
+import org.truffleruby.shared.options.RubyOptionTypes;
 import org.truffleruby.shared.options.Verbosity;
 
 public class CommandLineParser {
@@ -97,13 +98,32 @@ public class CommandLineParser {
         }
     }
 
+    // RUBYOPT can be disabled through CLI with --disable=rubyopt. To accommodate
+    // that, we parse CLI args first and don't overwrite them when parsing env later.
+    private boolean ignoreOption(OptionDescriptor descriptor) {
+        return !processArgv && config.containsOption(descriptor);
+    }
+
     private <T> void setOption(OptionDescriptor descriptor, T value) {
-        // RUBYOPT can be disabled through CLI with --disable=rubyopt. To accommodate
-        // that, we parse CLI args first and don't overwrite them when parsing env later.
-        if (!processArgv && config.containsOption(descriptor)) {
+        if (ignoreOption(descriptor)) {
             return;
         }
         config.setOption(descriptor, value);
+    }
+
+    private <T> void setOptionOnce(OptionDescriptor descriptor, T value) throws CommandLineException {
+        if (ignoreOption(descriptor)) {
+            return;
+        }
+
+        if (config.containsOption(descriptor)) {
+            final String current = config.getOptions().get(descriptor.getName());
+            final String overwrite = RubyOptionTypes.valueToString(value);
+            if (!current.equalsIgnoreCase(overwrite)) {
+                throw new CommandLineException(descriptor.getName() + " already set to " + current + " (RuntimeError)");
+            }
+        }
+        setOption(descriptor, value);
     }
 
     private boolean endOfInterpreterArguments() {
@@ -297,8 +317,8 @@ public class CommandLineParser {
                             break;
                     }
                     if (sourceEncodingName != null) {
-                        setOption(OptionsCatalog.SOURCE_ENCODING, sourceEncodingName);
-                        setOption(OptionsCatalog.EXTERNAL_ENCODING, sourceEncodingName);
+                        setOptionOnce(OptionsCatalog.SOURCE_ENCODING, sourceEncodingName);
+                        setOptionOnce(OptionsCatalog.EXTERNAL_ENCODING, sourceEncodingName);
                     }
                     break;
                 case 'l':
@@ -341,7 +361,7 @@ public class CommandLineParser {
                 case 'T':
                     throw notImplemented("-T");
                 case 'U':
-                    setOption(OptionsCatalog.INTERNAL_ENCODING, "UTF-8");
+                    setOptionOnce(OptionsCatalog.INTERNAL_ENCODING, "UTF-8");
                     break;
                 case 'v':
                     setOption(OptionsCatalog.VERBOSITY, Verbosity.TRUE);
@@ -424,15 +444,15 @@ public class CommandLineParser {
                         final String encodingNames = argument.substring(argument.indexOf('=') + 1);
                         final int index = encodingNames.indexOf(':');
                         if (index == -1) {
-                            setOption(OptionsCatalog.EXTERNAL_ENCODING, encodingNames);
+                            setOptionOnce(OptionsCatalog.EXTERNAL_ENCODING, encodingNames);
                         } else {
                             final int secondIndex = encodingNames.indexOf(':', index + 1);
                             if (secondIndex != -1) {
                                 throw new CommandLineException(
                                         "extra argument for --encoding: " + encodingNames.substring(secondIndex + 1));
                             }
-                            setOption(OptionsCatalog.EXTERNAL_ENCODING, encodingNames.substring(0, index));
-                            setOption(OptionsCatalog.INTERNAL_ENCODING, encodingNames.substring(index + 1));
+                            setOptionOnce(OptionsCatalog.EXTERNAL_ENCODING, encodingNames.substring(0, index));
+                            setOptionOnce(OptionsCatalog.INTERNAL_ENCODING, encodingNames.substring(index + 1));
                         }
                         break FOR;
                     } else if (argument.equals("--external-encoding") || argument.equals("--internal-encoding")) {
@@ -587,11 +607,11 @@ public class CommandLineParser {
         }
 
         if (encodings.size() >= 2) {
-            setOption(OptionsCatalog.INTERNAL_ENCODING, encodings.get(1));
+            setOptionOnce(OptionsCatalog.INTERNAL_ENCODING, encodings.get(1));
         }
 
         if (encodings.size() >= 1) {
-            setOption(OptionsCatalog.EXTERNAL_ENCODING, encodings.get(0));
+            setOptionOnce(OptionsCatalog.EXTERNAL_ENCODING, encodings.get(0));
         }
     }
 

--- a/src/launcher/java/org/truffleruby/launcher/CommandLineParser.java
+++ b/src/launcher/java/org/truffleruby/launcher/CommandLineParser.java
@@ -97,6 +97,15 @@ public class CommandLineParser {
         }
     }
 
+    private <T> void setOption(OptionDescriptor descriptor, T value) {
+        // RUBYOPT can be disabled through CLI with --disable=rubyopt. To accommodate
+        // that, we parse CLI args first and don't overwrite them when parsing env later.
+        if (!processArgv && config.containsOption(descriptor)) {
+            return;
+        }
+        config.setOption(descriptor, value);
+    }
+
     private boolean endOfInterpreterArguments() {
         return lastInterpreterArgumentIndex != -1;
     }
@@ -190,11 +199,11 @@ public class CommandLineParser {
                 }
                 case 'a':
                     disallowedInRubyOpts(argument);
-                    config.setOption(OptionsCatalog.SPLIT_LOOP, true);
+                    setOption(OptionsCatalog.SPLIT_LOOP, true);
                     break;
                 case 'c':
                     disallowedInRubyOpts(argument);
-                    config.setOption(OptionsCatalog.SYNTAX_CHECK, true);
+                    setOption(OptionsCatalog.SYNTAX_CHECK, true);
                     break;
                 case 'C':
                 case 'X':
@@ -203,11 +212,11 @@ public class CommandLineParser {
                             getArgumentError(
                                     " -" + argument.charAt(characterIndex) +
                                             " must be followed by a directory expression"));
-                    config.setOption(OptionsCatalog.WORKING_DIRECTORY, dir);
+                    setOption(OptionsCatalog.WORKING_DIRECTORY, dir);
                     break FOR;
                 case 'd':
-                    config.setOption(OptionsCatalog.DEBUG, true);
-                    config.setOption(OptionsCatalog.VERBOSITY, Verbosity.TRUE);
+                    setOption(OptionsCatalog.DEBUG, true);
+                    setOption(OptionsCatalog.VERBOSITY, Verbosity.TRUE);
                     break;
                 case 'e':
                     disallowedInRubyOpts(argument);
@@ -288,22 +297,22 @@ public class CommandLineParser {
                             break;
                     }
                     if (sourceEncodingName != null) {
-                        config.setOption(OptionsCatalog.SOURCE_ENCODING, sourceEncodingName);
-                        config.setOption(OptionsCatalog.EXTERNAL_ENCODING, sourceEncodingName);
+                        setOption(OptionsCatalog.SOURCE_ENCODING, sourceEncodingName);
+                        setOption(OptionsCatalog.EXTERNAL_ENCODING, sourceEncodingName);
                     }
                     break;
                 case 'l':
                     disallowedInRubyOpts(argument);
-                    config.setOption(OptionsCatalog.CHOMP_LOOP, true);
+                    setOption(OptionsCatalog.CHOMP_LOOP, true);
                     break;
                 case 'n':
                     disallowedInRubyOpts(argument);
-                    config.setOption(OptionsCatalog.GETS_LOOP, true);
+                    setOption(OptionsCatalog.GETS_LOOP, true);
                     break;
                 case 'p':
                     disallowedInRubyOpts(argument);
-                    config.setOption(OptionsCatalog.PRINT_LOOP, true);
-                    config.setOption(OptionsCatalog.GETS_LOOP, true);
+                    setOption(OptionsCatalog.PRINT_LOOP, true);
+                    setOption(OptionsCatalog.GETS_LOOP, true);
                     break;
                 case 'r':
                     final String library = grabValue(getArgumentError("-r must be followed by a package to require"));
@@ -311,7 +320,7 @@ public class CommandLineParser {
                     break FOR;
                 case 's':
                     disallowedInRubyOpts(argument);
-                    config.setOption(OptionsCatalog.ARGV_GLOBALS, true);
+                    setOption(OptionsCatalog.ARGV_GLOBALS, true);
                     break;
                 case 'G':
                     throw notImplemented("-G");
@@ -332,15 +341,15 @@ public class CommandLineParser {
                 case 'T':
                     throw notImplemented("-T");
                 case 'U':
-                    config.setOption(OptionsCatalog.INTERNAL_ENCODING, "UTF-8");
+                    setOption(OptionsCatalog.INTERNAL_ENCODING, "UTF-8");
                     break;
                 case 'v':
-                    config.setOption(OptionsCatalog.VERBOSITY, Verbosity.TRUE);
+                    setOption(OptionsCatalog.VERBOSITY, Verbosity.TRUE);
                     config.showVersion = true;
                     config.defaultExecutionAction = DefaultExecutionAction.NONE;
                     break;
                 case 'w':
-                    config.setOption(OptionsCatalog.VERBOSITY, Verbosity.TRUE);
+                    setOption(OptionsCatalog.VERBOSITY, Verbosity.TRUE);
                     setAllWarningCategories(true);
                     break;
                 case 'W': {
@@ -351,22 +360,22 @@ public class CommandLineParser {
                     if (temp.startsWith(":")) {
                         switch (temp) {
                             case ":deprecated":
-                                config.setOption(OptionsCatalog.WARN_DEPRECATED, true);
+                                setOption(OptionsCatalog.WARN_DEPRECATED, true);
                                 break;
                             case ":no-deprecated":
-                                config.setOption(OptionsCatalog.WARN_DEPRECATED, false);
+                                setOption(OptionsCatalog.WARN_DEPRECATED, false);
                                 break;
                             case ":experimental":
-                                config.setOption(OptionsCatalog.WARN_EXPERIMENTAL, true);
+                                setOption(OptionsCatalog.WARN_EXPERIMENTAL, true);
                                 break;
                             case ":no-experimental":
-                                config.setOption(OptionsCatalog.WARN_EXPERIMENTAL, false);
+                                setOption(OptionsCatalog.WARN_EXPERIMENTAL, false);
                                 break;
                             case ":performance":
-                                config.setOption(OptionsCatalog.WARN_PERFORMANCE, true);
+                                setOption(OptionsCatalog.WARN_PERFORMANCE, true);
                                 break;
                             case ":no-performance":
-                                config.setOption(OptionsCatalog.WARN_PERFORMANCE, false);
+                                setOption(OptionsCatalog.WARN_PERFORMANCE, false);
                                 break;
                             default:
                                 LOGGER.warning("unknown warning category: `" + temp.substring(1) + "'");
@@ -375,17 +384,17 @@ public class CommandLineParser {
                     } else {
                         switch (temp) {
                             case "0":
-                                config.setOption(OptionsCatalog.VERBOSITY, Verbosity.NIL);
+                                setOption(OptionsCatalog.VERBOSITY, Verbosity.NIL);
                                 setAllWarningCategories(false);
                                 break;
                             case "2":
-                                config.setOption(OptionsCatalog.VERBOSITY, Verbosity.TRUE);
+                                setOption(OptionsCatalog.VERBOSITY, Verbosity.TRUE);
                                 setAllWarningCategories(true);
                                 break;
                             case "1":
                             default:
-                                config.setOption(OptionsCatalog.VERBOSITY, Verbosity.FALSE);
-                                config.setOption(OptionsCatalog.WARN_DEPRECATED, false);
+                                setOption(OptionsCatalog.VERBOSITY, Verbosity.FALSE);
+                                setOption(OptionsCatalog.WARN_DEPRECATED, false);
                                 break;
                         }
                     }
@@ -393,7 +402,7 @@ public class CommandLineParser {
                 }
                 case 'x':
                     disallowedInRubyOpts(argument);
-                    config.setOption(OptionsCatalog.IGNORE_LINES_BEFORE_RUBY_SHEBANG, true);
+                    setOption(OptionsCatalog.IGNORE_LINES_BEFORE_RUBY_SHEBANG, true);
                     String directory = grabOptionalValue();
                     if (directory != null) {
                         throw notImplemented("-x with directory");
@@ -415,15 +424,15 @@ public class CommandLineParser {
                         final String encodingNames = argument.substring(argument.indexOf('=') + 1);
                         final int index = encodingNames.indexOf(':');
                         if (index == -1) {
-                            config.setOption(OptionsCatalog.EXTERNAL_ENCODING, encodingNames);
+                            setOption(OptionsCatalog.EXTERNAL_ENCODING, encodingNames);
                         } else {
                             final int secondIndex = encodingNames.indexOf(':', index + 1);
                             if (secondIndex != -1) {
                                 throw new CommandLineException(
                                         "extra argument for --encoding: " + encodingNames.substring(secondIndex + 1));
                             }
-                            config.setOption(OptionsCatalog.EXTERNAL_ENCODING, encodingNames.substring(0, index));
-                            config.setOption(OptionsCatalog.INTERNAL_ENCODING, encodingNames.substring(index + 1));
+                            setOption(OptionsCatalog.EXTERNAL_ENCODING, encodingNames.substring(0, index));
+                            setOption(OptionsCatalog.INTERNAL_ENCODING, encodingNames.substring(index + 1));
                         }
                         break FOR;
                     } else if (argument.equals("--external-encoding") || argument.equals("--internal-encoding")) {
@@ -499,8 +508,8 @@ public class CommandLineParser {
     }
 
     private void setAllWarningCategories(boolean value) {
-        config.setOption(OptionsCatalog.WARN_DEPRECATED, value);
-        config.setOption(OptionsCatalog.WARN_EXPERIMENTAL, value);
+        setOption(OptionsCatalog.WARN_DEPRECATED, value);
+        setOption(OptionsCatalog.WARN_EXPERIMENTAL, value);
         // WARN_PERFORMANCE is excluded here, it is not set by -w/-W2 on CRuby
     }
 
@@ -578,11 +587,11 @@ public class CommandLineParser {
         }
 
         if (encodings.size() >= 2) {
-            config.setOption(OptionsCatalog.INTERNAL_ENCODING, encodings.get(1));
+            setOption(OptionsCatalog.INTERNAL_ENCODING, encodings.get(1));
         }
 
         if (encodings.size() >= 1) {
-            config.setOption(OptionsCatalog.EXTERNAL_ENCODING, encodings.get(0));
+            setOption(OptionsCatalog.EXTERNAL_ENCODING, encodings.get(0));
         }
     }
 
@@ -632,7 +641,7 @@ public class CommandLineParser {
 
         FEATURES.put(
                 "did_you_mean",
-                (processor, enable) -> processor.config.setOption(OptionsCatalog.DID_YOU_MEAN, enable));
+                (processor, enable) -> processor.setOption(OptionsCatalog.DID_YOU_MEAN, enable));
 
         FEATURES.put(
                 "did-you-mean",
@@ -640,7 +649,7 @@ public class CommandLineParser {
 
         FEATURES.put(
                 "gem",
-                (processor, enable) -> processor.config.setOption(OptionsCatalog.RUBYGEMS, enable));
+                (processor, enable) -> processor.setOption(OptionsCatalog.RUBYGEMS, enable));
 
         FEATURES.put(
                 "gems",
@@ -648,7 +657,7 @@ public class CommandLineParser {
 
         FEATURES.put(
                 "frozen-string-literal",
-                (processor, enable) -> processor.config.setOption(OptionsCatalog.FROZEN_STRING_LITERALS, enable));
+                (processor, enable) -> processor.setOption(OptionsCatalog.FROZEN_STRING_LITERALS, enable));
 
         FEATURES.put(
                 "frozen_string_literal",

--- a/src/launcher/java/org/truffleruby/launcher/DefaultExecutionAction.java
+++ b/src/launcher/java/org/truffleruby/launcher/DefaultExecutionAction.java
@@ -12,6 +12,5 @@ package org.truffleruby.launcher;
 
 public enum DefaultExecutionAction {
     NONE,
-    STDIN,
     IRB
 }

--- a/src/launcher/java/org/truffleruby/launcher/RubyLauncher.java
+++ b/src/launcher/java/org/truffleruby/launcher/RubyLauncher.java
@@ -270,9 +270,6 @@ public class RubyLauncher extends AbstractLanguageLauncher {
             switch (config.defaultExecutionAction) {
                 case NONE:
                     return 0;
-                case STDIN:
-                    config.executionAction = ExecutionAction.STDIN;
-                    break;
                 case IRB:
                     config.executionAction = ExecutionAction.PATH;
                     if (isTTY()) {


### PR DESCRIPTION
CRuby rejects multiple encoding switches when they specify a different encoding than the previous one. So, `-U -Eutf-8:utf-8` is OK but not `-U -Eascii:ascii`.

I also wondered how this plays out with `RUBYOPT` and noticed that truffleruby currently overwrites CLI switches with `RUBYOPT`. That's the wrong way around, so I changed that as well. It's awkward because you are able to disable `RUBYOPT` via CLI so you can't just switch evaluation order.

There are some options like `-r` that append, they seem to be evaluated in the "correct" order, CLI switches come first and then `RUBYOPT` after. But it hardly seems worth to spec that. With files that print their filename, `RUBYOPT=-r./1.rb ruby -r./2.rb`, it will print `2.rb\n1.rb`. With the precedence I would have expected it the other way around, I guess CRuby implements parsing in a similar way to truffleruby to handle the possibility of disabling `RUBYOPT`. Either way, I doubt anyone relies on such behaviour.

- [x] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
