### PR TITLE
Fix path parameter encoding in File, File::Stat, IO, and Dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Compatibility:
 * Fix `FFI::DynamicLibrary.open` and raise `LoadError` instead of `RuntimeError` with adjusted message (#4345, @andrykonchin).
 * Fix `Enumerator::Lazy#{drop,drop_while,take,uniq,zip}` when doing multiple enumerations (#4357, @earlopain).
 * Fix `Enumerator::Lazy` methods and `Enumerable#take_while` to pack multi-argument source yields like CRuby (0-arg yield → `nil`, 1-arg → value, multi-arg → `Array`) (#4310, @sampokuokkanen).
+* Adjust `File.{write,read,open}` to accept a path parameter in any encoding on macOS (#4082, @andrykonchin).
 
 Performance:
 

--- a/spec/ruby/core/dir/chdir_spec.rb
+++ b/spec/ruby/core/dir/chdir_spec.rb
@@ -65,6 +65,26 @@ describe "Dir.chdir" do
     Dir.pwd.should == @original
   end
 
+  platform_is :darwin do
+    it "accepts a path in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters" do
+      dir = tmp("dir_chdir_\u{3042}")
+      non_utf8_dir = dir.encode(Encoding::Windows_31J)
+
+      begin
+        mkdir_p(dir)
+        original = Dir.pwd
+        begin
+          Dir.chdir(non_utf8_dir).should == 0
+          Dir.pwd.should == dir
+        ensure
+          Dir.chdir(original)
+        end
+      ensure
+        rm_r dir
+      end
+    end
+  end
+
   it "returns the value of the block when a block is given" do
     Dir.chdir(@original) { :block_value }.should == :block_value
   end
@@ -122,6 +142,23 @@ describe "Dir.chdir" do
     end
 
     Dir.pwd.should == @original
+  end
+
+  platform_is :darwin do
+    it "accepts a path in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters when given a block" do
+      dir = tmp("dir_chdir_\u{3042}")
+      non_utf8_dir = dir.encode(Encoding::Windows_31J)
+
+      begin
+        mkdir_p(dir)
+        current_dir = nil
+        Dir.chdir(non_utf8_dir) { current_dir = Dir.pwd }
+        current_dir.should == dir
+        Dir.pwd.should == @original
+      ensure
+        rm_r dir
+      end
+    end
   end
 end
 

--- a/spec/ruby/core/dir/delete_spec.rb
+++ b/spec/ruby/core/dir/delete_spec.rb
@@ -61,4 +61,19 @@ describe "Dir.delete" do
       end
     end
   end
+
+  platform_is :darwin do
+    it "accepts a path in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters" do
+      dir = tmp("dir_delete_\u{3042}")
+      non_utf8_dir = dir.encode(Encoding::Windows_31J)
+
+      begin
+        mkdir_p(dir)
+        Dir.delete(non_utf8_dir).should == 0
+        File.directory?(dir).should == false
+      ensure
+        rm_r dir
+      end
+    end
+  end
 end

--- a/spec/ruby/core/dir/element_reference_spec.rb
+++ b/spec/ruby/core/dir/element_reference_spec.rb
@@ -30,4 +30,23 @@ describe "Dir.[]" do
 
     Dir[pat1, pat2].should == %w[file_one.ext file_two.ext]
   end
+
+  platform_is :darwin do
+    it "accepts multiple patterns in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters" do
+      dir = tmp("dir_glob_\u{3042}")
+      utf8_file = File.join(dir, "file.txt")
+      non_utf8_pattern = File.join(dir, "*.txt").encode(Encoding::Windows_31J)
+
+      begin
+        mkdir_p(dir)
+        touch(utf8_file)
+        Dir[non_utf8_pattern, non_utf8_pattern].should == [
+          utf8_file.encode(Encoding::Windows_31J),
+          utf8_file.encode(Encoding::Windows_31J)
+        ]
+      ensure
+        rm_r dir
+      end
+    end
+  end
 end

--- a/spec/ruby/core/dir/empty_spec.rb
+++ b/spec/ruby/core/dir/empty_spec.rb
@@ -28,4 +28,18 @@ describe "Dir.empty?" do
   it "raises ENOENT for nonexistent directories" do
     -> { Dir.empty? tmp("nonexistent") }.should.raise(Errno::ENOENT)
   end
+
+  platform_is :darwin do
+    it "accepts a path in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters" do
+      dir = tmp("dir_empty_\u{3042}")
+      non_utf8_dir = dir.encode(Encoding::Windows_31J)
+
+      begin
+        mkdir_p(dir)
+        Dir.empty?(non_utf8_dir).should == true
+      ensure
+        rm_r dir
+      end
+    end
+  end
 end

--- a/spec/ruby/core/dir/entries_spec.rb
+++ b/spec/ruby/core/dir/entries_spec.rb
@@ -67,4 +67,18 @@ describe "Dir.entries" do
   it "raises a SystemCallError if called with a nonexistent directory" do
     -> { Dir.entries DirSpecs.nonexistent }.should.raise(SystemCallError)
   end
+
+  platform_is :darwin do
+    it "accepts a path in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters" do
+      dir = tmp("dir_entries_\u{3042}")
+      non_utf8_dir = dir.encode(Encoding::Windows_31J)
+
+      begin
+        mkdir_p(dir)
+        Dir.entries(non_utf8_dir).should.include?(".".encode(Encoding::Windows_31J))
+      ensure
+        rm_r dir
+      end
+    end
+  end
 end

--- a/spec/ruby/core/dir/foreach_spec.rb
+++ b/spec/ruby/core/dir/foreach_spec.rb
@@ -65,4 +65,18 @@ describe "Dir.foreach" do
       end
     end
   end
+
+  platform_is :darwin do
+    it "accepts a path in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters" do
+      dir = tmp("dir_foreach_\u{3042}")
+      non_utf8_dir = dir.encode(Encoding::Windows_31J)
+
+      begin
+        mkdir_p(dir)
+        Dir.foreach(non_utf8_dir).to_a.should.include?(".".encode(Encoding::Windows_31J))
+      ensure
+        rm_r dir
+      end
+    end
+  end
 end

--- a/spec/ruby/core/dir/mkdir_spec.rb
+++ b/spec/ruby/core/dir/mkdir_spec.rb
@@ -81,6 +81,20 @@ describe "Dir.mkdir" do
   it "raises Errno::EEXIST if the argument points to the existing file" do
     -> { Dir.mkdir("#{DirSpecs.mock_dir}/file_one.ext") }.should.raise(Errno::EEXIST)
   end
+
+  platform_is :darwin do
+    it "accepts a path in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters" do
+      dir = tmp("dir_mkdir_\u{3042}")
+      non_utf8_dir = dir.encode(Encoding::Windows_31J)
+
+      begin
+        Dir.mkdir(non_utf8_dir).should == 0
+        File.directory?(dir).should == true
+      ensure
+        rm_r dir
+      end
+    end
+  end
 end
 
 # The permissions flag are not supported on Windows as stated in documentation:

--- a/spec/ruby/core/dir/shared/chroot.rb
+++ b/spec/ruby/core/dir/shared/chroot.rb
@@ -41,4 +41,18 @@ describe :dir_chroot_as_root, shared: true do
     p.should_receive(:to_path).and_return(@real_root)
     Dir.send(@method, p)
   end
+
+  platform_is :darwin do
+    it "accepts a path in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters" do
+      dir = tmp("dir_chroot_\u{3042}")
+      non_utf8_dir = dir.encode(Encoding::Windows_31J)
+
+      begin
+        mkdir_p(dir)
+        Dir.chroot(non_utf8_dir).should == 0
+      ensure
+        rm_r dir
+      end
+    end
+  end
 end

--- a/spec/ruby/core/dir/shared/glob.rb
+++ b/spec/ruby/core/dir/shared/glob.rb
@@ -27,6 +27,22 @@ describe :dir_glob, shared: true do
     -> {Dir.send(@method, "file_o*\0file_t*")}.should.raise ArgumentError, /nul-separated/
   end
 
+  platform_is :darwin do
+    it "accepts a pattern in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters" do
+      dir = tmp("dir_glob_\u{3042}")
+      utf8_file = File.join(dir, "file.txt")
+      non_utf8_pattern = File.join(dir, "*.txt").encode(Encoding::Windows_31J)
+
+      begin
+        mkdir_p(dir)
+        touch(utf8_file)
+        Dir.send(@method, non_utf8_pattern).should == [utf8_file.encode(Encoding::Windows_31J)]
+      ensure
+        rm_r dir
+      end
+    end
+  end
+
   it "result is sorted by default" do
     result = Dir.send(@method, '*')
     result.should == result.sort

--- a/spec/ruby/core/file/atime_spec.rb
+++ b/spec/ruby/core/file/atime_spec.rb
@@ -41,6 +41,22 @@ describe "File.atime" do
   it "accepts an object that has a #to_path method" do
     File.atime(mock_to_path(@file))
   end
+
+  platform_is :darwin do
+    it "accepts a path in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters" do
+      utf8_path = tmp("file_atime_utf8_path_\u{3042}.txt")
+      # Can fail with UndefinedConversionError if tmp path has non-Shift_JIS chars (e.g. Emojis, Hangul, Cyrillic, accented letters)
+      non_utf8_path = utf8_path.encode(Encoding::Windows_31J)
+
+      begin
+        touch(utf8_path)
+        File.atime(non_utf8_path).should.is_a?(Time)
+      ensure
+        rm_r utf8_path
+        rm_r non_utf8_path
+      end
+    end
+  end
 end
 
 describe "File#atime" do

--- a/spec/ruby/core/file/birthtime_spec.rb
+++ b/spec/ruby/core/file/birthtime_spec.rb
@@ -35,6 +35,24 @@ platform_is :windows, :darwin, :freebsd, :netbsd, :linux do
       e.message.should.start_with?(*not_implemented_messages)
     end
 
+    platform_is :darwin do
+      it "accepts a path in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters" do
+        utf8_path = tmp("file_birthtime_utf8_path_\u{3042}.txt")
+        # Can fail with UndefinedConversionError if tmp path has non-Shift_JIS chars (e.g. Emojis, Hangul, Cyrillic, accented letters)
+        non_utf8_path = utf8_path.encode(Encoding::Windows_31J)
+
+        begin
+          touch(utf8_path)
+          File.birthtime(non_utf8_path).should.is_a?(Time)
+        ensure
+          rm_r utf8_path
+          rm_r non_utf8_path
+        end
+      rescue NotImplementedError => e
+        e.message.should.start_with?(*not_implemented_messages)
+      end
+    end
+
     platform_is :linux do
       guard -> { File.directory?('/proc') } do
         it "raises NotImplementedError for a filesystem that does not support birthtime" do

--- a/spec/ruby/core/file/chmod_spec.rb
+++ b/spec/ruby/core/file/chmod_spec.rb
@@ -182,4 +182,20 @@ describe "File.chmod" do
       File.stat(@file).mode.should == 33261
     end
   end
+
+  platform_is :darwin do
+    it "accepts a path in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters" do
+      utf8_path = tmp("file_chmod_utf8_path_\u{3042}.txt")
+      # Can fail with UndefinedConversionError if tmp path has non-Shift_JIS chars (e.g. Emojis, Hangul, Cyrillic, accented letters)
+      non_utf8_path = utf8_path.encode(Encoding::Windows_31J)
+
+      begin
+        touch(utf8_path)
+        File.chmod(0755, non_utf8_path).should == 1
+      ensure
+        rm_r utf8_path
+        rm_r non_utf8_path
+      end
+    end
+  end
 end

--- a/spec/ruby/core/file/chown_spec.rb
+++ b/spec/ruby/core/file/chown_spec.rb
@@ -75,6 +75,22 @@ describe "File.chown" do
   it "accepts an object that has a #to_path method" do
     File.chown(nil, nil, mock_to_path(@fname)).should == 1
   end
+
+  platform_is :darwin do
+    it "accepts a path in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters" do
+      utf8_path = tmp("file_chown_utf8_path_\u{3042}.txt")
+      # Can fail with UndefinedConversionError if tmp path has non-Shift_JIS chars (e.g. Emojis, Hangul, Cyrillic, accented letters)
+      non_utf8_path = utf8_path.encode(Encoding::Windows_31J)
+
+      begin
+        touch(utf8_path)
+        File.chown(nil, nil, non_utf8_path).should == 1
+      ensure
+        rm_r utf8_path
+        rm_r non_utf8_path
+      end
+    end
+  end
 end
 
 describe "File#chown" do

--- a/spec/ruby/core/file/ctime_spec.rb
+++ b/spec/ruby/core/file/ctime_spec.rb
@@ -35,6 +35,22 @@ describe "File.ctime" do
   it "raises an Errno::ENOENT exception if the file is not found" do
     -> { File.ctime('bogus') }.should.raise(Errno::ENOENT)
   end
+
+  platform_is :darwin do
+    it "accepts a path in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters" do
+      utf8_path = tmp("file_ctime_utf8_path_\u{3042}.txt")
+      # Can fail with UndefinedConversionError if tmp path has non-Shift_JIS chars (e.g. Emojis, Hangul, Cyrillic, accented letters)
+      non_utf8_path = utf8_path.encode(Encoding::Windows_31J)
+
+      begin
+        touch(utf8_path)
+        File.ctime(non_utf8_path).should.is_a?(Time)
+      ensure
+        rm_r utf8_path
+        rm_r non_utf8_path
+      end
+    end
+  end
 end
 
 describe "File#ctime" do

--- a/spec/ruby/core/file/delete_spec.rb
+++ b/spec/ruby/core/file/delete_spec.rb
@@ -50,6 +50,22 @@ describe "File.delete" do
     File.delete(mock_to_path(@file1)).should == 1
   end
 
+  platform_is :darwin do
+    it "accepts a path in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters" do
+      utf8_path = tmp("file_delete_utf8_path_\u{3042}.txt")
+      # Can fail with UndefinedConversionError if tmp path has non-Shift_JIS chars (e.g. Emojis, Hangul, Cyrillic, accented letters)
+      non_utf8_path = utf8_path.encode(Encoding::Windows_31J)
+
+      begin
+        touch(utf8_path)
+        File.delete(non_utf8_path).should == 1
+      ensure
+        rm_r utf8_path
+        rm_r non_utf8_path
+      end
+    end
+  end
+
   platform_is :windows do
     it "allows deleting an open file with File::SHARE_DELETE" do
       path = tmp("share_delete.txt")

--- a/spec/ruby/core/file/ftype_spec.rb
+++ b/spec/ruby/core/file/ftype_spec.rb
@@ -79,4 +79,20 @@ describe "File.ftype" do
       end
     end
   end
+
+  platform_is :darwin do
+    it "accepts a path in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters" do
+      utf8_path = tmp("file_ftype_utf8_path_\u{3042}.txt")
+      # Can fail with UndefinedConversionError if tmp path has non-Shift_JIS chars (e.g. Emojis, Hangul, Cyrillic, accented letters)
+      non_utf8_path = utf8_path.encode(Encoding::Windows_31J)
+
+      begin
+        touch(utf8_path)
+        File.ftype(non_utf8_path).should == 'file'
+      ensure
+        rm_r utf8_path
+        rm_r non_utf8_path
+      end
+    end
+  end
 end

--- a/spec/ruby/core/file/lchmod_spec.rb
+++ b/spec/ruby/core/file/lchmod_spec.rb
@@ -28,5 +28,21 @@ describe "File.lchmod" do
       File.stat(@lname).should_not.readable?
       File.stat(@lname).should.writable?
     end
+
+    platform_is :darwin do
+      it "accepts a path in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters" do
+        utf8_path = tmp("file_lchmod_utf8_path_\u{3042}.txt")
+        # Can fail with UndefinedConversionError if tmp path has non-Shift_JIS chars (e.g. Emojis, Hangul, Cyrillic, accented letters)
+        non_utf8_path = utf8_path.encode(Encoding::Windows_31J)
+
+        begin
+          touch(utf8_path)
+          File.lchmod(0755, non_utf8_path).should == 1
+        ensure
+          rm_r utf8_path
+          rm_r non_utf8_path
+        end
+      end
+    end
   end
 end

--- a/spec/ruby/core/file/lchown_spec.rb
+++ b/spec/ruby/core/file/lchown_spec.rb
@@ -55,5 +55,21 @@ as_superuser do
         File.lchown(nil, nil, @lname, @lname).should == 2
       end
     end
+
+    platform_is :darwin do
+      it "accepts a path in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters" do
+        utf8_path = tmp("file_lchown_utf8_path_\u{3042}.txt")
+        # Can fail with UndefinedConversionError if tmp path has non-Shift_JIS chars (e.g. Emojis, Hangul, Cyrillic, accented letters)
+        non_utf8_path = utf8_path.encode(Encoding::Windows_31J)
+
+        begin
+          touch(utf8_path)
+          File.lchown(nil, nil, non_utf8_path).should == 1
+        ensure
+          rm_r utf8_path
+          rm_r non_utf8_path
+        end
+      end
+    end
   end
 end

--- a/spec/ruby/core/file/link_spec.rb
+++ b/spec/ruby/core/file/link_spec.rb
@@ -35,5 +35,24 @@ describe "File.link" do
       -> { File.link(@file, nil) }.should.raise(TypeError)
       -> { File.link(@file, 1)   }.should.raise(TypeError)
     end
+
+    platform_is :darwin do
+      it "accepts a path in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters" do
+        utf8_file = tmp("file_link_file_utf8_path_\u{3042}.txt")
+        utf8_link = tmp("file_link_link_utf8_path_\u{3042}.txt")
+        # Can fail with UndefinedConversionError if tmp path has non-Shift_JIS chars (e.g. Emojis, Hangul, Cyrillic, accented letters)
+        non_utf8_file = utf8_file.encode(Encoding::Windows_31J)
+        non_utf8_link = utf8_link.encode(Encoding::Windows_31J)
+
+        begin
+          touch(utf8_file)
+          File.link(non_utf8_file, non_utf8_link).should == 0
+          File.should.exist?(utf8_link)
+        ensure
+          rm_r utf8_file, utf8_link
+          rm_r non_utf8_file, non_utf8_link
+        end
+      end
+    end
   end
 end

--- a/spec/ruby/core/file/mkfifo_spec.rb
+++ b/spec/ruby/core/file/mkfifo_spec.rb
@@ -47,5 +47,20 @@ describe "File.mkfifo" do
     it "returns 0 after creating the FIFO file" do
       File.mkfifo(@path).should == 0
     end
+
+    platform_is :darwin do
+      it "accepts a path in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters" do
+        utf8_path = tmp("file_mkfifo_utf8_path_\u{3042}.txt")
+        # Can fail with UndefinedConversionError if tmp path has non-Shift_JIS chars (e.g. Emojis, Hangul, Cyrillic, accented letters)
+        non_utf8_path = utf8_path.encode(Encoding::Windows_31J)
+
+        begin
+          File.mkfifo(non_utf8_path).should == 0
+        ensure
+          rm_r utf8_path
+          rm_r non_utf8_path
+        end
+      end
+    end
   end
 end

--- a/spec/ruby/core/file/mtime_spec.rb
+++ b/spec/ruby/core/file/mtime_spec.rb
@@ -36,6 +36,22 @@ describe "File.mtime" do
   it "raises an Errno::ENOENT exception if the file is not found" do
     -> { File.mtime('bogus') }.should.raise(Errno::ENOENT)
   end
+
+  platform_is :darwin do
+    it "accepts a path in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters" do
+      utf8_path = tmp("file_mtime_utf8_path_\u{3042}.txt")
+      # Can fail with UndefinedConversionError if tmp path has non-Shift_JIS chars (e.g. Emojis, Hangul, Cyrillic, accented letters)
+      non_utf8_path = utf8_path.encode(Encoding::Windows_31J)
+
+      begin
+        touch(utf8_path)
+        File.mtime(non_utf8_path).should.is_a?(Time)
+      ensure
+        rm_r utf8_path
+        rm_r non_utf8_path
+      end
+    end
+  end
 end
 
 describe "File#mtime" do

--- a/spec/ruby/core/file/new_spec.rb
+++ b/spec/ruby/core/file/new_spec.rb
@@ -37,6 +37,24 @@ describe "File.new" do
     File.should.exist?(@file)
   end
 
+  platform_is :darwin do
+    it "returns a new File when given a path in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters" do
+      utf8_path = tmp("file_new_utf8_path_\u{3042}.txt")
+      # Can fail with UndefinedConversionError if tmp path has non-Shift_JIS chars (e.g. Emojis, Hangul, Cyrillic, accented letters)
+      non_utf8_path = utf8_path.encode(Encoding::Windows_31J)
+
+      begin
+        @fh = File.new(non_utf8_path, "w")
+        @fh.should.is_a?(File)
+        File.should.exist?(utf8_path)
+      ensure
+        @fh.close if @fh and not @fh.closed?
+        rm_r utf8_path
+        rm_r non_utf8_path
+      end
+    end
+  end
+
   it "creates the file and returns writable descriptor when called with 'w' mode and r-o permissions" do
     # it should be possible to write to such a file via returned descriptor,
     # even though the file permissions are r-r-r.

--- a/spec/ruby/core/file/open_spec.rb
+++ b/spec/ruby/core/file/open_spec.rb
@@ -72,6 +72,24 @@ describe "File.open" do
     File.should.exist?(@unicode_path)
   end
 
+  platform_is :darwin do
+    it "opens a file when given a path in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters" do
+      utf8_path = tmp("file_open_utf8_path_\u{3042}.txt")
+      # Can fail with UndefinedConversionError if tmp path has non-Shift_JIS chars (e.g. Emojis, Hangul, Cyrillic, accented letters)
+      non_utf8_path = utf8_path.encode(Encoding::Windows_31J)
+
+      begin
+        @fh = File.open(non_utf8_path, "w")
+        @fh.should.is_a?(File)
+        File.should.exist?(utf8_path)
+      ensure
+        @fh.close if @fh and not @fh.closed?
+        rm_r utf8_path
+        rm_r non_utf8_path
+      end
+    end
+  end
+
   it "opens a file when called with a block" do
     File.open(@file) { |fh| }
     File.should.exist?(@file)

--- a/spec/ruby/core/file/readlink_spec.rb
+++ b/spec/ruby/core/file/readlink_spec.rb
@@ -82,5 +82,23 @@ describe "File.readlink" do
         File.readlink(@link).should == @file
       end
     end
+
+    platform_is :darwin do
+      it "accepts a path in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters" do
+        utf8_file = tmp("file_readlink_file_utf8_path_\u{3042}.txt")
+        utf8_link = tmp("file_readlink_link_utf8_path_\u{3042}.txt")
+        # Can fail with UndefinedConversionError if tmp path has non-Shift_JIS chars (e.g. Emojis, Hangul, Cyrillic, accented letters)
+        non_utf8_file = utf8_file.encode(Encoding::Windows_31J)
+        non_utf8_link = utf8_link.encode(Encoding::Windows_31J)
+
+        begin
+          File.symlink(utf8_file, utf8_link)
+          File.readlink(non_utf8_link).should == utf8_file
+        ensure
+          rm_r utf8_file, utf8_link
+          rm_r non_utf8_file, non_utf8_link
+        end
+      end
+    end
   end
 end

--- a/spec/ruby/core/file/realdirpath_spec.rb
+++ b/spec/ruby/core/file/realdirpath_spec.rb
@@ -79,6 +79,23 @@ platform_is_not :windows do
     it "raises Errno::ENOENT if the symlink points to an absent directory" do
       -> { File.realdirpath(@fake_link_to_fake_dir) }.should.raise(Errno::ENOENT)
     end
+
+    platform_is :darwin do
+      it "accepts a path in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters" do
+        dir = tmp("file_realdirpath_dir_\u{3042}")
+        utf8_file = File.join(dir, "file.txt")
+        # Can fail with UndefinedConversionError if tmp path has non-Shift_JIS chars (e.g. Emojis, Hangul, Cyrillic, accented letters)
+        non_utf8_file = utf8_file.encode(Encoding::Windows_31J)
+
+        begin
+          mkdir_p(dir)
+          touch(utf8_file)
+          File.realdirpath(non_utf8_file).should == File.realdirpath(utf8_file).encode(Encoding::Windows_31J)
+        ensure
+          rm_r dir
+        end
+      end
+    end
   end
 end
 

--- a/spec/ruby/core/file/realpath_spec.rb
+++ b/spec/ruby/core/file/realpath_spec.rb
@@ -77,6 +77,23 @@ platform_is_not :windows do
       path.should_receive(:to_path).and_return(__FILE__)
       File.realpath(path).should == File.realpath(__FILE__ )
     end
+
+    platform_is :darwin do
+      it "accepts a path in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters" do
+        dir = tmp("file_realpath_dir_\u{3042}")
+        utf8_file = File.join(dir, "file.txt")
+        # Can fail with UndefinedConversionError if tmp path has non-Shift_JIS chars (e.g. Emojis, Hangul, Cyrillic, accented letters)
+        non_utf8_file = utf8_file.encode(Encoding::Windows_31J)
+
+        begin
+          mkdir_p(dir)
+          touch(utf8_file)
+          File.realpath(non_utf8_file).should == File.realpath(utf8_file).encode(Encoding::Windows_31J)
+        ensure
+          rm_r dir
+        end
+      end
+    end
   end
 end
 

--- a/spec/ruby/core/file/rename_spec.rb
+++ b/spec/ruby/core/file/rename_spec.rb
@@ -34,4 +34,24 @@ describe "File.rename" do
   it "raises a TypeError if not passed String types" do
     -> { File.rename(1, 2)  }.should.raise(TypeError)
   end
+
+  platform_is :darwin do
+    it "accepts a path in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters" do
+      utf8_old = tmp("file_rename_old_utf8_path_\u{3042}.txt")
+      utf8_new = tmp("file_rename_new_utf8_path_\u{3042}.txt")
+      # Can fail with UndefinedConversionError if tmp path has non-Shift_JIS chars (e.g. Emojis, Hangul, Cyrillic, accented letters)
+      non_utf8_old = utf8_old.encode(Encoding::Windows_31J)
+      non_utf8_new = utf8_new.encode(Encoding::Windows_31J)
+
+      begin
+        touch(utf8_old)
+        File.rename(non_utf8_old, non_utf8_new).should == 0
+        File.should.exist?(utf8_new)
+        File.should_not.exist?(utf8_old)
+      ensure
+        rm_r utf8_old, utf8_new
+        rm_r non_utf8_old, non_utf8_new
+      end
+    end
+  end
 end

--- a/spec/ruby/core/file/shared/stat.rb
+++ b/spec/ruby/core/file/shared/stat.rb
@@ -24,6 +24,22 @@ describe :file_stat, shared: true do
     File.send(@method, mock_to_path(@file))
   end
 
+  platform_is :darwin do
+    it "accepts a path in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters" do
+      utf8_path = tmp("file_lstat_utf8_path_\u{3042}.txt")
+      # Can fail with UndefinedConversionError if tmp path has non-Shift_JIS chars (e.g. Emojis, Hangul, Cyrillic, accented letters)
+      non_utf8_path = utf8_path.encode(Encoding::Windows_31J)
+
+      begin
+        touch(utf8_path)
+        File.send(@method, non_utf8_path).should.is_a?(File::Stat)
+      ensure
+        rm_r utf8_path
+        rm_r non_utf8_path
+      end
+    end
+  end
+
   it "raises an Errno::ENOENT if the file does not exist" do
     -> {
       File.send(@method, "fake_file")

--- a/spec/ruby/core/file/shared/update_time.rb
+++ b/spec/ruby/core/file/shared/update_time.rb
@@ -53,6 +53,22 @@ describe :update_time, shared: true do
     File.send(@method, @atime, @mtime, mock_to_path(@file1), mock_to_path(@file2))
   end
 
+  platform_is :darwin do
+    it "accepts a path in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters" do
+      utf8_path = tmp("file_lutime_utf8_path_\u{3042}.txt")
+      # Can fail with UndefinedConversionError if tmp path has non-Shift_JIS chars (e.g. Emojis, Hangul, Cyrillic, accented letters)
+      non_utf8_path = utf8_path.encode(Encoding::Windows_31J)
+
+      begin
+        touch(utf8_path)
+        File.send(@method, @atime, @mtime, non_utf8_path).should == 1
+      ensure
+        rm_r utf8_path
+        rm_r non_utf8_path
+      end
+    end
+  end
+
   it "accepts numeric atime and mtime arguments" do
     if @time_is_float
       File.send(@method, @atime.to_f, @mtime.to_f, @file1, @file2)

--- a/spec/ruby/core/file/stat/new_spec.rb
+++ b/spec/ruby/core/file/stat/new_spec.rb
@@ -29,4 +29,20 @@ describe "File::Stat#initialize" do
     p.should_receive(:to_path).and_return @file
     File::Stat.new p
   end
+
+  platform_is :darwin do
+    it "accepts a path in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters" do
+      utf8_path = tmp("file_stat_new_utf8_path_\u{3042}.txt")
+      # Can fail with UndefinedConversionError if tmp path has non-Shift_JIS chars (e.g. Emojis, Hangul, Cyrillic, accented letters)
+      non_utf8_path = utf8_path.encode(Encoding::Windows_31J)
+
+      begin
+        touch(utf8_path)
+        File::Stat.new(non_utf8_path).should.is_a?(File::Stat)
+      ensure
+        rm_r utf8_path
+        rm_r non_utf8_path
+      end
+    end
+  end
 end

--- a/spec/ruby/core/file/symlink_spec.rb
+++ b/spec/ruby/core/file/symlink_spec.rb
@@ -45,6 +45,24 @@ describe "File.symlink" do
       -> { File.symlink(@file, 1)   }.should.raise(TypeError)
       -> { File.symlink(1, 1)       }.should.raise(TypeError)
     end
+
+    platform_is :darwin do
+      it "accepts a path in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters" do
+        utf8_file = tmp("file_symlink_file_utf8_path_\u{3042}.txt")
+        utf8_link = tmp("file_symlink_link_utf8_path_\u{3042}.txt")
+        # Can fail with UndefinedConversionError if tmp path has non-Shift_JIS chars (e.g. Emojis, Hangul, Cyrillic, accented letters)
+        non_utf8_file = utf8_file.encode(Encoding::Windows_31J)
+        non_utf8_link = utf8_link.encode(Encoding::Windows_31J)
+
+        begin
+          touch(utf8_file)
+          File.symlink(non_utf8_file, non_utf8_link).should == 0
+        ensure
+          rm_r utf8_file, utf8_link
+          rm_r non_utf8_file, non_utf8_link
+        end
+      end
+    end
   end
 end
 

--- a/spec/ruby/core/file/truncate_spec.rb
+++ b/spec/ruby/core/file/truncate_spec.rb
@@ -82,6 +82,22 @@ describe "File.truncate" do
   it "accepts an object that has a #to_path method" do
     File.truncate(mock_to_path(@name), 0).should == 0
   end
+
+  platform_is :darwin do
+    it "accepts a path in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters" do
+      utf8_path = tmp("file_truncate_utf8_path_\u{3042}.txt")
+      # Can fail with UndefinedConversionError if tmp path has non-Shift_JIS chars (e.g. Emojis, Hangul, Cyrillic, accented letters)
+      non_utf8_path = utf8_path.encode(Encoding::Windows_31J)
+
+      begin
+        touch(utf8_path)
+        File.truncate(non_utf8_path, 0).should == 0
+      ensure
+        rm_r utf8_path
+        rm_r non_utf8_path
+      end
+    end
+  end
 end
 
 

--- a/spec/ruby/core/io/binread_spec.rb
+++ b/spec/ruby/core/io/binread_spec.rb
@@ -67,4 +67,20 @@ describe "IO.binread" do
       end
     end
   end
+
+  platform_is :darwin do
+    it "reads a file when given a path string in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters" do
+      utf8_path = tmp("io_binread_utf8_path_\u{3042}.txt")
+      # Can fail with UndefinedConversionError if tmp path has non-Shift_JIS chars (e.g. Emojis, Hangul, Cyrillic, accented letters)
+      non_utf8_path = utf8_path.encode(Encoding::Windows_31J)
+
+      begin
+        File.write(utf8_path, "ok")
+        IO.binread(non_utf8_path).should == "ok".b
+      ensure
+        rm_r utf8_path
+        rm_r non_utf8_path
+      end
+    end
+  end
 end

--- a/spec/ruby/core/io/copy_stream_spec.rb
+++ b/spec/ruby/core/io/copy_stream_spec.rb
@@ -33,6 +33,22 @@ describe :io_copy_stream_to_file, shared: true do
 
     -> { IO.copy_stream(@object.from, obj) }.should.raise(TypeError)
   end
+
+  platform_is :darwin do
+    it "writes to a file when given a path in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters" do
+      utf8_path = tmp("io_read_utf8_path_\u{3042}.txt")
+      # Can fail with UndefinedConversionError if tmp path has non-Shift_JIS chars (e.g. Emojis, Hangul, Cyrillic, accented letters)
+      non_utf8_path = utf8_path.encode(Encoding::Windows_31J)
+
+      begin
+        IO.copy_stream(@object.from, non_utf8_path)
+        File.read(utf8_path).should == @content
+      ensure
+        rm_r utf8_path
+        rm_r non_utf8_path
+      end
+    end
+  end
 end
 
 describe :io_copy_stream_to_file_with_offset, shared: true do
@@ -207,6 +223,23 @@ describe "IO.copy_stream" do
       obj.should_receive(:to_path).and_return(1)
 
       -> { IO.copy_stream(obj, @to_name) }.should.raise(TypeError)
+    end
+
+    platform_is :darwin do
+      it "reads a file when given a path in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters" do
+        utf8_path = tmp("io_read_utf8_path_\u{3042}.txt")
+        # Can fail with UndefinedConversionError if tmp path has non-Shift_JIS chars (e.g. Emojis, Hangul, Cyrillic, accented letters)
+        non_utf8_path = utf8_path.encode(Encoding::Windows_31J)
+
+        begin
+          File.write(utf8_path, @content)
+          IO.copy_stream(non_utf8_path, @to_name)
+          File.read(@to_name).should == @content
+        ensure
+          rm_r utf8_path
+          rm_r non_utf8_path
+        end
+      end
     end
 
     describe "to a file name" do

--- a/spec/ruby/core/io/read_spec.rb
+++ b/spec/ruby/core/io/read_spec.rb
@@ -64,9 +64,6 @@ describe "IO.read" do
     IO.read(@fname, mode: "a+").should == @contents
   end
 
-  platform_is_not :windows do
-  end
-
   it "disregards other options if :open_args is given" do
     string = IO.read(@fname,mode: "w", encoding: Encoding::UTF_32LE, open_args: ["r", encoding: Encoding::UTF_8])
     string.encoding.should == Encoding::UTF_8
@@ -146,6 +143,22 @@ describe "IO.read" do
       # 0x1A is CTRL+Z and is EOF in Windows text mode.
       File.binwrite(@fname, "\x1Abbb")
       IO.read(@fname).should.empty?
+    end
+  end
+
+  platform_is :darwin do
+    it "reads a file when given a path in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters" do
+      utf8_path = tmp("io_read_utf8_path_\u{3042}.txt")
+      # Can fail with UndefinedConversionError if tmp path has non-Shift_JIS chars (e.g. Emojis, Hangul, Cyrillic, accented letters)
+      non_utf8_path = utf8_path.encode(Encoding::Windows_31J)
+
+      begin
+        File.write(utf8_path, "ok")
+        IO.read(non_utf8_path).should == "ok"
+      ensure
+        rm_r utf8_path
+        rm_r non_utf8_path
+      end
     end
   end
 end

--- a/spec/ruby/core/io/reopen_spec.rb
+++ b/spec/ruby/core/io/reopen_spec.rb
@@ -116,6 +116,41 @@ describe "IO#reopen with a String" do
     obj.should_receive(:to_path).and_return(@other_name)
     @io.reopen(obj)
   end
+
+  platform_is :darwin do
+    it "opens a file when given a path in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters" do
+      utf8_path = tmp("io_reopen_utf8_path_\u{3042}.txt")
+      # Can fail with UndefinedConversionError if tmp path has non-Shift_JIS chars (e.g. Emojis, Hangul, Cyrillic, accented letters)
+      non_utf8_path = utf8_path.encode(Encoding::Windows_31J)
+
+      begin
+        File.write(utf8_path, "ok")
+        @io = new_io @other_name, "r"
+        @io.reopen(non_utf8_path, "r")
+        @io.read.should == "ok"
+      ensure
+        rm_r utf8_path
+        rm_r non_utf8_path
+      end
+    end
+
+    it "opens a file when given a path in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters when called on a closed stream" do
+      utf8_path = tmp("io_reopen_utf8_path_closed_\u{3042}.txt")
+      # Can fail with UndefinedConversionError if tmp path has non-Shift_JIS chars (e.g. Emojis, Hangul, Cyrillic, accented letters)
+      non_utf8_path = utf8_path.encode(Encoding::Windows_31J)
+
+      begin
+        File.write(utf8_path, "ok")
+        @io = new_io @other_name, "r"
+        @io.close
+        @io.reopen(non_utf8_path, "r")
+        @io.read.should == "ok"
+      ensure
+        rm_r utf8_path
+        rm_r non_utf8_path
+      end
+    end
+  end
 end
 
 describe "IO#reopen with a String" do

--- a/spec/ruby/core/io/shared/binwrite.rb
+++ b/spec/ruby/core/io/shared/binwrite.rb
@@ -88,4 +88,20 @@ describe :io_binwrite, shared: true do
     IO.send(@method, @filename, "hello, world!", **{})
     File.read(@filename).should == "hello, world!"
   end
+
+  platform_is :darwin do
+    it "writes to a file when given a path in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters" do
+      utf8_path = tmp("io_binwrite_utf8_path_\u{3042}.txt")
+      # Can fail with UndefinedConversionError if tmp path has non-Shift_JIS chars (e.g. Emojis, Hangul, Cyrillic, accented letters)
+      non_utf8_path = utf8_path.encode(Encoding::Windows_31J)
+
+      begin
+        IO.send(@method, non_utf8_path, "ok").should == 2
+        File.read(utf8_path).should == "ok"
+      ensure
+        rm_r utf8_path
+        rm_r non_utf8_path
+      end
+    end
+  end
 end

--- a/spec/ruby/core/io/shared/readlines.rb
+++ b/spec/ruby/core/io/shared/readlines.rb
@@ -22,6 +22,23 @@ describe :io_readlines, shared: true do
     result = IO.send(@method, @name, chomp: true, &@object)
     (result ? result : ScratchPad.recorded).should == IOSpecs.lines_without_newline_characters
   end
+
+  platform_is :darwin do
+    it "reads a file when given a path string in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters" do
+      utf8_path = tmp("io_foreach_utf8_path_\u{3042}.txt")
+      # Can fail with UndefinedConversionError if tmp path has non-Shift_JIS chars (e.g. Emojis, Hangul, Cyrillic, accented letters)
+      non_utf8_path = utf8_path.encode(Encoding::Windows_31J)
+
+      begin
+        File.write(utf8_path, "ok\nline2")
+        result = IO.send(@method, non_utf8_path, &@object)
+        (result ? result : ScratchPad.recorded).should == ["ok\n", "line2"]
+      ensure
+        rm_r utf8_path
+        rm_r non_utf8_path
+      end
+    end
+  end
 end
 
 describe :io_readlines_options_19, shared: true do

--- a/spec/ruby/core/io/sysopen_spec.rb
+++ b/spec/ruby/core/io/sysopen_spec.rb
@@ -47,4 +47,21 @@ describe "IO.sysopen" do
     @fd = IO.sysopen(@filename, nil, nil)
     @fd.should_not.equal?(0)
   end
+
+  platform_is :darwin do
+    it "returns a file descriptor for a given path when a path in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters" do
+      utf8_path = tmp("io_sysopen_utf8_path_\u{3042}.txt")
+      # Can fail with UndefinedConversionError if tmp path has non-Shift_JIS chars (e.g. Emojis, Hangul, Cyrillic, accented letters)
+      non_utf8_path = utf8_path.encode(Encoding::Windows_31J)
+
+      begin
+        @fd = IO.sysopen(non_utf8_path, "w")
+        @fd.should.is_a?(Integer)
+        File.should.exist?(utf8_path)
+      ensure
+        rm_r utf8_path
+        rm_r non_utf8_path
+      end
+    end
+  end
 end

--- a/spec/ruby/shared/file/blockdev.rb
+++ b/spec/ruby/shared/file/blockdev.rb
@@ -6,4 +6,20 @@ describe :file_blockdev, shared: true do
   it "accepts an object that has a #to_path method" do
     @object.send(@method, mock_to_path(tmp(""))).should == false
   end
+
+  platform_is :darwin do
+    it "accepts a path in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters" do
+      utf8_path = tmp("file_predicate_utf8_path_\u{3042}.txt")
+      # Can fail with UndefinedConversionError if tmp path has non-Shift_JIS chars (e.g. Emojis, Hangul, Cyrillic, accented letters)
+      non_utf8_path = utf8_path.encode(Encoding::Windows_31J)
+
+      begin
+        touch(utf8_path)
+        @object.send(@method, non_utf8_path).should == false
+      ensure
+        rm_r utf8_path
+        rm_r non_utf8_path
+      end
+    end
+  end
 end

--- a/spec/ruby/shared/file/chardev.rb
+++ b/spec/ruby/shared/file/chardev.rb
@@ -6,4 +6,20 @@ describe :file_chardev, shared: true do
   it "accepts an object that has a #to_path method" do
     @object.send(@method, mock_to_path(tmp(""))).should == false
   end
+
+  platform_is :darwin do
+    it "accepts a path in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters" do
+      utf8_path = tmp("file_predicate_utf8_path_\u{3042}.txt")
+      # Can fail with UndefinedConversionError if tmp path has non-Shift_JIS chars (e.g. Emojis, Hangul, Cyrillic, accented letters)
+      non_utf8_path = utf8_path.encode(Encoding::Windows_31J)
+
+      begin
+        touch(utf8_path)
+        @object.send(@method, non_utf8_path).should == false
+      ensure
+        rm_r utf8_path
+        rm_r non_utf8_path
+      end
+    end
+  end
 end

--- a/spec/ruby/shared/file/directory.rb
+++ b/spec/ruby/shared/file/directory.rb
@@ -31,6 +31,28 @@ describe :file_directory, shared: true do
   it "raises a TypeError when passed nil" do
     -> { @object.send(@method, nil) }.should.raise(TypeError)
   end
+
+  platform_is :darwin do
+    it "accepts a path in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters" do
+      utf8_path = tmp("file_predicate_utf8_path_\u{3042}.txt")
+      # Can fail with UndefinedConversionError if tmp path has non-Shift_JIS chars (e.g. Emojis, Hangul, Cyrillic, accented letters)
+      non_utf8_path = utf8_path.encode(Encoding::Windows_31J)
+
+      begin
+        touch(utf8_path)
+        @object.send(@method, non_utf8_path).should == false
+
+        rm_r utf8_path
+        rm_r non_utf8_path
+
+        mkdir_p utf8_path
+        @object.send(@method, non_utf8_path).should == true
+      ensure
+        rm_r utf8_path
+        rm_r non_utf8_path
+      end
+    end
+  end
 end
 
 describe :file_directory_io, shared: true do

--- a/spec/ruby/shared/file/executable.rb
+++ b/spec/ruby/shared/file/executable.rb
@@ -40,6 +40,25 @@ describe :file_executable, shared: true do
     -> { @object.send(@method, false) }.should.raise(TypeError)
   end
 
+  platform_is :darwin do
+    it "accepts a path in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters" do
+      utf8_path = tmp("file_predicate_utf8_path_\u{3042}.txt")
+      # Can fail with UndefinedConversionError if tmp path has non-Shift_JIS chars (e.g. Emojis, Hangul, Cyrillic, accented letters)
+      non_utf8_path = utf8_path.encode(Encoding::Windows_31J)
+
+      begin
+        touch(utf8_path)
+        @object.send(@method, non_utf8_path).should == false
+
+        File.chmod(0755, utf8_path)
+        @object.send(@method, non_utf8_path).should == true
+      ensure
+        rm_r utf8_path
+        rm_r non_utf8_path
+      end
+    end
+  end
+
   platform_is_not :windows do
     as_superuser do
       context "when run by a superuser" do

--- a/spec/ruby/shared/file/executable_real.rb
+++ b/spec/ruby/shared/file/executable_real.rb
@@ -38,6 +38,25 @@ describe :file_executable_real, shared: true do
     -> { @object.send(@method, false) }.should.raise(TypeError)
   end
 
+  platform_is :darwin do
+    it "accepts a path in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters" do
+      utf8_path = tmp("file_predicate_utf8_path_\u{3042}.txt")
+      # Can fail with UndefinedConversionError if tmp path has non-Shift_JIS chars (e.g. Emojis, Hangul, Cyrillic, accented letters)
+      non_utf8_path = utf8_path.encode(Encoding::Windows_31J)
+
+      begin
+        touch(utf8_path)
+        @object.send(@method, non_utf8_path).should == false
+
+        File.chmod(0755, utf8_path)
+        @object.send(@method, non_utf8_path).should == true
+      ensure
+        rm_r utf8_path
+        rm_r non_utf8_path
+      end
+    end
+  end
+
   platform_is_not :windows do
     as_real_superuser do
       context "when run by a real superuser" do

--- a/spec/ruby/shared/file/exist.rb
+++ b/spec/ruby/shared/file/exist.rb
@@ -16,4 +16,22 @@ describe :file_exist, shared: true do
   it "accepts an object that has a #to_path method" do
     @object.send(@method, mock_to_path(__FILE__)).should == true
   end
+
+  platform_is :darwin do
+    it "accepts a path in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters" do
+      utf8_path = tmp("file_predicate_utf8_path_\u{3042}.txt")
+      # Can fail with UndefinedConversionError if tmp path has non-Shift_JIS chars (e.g. Emojis, Hangul, Cyrillic, accented letters)
+      non_utf8_path = utf8_path.encode(Encoding::Windows_31J)
+
+      begin
+        @object.send(@method, non_utf8_path).should == false
+
+        touch(utf8_path)
+        @object.send(@method, non_utf8_path).should == true
+      ensure
+        rm_r utf8_path
+        rm_r non_utf8_path
+      end
+    end
+  end
 end

--- a/spec/ruby/shared/file/file.rb
+++ b/spec/ruby/shared/file/file.rb
@@ -27,6 +27,22 @@ describe :file_file, shared: true do
     @object.send(@method, mock_to_path(@file)).should == true
   end
 
+  platform_is :darwin do
+    it "accepts a path in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters" do
+      utf8_path = tmp("file_predicate_utf8_path_\u{3042}.txt")
+      # Can fail with UndefinedConversionError if tmp path has non-Shift_JIS chars (e.g. Emojis, Hangul, Cyrillic, accented letters)
+      non_utf8_path = utf8_path.encode(Encoding::Windows_31J)
+
+      begin
+        touch(utf8_path)
+        @object.send(@method, non_utf8_path).should == true
+      ensure
+        rm_r utf8_path
+        rm_r non_utf8_path
+      end
+    end
+  end
+
   platform_is_not :windows do
     it "returns true if the null device exists and is a regular file." do
       @object.send(@method, @null).should == false # May fail on MS Windows

--- a/spec/ruby/shared/file/grpowned.rb
+++ b/spec/ruby/shared/file/grpowned.rb
@@ -18,6 +18,23 @@ describe :file_grpowned, shared: true do
       @object.send(@method, mock_to_path(@file)).should == true
     end
 
+    platform_is :darwin do
+      it "accepts a path in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters" do
+        utf8_path = tmp("file_predicate_utf8_path_\u{3042}.txt")
+        # Can fail with UndefinedConversionError if tmp path has non-Shift_JIS chars (e.g. Emojis, Hangul, Cyrillic, accented letters)
+        non_utf8_path = utf8_path.encode(Encoding::Windows_31J)
+
+        begin
+          touch(utf8_path)
+          File.chown(nil, Process.gid, utf8_path) rescue nil
+          @object.send(@method, non_utf8_path).should == true
+        ensure
+          rm_r utf8_path
+          rm_r non_utf8_path
+        end
+      end
+    end
+
     it 'takes non primary groups into account' do
       group = (Process.groups - [Process.egid]).first
 

--- a/spec/ruby/shared/file/owned.rb
+++ b/spec/ruby/shared/file/owned.rb
@@ -1,3 +1,19 @@
 describe :file_owned, shared: true do
   it "accepts an object that has a #to_path method"
+
+  platform_is :darwin do
+    it "accepts a path in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters" do
+      utf8_path = tmp("file_predicate_utf8_path_\u{3042}.txt")
+      # Can fail with UndefinedConversionError if tmp path has non-Shift_JIS chars (e.g. Emojis, Hangul, Cyrillic, accented letters)
+      non_utf8_path = utf8_path.encode(Encoding::Windows_31J)
+
+      begin
+        touch(utf8_path)
+        @object.send(@method, non_utf8_path).should == true
+      ensure
+        rm_r utf8_path
+        rm_r non_utf8_path
+      end
+    end
+  end
 end

--- a/spec/ruby/shared/file/pipe.rb
+++ b/spec/ruby/shared/file/pipe.rb
@@ -1,3 +1,19 @@
 describe :file_pipe, shared: true do
   it "accepts an object that has a #to_path method"
+
+platform_is :darwin do
+  it "accepts a path in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters" do
+    utf8_path = tmp("file_predicate_utf8_path_\u{3042}.txt")
+    # Can fail with UndefinedConversionError if tmp path has non-Shift_JIS chars (e.g. Emojis, Hangul, Cyrillic, accented letters)
+    non_utf8_path = utf8_path.encode(Encoding::Windows_31J)
+
+    begin
+      File.mkfifo(utf8_path)
+      @object.send(@method, non_utf8_path).should == true
+    ensure
+      rm_r utf8_path
+      rm_r non_utf8_path
+    end
+  end
+end
 end

--- a/spec/ruby/shared/file/readable.rb
+++ b/spec/ruby/shared/file/readable.rb
@@ -25,6 +25,22 @@ describe :file_readable, shared: true do
     @object.send(@method, mock_to_path(@file2)).should == true
   end
 
+  platform_is :darwin do
+    it "accepts a path in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters" do
+      utf8_path = tmp("file_predicate_utf8_path_\u{3042}.txt")
+      # Can fail with UndefinedConversionError if tmp path has non-Shift_JIS chars (e.g. Emojis, Hangul, Cyrillic, accented letters)
+      non_utf8_path = utf8_path.encode(Encoding::Windows_31J)
+
+      begin
+        touch(utf8_path)
+        @object.send(@method, non_utf8_path).should == true
+      ensure
+        rm_r utf8_path
+        rm_r non_utf8_path
+      end
+    end
+  end
+
   platform_is_not :windows do
     as_superuser do
       context "when run by a superuser" do

--- a/spec/ruby/shared/file/readable_real.rb
+++ b/spec/ruby/shared/file/readable_real.rb
@@ -15,6 +15,22 @@ describe :file_readable_real, shared: true do
     File.open(@file,'w') { @object.send(@method, mock_to_path(@file)).should == true }
   end
 
+  platform_is :darwin do
+    it "accepts a path in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters" do
+      utf8_path = tmp("file_predicate_utf8_path_\u{3042}.txt")
+      # Can fail with UndefinedConversionError if tmp path has non-Shift_JIS chars (e.g. Emojis, Hangul, Cyrillic, accented letters)
+      non_utf8_path = utf8_path.encode(Encoding::Windows_31J)
+
+      begin
+        touch(utf8_path)
+        @object.send(@method, non_utf8_path).should == true
+      ensure
+        rm_r utf8_path
+        rm_r non_utf8_path
+      end
+    end
+  end
+
   platform_is_not :windows do
     as_real_superuser do
       context "when run by a real superuser" do

--- a/spec/ruby/shared/file/setgid.rb
+++ b/spec/ruby/shared/file/setgid.rb
@@ -1,2 +1,18 @@
 describe :file_setgid, shared: true do
+  platform_is :darwin do
+    it "accepts a path in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters" do
+      utf8_path = tmp("file_predicate_utf8_path_\u{3042}.txt")
+      # Can fail with UndefinedConversionError if tmp path has non-Shift_JIS chars (e.g. Emojis, Hangul, Cyrillic, accented letters)
+      non_utf8_path = utf8_path.encode(Encoding::Windows_31J)
+
+      begin
+        touch(utf8_path)
+        system "chmod g+s #{utf8_path}"
+        @object.send(@method, non_utf8_path).should == true
+      ensure
+        rm_r utf8_path
+        rm_r non_utf8_path
+      end
+    end
+  end
 end

--- a/spec/ruby/shared/file/setuid.rb
+++ b/spec/ruby/shared/file/setuid.rb
@@ -1,2 +1,18 @@
 describe :file_setuid, shared: true do
+  platform_is :darwin do
+    it "accepts a path in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters" do
+      utf8_path = tmp("file_predicate_utf8_path_\u{3042}.txt")
+      # Can fail with UndefinedConversionError if tmp path has non-Shift_JIS chars (e.g. Emojis, Hangul, Cyrillic, accented letters)
+      non_utf8_path = utf8_path.encode(Encoding::Windows_31J)
+
+      begin
+        touch(utf8_path)
+        system "chmod u+s #{utf8_path}"
+        @object.send(@method, non_utf8_path).should == true
+      ensure
+        rm_r utf8_path
+        rm_r non_utf8_path
+      end
+    end
+  end
 end

--- a/spec/ruby/shared/file/size.rb
+++ b/spec/ruby/shared/file/size.rb
@@ -22,6 +22,22 @@ describe :file_size, shared: true do
   it "accepts an object that has a #to_path method" do
     @object.send(@method, mock_to_path(@exists)).should == 8
   end
+
+  platform_is :darwin do
+    it "accepts a path in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters" do
+      utf8_path = tmp("file_size_utf8_path_\u{3042}.txt")
+      # Can fail with UndefinedConversionError if tmp path has non-Shift_JIS chars (e.g. Emojis, Hangul, Cyrillic, accented letters)
+      non_utf8_path = utf8_path.encode(Encoding::Windows_31J)
+
+      begin
+        File.write(utf8_path, "ok")
+        @object.send(@method, non_utf8_path).should == 2
+      ensure
+        rm_r utf8_path
+        rm_r non_utf8_path
+      end
+    end
+  end
 end
 
 describe :file_size_to_io, shared: true do

--- a/spec/ruby/shared/file/socket.rb
+++ b/spec/ruby/shared/file/socket.rb
@@ -30,4 +30,21 @@ describe :file_socket, shared: true do
 
     @object.send(@method, obj).should == false
   end
+
+  platform_is :darwin do
+    it "accepts a path in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters" do
+      utf8_path = tmp("utf8_path_\u{3042}.txt")
+      # Can fail with UndefinedConversionError if tmp path has non-Shift_JIS chars (e.g. Emojis, Hangul, Cyrillic, accented letters)
+      non_utf8_path = utf8_path.encode(Encoding::Windows_31J)
+      server = UNIXServer.new(utf8_path)
+
+      begin
+        @object.send(@method, non_utf8_path).should == true
+      ensure
+        server.close
+        rm_r utf8_path
+        rm_r non_utf8_path
+      end
+    end
+  end
 end

--- a/spec/ruby/shared/file/sticky.rb
+++ b/spec/ruby/shared/file/sticky.rb
@@ -18,6 +18,25 @@ describe :file_sticky, shared: true do
   end
 
   it "accepts an object that has a #to_path method"
+
+  platform_is :darwin do
+    it "accepts a path in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters" do
+      utf8_path = tmp("file_predicate_utf8_path_\u{3042}.txt")
+      # Can fail with UndefinedConversionError if tmp path has non-Shift_JIS chars (e.g. Emojis, Hangul, Cyrillic, accented letters)
+      non_utf8_path = utf8_path.encode(Encoding::Windows_31J)
+
+      begin
+        touch(utf8_path)
+        @object.send(@method, non_utf8_path).should == false
+
+        system "chmod +t #{utf8_path}"
+        @object.send(@method, non_utf8_path).should == true
+      ensure
+        rm_r utf8_path
+        rm_r non_utf8_path
+      end
+    end
+  end
 end
 
 describe :file_sticky_missing, shared: true do

--- a/spec/ruby/shared/file/symlink.rb
+++ b/spec/ruby/shared/file/symlink.rb
@@ -22,6 +22,22 @@ describe :file_symlink, shared: true do
       @object.send(@method, mock_to_path(@link)).should == true
     end
   end
+
+  platform_is :darwin do
+    it "accepts a path in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters" do
+      utf8_path = tmp("file_predicate_utf8_path_\u{3042}.txt")
+      # Can fail with UndefinedConversionError if tmp path has non-Shift_JIS chars (e.g. Emojis, Hangul, Cyrillic, accented letters)
+      non_utf8_path = utf8_path.encode(Encoding::Windows_31J)
+      File.symlink(@file, utf8_path)
+
+      begin
+        @object.send(@method, non_utf8_path).should == true
+      ensure
+        rm_r utf8_path
+        rm_r non_utf8_path
+      end
+    end
+  end
 end
 
 describe :file_symlink_nonexistent, shared: true do

--- a/spec/ruby/shared/file/world_readable.rb
+++ b/spec/ruby/shared/file/world_readable.rb
@@ -46,4 +46,21 @@ describe :file_world_readable, shared: true do
   it "coerces the argument with #to_path" do
     @object.world_readable?(mock_to_path(@file))
   end
+
+  platform_is :darwin do
+    it "accepts a path in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters" do
+      utf8_path = tmp("file_predicate_utf8_path_\u{3042}.txt")
+      # Can fail with UndefinedConversionError if tmp path has non-Shift_JIS chars (e.g. Emojis, Hangul, Cyrillic, accented letters)
+      non_utf8_path = utf8_path.encode(Encoding::Windows_31J)
+
+      begin
+        touch(utf8_path)
+        File.chmod(0644, utf8_path)
+        @object.send(@method, non_utf8_path).should.instance_of?(Integer)
+      ensure
+        rm_r utf8_path
+        rm_r non_utf8_path
+      end
+    end
+  end
 end

--- a/spec/ruby/shared/file/world_writable.rb
+++ b/spec/ruby/shared/file/world_writable.rb
@@ -46,4 +46,21 @@ describe :file_world_writable, shared: true do
   it "coerces the argument with #to_path" do
     @object.world_writable?(mock_to_path(@file))
   end
+
+  platform_is :darwin do
+    it "accepts a path in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters" do
+      utf8_path = tmp("file_predicate_utf8_path_\u{3042}.txt")
+      # Can fail with UndefinedConversionError if tmp path has non-Shift_JIS chars (e.g. Emojis, Hangul, Cyrillic, accented letters)
+      non_utf8_path = utf8_path.encode(Encoding::Windows_31J)
+
+      begin
+        touch(utf8_path)
+        File.chmod(0777, utf8_path)
+        @object.send(@method, non_utf8_path).should.instance_of?(Integer)
+      ensure
+        rm_r utf8_path
+        rm_r non_utf8_path
+      end
+    end
+  end
 end

--- a/spec/ruby/shared/file/writable.rb
+++ b/spec/ruby/shared/file/writable.rb
@@ -20,6 +20,22 @@ describe :file_writable, shared: true do
     File.open(@file,'w') { @object.send(@method, mock_to_path(@file)).should == true }
   end
 
+  platform_is :darwin do
+    it "accepts a path in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters" do
+      utf8_path = tmp("file_predicate_utf8_path_\u{3042}.txt")
+      # Can fail with UndefinedConversionError if tmp path has non-Shift_JIS chars (e.g. Emojis, Hangul, Cyrillic, accented letters)
+      non_utf8_path = utf8_path.encode(Encoding::Windows_31J)
+
+      begin
+        touch(utf8_path)
+        @object.send(@method, non_utf8_path).should == true
+      ensure
+        rm_r utf8_path
+        rm_r non_utf8_path
+      end
+    end
+  end
+
   platform_is_not :windows do
     as_superuser do
       context "when run by a superuser" do

--- a/spec/ruby/shared/file/writable_real.rb
+++ b/spec/ruby/shared/file/writable_real.rb
@@ -15,6 +15,22 @@ describe :file_writable_real, shared: true do
     File.open(@file,'w') { @object.send(@method, mock_to_path(@file)).should == true }
   end
 
+  platform_is :darwin do
+    it "accepts a path in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters" do
+      utf8_path = tmp("file_predicate_utf8_path_\u{3042}.txt")
+      # Can fail with UndefinedConversionError if tmp path has non-Shift_JIS chars (e.g. Emojis, Hangul, Cyrillic, accented letters)
+      non_utf8_path = utf8_path.encode(Encoding::Windows_31J)
+
+      begin
+        touch(utf8_path)
+        @object.send(@method, non_utf8_path).should == true
+      ensure
+        rm_r utf8_path
+        rm_r non_utf8_path
+      end
+    end
+  end
+
   it "raises an ArgumentError if not passed one argument" do
     -> { File.writable_real?        }.should.raise(ArgumentError)
   end

--- a/spec/ruby/shared/file/zero.rb
+++ b/spec/ruby/shared/file/zero.rb
@@ -26,6 +26,25 @@ describe :file_zero, shared: true do
     @object.send(@method, mock_to_path(@zero_file)).should == true
   end
 
+  platform_is :darwin do
+    it "accepts a path in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters" do
+      utf8_path = tmp("file_predicate_utf8_path_\u{3042}.txt")
+      # Can fail with UndefinedConversionError if tmp path has non-Shift_JIS chars (e.g. Emojis, Hangul, Cyrillic, accented letters)
+      non_utf8_path = utf8_path.encode(Encoding::Windows_31J)
+
+      begin
+        touch(utf8_path)
+        @object.send(@method, non_utf8_path).should == true
+
+        File.write(utf8_path, "ok")
+        @object.send(@method, non_utf8_path).should == false
+      ensure
+        rm_r utf8_path
+        rm_r non_utf8_path
+      end
+    end
+  end
+
   platform_is :windows do
     it "returns true for NUL" do
       @object.send(@method, 'NUL').should == true

--- a/spec/tags/core/dir/element_reference_tags.txt
+++ b/spec/tags/core/dir/element_reference_tags.txt
@@ -1,1 +1,3 @@
 fails:Dir.[] raises an ArgumentError if sort: is not true or false
+fails:Dir.[] accepts a pattern in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters
+fails:Dir.[] accepts multiple patterns in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters

--- a/spec/tags/core/dir/glob_tags.txt
+++ b/spec/tags/core/dir/glob_tags.txt
@@ -1,1 +1,2 @@
 fails:Dir.glob raises an ArgumentError if sort: is not true or false
+fails:Dir.glob accepts a pattern in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters

--- a/spec/tags/core/file/realpath_tags.txt
+++ b/spec/tags/core/file/realpath_tags.txt
@@ -1,0 +1,1 @@
+fails:File.realpath accepts a path in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters

--- a/spec/tags/core/file/setgid_tags.txt
+++ b/spec/tags/core/file/setgid_tags.txt
@@ -1,1 +1,2 @@
 slow:File.setgid? returns true when the gid bit is set
+slow:File.setgid? accepts a path in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters

--- a/spec/tags/core/file/setuid_tags.txt
+++ b/spec/tags/core/file/setuid_tags.txt
@@ -1,1 +1,2 @@
 slow:File.setuid? returns true when the gid bit is set
+slow:File.setuid? accepts a path in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters

--- a/spec/tags/core/file/stat/setgid_tags.txt
+++ b/spec/tags/core/file/stat/setgid_tags.txt
@@ -1,0 +1,1 @@
+slow:File::Stat#setgid? accepts a path in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters

--- a/spec/tags/core/file/stat/setuid_tags.txt
+++ b/spec/tags/core/file/stat/setuid_tags.txt
@@ -1,0 +1,1 @@
+slow:File::Stat#setuid? accepts a path in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters

--- a/spec/tags/core/file/stat/sticky_tags.txt
+++ b/spec/tags/core/file/stat/sticky_tags.txt
@@ -1,0 +1,1 @@
+slow:File::Stat#sticky? accepts a path in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters

--- a/spec/tags/core/file/sticky_tags.txt
+++ b/spec/tags/core/file/sticky_tags.txt
@@ -1,1 +1,2 @@
 slow:File.sticky? returns true if the file has sticky bit set
+slow:File.sticky? accepts a path in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters

--- a/spec/tags/core/filetest/setgid_tags.txt
+++ b/spec/tags/core/filetest/setgid_tags.txt
@@ -1,0 +1,1 @@
+slow:FileTest.setgid? accepts a path in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters

--- a/spec/tags/core/filetest/setuid_tags.txt
+++ b/spec/tags/core/filetest/setuid_tags.txt
@@ -1,0 +1,1 @@
+slow:FileTest.setuid? accepts a path in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters

--- a/spec/tags/core/filetest/sticky_tags.txt
+++ b/spec/tags/core/filetest/sticky_tags.txt
@@ -1,0 +1,1 @@
+slow:FileTest.sticky? accepts a path in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters

--- a/src/main/ruby/truffleruby/core/dir.rb
+++ b/src/main/ruby/truffleruby/core/dir.rb
@@ -42,7 +42,7 @@ class Dir
   alias_method :to_path, :path
 
   def initialize(path, options = undefined)
-    path = Truffle::Type.coerce_to_path path
+    path = Truffle::Type.coerce_to_path_keep_encoding path
     Errno.handle path unless initialize_internal(path, options)
   end
 
@@ -59,7 +59,8 @@ class Dir
 
     @encoding = enc || Encoding.filesystem
 
-    @ptr = Truffle::POSIX.opendir(path)
+    path_encoded = Truffle::Type.coerce_to_path path
+    @ptr = Truffle::POSIX.opendir(path_encoded)
     @ptr.null? ? nil : self
   end
 
@@ -337,8 +338,12 @@ class Dir
     end
 
     def chdir(path = ENV['HOME'])
-      path = Truffle::Type.coerce_to_path path
+      path = Truffle::Type.coerce_to_path_keep_encoding path
+      # To get a properly-encoded String for Primitive.dir_set_truffle_working_directory
       path = path.dup.force_encoding(Encoding::LOCALE) if path.encoding == Encoding::BINARY
+      path = Truffle::Type.coerce_to_path path
+      # To get a properly-encoded String for Primitive.dir_set_truffle_working_directory
+      path = path.dup.force_encoding(Encoding::UTF_8) if path.encoding == Encoding::BINARY
 
       if block_given?
         original_path = self.getwd
@@ -403,7 +408,8 @@ class Dir
     end
 
     def rmdir(path)
-      ret = Truffle::POSIX.rmdir(Truffle::Type.coerce_to_path(path))
+      path = Truffle::Type.coerce_to_path(path)
+      ret = Truffle::POSIX.rmdir(path)
       Errno.handle path if ret != 0
       ret
     end

--- a/src/main/ruby/truffleruby/core/file.rb
+++ b/src/main/ruby/truffleruby/core/file.rb
@@ -160,7 +160,7 @@ class File < IO
   #  File.basename("/home/gumby/work/ruby.rb")          #=> "ruby.rb"
   #  File.basename("/home/gumby/work/ruby.rb", ".rb")   #=> "ruby"
   def self.basename(path, ext = undefined)
-    path = Truffle::Type.coerce_to_path(path)
+    path = Truffle::Type.coerce_to_path_keep_encoding(path)
 
     slash = '/'
 
@@ -478,7 +478,7 @@ class File < IO
   #  File.extname("test")            #=> ""
   #  File.extname(".profile")        #=> ""
   def self.extname(path)
-    path = Truffle::Type.coerce_to_path(path)
+    path = Truffle::Type.coerce_to_path_keep_encoding(path)
     path_size = path.bytesize
 
     dot_idx = Primitive.find_string_reverse(path, '.', path_size)
@@ -741,8 +741,8 @@ class File < IO
       raise ArgumentError, 'recursive array' if recursion
     else
       # We need to use dup here, since it's possible that
-      # coerce_to_path() gives us a direct object we shouldn't mutate
-      first = Truffle::Type.coerce_to_path(first).dup
+      # coerce_to_path_keep_encoding() gives us a direct object we shouldn't mutate
+      first = Truffle::Type.coerce_to_path_keep_encoding(first).dup
     end
     Truffle::Type.check_null_safe(first)
 
@@ -761,7 +761,7 @@ class File < IO
 
         raise ArgumentError, 'recursive array' if recursion
       else
-        value = Truffle::Type.coerce_to_path(el)
+        value = Truffle::Type.coerce_to_path_keep_encoding(el)
       end
       Truffle::Type.check_null_safe(value)
 
@@ -835,7 +835,7 @@ class File < IO
   end
 
   def self.path(obj)
-    Truffle::Type.coerce_to_path(obj)
+    Truffle::Type.coerce_to_path_keep_encoding(obj)
   end
 
   ##
@@ -1006,7 +1006,7 @@ class File < IO
   #
   #  File.split("/home/gumby/.profile")   #=> ["/home/gumby", ".profile"]
   def self.split(path)
-    p = Truffle::Type.coerce_to_path(path)
+    p = Truffle::Type.coerce_to_path_keep_encoding(path)
     [dirname(p), basename(p)]
   end
 
@@ -1190,7 +1190,7 @@ class File < IO
     if Primitive.is_a?(path_or_fd, Integer)
       super(path_or_fd, mode, **options)
     else
-      path = Truffle::Type.coerce_to_path path_or_fd
+      path = Truffle::Type.coerce_to_path_keep_encoding path_or_fd
       nmode, _binary, _external, _internal, _autoclose, perm = Truffle::IOOperations.normalize_options(mode, perm, options)
       fd = IO.sysopen(path, nmode, perm)
 

--- a/src/main/ruby/truffleruby/core/truffle/file_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/file_operations.rb
@@ -18,7 +18,7 @@ module Truffle
     PrivateDir = ::Dir
 
     def self.expand_path(path, dir, expand_tilde)
-      path = Truffle::Type.coerce_to_path(path)
+      path = Truffle::Type.coerce_to_path_keep_encoding(path)
       str = ''.encode path.encoding
       first = path[0]
       if first == ?~ && expand_tilde

--- a/src/main/ruby/truffleruby/core/type.rb
+++ b/src/main/ruby/truffleruby/core/type.rb
@@ -392,6 +392,12 @@ module Truffle
     end
 
     def self.coerce_to_path(obj, check_null = true)
+      path = coerce_to_path_keep_encoding(obj, check_null)
+      coerce_path_encoding(path)
+    end
+
+    # MRI: FilePathValue/rb_get_path
+    def self.coerce_to_path_keep_encoding(obj, check_null = true)
       if Primitive.is_a?(obj, String)
         path = obj
       else
@@ -407,6 +413,16 @@ module Truffle
       end
       check_null_safe(path) if check_null
       path
+    end
+
+    # MRI: rb_str_encode_ospath
+    def self.coerce_path_encoding(path)
+      return path unless Truffle::Platform.darwin?
+
+      encoding = path.encoding
+      return path if encoding == Encoding::UTF_8 || encoding == Encoding::BINARY
+
+      path.encode(Encoding::UTF_8)
     end
 
     # Convert an object to Symbol (e.g. a method name).


### PR DESCRIPTION
Encode a path parameter in UTF-8 on macOS before passing it to a syscall. On macOS syscalls expect a path to be in UTF-8.

Byte sequences that are invalid UTF-8 strings lead to the following failure (e.g. of the `open` syscall):

```
Errno::EILSEQ: Invalid or incomplete multibyte or wide character - .../truffleruby-ws/truffleruby/rubyspec_temp/40573/5-file_new_utf8_path_��.txt
```

Close #4082

### CRuby notes

In CRuby the logic is implemented in a `rb_str_encode_ospath` helper function.

- [x] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
