### PR TITLE
Update `Hash#==` to take `compare_by_identity` into account

### DIFF
--- a/spec/ruby/core/hash/compare_by_identity_spec.rb
+++ b/spec/ruby/core/hash/compare_by_identity_spec.rb
@@ -80,6 +80,16 @@ describe "Hash#compare_by_identity" do
     @h[o].should == :o
   end
 
+  it "regards two empty hashes equal, even if one isn't compare_by_identity" do
+    @h.should == @idh
+  end
+
+  it "doesn't regard two hashes equal when they differ only by compare_by_identity" do
+    @h[1] = 2
+    @idh[1] = 2
+    @h.should_not == @idh
+  end
+
   it "raises a FrozenError on frozen hashes" do
     @h = @h.freeze
     -> { @h.compare_by_identity }.should.raise(FrozenError)

--- a/spec/tags/core/set/compare_by_identity_tags.txt
+++ b/spec/tags/core/set/compare_by_identity_tags.txt
@@ -1,2 +1,1 @@
-fails:Set#compare_by_identity is not equal to set what does not compare by identity
 fails:Set#compare_by_identity raises a FrozenError on frozen sets

--- a/src/main/ruby/truffleruby/core/hash.rb
+++ b/src/main/ruby/truffleruby/core/hash.rb
@@ -143,6 +143,10 @@ class Hash
     return false unless other.size == size
 
     Truffle::ThreadOperations.detect_pair_recursion self, other do
+      # {} == {}.compare_by_identity but not {a: 1} == {a: 1}.compare_by_identity
+      return true if other.empty? && empty?
+      return false if other.compare_by_identity? != compare_by_identity?
+
       each_pair do |key, value|
         other_value = Primitive.hash_get_or_undefined(other, key)
 


### PR DESCRIPTION
Also fixes a spec in Set since it uses Hash under the hood

- [ ] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
