### PR TITLE
Handle `x` flag for `File.open`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ Compatibility:
 * Fix `Enumerator::Lazy#{drop,drop_while,take,uniq,zip}` when doing multiple enumerations (#4357, @earlopain).
 * Fix `Enumerator::Lazy` methods and `Enumerable#take_while` to pack multi-argument source yields like CRuby (0-arg yield → `nil`, 1-arg → value, multi-arg → `Array`) (#4310, @sampokuokkanen).
 * Adjust `File.{write,read,open}` to accept a path parameter in any encoding on macOS (#4082, @andrykonchin).
+* Implement `x` mode for `File.open` (`File::EXCL` integer flag was already respected) (#4370, @earlopain).
 
 Performance:
 

--- a/spec/ruby/core/file/open_spec.rb
+++ b/spec/ruby/core/file/open_spec.rb
@@ -241,7 +241,7 @@ describe "File.open" do
 
   # Check the grants associated to the different open modes combinations.
   it "raises an ArgumentError exception when call with an unknown mode" do
-    -> { File.open(@file, "q") }.should.raise(ArgumentError)
+    -> { File.open(@file, "q") }.should.raise(ArgumentError, "invalid access mode q")
   end
 
   it "can read in a block when call open with RDONLY mode" do
@@ -258,13 +258,13 @@ describe "File.open" do
 
   it "raises an IO exception when write in a block opened with RDONLY mode" do
     File.open(@file, File::RDONLY) do |f|
-      -> { f.puts "writing ..." }.should.raise(IOError)
+      -> { f.puts "writing ..." }.should.raise(IOError, "not opened for writing")
     end
   end
 
   it "raises an IO exception when write in a block opened with 'r' mode" do
     File.open(@file, "r") do |f|
-      -> { f.puts "writing ..." }.should.raise(IOError)
+      -> { f.puts "writing ..." }.should.raise(IOError, "not opened for writing")
     end
   end
 
@@ -279,7 +279,7 @@ describe "File.open" do
       File.open(@file, File::WRONLY|File::RDONLY ) do |f|
         f.gets.should == nil
       end
-    }.should.raise(IOError)
+    }.should.raise(IOError, "not opened for reading")
   end
 
   it "can write in a block when call open with WRONLY mode" do
@@ -296,39 +296,39 @@ describe "File.open" do
 
   it "raises an IOError when read in a block opened with WRONLY mode" do
     File.open(@file, File::WRONLY) do |f|
-      -> { f.gets  }.should.raise(IOError)
+      -> { f.gets  }.should.raise(IOError, "not opened for reading")
     end
   end
 
   it "raises an IOError when read in a block opened with 'w' mode" do
     File.open(@file, "w") do |f|
-      -> { f.gets   }.should.raise(IOError)
+      -> { f.gets   }.should.raise(IOError, "not opened for reading")
     end
   end
 
   it "raises an IOError when read in a block opened with 'a' mode" do
     File.open(@file, "a") do |f|
-      -> { f.gets  }.should.raise(IOError)
+      -> { f.gets  }.should.raise(IOError, "not opened for reading")
     end
   end
 
   it "raises an IOError when read in a block opened with 'a' mode" do
     File.open(@file, "a") do |f|
       f.puts("writing").should == nil
-      -> { f.gets }.should.raise(IOError)
+      -> { f.gets }.should.raise(IOError, "not opened for reading")
     end
   end
 
   it "raises an IOError when read in a block opened with 'a' mode" do
     File.open(@file, File::WRONLY|File::APPEND ) do |f|
-      -> { f.gets }.should.raise(IOError)
+      -> { f.gets }.should.raise(IOError, "not opened for reading")
     end
   end
 
   it "raises an IOError when read in a block opened with File::WRONLY|File::APPEND mode" do
     File.open(@file, File::WRONLY|File::APPEND ) do |f|
       f.puts("writing").should == nil
-      -> { f.gets }.should.raise(IOError)
+      -> { f.gets }.should.raise(IOError, "not opened for reading")
     end
   end
 
@@ -337,7 +337,7 @@ describe "File.open" do
       File.open(@file, File::RDONLY|File::APPEND ) do |f|
         f.puts("writing")
       end
-    }.should.raise(IOError)
+    }.should.raise(IOError, "not opened for writing")
   end
 
   it "can read and write in a block when call open with RDWR mode" do
@@ -354,7 +354,7 @@ describe "File.open" do
       File.open(@file, File::EXCL) do |f|
         f.puts("writing").should == nil
       end
-    }.should.raise(IOError)
+    }.should.raise(IOError, "not opened for writing")
   end
 
   it "can read in a block when call open with File::EXCL mode" do
@@ -404,7 +404,7 @@ describe "File.open" do
       File.open(@file, File::RDONLY|File::APPEND) do |f|
         f.puts("writing").should == nil
       end
-    }.should.raise(IOError)
+    }.should.raise(IOError, "not opened for writing")
   end
 
   platform_is_not :openbsd, :windows do
@@ -438,7 +438,7 @@ describe "File.open" do
         File.open(@file, File::TRUNC) do |f|
           f.puts("writing")
         end
-      }.should.raise(IOError)
+      }.should.raise(IOError, "not opened for writing")
     end
 
     it "raises an Errno::EEXIST if the file exists when open with File::RDONLY|File::TRUNC" do
@@ -446,7 +446,7 @@ describe "File.open" do
         File.open(@file, File::RDONLY|File::TRUNC) do |f|
           f.puts("writing").should == nil
         end
-      }.should.raise(IOError)
+      }.should.raise(IOError, "not opened for writing")
     end
   end
 
@@ -571,11 +571,11 @@ describe "File.open" do
   end
 
   it "raises an ArgumentError if passed the wrong number of arguments" do
-    -> { File.open(@file, File::CREAT, 0755, 'test') }.should.raise(ArgumentError)
+    -> { File.open(@file, File::CREAT, 0755, 'test') }.should.raise(ArgumentError, "wrong number of arguments (given 4, expected 1..3)")
   end
 
   it "raises an ArgumentError if passed an invalid string for mode" do
-    -> { File.open(@file, 'fake') }.should.raise(ArgumentError)
+    -> { File.open(@file, 'fake') }.should.raise(ArgumentError, "invalid access mode fake")
   end
 
   it "defaults external_encoding to BINARY for binary modes" do

--- a/spec/tags/core/file/open_tags.txt
+++ b/spec/tags/core/file/open_tags.txt
@@ -1,6 +1,3 @@
 fails:File.open with a block propagates StandardErrors produced by close
 slow:File.open on a FIFO opens it as a normal file
-fails:File.open 'x' flag does nothing if the file doesn't exist
-fails:File.open 'x' flag throws a Errno::EEXIST error if the file exists
-fails:File.open 'x' flag can't be used with 'r' and 'a' flags
 fails:File.open raises ArgumentError if mixing :newline and binary mode

--- a/src/main/ruby/truffleruby/core/truffle/io_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/io_operations.rb
@@ -378,39 +378,32 @@ module Truffle
       when ?a
         ret |= WRONLY | CREAT | APPEND
       else
-        raise ArgumentError, "invalid mode -- #{mode}"
+        raise ArgumentError, "invalid access mode #{mode}"
       end
 
       return ret if mode.length == 1
 
-      case mode[1]
-      when ?+
-        ret &= ~(RDONLY | WRONLY)
-        ret |= RDWR
-      when ?b
-        ret |= BINARY
-      when ?t
-        ret &= ~BINARY
-      when ?:
-        return ret
-      else
-        raise ArgumentError, "invalid mode -- #{mode}"
-      end
-
-      return ret if mode.length == 2
-
-      case mode[2]
-      when ?+
-        ret &= ~(RDONLY | WRONLY)
-        ret |= RDWR
-      when ?b
-        ret |= BINARY
-      when ?t
-        ret &= ~BINARY
-      when ?:
-        return ret
-      else
-        raise ArgumentError, "invalid mode -- #{mode}"
+      i = 1
+      while (char = mode[i])
+        i += 1
+        case char
+        when ?+
+          ret &= ~(RDONLY | WRONLY)
+          ret |= RDWR
+        when ?b
+          ret |= BINARY
+        when ?t
+          ret &= ~BINARY
+        when ?x
+          if mode[0] != ?w
+            raise ArgumentError, "invalid access mode #{mode}"
+          end
+          ret |= EXCL
+        when ?:
+          return ret
+        else
+          raise ArgumentError, "invalid access mode #{mode}"
+        end
       end
 
       ret


### PR DESCRIPTION
Just parses it from the string like MRI does it. `File::EXCL` is already handled, so this is not much work.

Reference: https://github.com/ruby/ruby/blob/ee1a20aec7dc6506198ac4b5ac60afbc89b0346c/io.c#L6519-L6574

- [x] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
