### PR TITLE
Fix some IO read specs

### DIFF
--- a/spec/ruby/core/io/read_spec.rb
+++ b/spec/ruby/core/io/read_spec.rb
@@ -45,11 +45,11 @@ describe "IO.read" do
   end
 
   it "raises an IOError if the options Hash specifies write mode" do
-    -> { IO.read(@fname, 3, 0, mode: "w") }.should.raise(IOError)
+    -> { IO.read(@fname, 3, 0, mode: "w") }.should.raise(IOError, "not opened for reading")
   end
 
   it "raises an IOError if the options Hash specifies append only mode" do
-    -> { IO.read(@fname, mode: "a") }.should.raise(IOError)
+    -> { IO.read(@fname, mode: "a") }.should.raise(IOError, "not opened for reading")
   end
 
   it "reads the file if the options Hash includes read mode" do
@@ -119,16 +119,16 @@ describe "IO.read" do
   end
 
   it "raises a TypeError when not passed a String type" do
-    -> { IO.read nil }.should.raise(TypeError)
+    -> { IO.read nil }.should raise_consistent_error(TypeError, "no implicit conversion of nil into String")
   end
 
   it "raises an ArgumentError when not passed a valid length" do
-    -> { IO.read @fname, -1 }.should.raise(ArgumentError)
+    -> { IO.read @fname, -1 }.should.raise(ArgumentError, "negative length -1 given")
   end
 
   it "raises an ArgumentError when not passed a valid offset" do
-    -> { IO.read @fname, 0, -1  }.should.raise(ArgumentError)
-    -> { IO.read @fname, -1, -1 }.should.raise(ArgumentError)
+    -> { IO.read @fname, 0, -1  }.should.raise(ArgumentError, "negative offset -1 given")
+    -> { IO.read @fname, -1, -1 }.should.raise(ArgumentError, "negative offset -1 given")
   end
 
   it "uses the external encoding specified via the :external_encoding option" do
@@ -275,29 +275,32 @@ describe "IO#read" do
   end
 
   it "raises an ArgumentError when not passed a valid length" do
-    -> { @io.read(-1) }.should.raise(ArgumentError)
+    -> { @io.read(-1) }.should.raise(ArgumentError, "negative length -1 given")
   end
 
   it "clears the output buffer if there is nothing to read" do
-    @io.pos = 10
-
     buf = +'non-empty string'
-
+    @io.pos = 10
     @io.read(10, buf).should == nil
 
     buf.should == ''
 
     buf = +'non-empty string'
-
+    @io.pos = 10
     @io.read(nil, buf).should == ""
 
     buf.should == ''
 
     buf = +'non-empty string'
-
+    @io.pos = 10
     @io.read(0, buf).should == ""
 
     buf.should == ''
+  end
+
+  it "returns the empty string when there is nothing to read and lenght=0 is given" do
+    @io.read(11)
+    @io.read(0).should == ""
   end
 
   it "raise FrozenError if the output buffer is frozen" do
@@ -428,11 +431,11 @@ describe "IO#read" do
   end
 
   it "raises IOError on closed stream" do
-    -> { IOSpecs.closed_io.read }.should.raise(IOError)
+    -> { IOSpecs.closed_io.read }.should.raise(IOError, "closed stream")
   end
 
   it "raises ArgumentError when length is less than 0" do
-    -> { @io.read(-1) }.should.raise(ArgumentError)
+    -> { @io.read(-1) }.should.raise(ArgumentError, "negative length -1 given")
   end
 
   platform_is_not :windows do

--- a/spec/tags/core/io/read_tags.txt
+++ b/spec/tags/core/io/read_tags.txt
@@ -1,5 +1,1 @@
-fails:IO.read from a pipe opens a pipe to a fork if the rest is -
 keep(hangs):IO#read raises IOError when stream is closed by another thread
-fails:IO#read clears the output buffer if there is nothing to read
-fails:IO.read raises an ArgumentError when not passed a valid offset
-fails:IO.read from a pipe warns about deprecation

--- a/src/main/ruby/truffleruby/core/io.rb
+++ b/src/main/ruby/truffleruby/core/io.rb
@@ -518,11 +518,11 @@ class IO
     name = Truffle::Type.coerce_to_path name
 
     offset = Primitive.convert_with_to_int(offset || 0)
-    raise Errno::EINVAL, 'offset must not be negative' if offset < 0
+    raise ArgumentError, "negative offset #{offset} given" if offset < 0
 
     unless Primitive.nil?(length)
       length = Primitive.convert_with_to_int(length)
-      raise ArgumentError, 'length must not be negative' if length < 0
+      raise ArgumentError, "negative length #{length} given" if length < 0
     end
 
     if Primitive.nil?(options[:open_args])
@@ -1691,7 +1691,11 @@ class IO
     ensure_open_and_readable
     buffer = Primitive.convert_with_to_str(buffer) if buffer
 
-    unless length
+    case length
+    when 0
+      buffer&.clear
+      return ''.b
+    when nil
       str = IO.read_encode self, read_all
       return str unless buffer
 
@@ -1705,7 +1709,7 @@ class IO
       return nil
     end
 
-    raise ArgumentError, 'length must not be negative' if length < 0
+    raise ArgumentError, "negative length #{length} given" if length < 0
 
     str = +''
     needed = length


### PR DESCRIPTION
`io.read(0)` should return the empty string even if the io is exhausted.

Also do misc error message changes, and raise ArgumentError instead of `Errno::EINVAL` for `IO.read`

Reset the buffer position in that one spec back to what it was initially. The spec failed in truffleruby but it didn't really test what it said it did since the buffer went from not exhausted to exhausted after repeated `read` calls.

Two of the removed tags are for behaviour that doesn't apply to 4.0 anymore, so removing them is free.

- [ ] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
