### PR TITLE
Warn for IO methods when both `encoding` and `{internal,external}_encoding` is given

### DIFF
--- a/spec/ruby/core/io/shared/new.rb
+++ b/spec/ruby/core/io/shared/new.rb
@@ -127,15 +127,15 @@ describe :io_new, shared: true do
 
   it "ignores the :encoding option when the :external_encoding option is present" do
     -> {
-      @io = IO.send(@method, @fd, 'w', external_encoding: 'utf-8', encoding: 'iso-8859-1:iso-8859-1')
-    }.should complain(/Ignoring encoding parameter/)
-    @io.external_encoding.to_s.should == 'UTF-8'
+      @io = IO.send(@method, @fd, 'w', external_encoding: 'ibm866', encoding: 'iso-8859-1:iso-8859-1')
+    }.should complain(/Ignoring encoding parameter 'iso-8859-1:iso-8859-1': external_encoding is used/)
+    @io.external_encoding.to_s.should == 'IBM866'
   end
 
   it "ignores the :encoding option when the :internal_encoding option is present" do
     -> {
       @io = IO.send(@method, @fd, 'w', internal_encoding: 'ibm866', encoding: 'iso-8859-1:iso-8859-1')
-    }.should complain(/Ignoring encoding parameter/)
+    }.should complain(/Ignoring encoding parameter 'iso-8859-1:iso-8859-1': internal_encoding is used/)
     @io.internal_encoding.to_s.should == 'IBM866'
   end
 

--- a/spec/tags/core/io/for_fd_tags.txt
+++ b/spec/tags/core/io/for_fd_tags.txt
@@ -1,3 +1,1 @@
-fails:IO.for_fd ignores the :encoding option when the :external_encoding option is present
-fails:IO.for_fd ignores the :encoding option when the :internal_encoding option is present
 fails:IO.for_fd raises an Errno::EINVAL if the new mode is not compatible with the descriptor's current mode

--- a/spec/tags/core/io/new_tags.txt
+++ b/spec/tags/core/io/new_tags.txt
@@ -1,3 +1,1 @@
-fails:IO.new ignores the :encoding option when the :external_encoding option is present
-fails:IO.new ignores the :encoding option when the :internal_encoding option is present
 fails:IO.new raises an Errno::EINVAL if the new mode is not compatible with the descriptor's current mode

--- a/spec/tags/core/io/open_tags.txt
+++ b/spec/tags/core/io/open_tags.txt
@@ -1,4 +1,2 @@
 fails:IO.open propagates an exception raised by #close that is a StandardError
-fails:IO.open ignores the :encoding option when the :external_encoding option is present
-fails:IO.open ignores the :encoding option when the :internal_encoding option is present
 fails:IO.open raises an Errno::EINVAL if the new mode is not compatible with the descriptor's current mode

--- a/src/main/ruby/truffleruby/core/truffle/io_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/io_operations.rb
@@ -559,6 +559,10 @@ module Truffle
         if !external and !internal
           external = options[:external_encoding]
           internal = options[:internal_encoding]
+          if options[:encoding] && (external || internal)
+            used = external ? 'external_encoding' : 'internal_encoding'
+            warn "Ignoring encoding parameter '#{options[:encoding]}': #{used} is used", uplevel: 1
+          end
         elsif options[:external_encoding] or options[:internal_encoding] or options[:encoding]
           raise ArgumentError, 'encoding specified twice'
         end


### PR DESCRIPTION
Gives some easy spec passes

- [ ] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
