### PR TITLE
Fix FFI::Pointer#initialize(FFI::Pointer) to keep the original Pointer alive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Bug fixes:
 * Fix `rb_proc_new()`, `rb_iterate()`, `rb_exec_recursive()` and `rb_fiber_new()` to pass the callback argument as-is and not assume it's a Ruby object (#4334, @eregon).
 * Fix infinite cause chain when a Ruby exception is raised inside another language and goes back to Ruby (#4233, @eregon).
 * Fix `IO.copy_stream()` when given optional length argument (#3947, @andrykonchin).
+* Fix `FFI::Pointer.new(FFI::Pointer)` to keep the original Pointer alive like CRuby (#4347, @eregon)
 
 Compatibility:
 

--- a/src/main/ruby/truffleruby/core/truffle/ffi/pointer.rb
+++ b/src/main/ruby/truffleruby/core/truffle/ffi/pointer.rb
@@ -50,6 +50,7 @@ module Truffle::FFI
 
     def initialize(type = nil, address)
       if Truffle::Interop.pointer?(address)
+        @parent = address # keep the original pointer alive
         address = Truffle::Interop.as_pointer(address)
       end
       self.address = address
@@ -112,15 +113,14 @@ module Truffle::FFI
     end
 
     def +(offset)
-      ptr = Pointer.new(address + offset)
-      if Primitive.pointer_size(self) != UNBOUNDED
-        ptr.total = Primitive.pointer_size(self) - offset
-      end
-      ptr
+      size = Primitive.pointer_size(self)
+      length = size == UNBOUNDED ? UNBOUNDED : size - offset
+      slice(offset, length)
     end
 
     def slice(offset, length)
-      ptr = Pointer.new(address + offset)
+      ptr = Pointer.new(self) # to keep self alive
+      ptr.address = address + offset
       ptr.total = length
       ptr
     end


### PR DESCRIPTION
* Also do the same in FFI::Pointer#+ and #slice.
* Fixes https://github.com/truffleruby/truffleruby/issues/4347

- [x] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
