### PR TITLE
Fix Module#module_function and keep new Module methods public created from implicitly private callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Compatibility:
 * Implement `rb_call_super_kw()` (#4056, @andrykonchyn).
 * Fix `rb_get_kwargs` for nil `keyword_hash` with required keywords. (#4376, @earlopain)
 * Run a signal handler immediately when `Process.kill(signal, Process.pid)` is called on the main Thread (#4383, @eregon).
+* Fix `Module#module_function` and keep new Module methods public created from implicitly private callbacks (#4388, @andrykonchin).
 
 Performance:
 

--- a/spec/ruby/core/module/module_function_spec.rb
+++ b/spec/ruby/core/module/module_function_spec.rb
@@ -94,7 +94,46 @@ describe "Module#module_function with specific method names" do
       module_function :test
     end
 
-    m.public_methods.map {|me| me.to_s }.include?('test').should == true
+    m.public_methods(false).should.include?(:test)
+  end
+
+  it "makes the new Module method public even if the instance method is private" do
+    m = Module.new do
+      private
+      def test() end
+      module_function :test
+    end
+
+    m.public_methods(false).should.include?(:test)
+    m.private_instance_methods(false).should.include?(:test)
+  end
+
+  it "makes the new Module method public even if the instance method is protected" do
+    m = Module.new do
+      protected
+      def test() end
+      module_function :test
+    end
+
+    m.public_methods(false).should.include?(:test)
+    m.private_instance_methods(false).should.include?(:test)
+  end
+
+  it "makes initialize, initialize_copy, initialize_clone, initialize_dup, and respond_to_missing? public Module methods" do
+    m = Module.new do
+      def initialize() end
+      def initialize_copy() end
+      def initialize_clone() end
+      def initialize_dup() end
+      def respond_to_missing?() end
+
+      module_function :initialize, :initialize_copy, :initialize_clone, :initialize_dup, :respond_to_missing?
+    end
+
+    [:initialize, :initialize_copy, :initialize_clone, :initialize_dup, :respond_to_missing?].each do |method|
+      m.public_methods(false).should.include?(method)
+      m.private_instance_methods(false).should.include?(method)
+    end
   end
 
   it "tries to convert the given names to strings using to_str" do
@@ -242,6 +281,22 @@ describe "Module#module_function as a toggle (no arguments) in a Module body" do
     m.respond_to?(:test3).should == true
   end
 
+  it "makes the initialize-related and respond_to_missing? Module methods public when defined after toggle" do
+    m = Module.new do
+      module_function
+      def initialize() end
+      def initialize_copy() end
+      def initialize_clone() end
+      def initialize_dup() end
+      def respond_to_missing?() end
+    end
+
+    [:initialize, :initialize_copy, :initialize_clone, :initialize_dup, :respond_to_missing?].each do |method|
+      m.public_methods(false).should.include?(method)
+      m.private_instance_methods(false).should.include?(method)
+    end
+  end
+
   it "does not affect module_evaled method definitions also if outside the eval itself" do
     m = Module.new do
       module_function
@@ -309,7 +364,7 @@ describe "Module#module_function as a toggle (no arguments) in a Module body" do
     m.respond_to?(:test2).should == true
   end
 
-  context "methods are defined with define_method" do
+  context "when defining methods using define_method" do
     context "passed a block" do
       it "makes any subsequently defined methods module functions with the normal semantics" do
         m = Module.new do
@@ -353,6 +408,53 @@ describe "Module#module_function as a toggle (no arguments) in a Module body" do
 
         m.respond_to?(:test2).should == true
       end
+    end
+  end
+
+  context "when defining methods using define_method" do
+    it "makes the initialize-related and respond_to_missing? module methods public" do
+      m = Module.new do
+        module_function
+
+        define_method :initialize do; end
+        define_method :initialize_copy do; end
+        define_method :initialize_clone do; end
+        define_method :initialize_dup do; end
+        define_method :respond_to_missing? do; end
+      end
+
+      [:initialize, :initialize_copy, :initialize_clone, :initialize_dup, :respond_to_missing?].each do |method|
+        m.public_methods(false).should.include?(method)
+        m.private_instance_methods(false).should.include?(method)
+      end
+    end
+  end
+
+  context "when defining methods using alias" do
+    it "does not create module functions for the aliased method" do
+      m = Module.new do
+        def test; end
+
+        module_function
+        alias test_alias test
+      end
+
+      m.should_not.respond_to?(:test)
+      m.should_not.respond_to?(:test_alias)
+    end
+  end
+
+  context "when defining methods using alias_method" do
+    it "does not create module functions for the aliased method" do
+      m = Module.new do
+        def test; end
+
+        module_function
+        alias_method :test_alias, :test
+      end
+
+      m.should_not.respond_to?(:test)
+      m.should_not.respond_to?(:test_alias)
     end
   end
 end

--- a/src/main/java/org/truffleruby/core/module/ModuleOperations.java
+++ b/src/main/java/org/truffleruby/core/module/ModuleOperations.java
@@ -691,6 +691,8 @@ public abstract class ModuleOperations {
         return null;
     }
 
+    /** These methods automatically default to private visibility when defined as instance methods. This default does
+     * not apply to {@code def expr.foo} methods or when using {@code module_function}. */
     @TruffleBoundary
     public static boolean isMethodPrivateFromName(String name) {
         return (name.equals("initialize") || name.equals("initialize_copy") ||

--- a/src/main/java/org/truffleruby/core/module/RubyModule.java
+++ b/src/main/java/org/truffleruby/core/module/RubyModule.java
@@ -82,7 +82,7 @@ public class RubyModule extends RubyDynamicObject implements ObjectGraphNode {
     @TruffleBoundary
     public void addMethodConsiderNameVisibility(RubyContext context, InternalMethod method, Visibility visibility,
             Node currentNode) {
-        if (ModuleOperations.isMethodPrivateFromName(method.getName())) {
+        if (visibility != Visibility.MODULE_FUNCTION && ModuleOperations.isMethodPrivateFromName(method.getName())) {
             visibility = Visibility.PRIVATE;
         }
 


### PR DESCRIPTION
Fix `Module#module_function` to correctly define the module's singleton methods as public when created from default-private lifecycle/hook methods (`initialize`, `initialize_copy`, `initialize_clone`, `initialize_dup`, and `respond_to_missing?`).

These lifecycle and hook methods default to private visibility when defined as instance methods. Under the `module_function` visibility context (such as when called as a toggle without arguments), TruffleRuby was incorrectly applying this default private visibility to the copied singleton methods, which must always be public.

Close #4388

- [x] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
