### PR TITLE
Run a signal handler immediately when `Process.kill(signal, Process.pid)` is called on the main Thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Compatibility:
 * Fix `rb_call_super()` and pass block argument to a super method (@andrykonchyn).
 * Implement `rb_call_super_kw()` (#4056, @andrykonchyn).
 * Fix `rb_get_kwargs` for nil `keyword_hash` with required keywords. (#4376, @earlopain)
+* Run a signal handler immediately when `Process.kill(signal, Process.pid)` is called on the main Thread (#4383, @eregon).
 
 Performance:
 

--- a/spec/ruby/core/process/kill_spec.rb
+++ b/spec/ruby/core/process/kill_spec.rb
@@ -39,6 +39,43 @@ end
 
 platform_is_not :windows do
   describe "Process.kill" do
+    it "runs a registered signal handler immediately if called with the current process PID on the main Thread" do
+      backtrace = nil
+      old = trap(:SIGTERM) { backtrace = caller(0) }
+      begin
+        Process.kill(:SIGTERM, Process.pid)
+        backtrace.should.is_a?(Array)
+        backtrace[0].should.include?(__FILE__)
+        backtrace.join.should =~ /in ('Process[.#]kill'|`kill')/
+      ensure
+        trap(:SIGTERM, old)
+      end
+    end
+
+    it "runs a registered signal handler later on the main Thread if called with the current process PID on a non-main Thread" do
+      backtrace = nil
+      old = trap(:SIGTERM) {
+        backtrace = caller(0)
+        Thread.current.should == Thread.main
+      }
+      begin
+        # a way to detect it's a backtrace of the main thread
+        caller(0).join.should.include?("<main>")
+
+        Thread.new do
+          caller(0).join.should_not.include?("<main>")
+          Process.kill(:SIGTERM, Process.pid)
+        end.join
+
+        Thread.pass until backtrace
+        backtrace.join.should.include?("<main>") # the signal handler was run on the main thread
+      ensure
+        trap(:SIGTERM, old)
+      end
+    end
+  end
+
+  describe "Process.kill" do
     ProcessSpecs.use_system_ruby(self)
 
     before :each do

--- a/src/main/ruby/truffleruby/core/process.rb
+++ b/src/main/ruby/truffleruby/core/process.rb
@@ -302,6 +302,10 @@ module Process
       pid = Primitive.convert_with_to_int pid
 
       if pid == Process.pid && signal != 0
+        if Thread.current == Thread.main and Signal.send(:run_handler_directly, signal)
+          next
+        end
+
         signal_name = Signal::Numbers[signal].to_sym
         result = Primitive.process_kill_raise signal_name
         if result == -1 # Try kill() if the java Signal.raise() failed

--- a/src/main/ruby/truffleruby/core/signal.rb
+++ b/src/main/ruby/truffleruby/core/signal.rb
@@ -151,4 +151,14 @@ module Signal
 
     Numbers[index]
   end
+
+  def self.run_handler_directly(signo)
+    if handler = @handlers[signo] and Primitive.is_a?(handler, Proc)
+      handler.call(signo)
+      true
+    else
+      false
+    end
+  end
+  private_class_method :run_handler_directly
 end


### PR DESCRIPTION
* Fixes https://github.com/truffleruby/truffleruby/issues/4383

- [x] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
