### PR TITLE
Warn for all deprecated global variable setters

### DIFF
--- a/spec/tags/language/predefined_tags.txt
+++ b/spec/tags/language/predefined_tags.txt
@@ -6,6 +6,3 @@ slow:The predefined global constant ARGV contains Strings encoded in locale Enco
 slow:Global variable $0 is the path given as the main script and the same as __FILE__
 slow:Global variable $? is thread-local
 slow:Global variable $0 actually sets the program name
-fails:Predefined global $/ warns if assigned non-nil
-fails:Predefined global $-0 warns if assigned non-nil
-fails:Predefined global $\ warns if assigned non-nil

--- a/src/main/ruby/truffleruby/core/truffle/kernel_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/kernel_operations.rb
@@ -80,10 +80,11 @@ module Truffle
         if v && !Primitive.is_a?(v, String)
           raise TypeError, "value of #{name} must be String"
         end
+        warn "non-nil '#{name}' is deprecated", uplevel: 1, category: :deprecated if !Primitive.nil?(v)
         Primitive.global_variable_set :$/, v ? -v.to_s : v
       })
 
-    $/ = "\n".freeze
+    Primitive.global_variable_set :$/, "\n".freeze
 
     define_hooked_variable(
       :$\,
@@ -92,6 +93,7 @@ module Truffle
         if v && !Primitive.is_a?(v, String)
           raise TypeError, "value of #{name} must be String"
         end
+        warn "non-nil '#{name}' is deprecated", uplevel: 1, category: :deprecated if !Primitive.nil?(v)
         Primitive.global_variable_set :$\, v
       })
 
@@ -99,7 +101,7 @@ module Truffle
 
     Truffle::Boot.delay do
       if Truffle::Boot.get_option 'chomp-loop'
-        $\ = $/
+        Primitive.global_variable_set :$\, $/
       end
     end
 
@@ -112,7 +114,7 @@ module Truffle
         if v && !Primitive.is_a?(v, String)
           raise TypeError, "value of #{name} must be String"
         end
-        warn "'#{name}' is deprecated", uplevel: 1 if !Primitive.nil?(v) && Warning[:deprecated]
+        warn "non-nil '#{name}' is deprecated", uplevel: 1, category: :deprecated if !Primitive.nil?(v)
         Primitive.global_variable_set :$,, v
       })
 

--- a/src/main/ruby/truffleruby/core/truffle/kernel_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/kernel_operations.rb
@@ -244,15 +244,5 @@ module Truffle
       end
       [omit, length]
     end
-
-    KERNEL_FROZEN = Kernel.instance_method(:frozen?)
-    private_constant :KERNEL_FROZEN
-
-    # Returns whether the value is frozen, even if the value's class does not include `Kernel`.
-    def self.value_frozen?(value)
-      KERNEL_FROZEN.bind(value).call
-    end
-
-    # To get the class even if the value's class does not include `Kernel`, use `Primitive.class`.
   end
 end


### PR DESCRIPTION
Only `$,` already did. `$/` is non-nil by default, so directly use `global_variable_set` to skip the hook

- [ ] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
