### PR TITLE
Implement `Process.getsid`

### DIFF
--- a/spec/tags/core/process/setsid_tags.txt
+++ b/spec/tags/core/process/setsid_tags.txt
@@ -1,1 +1,1 @@
-fails:Process.setsid establishes this process as a new session and process group leader
+slow:Process.setsid establishes this process as a new session and process group leader

--- a/src/main/ruby/truffleruby/core/posix.rb
+++ b/src/main/ruby/truffleruby/core/posix.rb
@@ -273,6 +273,7 @@ module Truffle::POSIX
   attach_function :getpgid, [:pid_t], :pid_t
   attach_function :setpgid, [:pid_t, :pid_t], :int
   attach_function :setsid, [], :pid_t
+  attach_function :getsid, [:pid_t], :pid_t
 
   attach_function :getgroups, [:int, :pointer], :int
   attach_function :setgroups, [:size_t, :pointer], :int

--- a/src/main/ruby/truffleruby/core/process.rb
+++ b/src/main/ruby/truffleruby/core/process.rb
@@ -236,9 +236,17 @@ module Process
   end
 
   def setsid
-    pgid = Truffle::POSIX.setsid
-    Errno.handle if pgid == -1
-    pgid
+    sid = Truffle::POSIX.setsid
+    Errno.handle if sid == -1
+    sid
+  end
+
+  def getsid(pid = Process.pid)
+    pid = Primitive.convert_with_to_int pid
+
+    sid = Truffle::POSIX.getsid(pid)
+    Errno.handle if sid == -1
+    sid
   end
 
   def self.fork


### PR DESCRIPTION
The setter is already imlpemented, this is pretty much the same.

Specs don't have it individually, it's tested via set/get combo.

https://docs.ruby-lang.org/en/4.0/Process.html#method-c-getsid

- [ ] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
