### PR TITLE
Raise specific error when Signal.trap is called with a negative signal

### DIFF
--- a/spec/ruby/core/signal/trap_spec.rb
+++ b/spec/ruby/core/signal/trap_spec.rb
@@ -240,6 +240,10 @@ describe "Signal.trap" do
       -> { Signal.trap obj, @proc }.should.raise(ArgumentError, /bad signal type/)
     end
 
+    it "raises ArgumentError when passed negative signal name" do
+      -> { Signal.trap("-HUP") { } }.should.raise(ArgumentError, "negative signal name: -HUP")
+    end
+
     it "raises ArgumentError when passed unknown signal" do
       -> { Signal.trap(300) { } }.should.raise(ArgumentError, "invalid signal number (300)")
       -> { Signal.trap("USR10") { } }.should.raise(ArgumentError, /\Aunsupported signal [`']SIGUSR10'\z/)

--- a/src/main/ruby/truffleruby/core/signal.rb
+++ b/src/main/ruby/truffleruby/core/signal.rb
@@ -69,6 +69,10 @@ module Signal
     signal = signal.to_s if Primitive.is_a?(signal, Symbol)
 
     if Primitive.is_a?(signal, String)
+      if signal.start_with?('-')
+        raise ArgumentError, "negative signal name: #{signal}"
+      end
+
       if signal.start_with? 'SIG'
         signal = signal[3..-1]
       end


### PR DESCRIPTION
Follow-up for #4372

- [ ] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
