### PR TITLE
Drop Ubuntu 18.04 in Docker testing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,7 +95,7 @@ jobs:
       matrix:
         arch: [amd64, aarch64]
         # Keep this list in sync with tool/docker-configs.yaml
-        image: [ol8, ol9, ol10, fedora37, fedora38, ubuntu1804, ubuntu2004, ubuntu2204, debian11, debian12, debian13]
+        image: [ol8, ol9, ol10, fedora37, fedora38, ubuntu2004, ubuntu2204, debian11, debian12, debian13]
     runs-on: ${{ matrix.arch == 'amd64' && 'ubuntu-22.04' || 'ubuntu-22.04-arm' }}
     steps:
     - name: Clone TruffleRuby

--- a/doc/contributor/docker.md
+++ b/doc/contributor/docker.md
@@ -55,7 +55,7 @@ jt docker test --standalone truffleruby-linux-amd64.tar.gz --test release_branch
 
 To run tests on a specific distribution:
 ```bash
-DOCKER=podman jt docker build --ubuntu1804 --standalone ~/Downloads/truffleruby-21.2.0-linux-amd64.tar.gz --test release/graal-vm/21.2
+DOCKER=podman jt docker build --ubuntu2004 --standalone ~/Downloads/truffleruby-21.2.0-linux-amd64.tar.gz --test release/graal-vm/21.2
 ```
 
 ## Distributions

--- a/tool/docker-configs.yaml
+++ b/tool/docker-configs.yaml
@@ -55,11 +55,6 @@ fedora38:
   locale: glibc-langpack-en
   <<: *rpm
 
-ubuntu1804:
-  base: ubuntu:18.04
-  install: RUN apt-get update && apt-get install -y
-  <<: *deb
-
 ubuntu2004:
   base: ubuntu:20.04
   install: RUN apt-get update && apt-get install -y


### PR DESCRIPTION
* Its glibc is too old and cause an error for statx(), see https://github.com/truffleruby/truffleruby/pull/4324#issuecomment-4984652550