### PR TITLE
Untag Unicode version specs now that we have Unicode 17

### DIFF
--- a/spec/tags/library/rbconfig/unicode_emoji_version_tags.txt
+++ b/spec/tags/library/rbconfig/unicode_emoji_version_tags.txt
@@ -1,2 +1,0 @@
-fails:RbConfig::CONFIG['UNICODE_EMOJI_VERSION'] is 15.0
-fails:RbConfig::CONFIG['UNICODE_EMOJI_VERSION'] is 17.0

--- a/spec/tags/library/rbconfig/unicode_version_tags.txt
+++ b/spec/tags/library/rbconfig/unicode_version_tags.txt
@@ -1,2 +1,0 @@
-fails:RbConfig::CONFIG['UNICODE_VERSION'] is 15.0.0
-fails:RbConfig::CONFIG['UNICODE_VERSION'] is 17.0.0


### PR DESCRIPTION
- [x] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
