### PR TITLE
Strictly validate boolean arguments where applicable

### DIFF
--- a/spec/ruby/core/exception/detailed_message_spec.rb
+++ b/spec/ruby/core/exception/detailed_message_spec.rb
@@ -44,6 +44,11 @@ describe "Exception#detailed_message" do
     StandardError.new("").detailed_message(highlight: true).should == "\e[1;4mStandardError\e[m"
   end
 
+  it "raises an ArgumentError if exception: is not true or false" do
+    -> { StandardError.new("").detailed_message(highlight: 0) }.should.raise ArgumentError, /expected true or false/
+    -> { StandardError.new("").detailed_message(highlight: 'false') }.should.raise ArgumentError, /expected true or false/
+  end
+
   it "allows and ignores other keyword arguments" do
     RuntimeError.new("new error").detailed_message(foo: true).should == "new error (RuntimeError)"
   end

--- a/spec/ruby/core/exception/full_message_spec.rb
+++ b/spec/ruby/core/exception/full_message_spec.rb
@@ -38,6 +38,11 @@ describe "Exception#full_message" do
     e.full_message(order: :bottom, highlight: false).should =~ /b.rb:2.*a.rb:1/m
   end
 
+  it "raises an ArgumentError if exception: is not true or false" do
+    -> { StandardError.new("").full_message(highlight: 0) }.should.raise ArgumentError, /expected true or false/
+    -> { StandardError.new("").full_message(highlight: 'false') }.should.raise ArgumentError, /expected true or false/
+  end
+
   it "shows the caller if the exception has no backtrace" do
     e = RuntimeError.new("Some runtime error")
     e.backtrace.should == nil

--- a/spec/ruby/core/io/read_nonblock_spec.rb
+++ b/spec/ruby/core/io/read_nonblock_spec.rb
@@ -22,6 +22,12 @@ describe "IO#read_nonblock" do
     }
   end
 
+  it "raises an ArgumentError if exception: is not true or false" do
+    -> { @read.read_nonblock(5, exception: 0) }.should.raise ArgumentError, /expected true or false/
+    -> { @read.read_nonblock(5, exception: nil) }.should.raise ArgumentError, /expected true or false/
+    -> { @read.read_nonblock(5, exception: 'false') }.should.raise ArgumentError, /expected true or false/
+  end
+
   context "when exception option is set to false" do
     context "when there is no data" do
       it "returns :wait_readable" do

--- a/spec/ruby/core/io/write_nonblock_spec.rb
+++ b/spec/ruby/core/io/write_nonblock_spec.rb
@@ -77,6 +77,12 @@ describe 'IO#write_nonblock' do
     }
   end
 
+  it "raises an ArgumentError if exception: is not true or false" do
+    -> { @write.write_nonblock("a", exception: 0) }.should.raise ArgumentError, /expected true or false/
+    -> { @write.write_nonblock("a", exception: nil) }.should.raise ArgumentError, /expected true or false/
+    -> { @write.write_nonblock("a", exception: 'false') }.should.raise ArgumentError, /expected true or false/
+  end
+
   context "when exception option is set to false" do
     it "returns :wait_writable when the operation would block" do
       loop {

--- a/spec/ruby/core/kernel/Complex_spec.rb
+++ b/spec/ruby/core/kernel/Complex_spec.rb
@@ -274,6 +274,12 @@ describe "Kernel#Complex" do
   it "freezes its result" do
     Complex(1).frozen?.should == true
   end
+
+  it "raises an ArgumentError if exception: is not true or false" do
+    -> { Complex(1, exception: 0) }.should.raise ArgumentError, /expected true or false/
+    -> { Complex(1, exception: nil) }.should.raise ArgumentError, /expected true or false/
+    -> { Complex(1, exception: 'false') }.should.raise ArgumentError, /expected true or false/
+  end
 end
 
 describe "Kernel.Complex" do

--- a/spec/ruby/core/kernel/Float_spec.rb
+++ b/spec/ruby/core/kernel/Float_spec.rb
@@ -384,6 +384,12 @@ describe "Kernel#Float" do
     -> { Float(c) }.should.raise(RangeError)
   end
 
+  it "raises an ArgumentError if exception: is not true or false" do
+    -> { Float(1, exception: 0) }.should.raise ArgumentError, /expected true or false/
+    -> { Float(1, exception: nil) }.should.raise ArgumentError, /expected true or false/
+    -> { Float(1, exception: 'false') }.should.raise ArgumentError, /expected true or false/
+  end
+
   describe "when passed exception: false" do
     describe "and valid input" do
       it "returns a Float number" do

--- a/spec/ruby/core/kernel/Integer_spec.rb
+++ b/spec/ruby/core/kernel/Integer_spec.rb
@@ -124,6 +124,12 @@ describe "Kernel#Integer" do
     -> { Integer(infinity_value) }.should.raise(FloatDomainError)
   end
 
+  it "raises an ArgumentError if exception: is not true or false" do
+    -> { Integer(1, exception: 0) }.should.raise ArgumentError, /expected true or false/
+    -> { Integer(1, exception: nil) }.should.raise ArgumentError, /expected true or false/
+    -> { Integer(1, exception: 'false') }.should.raise ArgumentError, /expected true or false/
+  end
+
   describe "when passed exception: false" do
     describe "and to_i returns a value that is not an Integer" do
       it "swallows an error" do

--- a/spec/ruby/core/kernel/Rational_spec.rb
+++ b/spec/ruby/core/kernel/Rational_spec.rb
@@ -234,6 +234,12 @@ describe "Kernel#Rational" do
   it "freezes its result" do
     Rational(1).frozen?.should == true
   end
+
+  it "raises an ArgumentError if exception: is not true or false" do
+    -> { Rational(1, exception: 0) }.should.raise ArgumentError, /expected true or false/
+    -> { Rational(1, exception: nil) }.should.raise ArgumentError, /expected true or false/
+    -> { Rational(1, exception: 'false') }.should.raise ArgumentError, /expected true or false/
+  end
 end
 
 describe "Kernel.Rational" do

--- a/spec/tags/core/dir/element_reference_tags.txt
+++ b/spec/tags/core/dir/element_reference_tags.txt
@@ -1,3 +1,2 @@
-fails:Dir.[] raises an ArgumentError if sort: is not true or false
 fails:Dir.[] accepts a pattern in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters
 fails:Dir.[] accepts multiple patterns in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters

--- a/spec/tags/core/dir/glob_tags.txt
+++ b/spec/tags/core/dir/glob_tags.txt
@@ -1,2 +1,1 @@
-fails:Dir.glob raises an ArgumentError if sort: is not true or false
 fails:Dir.glob accepts a pattern in a non-UTF-8, ASCII-compatible encoding containing non-ASCII characters

--- a/src/main/ruby/truffleruby/core/dir.rb
+++ b/src/main/ruby/truffleruby/core/dir.rb
@@ -283,6 +283,7 @@ class Dir
         raise ArgumentError, 'nul-separated glob pattern is deprecated' if pattern.include? "\0"
         patterns = [pattern]
       end
+      Truffle::Type.rb_bool_expected(sort, 'sort')
 
       matches = []
       index = 0

--- a/src/main/ruby/truffleruby/core/exception.rb
+++ b/src/main/ruby/truffleruby/core/exception.rb
@@ -86,10 +86,6 @@ class Exception
   end
 
   def detailed_message(highlight: nil, **options)
-    unless Primitive.true?(highlight) || Primitive.false?(highlight) || Primitive.nil?(highlight)
-      raise ArgumentError, "expected true of false as highlight: #{highlight}"
-    end
-
     Truffle::ExceptionOperations.detailed_message(self, highlight)
   end
 

--- a/src/main/ruby/truffleruby/core/io.rb
+++ b/src/main/ruby/truffleruby/core/io.rb
@@ -1782,6 +1782,7 @@ class IO
   # buffer like readpartial. In this case, read(2) is not called.
   def read_nonblock(size, buffer = nil, exception: true)
     raise ArgumentError, 'illegal read size' if size < 0
+    Truffle::Type.rb_bool_expected(exception, 'exception')
     ensure_open_and_readable
     self.nonblock = true
 
@@ -2370,6 +2371,7 @@ class IO
   end
 
   def write_nonblock(data, exception: true)
+    Truffle::Type.rb_bool_expected(exception, 'exception')
     ensure_open_and_writable
 
     data = String data

--- a/src/main/ruby/truffleruby/core/kernel.rb
+++ b/src/main/ruby/truffleruby/core/kernel.rb
@@ -50,18 +50,19 @@ module Kernel
   module_function :Array
 
   def Complex(real, imag = undefined, exception: true)
+    Truffle::Type.rb_bool_expected(exception, 'exception')
     Complex.__send__(:convert, real, imag, exception: exception)
   end
   module_function :Complex
 
   def Float(obj, exception: true)
-    raise_exception = !Primitive.false?(exception)
+    Truffle::Type.rb_bool_expected(exception, 'exception')
     obj = Truffle::Interop.unbox_if_needed(obj)
 
     case obj
     when String
       converted = Primitive.string_to_f obj
-      if Primitive.nil?(converted) && raise_exception
+      if Primitive.nil?(converted) && exception
         raise ArgumentError, "invalid value for Float(): #{obj.inspect}"
       else
         converted
@@ -69,7 +70,7 @@ module Kernel
     when Float
       obj
     when nil
-      if raise_exception
+      if exception
         raise TypeError, "can't convert nil into Float"
       else
         nil
@@ -81,7 +82,7 @@ module Kernel
         raise RangeError, "can't convert #{obj} into Float"
       end
     else
-      if raise_exception
+      if exception
         Primitive.convert_type(obj, Float, :to_f)
       else
         Truffle::Type.rb_check_convert_type(obj, Float, :to_f)
@@ -104,14 +105,14 @@ module Kernel
   def Integer(obj, base = 0, exception: true)
     obj = Truffle::Interop.unbox_if_needed(obj)
     base = Primitive.convert_with_to_int(base)
-    raise_exception = !Primitive.false?(exception)
+    Truffle::Type.rb_bool_expected(exception, 'exception')
 
     if Primitive.is_a?(obj, String)
-      Primitive.string_to_inum(obj, base, true, raise_exception)
+      Primitive.string_to_inum(obj, base, true, exception)
     else
       bad_base_check = Proc.new do
         if base != 0
-          return nil unless raise_exception
+          return nil unless exception
           raise ArgumentError, 'base specified for non string value'
         end
       end
@@ -122,13 +123,13 @@ module Kernel
       when Float
         bad_base_check.call
         if obj.nan? or obj.infinite?
-          return nil unless raise_exception
+          return nil unless exception
         end
         # TODO BJF 14-Jan-2020 Add fixable conversion logic
         obj.to_int
       when NilClass
         bad_base_check.call
-        return nil unless raise_exception
+        return nil unless exception
         raise TypeError, "can't convert nil into Integer"
       else
         converted_to_int_obj = Truffle::Type.rb_check_to_integer(obj, :to_int)
@@ -139,11 +140,11 @@ module Kernel
 
         converted_to_str_obj = Truffle::Type.rb_check_convert_type(obj, String, :to_str)
         unless Primitive.nil? converted_to_str_obj
-          return Primitive.string_to_inum(converted_to_str_obj, base, true, raise_exception)
+          return Primitive.string_to_inum(converted_to_str_obj, base, true, exception)
         end
 
         bad_base_check.call
-        if raise_exception
+        if exception
           Primitive.convert_type(obj, Integer, :to_i)
         else
           Truffle::Type.rb_check_to_integer(obj, :to_i)
@@ -154,6 +155,7 @@ module Kernel
   module_function :Integer
 
   def Rational(a, b = 1, exception: true)
+    Truffle::Type.rb_bool_expected(exception, 'exception')
     Rational.__send__ :convert, a, b, exception
   end
   module_function :Rational

--- a/src/main/ruby/truffleruby/core/truffle/exception_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/exception_operations.rb
@@ -177,6 +177,8 @@ module Truffle
 
     # default implementation of Exception#detailed_message hook
     def self.detailed_message(exception, highlight)
+      Truffle::Type.rb_bool_expected(highlight, 'highlight') unless Primitive.nil?(highlight)
+
       message = Primitive.convert_with_to_str(exception.message.to_s)
 
       exception_class = Primitive.class(exception)
@@ -259,7 +261,7 @@ module Truffle
       highlight = if Primitive.nil?(highlight)
                     Exception.to_tty?
                   else
-                    raise ArgumentError, "expected true of false as highlight: #{highlight}" unless Primitive.true?(highlight) || Primitive.false?(highlight)
+                    Truffle::Type.rb_bool_expected(highlight, 'highlight')
                     !Primitive.false?(highlight)
                   end
 

--- a/src/main/ruby/truffleruby/core/type.rb
+++ b/src/main/ruby/truffleruby/core/type.rb
@@ -225,6 +225,12 @@ module Truffle
       obj
     end
 
+    def self.rb_bool_expected(value, arg_name)
+      return if Primitive.false?(value) || Primitive.true?(value)
+
+      raise ArgumentError, "expected true or false as #{arg_name}: #{value}"
+    end
+
     def self.to_class_name(object)
       case object
       when nil


### PR DESCRIPTION
It's mostly for `exception` keyword but there are some outliers like glob `sort`

`highlight` for `detailed_message`/`full_message` is special, `nil` (the default) means `true if tty?`

- [ ] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
