### PR TITLE
Convert with `to_str` for `Signal.trap`

### DIFF
--- a/spec/tags/core/signal/trap_tags.txt
+++ b/spec/tags/core/signal/trap_tags.txt
@@ -4,4 +4,3 @@ slow:Signal.trap allows to register a handler for all known signals, except rese
 slow:Signal.trap returns 'DEFAULT' for the initial SIGINT handler
 slow:Signal.trap accepts 'SYSTEM_DEFAULT' and uses the OS handler for SIGPIPE
 slow:Signal.trap the special EXIT signal code can unset the handler
-fails:Signal.trap calls #to_str on an object to convert to a String

--- a/src/main/ruby/truffleruby/core/signal.rb
+++ b/src/main/ruby/truffleruby/core/signal.rb
@@ -61,7 +61,9 @@ module Signal
   def self.trap(signal, handler = nil, &block)
     unless Primitive.is_a?(signal, Symbol) || Primitive.is_a?(signal, String) \
         || Primitive.is_a?(signal, Integer)
-      raise ArgumentError, "bad signal type #{Primitive.class(signal)}"
+      converted_signal = Truffle::Type.rb_check_convert_type(signal, String, :to_str)
+      raise ArgumentError, "bad signal type #{Primitive.class(signal)}" unless converted_signal
+      signal = converted_signal
     end
 
     signal = signal.to_s if Primitive.is_a?(signal, Symbol)
@@ -75,7 +77,7 @@ module Signal
         raise ArgumentError, "unsupported signal 'SIG#{signal}'"
       end
     else
-      number = Primitive.convert_with_to_int signal
+      number = signal
 
       unless Numbers.key? number
         raise ArgumentError, "invalid signal number (#{number})"


### PR DESCRIPTION
Also remove some unnecessary to_int convertsion,
it's not possible to not already have an integer there.

- [ ] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
