### PR TITLE
Update `GC.config` for ruby 4.0

### DIFF
--- a/spec/tags/core/gc/config_tags.txt
+++ b/spec/tags/core/gc/config_tags.txt
@@ -1,1 +1,0 @@
-fails:GC.config with a hash of options returns the same as GC.config, including the :implementation key

--- a/src/main/ruby/truffleruby/core/gc.rb
+++ b/src/main/ruby/truffleruby/core/gc.rb
@@ -156,17 +156,17 @@ module GC
   end
 
   def self.config(hash = nil)
-    if Primitive.nil?(hash)
-      { implementation: 'default' }
-    else
-      raise ArgumentError unless Primitive.is_a?(hash, Hash)
+    if Primitive.is_a?(hash, Hash)
       hash.each_key do |key|
         if key == :implementation
           raise ArgumentError, 'Attempting to set read-only key "Implementation"'
         end
       end
-      {}
+    elsif !Primitive.nil?(hash)
+      raise ArgumentError
     end
+
+    { implementation: 'default' }
   end
 
   def garbage_collect(...)


### PR DESCRIPTION
It's supposed to return the updated config when a hash is provided. For truffleruby, since there is nothing to udpate it always returns the same hash.

- [ ] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
