### PR TITLE
Fix repeated enumerations for a handful of `Enumerator::Lazy` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Compatibility:
 * Implement `IO#advise` (#4341, @earlopain).
 * Fix `Process.spawn` and raise `Errno::ENOENT` when called with `chdir` option and a directory doesn't exist (#3825, @andrykonchin).
 * Fix precedence between `RUBYOPT` and CLI switches (#4342, @earlopain).
+* Fix `Enumerator::Lazy#uniq` when doing multiple enumerations (#4357, @earlopain).
 
 Performance:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ Compatibility:
 * Implement `IO#advise` (#4341, @earlopain).
 * Fix `Process.spawn` and raise `Errno::ENOENT` when called with `chdir` option and a directory doesn't exist (#3825, @andrykonchin).
 * Fix precedence between `RUBYOPT` and CLI switches (#4342, @earlopain).
-* Fix `Enumerator::Lazy#uniq` when doing multiple enumerations (#4357, @earlopain).
+* Fix `Enumerator::Lazy#{drop,drop_while,take,uniq,zip}` when doing multiple enumerations (#4357, @earlopain).
 
 Performance:
 

--- a/spec/ruby/core/enumerator/lazy/drop_spec.rb
+++ b/spec/ruby/core/enumerator/lazy/drop_spec.rb
@@ -34,6 +34,14 @@ describe "Enumerator::Lazy#drop" do
     end
   end
 
+  describe "when the returned lazy enumerator is evaluated by .force" do
+    it "return same value when called twice" do
+      lazy = [0, 1].lazy.drop(1)
+      lazy.force.should == [1]
+      lazy.force.should == [1]
+    end
+  end
+
   describe "on a nested Lazy" do
     it "sets difference of given count with old size to new size" do
       Enumerator::Lazy.new(Object.new, 100) {}.drop(20).drop(50).size.should == 30

--- a/spec/ruby/core/enumerator/lazy/drop_while_spec.rb
+++ b/spec/ruby/core/enumerator/lazy/drop_while_spec.rb
@@ -43,6 +43,14 @@ describe "Enumerator::Lazy#drop_while" do
     -> { @yieldsmixed.drop_while }.should.raise(ArgumentError)
   end
 
+  describe "when the returned lazy enumerator is evaluated by .force" do
+    it "return same value when called twice" do
+      lazy = [0, 1, 2, 3].lazy.drop_while { |v| v < 2 }
+      lazy.force.should == [2, 3]
+      lazy.force.should == [2, 3]
+    end
+  end
+
   describe "on a nested Lazy" do
     it "sets #size to nil" do
       Enumerator::Lazy.new(Object.new, 100) {}.take(20).drop_while { |v| v }.size.should == nil

--- a/spec/ruby/core/enumerator/lazy/take_spec.rb
+++ b/spec/ruby/core/enumerator/lazy/take_spec.rb
@@ -49,6 +49,12 @@ describe "Enumerator::Lazy#take" do
       @eventsmixed.take(0).force
       ScratchPad.recorded.should == []
     end
+
+    it "return same value when called twice" do
+      lazy = [0, 1].lazy.take(1)
+      lazy.force.should == [0]
+      lazy.force.should == [0]
+    end
   end
 
   describe "on a nested Lazy" do

--- a/spec/ruby/core/enumerator/lazy/zip_spec.rb
+++ b/spec/ruby/core/enumerator/lazy/zip_spec.rb
@@ -47,6 +47,14 @@ describe "Enumerator::Lazy#zip" do
     -> { @yieldsmixed.zip [], Object.new, [] }.should.raise(TypeError)
   end
 
+  describe "when the returned lazy enumerator is evaluated by .force" do
+    it "return same value when called twice" do
+      lazy = [0, 1].lazy.zip([2, 3])
+      lazy.force.should == [[0, 2], [1, 3]]
+      lazy.force.should == [[0, 2], [1, 3]]
+    end
+  end
+
   describe "on a nested Lazy" do
     it "keeps size" do
       Enumerator::Lazy.new(Object.new, 100) {}.map {}.zip([], []).size.should == 100

--- a/spec/tags/core/enumerator/lazy/uniq_tags.txt
+++ b/spec/tags/core/enumerator/lazy/uniq_tags.txt
@@ -1,3 +1,0 @@
-fails:Enumerator::Lazy#uniq without block return same value after rewind
-fails:Enumerator::Lazy#uniq when yielded with an argument return same value after rewind
-fails:Enumerator::Lazy#uniq when yielded with multiple arguments return same value after rewind

--- a/src/main/ruby/truffleruby/core/enumerator.rb
+++ b/src/main/ruby/truffleruby/core/enumerator.rb
@@ -379,8 +379,6 @@ class Enumerator
       Enumerator.instance_method(:enum_for).bind(self).call(:each) { size }
     end
 
-    # TODO: rewind and/or to_a/force behave improperly on outputs of take, drop, uniq, possibly more
-
     alias_method :force, :to_a
 
     def take(n)
@@ -397,11 +395,12 @@ class Enumerator
 
       return to_enum(:cycle, 0).lazy if n.zero?
 
-      taken = 0
       Lazy.new(self, set_size) do |yielder, *args|
+        taken = yielder.memo || 0
         if taken < n
           yielder.yield(*args)
           taken += 1
+          yielder.memo = taken
           raise StopLazyError unless taken < n
         else
           raise StopLazyError
@@ -420,10 +419,10 @@ class Enumerator
         set_size = current_size
       end
 
-      dropped = 0
       Lazy.new(self, set_size) do |yielder, *args|
+        dropped = yielder.memo || 0
         if dropped < n
-          dropped += 1
+          yielder.memo = dropped + 1
         else
           yielder.yield(*args)
         end
@@ -445,11 +444,11 @@ class Enumerator
     def drop_while
       raise ArgumentError, 'Lazy#drop_while requires a block' unless block_given?
 
-      succeeding = true
       Lazy.new(self, nil) do |yielder, *args|
+        succeeding = Primitive.nil?(yielder.memo) ? true : yielder.memo
         if succeeding
           unless yield(*args)
-            succeeding = false
+            yielder.memo = false
             yielder.yield(*args)
           end
         else
@@ -591,8 +590,8 @@ class Enumerator
         end
       end
 
-      index = 0
       Lazy.new(self, enumerator_size) do |yielder, *args|
+        index = yielder.memo || 0
         val = args.length >= 2 ? args : args.first
         rests = lists.map do |list|
           case list
@@ -607,7 +606,7 @@ class Enumerator
           end
         end
         yielder.yield [val, *rests]
-        index += 1
+        yielder.memo = index + 1
       end
     end
 

--- a/src/main/ruby/truffleruby/core/enumerator.rb
+++ b/src/main/ruby/truffleruby/core/enumerator.rb
@@ -639,23 +639,23 @@ class Enumerator
 
     def uniq
       if block_given?
-        h = {}
         Lazy.new(self, nil) do |yielder, *args|
+          memo = yielder.memo || Set.new
+
           val = args.length >= 2 ? args : args.first
           comp = yield(val)
-          unless h.key?(comp)
-            h[comp] = true
-            yielder.yield(*args)
-          end
+          yielder.yield(*args) if memo.add?(comp)
+
+          yielder.memo = memo
         end
       else
-        h = {}
         Lazy.new(self, nil) do |yielder, *args|
+          memo = yielder.memo || Set.new
+
           val = args.length >= 2 ? args : args.first
-          unless h.key?(val)
-            h[val] = true
-            yielder.yield(*args)
-          end
+          yielder.yield(*args) if memo.add?(val)
+
+          yielder.memo = memo
         end
       end
     end


### PR DESCRIPTION
The value was reused, which resulted in the second call working with stale data.

Also see https://github.com/truffleruby/truffleruby/commit/c2a159bfe88cf586f44d5cc082655b31b5ee5ca3, which did it for `with_index`.

Initially I only did `uniq` since that seems to have been the only one with specs for this but there are also a handful of other methods with the same problem, which I fixed in the second commit.

- [x] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
