### PR TITLE
Fix result encoding in File.{dirname,realpath,realdirpath} and Dir.{[],glob}

### DIFF
--- a/spec/ruby/core/dir/element_reference_spec.rb
+++ b/spec/ruby/core/dir/element_reference_spec.rb
@@ -31,6 +31,13 @@ describe "Dir.[]" do
     Dir[pat1, pat2].should == %w[file_one.ext file_two.ext]
   end
 
+  it "preserves the encoding of the path" do
+    pattern1 = "file_one.ext".encode(Encoding::EUC_JP)
+    pattern2 = "file_two.ext".encode(Encoding::EUC_JP)
+    results = Dir[pattern1, pattern2]
+    results.map(&:encoding).should == [Encoding::EUC_JP, Encoding::EUC_JP]
+  end
+
   platform_is :darwin do
     it "accepts multiple patterns in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters" do
       dir = tmp("dir_glob_\u{3042}")

--- a/spec/ruby/core/dir/glob_spec.rb
+++ b/spec/ruby/core/dir/glob_spec.rb
@@ -359,4 +359,9 @@ describe "Dir.glob" do
       Dir.glob('**/*/nondotfile').sort.should == expected
     end
   end
+
+  it "preserves the encoding of the path" do
+    pattern = "file_one.ext".encode(Encoding::EUC_JP)
+    Dir.glob(pattern).first.encoding.should == Encoding::EUC_JP
+  end
 end

--- a/spec/ruby/core/file/absolute_path_spec.rb
+++ b/spec/ruby/core/file/absolute_path_spec.rb
@@ -91,4 +91,10 @@ describe "File.absolute_path" do
   it "calls #to_path on its argument" do
     File.absolute_path(mock_to_path(@abs)).should == @abs
   end
+
+  it "preserves the encoding of the path" do
+    path = "foo/bar".encode(Encoding::EUC_JP)
+    File.absolute_path(path).encoding.should == Encoding::EUC_JP
+    File.absolute_path(path, "dir".encode(Encoding::EUC_JP)).encoding.should == Encoding::EUC_JP
+  end
 end

--- a/spec/ruby/core/file/basename_spec.rb
+++ b/spec/ruby/core/file/basename_spec.rb
@@ -180,12 +180,6 @@ describe "File.basename" do
     File.basename('/path/Офис.m4a').should == "Офис.m4a"
   end
 
-  it "returns the basename with the same encoding as the original" do
-    basename = File.basename('C:/Users/Scuby Pagrubý'.encode(Encoding::Windows_1250))
-    basename.should == 'Scuby Pagrubý'.encode(Encoding::Windows_1250)
-    basename.encoding.should == Encoding::Windows_1250
-  end
-
   it "returns a new unfrozen String" do
     exts = [nil, '.rb', '.*', '.txt']
     ['foo.rb','//', '/test/', 'test'].each do |example|
@@ -202,4 +196,10 @@ describe "File.basename" do
     end
   end
 
+  it "preserves the encoding of the path" do
+    path = "foo.bar".encode(Encoding::EUC_JP)
+    File.basename(path).encoding.should == Encoding::EUC_JP
+    File.basename(path, ".bar").encoding.should == Encoding::EUC_JP
+    File.basename(path, ".bar".encode(Encoding::EUC_JP)).encoding.should == Encoding::EUC_JP
+  end
 end

--- a/spec/ruby/core/file/dirname_spec.rb
+++ b/spec/ruby/core/file/dirname_spec.rb
@@ -167,4 +167,9 @@ describe "File.dirname" do
       File.dirname("C:/foo/bar//").should == "C:/foo"
     end
   end
+
+  it "preserves the encoding of the path" do
+    path = "foo/bar".encode(Encoding::EUC_JP)
+    File.dirname(path).encoding.should == Encoding::EUC_JP
+  end
 end

--- a/spec/ruby/core/file/expand_path_spec.rb
+++ b/spec/ruby/core/file/expand_path_spec.rb
@@ -134,7 +134,7 @@ describe "File.expand_path" do
     end
   end
 
-  it "returns a String in the same encoding as the argument" do
+  it "preserves the encoding of the path" do
     Encoding.default_external = Encoding::SHIFT_JIS
 
     path = "./a".dup.force_encoding Encoding::CP1251

--- a/spec/ruby/core/file/extname_spec.rb
+++ b/spec/ruby/core/file/extname_spec.rb
@@ -73,4 +73,8 @@ describe "File.extname" do
     File.extname('Имя.m4a').should == ".m4a"
   end
 
+  it "preserves the encoding of the path" do
+    path = "foo.bar".encode(Encoding::EUC_JP)
+    File.extname(path).encoding.should == Encoding::EUC_JP
+  end
 end

--- a/spec/ruby/core/file/join_spec.rb
+++ b/spec/ruby/core/file/join_spec.rb
@@ -145,4 +145,10 @@ describe "File.join" do
       e.message.should == 'string contains null byte'
     }
   end
+
+  it "preserves the encoding of the path" do
+    path1 = "foo".encode(Encoding::EUC_JP)
+    path2 = "bar".encode(Encoding::EUC_JP)
+    File.join(path1, path2).encoding.should == Encoding::EUC_JP
+  end
 end

--- a/spec/ruby/core/file/path_spec.rb
+++ b/spec/ruby/core/file/path_spec.rb
@@ -79,4 +79,9 @@ describe "File.path" do
     path.should_receive(:to_path).and_return("abc".encode(Encoding::UTF_32BE))
     -> { File.path(path) }.should.raise Encoding::CompatibilityError
   end
+
+  it "preserves the encoding of the path" do
+    path = "abc".encode(Encoding::EUC_JP)
+    File.path(path).encoding.should == Encoding::EUC_JP
+  end
 end

--- a/spec/ruby/core/file/realdirpath_spec.rb
+++ b/spec/ruby/core/file/realdirpath_spec.rb
@@ -119,3 +119,12 @@ platform_is :windows do
     end
   end
 end
+
+describe "File.realdirpath" do
+  it "preserves the encoding of the path" do
+    path = __FILE__.encode(Encoding::EUC_JP)
+    File.realdirpath(path).encoding.should == Encoding::EUC_JP
+    dir = File.dirname(__FILE__).encode(Encoding::EUC_JP)
+    File.realdirpath(File.basename(path), dir).encoding.should == Encoding::EUC_JP
+  end
+end

--- a/spec/ruby/core/file/realdirpath_spec.rb
+++ b/spec/ruby/core/file/realdirpath_spec.rb
@@ -127,4 +127,18 @@ describe "File.realdirpath" do
     dir = File.dirname(__FILE__).encode(Encoding::EUC_JP)
     File.realdirpath(File.basename(path), dir).encoding.should == Encoding::EUC_JP
   end
+
+  platform_is_not :windows do
+    it "retains the filesystem encoding when encoding conversion fails" do
+      dir = tmp("realdirpath_あ")
+      mkdir_p(dir)
+      begin
+        resolved = File.realdirpath(".".encode(Encoding::ISO_8859_1), dir)
+        resolved.encoding.should == Encoding.find("filesystem")
+        resolved.b.should.include?(dir.b)
+      ensure
+        rm_r dir
+      end
+    end
+  end
 end

--- a/spec/ruby/core/file/realpath_spec.rb
+++ b/spec/ruby/core/file/realpath_spec.rb
@@ -121,4 +121,18 @@ describe "File.realpath" do
     dir = File.dirname(__FILE__).encode(Encoding::EUC_JP)
     File.realpath(File.basename(path), dir).encoding.should == Encoding::EUC_JP
   end
+
+  platform_is_not :windows do
+    it "forces the encoding of the path when encoding conversion fails" do
+      dir = tmp("realpath_あ")
+      mkdir_p(dir)
+      begin
+        resolved = File.realpath(".".encode(Encoding::ISO_8859_1), dir)
+        resolved.encoding.should == Encoding::ISO_8859_1
+        resolved.b.should.include?(dir.b)
+      ensure
+        rm_r dir
+      end
+    end
+  end
 end

--- a/spec/ruby/core/file/realpath_spec.rb
+++ b/spec/ruby/core/file/realpath_spec.rb
@@ -113,3 +113,12 @@ platform_is :windows do
     end
   end
 end
+
+describe "File.realpath" do
+  it "preserves the encoding of the path" do
+    path = __FILE__.encode(Encoding::EUC_JP)
+    File.realpath(path).encoding.should == Encoding::EUC_JP
+    dir = File.dirname(__FILE__).encode(Encoding::EUC_JP)
+    File.realpath(File.basename(path), dir).encoding.should == Encoding::EUC_JP
+  end
+end

--- a/spec/ruby/core/file/split_spec.rb
+++ b/spec/ruby/core/file/split_spec.rb
@@ -61,4 +61,11 @@ describe "File.split" do
   it "accepts an object that has a #to_path method" do
     File.split(mock_to_path("")).should == [".", ""]
   end
+
+  it "preserves the encoding of the path" do
+    path = "/foo/bar".encode(Encoding::EUC_JP)
+    dir, file = File.split(path)
+    dir.encoding.should == Encoding::EUC_JP
+    file.encoding.should == Encoding::EUC_JP
+  end
 end

--- a/spec/tags/core/dir/element_reference_tags.txt
+++ b/spec/tags/core/dir/element_reference_tags.txt
@@ -1,2 +1,0 @@
-fails:Dir.[] accepts a pattern in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters
-fails:Dir.[] accepts multiple patterns in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters

--- a/spec/tags/core/dir/glob_tags.txt
+++ b/spec/tags/core/dir/glob_tags.txt
@@ -1,1 +1,0 @@
-fails:Dir.glob accepts a pattern in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters

--- a/spec/tags/core/file/realpath_tags.txt
+++ b/spec/tags/core/file/realpath_tags.txt
@@ -1,1 +1,0 @@
-fails:File.realpath accepts a path in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters

--- a/src/main/java/org/truffleruby/core/string/StringNodes.java
+++ b/src/main/java/org/truffleruby/core/string/StringNodes.java
@@ -1081,6 +1081,7 @@ public abstract class StringNodes {
 
         protected abstract RubyString execute(Object string, RubyEncoding other);
 
+        @NeverDefault
         public static ForceEncodingNode create() {
             return StringNodesFactory.ForceEncodingNodeFactory.create(null);
         }

--- a/src/main/java/org/truffleruby/core/string/StringPrimitiveNodes.java
+++ b/src/main/java/org/truffleruby/core/string/StringPrimitiveNodes.java
@@ -118,6 +118,7 @@ import org.truffleruby.core.format.unpack.UnpackCompiler;
 import org.truffleruby.core.proc.RubyProc;
 import org.truffleruby.core.string.StringHelperNodes.SingleByteOptimizableNode;
 import org.truffleruby.core.string.StringHelperNodes.ToMutableTruffleStringNode;
+import org.truffleruby.core.string.StringNodes.ForceEncodingNode;
 import org.truffleruby.core.support.RubyByteArray;
 import org.truffleruby.core.symbol.RubySymbol;
 import org.truffleruby.interop.ToJavaStringNode;
@@ -126,6 +127,8 @@ import org.truffleruby.language.NotProvided;
 import org.truffleruby.language.RubyBaseNode;
 import org.truffleruby.language.control.DeferredRaiseException;
 import org.truffleruby.language.control.RaiseException;
+import org.truffleruby.language.dispatch.DispatchNode;
+import org.truffleruby.language.objects.IsFrozenNode;
 import org.truffleruby.language.library.RubyStringLibrary;
 import org.truffleruby.language.yield.CallBlockNode;
 
@@ -2583,6 +2586,63 @@ public abstract class StringPrimitiveNodes {
             var tstring = libString.getTString(this, string);
             return isCharacterHeadNode.execute(enc, tstring, byteOffset);
         }
+    }
+
+    /** Changes the encoding of a string. Tries to mutate the string in-place if mutable, otherwise allocates a new
+     * string copy with the target encoding. */
+    @Primitive(name = "string_with_encoding!")
+    public abstract static class StringWithEncodingPrimitiveNode extends PrimitiveArrayArgumentsNode {
+
+        @Specialization(guards = "!isFrozenNode.execute(string)")
+        static Object withEncoding(Object string, RubyEncoding toEncoding,
+                @Cached @Shared IsFrozenNode isFrozenNode,
+                @Cached @Shared RubyStringLibrary libString,
+                @Cached @Shared GetByteCodeRangeNode codeRangeNode,
+                @Cached(neverDefault = true) @Shared ForceEncodingNode forceEncodingNode,
+                @Cached @Shared DispatchNode stringEncodeNode,
+                @Bind Node node) {
+            var encoding = libString.getEncoding(node, string);
+
+            if (encoding == toEncoding) {
+                return string;
+            }
+
+            var tstring = libString.getTString(node, string);
+            boolean is7Bit = StringGuards.is7Bit(tstring, encoding, codeRangeNode);
+
+            if (is7Bit && toEncoding.isAsciiCompatible) {
+                return forceEncodingNode.execute(string, toEncoding);
+            }
+
+            return stringEncodeNode.call(string, "encode!", toEncoding);
+        }
+
+        @Specialization(guards = "isFrozenNode.execute(string)")
+        static Object withEncodingFrozen(Object string, RubyEncoding toEncoding,
+                @Cached @Shared IsFrozenNode isFrozenNode,
+                @Cached @Shared RubyStringLibrary libString,
+                @Cached AsTruffleStringNode asTruffleStringNode,
+                @Cached @Shared GetByteCodeRangeNode codeRangeNode,
+                @Cached(neverDefault = true) @Shared ForceEncodingNode forceEncodingNode,
+                @Cached @Shared DispatchNode stringEncodeNode,
+                @Bind Node node) {
+            var encoding = libString.getEncoding(node, string);
+
+            if (encoding == toEncoding) {
+                return string;
+            }
+
+            var tstring = libString.getTString(node, string);
+            boolean is7Bit = StringGuards.is7Bit(tstring, encoding, codeRangeNode);
+
+            if (is7Bit && toEncoding.isAsciiCompatible) {
+                var copy = createStringCopy(node, asTruffleStringNode, tstring, encoding);
+                return forceEncodingNode.execute(copy, toEncoding);
+            }
+
+            return stringEncodeNode.call(string, "encode", toEncoding);
+        }
+
     }
 
 }

--- a/src/main/java/org/truffleruby/core/string/StringPrimitiveNodes.java
+++ b/src/main/java/org/truffleruby/core/string/StringPrimitiveNodes.java
@@ -118,7 +118,6 @@ import org.truffleruby.core.format.unpack.UnpackCompiler;
 import org.truffleruby.core.proc.RubyProc;
 import org.truffleruby.core.string.StringHelperNodes.SingleByteOptimizableNode;
 import org.truffleruby.core.string.StringHelperNodes.ToMutableTruffleStringNode;
-import org.truffleruby.core.string.StringNodes.ForceEncodingNode;
 import org.truffleruby.core.support.RubyByteArray;
 import org.truffleruby.core.symbol.RubySymbol;
 import org.truffleruby.interop.ToJavaStringNode;
@@ -2588,61 +2587,42 @@ public abstract class StringPrimitiveNodes {
         }
     }
 
-    /** Changes the encoding of a string. Tries to mutate the string in-place if mutable, otherwise allocates a new
-     * string copy with the target encoding. */
+    /** Changes the encoding of a string with String#encode semantics. Tries to mutate the string in-place if mutable,
+     * otherwise allocates a new string copy with the target encoding. */
     @Primitive(name = "string_with_encoding!")
     public abstract static class StringWithEncodingPrimitiveNode extends PrimitiveArrayArgumentsNode {
 
-        @Specialization(guards = "!isFrozenNode.execute(string)")
-        static Object withEncoding(Object string, RubyEncoding toEncoding,
-                @Cached @Shared IsFrozenNode isFrozenNode,
-                @Cached @Shared RubyStringLibrary libString,
-                @Cached @Shared GetByteCodeRangeNode codeRangeNode,
-                @Cached(neverDefault = true) @Shared ForceEncodingNode forceEncodingNode,
-                @Cached @Shared DispatchNode stringEncodeNode,
-                @Bind Node node) {
-            var encoding = libString.getEncoding(node, string);
-
-            if (encoding == toEncoding) {
-                return string;
-            }
-
-            var tstring = libString.getTString(node, string);
-            boolean is7Bit = StringGuards.is7Bit(tstring, encoding, codeRangeNode);
-
-            if (is7Bit && toEncoding.isAsciiCompatible) {
-                return forceEncodingNode.execute(string, toEncoding);
-            }
-
-            return stringEncodeNode.call(string, "encode!", toEncoding);
-        }
-
-        @Specialization(guards = "isFrozenNode.execute(string)")
-        static Object withEncodingFrozen(Object string, RubyEncoding toEncoding,
-                @Cached @Shared IsFrozenNode isFrozenNode,
-                @Cached @Shared RubyStringLibrary libString,
+        @Specialization
+        Object withEncoding(Object string, RubyEncoding toEncoding,
+                @Cached RubyStringLibrary libString,
+                @Cached InlinedConditionProfile isSameEncodingProfile,
+                @Cached GetByteCodeRangeNode codeRangeNode,
+                @Cached InlinedConditionProfile isAsciiOnlyProfile,
                 @Cached AsTruffleStringNode asTruffleStringNode,
-                @Cached @Shared GetByteCodeRangeNode codeRangeNode,
-                @Cached(neverDefault = true) @Shared ForceEncodingNode forceEncodingNode,
-                @Cached @Shared DispatchNode stringEncodeNode,
-                @Bind Node node) {
-            var encoding = libString.getEncoding(node, string);
+                @Cached IsFrozenNode isFrozenNode,
+                @Cached InlinedConditionProfile isFrozenProfile,
+                @Cached StringNodes.ForceEncodingNode forceEncodingNode,
+                @Cached DispatchNode stringEncodeNode) {
+            var encoding = libString.getEncoding(this, string);
 
-            if (encoding == toEncoding) {
+            if (isSameEncodingProfile.profile(this, encoding == toEncoding)) {
                 return string;
             }
 
-            var tstring = libString.getTString(node, string);
+            var tstring = libString.getTString(this, string);
             boolean is7Bit = StringGuards.is7Bit(tstring, encoding, codeRangeNode);
 
-            if (is7Bit && toEncoding.isAsciiCompatible) {
-                var copy = createStringCopy(node, asTruffleStringNode, tstring, encoding);
-                return forceEncodingNode.execute(copy, toEncoding);
+            if (isAsciiOnlyProfile.profile(this, is7Bit && toEncoding.isAsciiCompatible)) {
+                Object stringToModify = string;
+                if (isFrozenProfile.profile(this, isFrozenNode.execute(string))) {
+                    stringToModify = createStringCopy(asTruffleStringNode, tstring, encoding);
+                }
+                // Since the String is ASCII-only and toEncoding is ASCII-compatible, we can just use #force_encoding
+                return forceEncodingNode.execute(stringToModify, toEncoding);
             }
 
             return stringEncodeNode.call(string, "encode", toEncoding);
         }
-
     }
 
 }

--- a/src/main/ruby/truffleruby/core/array.rb
+++ b/src/main/ruby/truffleruby/core/array.rb
@@ -615,7 +615,7 @@ class Array
   Primitive.always_split self, :insert
 
   def inspect
-    return '[]'.encode(Encoding::US_ASCII) if empty?
+    return Primitive.string_with_encoding!('[]', Encoding::US_ASCII) if empty?
     result = +'['
 
     return +'[...]' if Truffle::ThreadOperations.detect_recursion self do
@@ -669,7 +669,7 @@ class Array
   end
 
   def join(sep = nil)
-    return ''.encode(Encoding::US_ASCII) if size == 0
+    return Primitive.string_with_encoding!('', Encoding::US_ASCII) if size == 0
 
     out = +''
     raise ArgumentError, 'recursive array join' if Truffle::ThreadOperations.detect_recursion self do

--- a/src/main/ruby/truffleruby/core/dir.rb
+++ b/src/main/ruby/truffleruby/core/dir.rb
@@ -308,7 +308,13 @@ class Dir
 
         total = matches.size
         while index < total
-          matches[index] = matches[index].force_encoding(enc) unless matches[index].encoding == enc
+          unless matches[index].encoding == enc
+            begin
+              matches[index].encode!(enc)
+            rescue EncodingError
+              matches[index].force_encoding(enc)
+            end
+          end
           index += 1
         end
       end

--- a/src/main/ruby/truffleruby/core/dir.rb
+++ b/src/main/ruby/truffleruby/core/dir.rb
@@ -264,7 +264,7 @@ class Dir
 
     def [](*patterns, base: nil, sort: true)
       if patterns.size == 1
-        pattern = Truffle::Type.coerce_to_path(patterns[0], false)
+        pattern = Truffle::Type.coerce_to_path_keep_encoding(patterns[0], false)
         return [] if pattern.empty?
         raise ArgumentError, 'nul-separated glob pattern is deprecated' if pattern.include? "\0"
         patterns = [pattern]
@@ -277,7 +277,7 @@ class Dir
       if Primitive.is_a?(pattern, Array)
         patterns = pattern
       else
-        pattern = Truffle::Type.coerce_to_path(pattern, false)
+        pattern = Truffle::Type.coerce_to_path_keep_encoding(pattern, false)
 
         return [] if pattern.empty?
         raise ArgumentError, 'nul-separated glob pattern is deprecated' if pattern.include? "\0"
@@ -297,12 +297,13 @@ class Dir
                         end
 
       patterns.each do |pat|
-        pat = Truffle::Type.coerce_to_path pat
+        pat = Truffle::Type.coerce_to_path_keep_encoding pat
         enc = Primitive.encoding_compatible? pat, Encoding::US_ASCII
         unless enc
           enc_name = Truffle::EncodingOperations.name_for_inspect(pat.encoding)
           raise Encoding::CompatibilityError, "incompatible character encodings: #{enc_name} and US-ASCII"
         end
+        pat = Truffle::Type.coerce_path_encoding pat
         Dir::Glob.glob normalized_base, pat, flags, matches
 
         total = matches.size

--- a/src/main/ruby/truffleruby/core/dir.rb
+++ b/src/main/ruby/truffleruby/core/dir.rb
@@ -310,7 +310,7 @@ class Dir
         while index < total
           unless matches[index].encoding == enc
             begin
-              matches[index].encode!(enc)
+              matches[index] = Primitive.string_with_encoding!(matches[index], enc)
             rescue EncodingError
               matches[index].force_encoding(enc)
             end

--- a/src/main/ruby/truffleruby/core/file.rb
+++ b/src/main/ruby/truffleruby/core/file.rb
@@ -409,24 +409,26 @@ class File < IO
   #
   #  File.dirname("/home/gumby/work/ruby.rb")   #=> "/home/gumby/work"
   def self.dirname(path, level = 1)
-    path = Truffle::Type.coerce_to_path(path)
+    path = Truffle::Type.coerce_to_path_keep_encoding(path)
+    path_encoding = path.encoding
+    path = Truffle::Type.coerce_path_encoding(path)
     level = Primitive.rb_num2int(level)
 
     raise ArgumentError, "negative level: #{level}" if level < 0
-    return path if level == 0
+    return path.encode(path_encoding) if level == 0
 
     # fast path
     if level == 1
-      return +'.' if path.empty?
-      return Truffle::FileOperations.dirname(path)
+      return '.'.encode(path_encoding) if path.empty?
+      return Truffle::FileOperations.dirname(path).encode(path_encoding)
     end
 
     level.times do
-      return +'.' if path.empty?
+      return '.'.encode(path_encoding) if path.empty?
       path = Truffle::FileOperations.dirname(path)
     end
 
-    path
+    path.encode(path_encoding)
   end
 
   ##
@@ -876,7 +878,9 @@ class File < IO
   end
 
   def self.realpath(path, basedir = nil)
-    path = Truffle::Type.coerce_to_path(path)
+    path = Truffle::Type.coerce_to_path_keep_encoding(path)
+    path_encoding = path.encoding
+    path = Truffle::Type.coerce_path_encoding(path)
 
     unless absolute_path?(path)
       path = expand_path(path, basedir)
@@ -897,10 +901,12 @@ class File < IO
       raise Errno::ENOENT, real
     end
 
-    real
+    real.encode(path_encoding)
   end
 
   def self.realdirpath(path, basedir = nil)
+    path = Truffle::Type.coerce_to_path_keep_encoding(path)
+    path_encoding = path.encoding
     real = basic_realpath path, basedir
     dir = dirname real
 
@@ -908,7 +914,7 @@ class File < IO
       raise Errno::ENOENT, real
     end
 
-    real
+    real.encode(path_encoding)
   end
 
   def self.basic_realpath(path, basedir = nil)

--- a/src/main/ruby/truffleruby/core/file.rb
+++ b/src/main/ruby/truffleruby/core/file.rb
@@ -889,7 +889,7 @@ class File < IO
     buffer = Primitive.io_thread_buffer_allocate(Truffle::Platform::PATH_MAX)
     begin
       if ptr = Truffle::POSIX.realpath(path, buffer) and !ptr.null?
-        real = ptr.read_string
+        real = ptr.read_string.force_encoding(Encoding.find('filesystem'))
       else
         Errno.handle(path)
       end
@@ -901,12 +901,17 @@ class File < IO
       raise Errno::ENOENT, real
     end
 
-    real.encode(path_encoding)
+    begin
+      real.encode(path_encoding)
+    rescue EncodingError
+      real.force_encoding(path_encoding)
+    end
   end
 
   def self.realdirpath(path, basedir = nil)
     path = Truffle::Type.coerce_to_path_keep_encoding(path)
     path_encoding = path.encoding
+    path = Truffle::Type.coerce_path_encoding(path)
     real = basic_realpath path, basedir
     dir = dirname real
 
@@ -914,7 +919,11 @@ class File < IO
       raise Errno::ENOENT, real
     end
 
-    real.encode(path_encoding)
+    begin
+      real.encode(path_encoding)
+    rescue EncodingError
+      real
+    end
   end
 
   def self.basic_realpath(path, basedir = nil)

--- a/src/main/ruby/truffleruby/core/file.rb
+++ b/src/main/ruby/truffleruby/core/file.rb
@@ -419,16 +419,16 @@ class File < IO
 
     # fast path
     if level == 1
-      return '.'.encode(path_encoding) if path.empty?
-      return Truffle::FileOperations.dirname(path).encode(path_encoding)
+      return Primitive.string_with_encoding!(+'.', path_encoding) if path.empty?
+      return Primitive.string_with_encoding!(Truffle::FileOperations.dirname(path), path_encoding)
     end
 
     level.times do
-      return '.'.encode(path_encoding) if path.empty?
+      return Primitive.string_with_encoding!(+'.', path_encoding) if path.empty?
       path = Truffle::FileOperations.dirname(path)
     end
 
-    path.encode(path_encoding)
+    Primitive.string_with_encoding!(path, path_encoding)
   end
 
   ##
@@ -902,7 +902,7 @@ class File < IO
     end
 
     begin
-      real.encode(path_encoding)
+      Primitive.string_with_encoding!(real, path_encoding)
     rescue EncodingError
       real.force_encoding(path_encoding)
     end
@@ -920,7 +920,7 @@ class File < IO
     end
 
     begin
-      real.encode(path_encoding)
+      Primitive.string_with_encoding!(real, path_encoding)
     rescue EncodingError
       real
     end

--- a/src/main/ruby/truffleruby/core/file.rb
+++ b/src/main/ruby/truffleruby/core/file.rb
@@ -409,13 +409,13 @@ class File < IO
   #
   #  File.dirname("/home/gumby/work/ruby.rb")   #=> "/home/gumby/work"
   def self.dirname(path, level = 1)
-    path = Truffle::Type.coerce_to_path_keep_encoding(path)
-    path_encoding = path.encoding
-    path = Truffle::Type.coerce_path_encoding(path)
+    original_path = Truffle::Type.coerce_to_path_keep_encoding(path)
+    path_encoding = original_path.encoding
+    path = Truffle::Type.coerce_path_encoding(original_path)
     level = Primitive.rb_num2int(level)
 
     raise ArgumentError, "negative level: #{level}" if level < 0
-    return path.encode(path_encoding) if level == 0
+    return original_path if level == 0
 
     # fast path
     if level == 1

--- a/src/main/ruby/truffleruby/core/string.rb
+++ b/src/main/ruby/truffleruby/core/string.rb
@@ -437,55 +437,22 @@ class String
         raise Encoding::ConverterNotFoundError, "Encoding #{from} not found."
       end
     else
-      from_enc = encoding
+      from_enc = self.encoding
     end
 
-    if ascii_only? and from_enc.ascii_compatible? and to_enc and to_enc.ascii_compatible?
-      force_encoding to_enc
-    elsif to_enc
-      if from_enc != to_enc
-        ec = Encoding::Converter.new from_enc, to_enc, **options
-        dest = +''
-        src = self.dup
-        fallback = options[:fallback]
-        status = ec.primitive_convert src, dest, nil, nil
-        while status != :finished
-          raise ec.last_error unless fallback && status == :undefined_conversion
-          (_, fallback_enc_from, fallback_enc_to, error_bytes, _) = ec.primitive_errinfo
-          rep = fallback[error_bytes.force_encoding(fallback_enc_from)]
-          raise ec.last_error unless rep
-          rep = Primitive.convert_with_to_str(rep)
-          dest << rep.encode(fallback_enc_to)
-          status = ec.primitive_convert src, dest, nil, nil
-        end
-
-        return Primitive.string_replace(self, dest)
+    if to_enc
+      if from_enc == self.encoding && from_enc == to_enc
+        # nothing
+      elsif ascii_only? and from_enc.ascii_compatible? and to_enc.ascii_compatible?
+        self.force_encoding to_enc
+      elsif from_enc == to_enc
+        self.force_encoding to_enc
       else
-        force_encoding to_enc
+        return Primitive.string_replace(self, Truffle::EncodingOperations.transcode(self, from_enc, to_enc, **options))
       end
     end
 
-    case options[:invalid]
-    when :replace
-      replacement = options[:replace] || (Primitive.encoding_is_unicode?(from_enc) ? "\ufffd" : '?')
-      self.scrub!(replacement)
-    end
-    case xml = options[:xml]
-    when :text
-      gsub!(/[&><]/, '&' => '&amp;', '>' => '&gt;', '<' => '&lt;')
-    when :attr
-      gsub!(/[&><"]/, '&' => '&amp;', '>' => '&gt;', '<' => '&lt;', '"' => '&quot;')
-      insert(0, '"')
-      insert(-1, '"')
-    when nil
-    # nothing
-    else
-      raise ArgumentError, "unexpected value for xml option: #{xml.inspect}"
-    end
-
-    if options[:universal_newline]
-      gsub!(/\r\n|\r/, "\r\n" => "\n", "\r" => "\n")
-    end
+    Truffle::EncodingOperations.handle_encode_options(self, from_enc, **options) unless options.empty?
 
     self
   end

--- a/src/main/ruby/truffleruby/core/truffle/dir_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/dir_operations.rb
@@ -77,7 +77,7 @@ module Truffle
         else
           enc = Encoding.default_internal
           begin
-            str = str.encode(enc) if enc
+            str = Primitive.string_with_encoding!(str, enc) if enc
           rescue EncodingError
             # If the attempt to convert fails we'll return the string as is, just like MRI.
           end

--- a/src/main/ruby/truffleruby/core/truffle/encoding_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/encoding_operations.rb
@@ -63,5 +63,50 @@ module Truffle
         encoding.name
       end
     end
+
+    def self.transcode(string, from_enc, to_enc, **options)
+      ec = Encoding::Converter.new from_enc, to_enc, **options
+      dest = +''
+      src = string.dup
+      fallback = options[:fallback]
+      status = ec.primitive_convert src, dest, nil, nil
+      while status != :finished
+        raise ec.last_error unless fallback && status == :undefined_conversion
+        (_, fallback_enc_from, fallback_enc_to, error_bytes, _) = ec.primitive_errinfo
+        rep = fallback[error_bytes.force_encoding(fallback_enc_from)]
+        raise ec.last_error unless rep
+        rep = Primitive.convert_with_to_str(rep)
+        dest << rep.encode(fallback_enc_to)
+        status = ec.primitive_convert src, dest, nil, nil
+      end
+
+      dest
+    end
+
+    def self.handle_encode_options(string, from_enc, invalid: nil, replace: nil, xml: nil, universal_newline: nil, **)
+      if invalid == :replace
+        replacement = replace || (Primitive.encoding_is_unicode?(from_enc) ? "\ufffd" : '?')
+        string.scrub!(replacement)
+      end
+
+      case xml
+      when :text
+        string.gsub!(/[&><]/, '&' => '&amp;', '>' => '&gt;', '<' => '&lt;')
+      when :attr
+        string.gsub!(/[&><"]/, '&' => '&amp;', '>' => '&gt;', '<' => '&lt;', '"' => '&quot;')
+        string.insert(0, '"')
+        string.insert(-1, '"')
+      when nil
+        # nothing
+      else
+        raise ArgumentError, "unexpected value for xml option: #{xml.inspect}"
+      end
+
+      if universal_newline
+        string.gsub!(/\r\n|\r/, "\r\n" => "\n", "\r" => "\n")
+      end
+
+      string
+    end
   end
 end


### PR DESCRIPTION
Follow-up for #4348

Changes:
- fixed failing specs added and tagged in #4348
- fixed File.{dirname,realpath,realdirpath} and Dir.{[],glob} to preserve encoding of a path argument in result

---

- [ ] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
