### PR TITLE
Remove `ENV.index`

### DIFF
--- a/spec/tags/truffle/methods_tags.txt
+++ b/spec/tags/truffle/methods_tags.txt
@@ -46,7 +46,6 @@ fails:Public methods on Socket::AncillaryData should include timestamp
 fails:Public methods on Socket::Option should include byte
 fails:Public methods on Socket::Option should include ipv4_multicast_loop
 fails:Public methods on Socket::Option should include ipv4_multicast_ttl
-fails:Public methods on ENV.singleton_class should not include index
 fails:Public methods on Fiber should include backtrace
 fails:Public methods on Fiber should include backtrace_locations
 fails:Public methods on Random should not include bytes

--- a/src/main/ruby/truffleruby/core/env.rb
+++ b/src/main/ruby/truffleruby/core/env.rb
@@ -213,11 +213,6 @@ class << ENV
     params.map { |k| lookup(k) }
   end
 
-  def index(value)
-    warn 'ENV.index is deprecated; use ENV.key', uplevel: 1
-    key(value)
-  end
-
   def invert
     to_hash.invert
   end


### PR DESCRIPTION
Gone since https://github.com/ruby/ruby/commit/12a121cc0f7f5b438388288383a7b8b9baf3e2fe

- [ ] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
