### PR TITLE
Fix the ffi Truffle backend and raise LoadError instead of RuntimeError when a library not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Compatibility:
 * Implement `IO#advise` (#4341, @earlopain).
 * Fix `Process.spawn` and raise `Errno::ENOENT` when called with `chdir` option and a directory doesn't exist (#3825, @andrykonchin).
 * Fix precedence between `RUBYOPT` and CLI switches (#4342, @earlopain).
+* Fix `FFI::DynamicLibrary.open` and raise `LoadError` instead of `RuntimeError` with adjusted message (#4345, @andrykonchin).
 
 Performance:
 

--- a/lib/truffle/truffle/ffi_backend/dynamic_library.rb
+++ b/lib/truffle/truffle/ffi_backend/dynamic_library.rb
@@ -57,9 +57,7 @@ module FFI
       begin
         handle = Primitive.interop_eval_nfi code
       rescue Polyglot::ForeignException => e
-        # Translate to a Ruby exception as it needs to be rescue'd by
-        # `rescue Exception` in FFI::Library#ffi_lib (which is part of the ffi gem)
-        raise RuntimeError, e.message
+        raise LoadError, "Could not open library '#{libname || '[current process]'}': #{e.message}", cause: nil
       end
       DynamicLibrary.new(libname, handle)
     end

--- a/spec/ffi/dynamic_library_spec.rb
+++ b/spec/ffi/dynamic_library_spec.rb
@@ -37,6 +37,12 @@ describe FFI::DynamicLibrary do
     expect(size).to be > base_size
   end
 
+  it "raises LoadError if the library isn't found" do
+    expect do
+      FFI::DynamicLibrary.open("not-exists.so", FFI::DynamicLibrary::RTLD_LAZY | FFI::DynamicLibrary::RTLD_LOCAL)
+    end.to raise_error(LoadError, /Could not open library 'not-exists.so'/)
+  end
+
   describe Symbol do
     before do
       @libtest = FFI::DynamicLibrary.open(


### PR DESCRIPTION
Close #4345

A relevant code in `ffi` gem - https://github.com/ffi/ffi/blob/fc5401e3013d87100df7db4118b3ecd30b06b8e0/ext/ffi_c/DynamicLibrary.c#L148-L154

### Example

```ruby
require "ffi"

FFI::DynamicLibrary.open("libmissing.so", 0)
```

Output:
```
.../truffleruby/mxbuild/truffleruby-jvm/lib/truffle/truffle/ffi_backend/dynamic_library.rb:60:in 'FFI::DynamicLibrary.open': Could not open library 'libmissing.so': dlopen(libmissing.so, 0x0002): tried: 'libmissing.so' (no such file), '/System/Volumes/Preboot/Cryptexes/OSlibmissing.so' (no such file), '/usr/lib/libmissing.so' (no such file, not in dyld cache), 'libmissing.so' (no such file) (LoadError)
	from (irb):26:in '<main>'
	from <internal:core> core/kernel.rb:424:in 'Kernel#loop'
	from <internal:core> core/throw_catch.rb:36:in 'Kernel#catch'
	from .../truffleruby/mxbuild/truffleruby-jvm/lib/gems/gems/irb-1.16.0/exe/irb:9:in '<top (required)>'
	from <internal:core> core/kernel.rb:393:in 'Kernel#load'
	from .../truffleruby/mxbuild/truffleruby-jvm/lib/mri/rubygems.rb:304:in 'Gem.activate_and_load_bin_path'
	from .../truffleruby/mxbuild/truffleruby-jvm/bin/irb:44:in '<main>'
```

- [x] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
