### PR TITLE
Fix IO.copy_stream when called with length argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Bug fixes:
 * Fix `rb_catch_obj()` to pass the `data` argument as-is and not assume it's a Ruby object (#4329, @eregon).
 * Fix `rb_proc_new()`, `rb_iterate()`, `rb_exec_recursive()` and `rb_fiber_new()` to pass the callback argument as-is and not assume it's a Ruby object (#4334, @eregon).
 * Fix infinite cause chain when a Ruby exception is raised inside another language and goes back to Ruby (#4233, @eregon).
+* Fix `IO.copy_stream()` when given optional length argument (#3947, @andrykonchin).
 
 Compatibility:
 

--- a/spec/ruby/core/io/copy_stream_spec.rb
+++ b/spec/ruby/core/io/copy_stream_spec.rb
@@ -19,6 +19,11 @@ describe :io_copy_stream_to_file, shared: true do
     File.read(@to_name).should == "Line one"
   end
 
+  it "copies nothing when given 0 bytes length to read" do
+    IO.copy_stream(@object.from, @to_name, 0).should == 0
+    File.read(@to_name).should == ""
+  end
+
   it "calls #to_path to convert on object to a file name" do
     obj = mock("io_copy_stream_to")
     obj.should_receive(:to_path).and_return(@to_name)
@@ -40,6 +45,11 @@ describe :io_copy_stream_to_file_with_offset, shared: true do
     it "copies only length bytes from the offset" do
       IO.copy_stream(@object.from, @to_name, 8, 4).should == 8
       File.read(@to_name).should == " one\n\nLi"
+    end
+
+    it "copies nothing when given 0 bytes length to read" do
+      IO.copy_stream(@object.from, @to_name, 0, 4).should == 0
+      File.read(@to_name).should == ""
     end
   end
 end
@@ -86,6 +96,11 @@ describe :io_copy_stream_to_io, shared: true do
     IO.copy_stream(@object.from, @to_io, 8).should == 8
     File.read(@to_name).should == "Line one"
   end
+
+  it "copies nothing when given 0 bytes length to read" do
+    IO.copy_stream(@object.from, @to_io, 0).should == 0
+    File.read(@to_name).should == ""
+  end
 end
 
 describe :io_copy_stream_to_io_with_offset, shared: true do
@@ -93,6 +108,11 @@ describe :io_copy_stream_to_io_with_offset, shared: true do
     it "copies only length bytes from the offset" do
       IO.copy_stream(@object.from, @to_io, 8, 4).should == 8
       File.read(@to_name).should == " one\n\nLi"
+    end
+
+    it "copies nothing when given 0 bytes length to read" do
+      IO.copy_stream(@object.from, @to_io, 0, 4).should == 0
+      File.read(@to_name).should == ""
     end
   end
 end
@@ -305,8 +325,9 @@ describe "IO.copy_stream" do
       from = mock("io_copy_stream_to_object_zero_length_read")
       to = mock("io_copy_stream_to_object_zero_length_write")
       from.should_not_receive(:read)
+      from.should_not_receive(:readpartial)
       to.should_not_receive(:write)
-      IO.copy_stream(from, to, 0)
+      IO.copy_stream(from, to, 0).should == 0
     end
   end
 

--- a/spec/ruby/core/io/copy_stream_spec.rb
+++ b/spec/ruby/core/io/copy_stream_spec.rb
@@ -349,3 +349,31 @@ describe "IO.copy_stream" do
     end
   end
 end
+
+describe "IO.copy_stream" do
+  context "given length" do
+    it "calls #read/#readpartial with remaining bytes count" do
+      input = +"abcdefghijklmnopqrstuvwxyz"
+      read_maxlens = []
+      from = Object.new
+      from.define_singleton_method(:read) do |maxlen, buf = nil|
+        read_maxlens << maxlen
+        bytes_to_read = read_maxlens.size == 1 ? 5 : maxlen
+        bytes = input.slice!(0, bytes_to_read)
+        buf.replace(bytes) if buf
+        bytes
+      end
+
+      output = +""
+      to = Object.new
+      to.define_singleton_method(:write) do |bytes|
+        output << bytes
+        bytes.bytesize
+      end
+
+      IO.copy_stream(from, to, 12).should == 12
+      read_maxlens.should == [12, 7]
+      output.should == "abcdefghijkl"
+    end
+  end
+end

--- a/spec/ruby/core/io/copy_stream_spec.rb
+++ b/spec/ruby/core/io/copy_stream_spec.rb
@@ -24,6 +24,24 @@ describe :io_copy_stream_to_file, shared: true do
     File.read(@to_name).should == ""
   end
 
+  it "calls #to_int to convert length" do
+    length = mock("length")
+    length.should_receive(:to_int).and_return(8)
+    IO.copy_stream(@object.from, @to_name, length).should == 8
+    File.read(@to_name).should == "Line one"
+  end
+
+  it "raises a TypeError if #to_int does not return an Integer" do
+    length = mock("length")
+    length.should_receive(:to_int).and_return("8")
+    -> { IO.copy_stream(@object.from, @to_name, length) }.should.raise(TypeError)
+  end
+
+  it "raises a TypeError if passed an object that does not respond to #to_int" do
+    length = mock("length")
+    -> { IO.copy_stream(@object.from, @to_name, length) }.should.raise(TypeError)
+  end
+
   it "calls #to_path to convert on object to a file name" do
     obj = mock("io_copy_stream_to")
     obj.should_receive(:to_path).and_return(@to_name)
@@ -50,6 +68,24 @@ describe :io_copy_stream_to_file_with_offset, shared: true do
     it "copies nothing when given 0 bytes length to read" do
       IO.copy_stream(@object.from, @to_name, 0, 4).should == 0
       File.read(@to_name).should == ""
+    end
+
+    it "calls #to_int to convert the offset" do
+      offset = mock("offset")
+      offset.should_receive(:to_int).and_return(4)
+      IO.copy_stream(@object.from, @to_name, 8, offset).should == 8
+      File.read(@to_name).should == " one\n\nLi"
+    end
+
+    it "raises a TypeError if #to_int does not return an Integer" do
+      offset = mock("offset")
+      offset.should_receive(:to_int).and_return("4")
+      -> { IO.copy_stream(@object.from, @to_name, 8, offset) }.should.raise(TypeError)
+    end
+
+    it "raises a TypeError if passed an object that does not respond to #to_int" do
+      offset = mock("offset")
+      -> { IO.copy_stream(@object.from, @to_name, 8, offset) }.should.raise(TypeError)
     end
   end
 end
@@ -101,6 +137,24 @@ describe :io_copy_stream_to_io, shared: true do
     IO.copy_stream(@object.from, @to_io, 0).should == 0
     File.read(@to_name).should == ""
   end
+
+  it "calls #to_int to convert length" do
+    length = mock("length")
+    length.should_receive(:to_int).and_return(8)
+    IO.copy_stream(@object.from, @to_io, length).should == 8
+    File.read(@to_name).should == "Line one"
+  end
+
+  it "raises a TypeError if #to_int does not return an Integer" do
+    length = mock("length")
+    length.should_receive(:to_int).and_return("8")
+    -> { IO.copy_stream(@object.from, @to_io, length) }.should.raise(TypeError)
+  end
+
+  it "raises a TypeError if passed an object that does not respond to #to_int" do
+    length = mock("length")
+    -> { IO.copy_stream(@object.from, @to_io, length) }.should.raise(TypeError)
+  end
 end
 
 describe :io_copy_stream_to_io_with_offset, shared: true do
@@ -113,6 +167,24 @@ describe :io_copy_stream_to_io_with_offset, shared: true do
     it "copies nothing when given 0 bytes length to read" do
       IO.copy_stream(@object.from, @to_io, 0, 4).should == 0
       File.read(@to_name).should == ""
+    end
+
+    it "calls #to_int to convert the offset" do
+      offset = mock("offset")
+      offset.should_receive(:to_int).and_return(4)
+      IO.copy_stream(@object.from, @to_io, 8, offset).should == 8
+      File.read(@to_name).should == " one\n\nLi"
+    end
+
+    it "raises a TypeError if #to_int does not return an Integer" do
+      offset = mock("offset")
+      offset.should_receive(:to_int).and_return("4")
+      -> { IO.copy_stream(@object.from, @to_io, 8, offset) }.should.raise(TypeError)
+    end
+
+    it "raises a TypeError if passed an object that does not respond to #to_int" do
+      offset = mock("offset")
+      -> { IO.copy_stream(@object.from, @to_io, 8, offset) }.should.raise(TypeError)
     end
   end
 end

--- a/spec/tags/core/io/copy_stream_tags.txt
+++ b/spec/tags/core/io/copy_stream_tags.txt
@@ -1,2 +1,1 @@
 slow:IO.copy_stream does not use buffering when writing to STDOUT
-fails:IO.copy_stream with non-IO Objects does not call #read on the source or #write on the destination if zero length is given

--- a/src/main/ruby/truffleruby/core/io.rb
+++ b/src/main/ruby/truffleruby/core/io.rb
@@ -350,8 +350,8 @@ class IO
 
   class StreamCopier
     def initialize(from, to, length, offset)
-      @length = length
-      @offset = offset
+      @length = length && Primitive.convert_type(length, Integer, :to_int)
+      @offset = offset && Primitive.convert_type(offset, Integer, :to_int)
 
       @from_io, @from = to_io(from, 'rb')
       @to_io, @to = to_io(to, 'wb')

--- a/src/main/ruby/truffleruby/core/io.rb
+++ b/src/main/ruby/truffleruby/core/io.rb
@@ -402,12 +402,18 @@ class IO
 
       begin
         # Use the buffer form here like MRI, since read/readpartial might be defined by the user
+        # IO#read returns nil at the end of input, IO#readpartial raises EOFError.
         while data = @from.__send__(@method, size, +'')
           @to.write data
           @to.flush if Primitive.is_a?(@to, IO)
           bytes += data.bytesize
 
-          break if @length && bytes >= @length
+          if @length
+            break if bytes == @length
+            raise "read more bytes than expected with #{@method}" if bytes > @length
+
+            size = @length - bytes
+          end
         end
       rescue EOFError
         nil # done reading

--- a/src/main/ruby/truffleruby/core/io.rb
+++ b/src/main/ruby/truffleruby/core/io.rb
@@ -397,6 +397,8 @@ class IO
         @from.seek @offset, IO::SEEK_CUR
       end
 
+      return 0 if @length == 0
+
       size = @length || InternalBuffer::DEFAULT_READ_SIZE
       bytes = 0
 


### PR DESCRIPTION
Fixed `IO.copy_stream` when called with `length` argument:

```ruby
IO.copy_stream(io_from, io_to, 1024)
```

Close #3947

### Conclusion

The issue happened when multiple `#read`/`#readpartial` calls are made in order to read all the available bytes (if the first call doesn't return asked `length` bytes). All the calls are being made with the same `maxlen` parameter (the given `length`) but not with the remaining to read bytes count. So the last call reads  more bytes than was asked and consequently more bytes are written into the `to` io.

### Testing

After the PR merging we can run tests against truffleruby-head on Rubygems' fork CI (https://github.com/andrykonchin/rubygems/pull/1).

Locally I have run all the commands from the `install-rubygems` job (mentioned in the reported GitHub issue) and ensured they pass now (with disabled Rubygems workaround ).

Before the fix (with disabled workaround) the first command failed.

<details>

```
ruby -Ilib -S rake install
  Successfully built RubyGem
  Name: rubygems-update
  Version: 4.1.0.dev
  File: rubygems-update-4.1.0.dev.gem
Successfully installed rubygems-update-4.1.0.dev
1 gem installed
/Users/andrii/projects/truffleruby-ws/truffleruby/mxbuild/truffleruby-jvm/lib/gems/gems/rubygems-update-4.1.0.dev/lib/rubygems/platform.rb:393:in '<top (required)>': undefined local variable or method 'lib' for #<Object:0x8> (NameError)
	from <internal:core> core/kernel.rb:288:in 'Kernel#require_relative'
	from /Users/andrii/projects/truffleruby-ws/truffleruby/mxbuild/truffleruby-jvm/lib/gems/gems/rubygems-update-4.1.0.dev/lib/rubygems/specification.rb:12:in '<top (required)>'
	from <internal:core> core/kernel.rb:251:in 'Kernel#require'
	from /Users/andrii/projects/truffleruby-ws/truffleruby/mxbuild/truffleruby-jvm/lib/patches/rubygems/specification.rb:14:in '<top (required)>'
	from <internal:core> core/kernel.rb:288:in 'Kernel#require_relative'
	from /Users/andrii/projects/truffleruby-ws/truffleruby/mxbuild/truffleruby-jvm/lib/gems/gems/rubygems-update-4.1.0.dev/lib/rubygems.rb:1433:in '<top (required)>'
	from <internal:core> core/kernel.rb:251:in 'Kernel#require'
	from /Users/andrii/projects/truffleruby-ws/truffleruby/mxbuild/truffleruby-jvm/lib/patches/rubygems.rb:8:in '<top (required)>'
	from <internal:core> core/kernel.rb:251:in 'Kernel#require'
	from setup.rb:25:in '<main>'
rake aborted!
Command failed with status (1): [ruby -Ilib exe/gem install --no-document pkg/rubygems-update-4.1.0.dev.gem --backtrace && update_rubygems --no-document --backtrace]
/Users/andrii/projects/truffleruby-ws/truffleruby-gem-tracker-gems/rubygems/rakefile:214:in 'block in <top (required)>'
/Users/andrii/projects/truffleruby-ws/truffleruby-gem-tracker-gems/rubygems/lib/rubygems.rb:306:in 'Gem.activate_and_load_bin_path'
Tasks: TOP => install
(See full trace by running task with --trace)
```
</details>

After the fix it pass.

<details>

```
ruby -Ilib -S rake install
  Successfully built RubyGem
  Name: rubygems-update
  Version: 4.1.0.dev
  File: rubygems-update-4.1.0.dev.gem
Successfully installed rubygems-update-4.1.0.dev
1 gem installed
  Successfully built RubyGem
  Name: bundler
  Version: 4.1.0.dev
  File: bundler-4.1.0.dev.gem
Bundler 4.1.0.dev installed
RubyGems 4.1.0.dev installed
Regenerating binstubs
Regenerating plugins

## 4.0.15 / 2026-06-24
...
------------------------------------------------------------------------------

RubyGems installed the following executables:
	/Users/andrii/projects/truffleruby-ws/truffleruby/mxbuild/truffleruby-jvm/bin/gem
	/Users/andrii/projects/truffleruby-ws/truffleruby/mxbuild/truffleruby-jvm/bin/bundle
	/Users/andrii/projects/truffleruby-ws/truffleruby/mxbuild/truffleruby-jvm/bin/bundler
```
</details>

- [x] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
