### PR TITLE
Fix raised error class for `sendmsg_nonblock`

### DIFF
--- a/lib/truffle/socket/basic_socket.rb
+++ b/lib/truffle/socket/basic_socket.rb
@@ -282,7 +282,7 @@ class BasicSocket < IO
         if !exception and Errno.errno == Truffle::POSIX::EAGAIN_ERRNO
           return :wait_writable
         else
-          Truffle::Socket::Error.read_error('sendmsg(2)', self)
+          Truffle::Socket::Error.write_error('sendmsg(2)', self)
         end
       end
 

--- a/spec/tags/library/socket/basicsocket/sendmsg_nonblock_tags.txt
+++ b/spec/tags/library/socket/basicsocket/sendmsg_nonblock_tags.txt
@@ -1,2 +1,0 @@
-fails:BasicSocket#sendmsg_nonblock using IPv4 using a connected TCP socket raises IO::WaitWritable when the underlying buffer is full
-fails:BasicSocket#sendmsg_nonblock using IPv6 using a connected TCP socket raises IO::WaitWritable when the underlying buffer is full


### PR DESCRIPTION
`sendmsg` is a write operation

- [ ] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
