### PR TITLE
Update `rb_io_maybe_wait` and similar to latest

### DIFF
--- a/lib/cext/include/truffleruby/truffleruby-abi-version.h
+++ b/lib/cext/include/truffleruby/truffleruby-abi-version.h
@@ -26,6 +26,6 @@
 // and cannot reach the same version while having different ABI
 // ($TRUFFLERUBY_VERSION is never the same as $RUBY_VERSION).
 
-#define TRUFFLERUBY_ABI_VERSION "4.0.2.5"
+#define TRUFFLERUBY_ABI_VERSION "4.0.2.6"
 
 #endif

--- a/lib/truffle/truffle/cext_constants.rb
+++ b/lib/truffle/truffle/cext_constants.rb
@@ -216,6 +216,10 @@ module Truffle::CExt
     IOError
   end
 
+  def rb_eIOTimeoutError
+    IO::TimeoutError
+  end
+
   def rb_eKeyError
     KeyError
   end

--- a/spec/ruby/optional/capi/ext/io_spec.c
+++ b/spec/ruby/optional/capi/ext/io_spec.c
@@ -370,6 +370,10 @@ static VALUE io_spec_rb_io_open_descriptor_without_encoding(VALUE self, VALUE kl
   return rb_io_open_descriptor(klass, FIX2INT(descriptor), FIX2INT(mode), path, timeout, NULL);
 }
 
+static VALUE io_spec_rb_eIOTimeoutError(VALUE self) {
+  return rb_eIOTimeoutError;
+}
+
 void Init_io_spec(void) {
   VALUE cls = rb_define_class("CApiIOSpecs", rb_cObject);
   rb_define_method(cls, "GetOpenFile_fd", io_spec_GetOpenFile_fd, 1);
@@ -409,6 +413,7 @@ void Init_io_spec(void) {
   rb_define_method(cls, "rb_io_closed_p", io_spec_rb_io_closed_p, 1);
   rb_define_method(cls, "rb_io_open_descriptor", io_spec_rb_io_open_descriptor, 9);
   rb_define_method(cls, "rb_io_open_descriptor_without_encoding", io_spec_rb_io_open_descriptor_without_encoding, 5);
+  rb_define_method(cls, "rb_eIOTimeoutError", io_spec_rb_eIOTimeoutError, 0);
   rb_define_const(cls, "FMODE_READABLE", INT2FIX(FMODE_READABLE));
   rb_define_const(cls, "FMODE_WRITABLE", INT2FIX(FMODE_WRITABLE));
   rb_define_const(cls, "FMODE_BINMODE", INT2FIX(FMODE_BINMODE));

--- a/spec/ruby/optional/capi/io_spec.rb
+++ b/spec/ruby/optional/capi/io_spec.rb
@@ -319,6 +319,14 @@ describe "C-API IO function" do
       -> { @o.rb_io_maybe_wait_writable(0, IO.allocate, nil) }.should.raise(IOError, "uninitialized stream")
     end
 
+    ruby_version_is "3.4" do
+      it "raises a IO::TimeoutError if the timeout elapses" do
+        IOSpec.exhaust_write_buffer(@w_io)
+        -> { @o.rb_io_maybe_wait_writable(Errno::EAGAIN::Errno, @w_io, 0) }.
+          should.raise(IO::TimeoutError, "Timed out waiting for IO to become writable!")
+      end
+    end
+
     it "can be interrupted" do
       IOSpec.exhaust_write_buffer(@w_io)
       start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
@@ -430,6 +438,13 @@ describe "C-API IO function" do
 
       it "raises an IOError if the IO is not initialized" do
         -> { @o.rb_io_maybe_wait_readable(0, IO.allocate, nil, false) }.should.raise(IOError, "uninitialized stream")
+      end
+
+      ruby_version_is "3.4" do
+        it "raises a IO::TimeoutError if the timeout elapses" do
+          -> { @o.rb_io_maybe_wait_readable(Errno::EAGAIN::Errno, @r_io, 0, false) }.
+            should.raise(IO::TimeoutError, "Timed out waiting for IO to become readable!")
+        end
       end
     end
   end
@@ -823,5 +838,9 @@ describe "rb_io_t modes flags" do
       io.sync = false
       @o.rb_io_mode_sync_flag(io).should == false
     }
+  end
+
+  specify "rb_eIOTimeoutError references the IO::TimeoutError class" do
+    @o.rb_eIOTimeoutError.should == IO::TimeoutError
   end
 end

--- a/spec/tags/optional/capi/io_tags.txt
+++ b/spec/tags/optional/capi/io_tags.txt
@@ -3,4 +3,3 @@ fails:C-API IO function rb_io_maybe_wait_readable raises an IOError if the IO is
 fails:C-API IO function rb_io_maybe_wait raises an IOError if the IO is not initialized
 fails:C-API IO function rb_io_open_descriptor sets the specified timeout
 fails:C-API IO function rb_io_open_descriptor ignores the IO open options
-fails:C-API IO function rb_io_maybe_wait returns nil if there is no error condition

--- a/src/main/c/cext-trampoline/cext_constants.c
+++ b/src/main/c/cext-trampoline/cext_constants.c
@@ -87,6 +87,7 @@ VALUE rb_eSystemExit;
 VALUE rb_eSysStackError;
 VALUE rb_eTypeError;
 VALUE rb_eThreadError;
+VALUE rb_eIOTimeoutError;
 VALUE rb_mWaitReadable;
 VALUE rb_mWaitWritable;
 VALUE rb_eZeroDivError;
@@ -168,6 +169,7 @@ void rb_tr_trampoline_init_global_constants(VALUE (*get_constant)(const char*)) 
   rb_eSysStackError = get_constant("rb_eSysStackError");
   rb_eTypeError = get_constant("rb_eTypeError");
   rb_eThreadError = get_constant("rb_eThreadError");
+  rb_eIOTimeoutError = get_constant("rb_eIOTimeoutError");
   rb_mWaitReadable = get_constant("rb_mWaitReadable");
   rb_mWaitWritable = get_constant("rb_mWaitWritable");
   rb_eZeroDivError = get_constant("rb_eZeroDivError");

--- a/src/main/c/cext/cext_constants.c
+++ b/src/main/c/cext/cext_constants.c
@@ -87,6 +87,7 @@ VALUE rb_eSystemExit;
 VALUE rb_eSysStackError;
 VALUE rb_eTypeError;
 VALUE rb_eThreadError;
+VALUE rb_eIOTimeoutError;
 VALUE rb_mWaitReadable;
 VALUE rb_mWaitWritable;
 VALUE rb_eZeroDivError;
@@ -168,6 +169,7 @@ void rb_tr_init_global_constants(VALUE (*get_constant)(const char*)) {
   rb_eSysStackError = get_constant("rb_eSysStackError");
   rb_eTypeError = get_constant("rb_eTypeError");
   rb_eThreadError = get_constant("rb_eThreadError");
+  rb_eIOTimeoutError = get_constant("rb_eIOTimeoutError");
   rb_mWaitReadable = get_constant("rb_mWaitReadable");
   rb_mWaitWritable = get_constant("rb_mWaitWritable");
   rb_eZeroDivError = get_constant("rb_eZeroDivError");

--- a/src/main/c/cext/io.c
+++ b/src/main/c/cext/io.c
@@ -230,8 +230,8 @@ VALUE rb_io_maybe_wait(int error, VALUE io, VALUE events, VALUE timeout) {
   // In old Linux, several special files under /proc and /sys don't handle
   // select properly. Thus we need avoid to call if don't use O_NONBLOCK.
   // Otherwise, we face nasty hang up. Sigh.
-  // e.g. http://git.kernel.org/?p=linux/kernel/git/torvalds/linux-2.6.git;a=commit;h=31b07093c44a7a442394d44423e21d783f5523b8
-  // http://git.kernel.org/?p=linux/kernel/git/torvalds/linux-2.6.git;a=commit;h=31b07093c44a7a442394d44423e21d783f5523b8
+  // e.g. https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=31b07093c44a7a442394d44423e21d783f5523b8
+  // https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=31b07093c44a7a442394d44423e21d783f5523b8
   // In EINTR case, we only need to call RUBY_VM_CHECK_INTS_BLOCKING().
   // Then rb_thread_check_ints() is enough.
   case EINTR:
@@ -253,7 +253,7 @@ VALUE rb_io_maybe_wait(int error, VALUE io, VALUE events, VALUE timeout) {
 
   default:
     // Non-specific error, no event is ready:
-    return Qfalse;
+    return Qnil;
   }
 }
 
@@ -263,9 +263,11 @@ int rb_io_maybe_wait_readable(int error, VALUE io, VALUE timeout) {
   if (RTEST(result)) {
     return RB_NUM2INT(result);
   }
-  else {
-    return 0;
+  else if (result == RUBY_Qfalse) {
+    rb_raise(rb_eIOTimeoutError, "Timed out waiting for IO to become readable!");
   }
+
+  return 0;
 }
 
 int rb_io_maybe_wait_writable(int error, VALUE io, VALUE timeout) {
@@ -274,9 +276,11 @@ int rb_io_maybe_wait_writable(int error, VALUE io, VALUE timeout) {
   if (RTEST(result)) {
     return RB_NUM2INT(result);
   }
-  else {
-    return 0;
+  else if (result == RUBY_Qfalse) {
+    rb_raise(rb_eIOTimeoutError, "Timed out waiting for IO to become writable!");
   }
+
+  return 0;
 }
 
 VALUE rb_io_addstr(VALUE io, VALUE str) {

--- a/tool/generate-cext-constants.rb
+++ b/tool/generate-cext-constants.rb
@@ -88,6 +88,7 @@ constants = [
     [SystemStackError, 'SysStackError'],
     TypeError,
     ThreadError,
+    [IO::TimeoutError, "IOTimeoutError"],
     IO::WaitReadable,
     IO::WaitWritable,
     [ZeroDivisionError, 'ZeroDivError'],


### PR DESCRIPTION
They appear to be a 1:1 copy of the CRuby equivalent, so I simply updated them

Initially changed in https://github.com/ruby/ruby/commit/c878843b2cb8fd54ebfaabd10b6334cf4d400208

Also define `rb_eIOTimeoutError`. That actually comes from `ruby/io.h`, so I didn't put it in `ConstantsSpecs`.

- [ ] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
