### PR TITLE
Update error messages related to class/module reopening

### DIFF
--- a/spec/ruby/language/class_spec.rb
+++ b/spec/ruby/language/class_spec.rb
@@ -1,12 +1,6 @@
 require_relative '../spec_helper'
 require_relative '../fixtures/class'
 
-ClassSpecsNumber = 12
-
-module ClassSpecs
-  Number = 12
-end
-
 describe "The class keyword" do
   it "creates a new class with semicolon" do
     class ClassSpecsKeywordWithSemicolon; end
@@ -43,17 +37,27 @@ describe "A class definition" do
   end
 
   it "raises TypeError if constant given as class name exists and is not a Module" do
+    ClassSpecsNumber = 123
     -> {
-      class ClassSpecsNumber
-      end
-    }.should.raise(TypeError, /\AClassSpecsNumber is not a class/)
+      class ClassSpecsNumber; end
+    }.should.raise(TypeError, <<~MSG.strip)
+      ClassSpecsNumber is not a class
+      #{__FILE__}:#{__LINE__ - 5}: previous definition of ClassSpecsNumber was here
+    MSG
+  ensure
+    Object.send(:remove_const, :ClassSpecsNumber)
   end
 
   it "raises TypeError if constant given as class name exists and is a Module but not a Class" do
+    module ClassSpecsModule; end
     -> {
-      class ClassSpecs
-      end
-    }.should.raise(TypeError, /\AClassSpecs is not a class/)
+      class ClassSpecsModule; end
+    }.should.raise(TypeError, <<~MSG.strip)
+      ClassSpecsModule is not a class
+      #{__FILE__}:#{__LINE__ - 5}: previous definition of ClassSpecsModule was here
+    MSG
+  ensure
+    Object.send(:remove_const, :ClassSpecsModule)
   end
 
   # test case known to be detecting bugs (JRuby, MRI)
@@ -61,19 +65,27 @@ describe "A class definition" do
     -> {
       class nil::Foo
       end
-    }.should.raise(TypeError)
+    }.should.raise(TypeError, "nil is not a class/module")
   end
 
   it "raises TypeError if any constant qualifying the class is not a Module" do
+    ClassSpecsNumber = 123
+    module ClassSpecsNested
+      Number = 123
+    end
+
     -> {
-      class ClassSpecs::Number::MyClass
+      class ClassSpecsNested::Number::MyClass
       end
-    }.should.raise(TypeError)
+    }.should.raise(TypeError, "123 is not a class/module")
 
     -> {
       class ClassSpecsNumber::MyClass
       end
-    }.should.raise(TypeError)
+    }.should.raise(TypeError, "123 is not a class/module")
+  ensure
+    Object.send(:remove_const, :ClassSpecsNumber)
+    Object.send(:remove_const, :ClassSpecsNested)
   end
 
   it "inherits from Object by default" do
@@ -87,7 +99,7 @@ describe "A class definition" do
       -> {
         class SuperclassResetToSubclass < M
         end
-      }.should.raise(TypeError, /superclass mismatch/)
+      }.should.raise(TypeError, "superclass mismatch for class SuperclassResetToSubclass")
     end
   end
 
@@ -100,7 +112,7 @@ describe "A class definition" do
       -> {
         class SuperclassReopenedBasicObject < BasicObject
         end
-      }.should.raise(TypeError, /superclass mismatch/)
+      }.should.raise(TypeError, "superclass mismatch for class SuperclassReopenedBasicObject")
       SuperclassReopenedBasicObject.superclass.should == A
     end
   end
@@ -115,7 +127,7 @@ describe "A class definition" do
       -> {
         class SuperclassReopenedObject < Object
         end
-      }.should.raise(TypeError, /superclass mismatch/)
+      }.should.raise(TypeError, "superclass mismatch for class SuperclassReopenedObject")
       SuperclassReopenedObject.superclass.should == A
     end
   end
@@ -140,7 +152,7 @@ describe "A class definition" do
       -> {
         class NoSuperclassSet < String
         end
-      }.should.raise(TypeError, /superclass mismatch/)
+      }.should.raise(TypeError, "superclass mismatch for class NoSuperclassSet")
     end
   end
 
@@ -149,7 +161,7 @@ describe "A class definition" do
 
     -> {
       class ShouldNotWork < self; end
-    }.should.raise(TypeError)
+    }.should.raise(TypeError, "superclass must be an instance of Class (given an instance of MSpecEnv)")
   end
 
   it "first evaluates the superclass before checking if the class already exists" do
@@ -168,7 +180,9 @@ describe "A class definition" do
   it "raises a TypeError if inheriting from a metaclass" do
     obj = mock("metaclass super")
     meta = obj.singleton_class
-    -> { class ClassSpecs::MetaclassSuper < meta; end }.should.raise(TypeError)
+    -> {
+      class ClassSpecs::MetaclassSuper < meta; end
+    }.should.raise(TypeError, "can't make subclass of singleton class")
   end
 
   it "allows the declaration of class variables in the body" do
@@ -298,18 +312,16 @@ describe "A class definition extending an object (sclass)" do
 
   it "raises a TypeError when trying to extend numbers" do
     -> {
-      eval <<-CODE
-        class << 1
-          def xyz
-            self
-          end
+      class << 1
+        def xyz
+          self
         end
-      CODE
-    }.should.raise(TypeError)
+      end
+    }.should.raise(TypeError, "can't define singleton")
   end
 
   it "raises a TypeError when trying to extend non-Class" do
-    error_msg = /superclass must be a.* Class/
+    error_msg = /superclass must be an instance of Class \(given an instance of .*\)/
     -> { class TestClass < "";              end }.should.raise(TypeError, error_msg)
     -> { class TestClass < 1;               end }.should.raise(TypeError, error_msg)
     -> { class TestClass < :symbol;         end }.should.raise(TypeError, error_msg)
@@ -341,7 +353,7 @@ describe "Reopening a class" do
   end
 
   it "raises a TypeError when superclasses mismatch" do
-    -> { class ClassSpecs::A < Array; end }.should.raise(TypeError)
+    -> { class ClassSpecs::A < Array; end }.should.raise(TypeError, "superclass mismatch for class A")
   end
 
   it "adds new methods to subclasses" do

--- a/spec/ruby/language/fixtures/module.rb
+++ b/spec/ruby/language/fixtures/module.rb
@@ -1,8 +1,5 @@
 module ModuleSpecs
   module Modules
-    class Klass
-    end
-
     A = "Module"
     B = 1
     C = nil

--- a/spec/ruby/language/module_spec.rb
+++ b/spec/ruby/language/module_spec.rb
@@ -62,9 +62,15 @@ describe "The module keyword" do
   end
 
   it "raises a TypeError if the constant is a Class" do
+    class Klass; end
     -> do
-      module ModuleSpecs::Modules::Klass; end
-    end.should.raise(TypeError)
+      module Klass; end
+    end.should.raise(TypeError, <<~MSG.strip)
+      Klass is not a module
+      #{__FILE__}:#{__LINE__ - 5}: previous definition of Klass was here
+    MSG
+  ensure
+    Object.send(:remove_const, :Klass)
   end
 
   it "raises a TypeError if the constant is a String" do

--- a/spec/ruby/optional/capi/class_spec.rb
+++ b/spec/ruby/optional/capi/class_spec.rb
@@ -662,4 +662,12 @@ describe "C-API Class function" do
       @s.rb_class_get_superclass(Module.new).should == false
     end
   end
+
+  describe "a constant defined in C" do
+    it "raises TypeError if constant given as class name exists and is a Number" do
+      -> {
+         class CApiClassSpecs::CONST_DEFINED_IN_NATIVE_CODE; end
+      }.should.raise(TypeError, /CONST_DEFINED_IN_NATIVE_CODE is not a class/)
+    end
+  end
 end

--- a/spec/ruby/optional/capi/ext/class_spec.c
+++ b/spec/ruby/optional/capi/ext/class_spec.c
@@ -172,6 +172,7 @@ static VALUE class_spec_include_module(VALUE self, VALUE klass, VALUE module) {
 
 void Init_class_spec(void) {
   VALUE cls = rb_define_class("CApiClassSpecs", rb_cObject);
+  rb_define_const(cls, "CONST_DEFINED_IN_NATIVE_CODE", INT2NUM(42));
   rb_define_method(cls, "define_call_super_method", class_spec_define_call_super_method, 2);
   rb_define_method(cls, "define_call_super_kw_method", class_spec_define_call_super_kw_method, 3);
   rb_define_method(cls, "rb_class_path", class_spec_rb_class_path, 1);

--- a/spec/tags/language/class_tags.txt
+++ b/spec/tags/language/class_tags.txt
@@ -1,5 +1,3 @@
 slow:Reopening a class does not reopen a class included in Object
 slow:Reopening a class does not reopen a class included in non-Object modules
-fails:A class definition raises TypeError if constant given as class name exists and is not a Module
-fails:A class definition raises TypeError if constant given as class name exists and is a Module but not a Class
 fails:Reopening a class does not reopen a class included in Object

--- a/src/main/java/org/truffleruby/core/exception/CoreExceptions.java
+++ b/src/main/java/org/truffleruby/core/exception/CoreExceptions.java
@@ -252,7 +252,7 @@ public final class CoreExceptions {
 
     @TruffleBoundary
     public RubyException argumentErrorWrongArgumentType(Object object, String expectedType, Node currentNode) {
-        String badClassName = LogicalClassNode.getUncached().execute(object).fields.getName();
+        String badClassName = getClassName(object);
         return argumentError(
                 StringUtils.format("wrong argument type %s (should be %s)", badClassName, expectedType),
                 currentNode);
@@ -286,7 +286,7 @@ public final class CoreExceptions {
 
     @TruffleBoundary
     public RubyException argumentErrorCantUnfreeze(Object self, Node currentNode) {
-        String className = LogicalClassNode.getUncached().execute(self).fields.getName();
+        String className = getClassName(self);
         return argumentError(StringUtils.format("can't unfreeze %s", className), currentNode);
     }
 
@@ -294,7 +294,7 @@ public final class CoreExceptions {
 
     @TruffleBoundary
     public RubyException frozenError(Object object, Node currentNode) {
-        String className = LogicalClassNode.getUncached().execute(object).fields.getName();
+        String className = getClassName(object);
         String string = inspectFrozenObject(object);
         return frozenError(StringUtils.format("can't modify frozen %s: %s", className, string), currentNode,
                 object);
@@ -530,7 +530,7 @@ public final class CoreExceptions {
     @TruffleBoundary
     public RubyException typeErrorCantConvertTo(Object from, String toClass, String methodUsed, Object result,
             Node currentNode) {
-        String fromClass = LogicalClassNode.getUncached().execute(from).fields.getName();
+        String fromClass = getClassName(from);
         return typeError(StringUtils.format(
                 "can't convert %s into %s (%s#%s gives %s)",
                 fromClass,
@@ -546,17 +546,6 @@ public final class CoreExceptions {
                 "can't convert %s into %s",
                 toClassName(from),
                 toClass), currentNode);
-    }
-
-    // Like Truffle::Type.to_class_name
-    public static String toClassName(Object object) {
-        if (object == Nil.INSTANCE) {
-            return "nil";
-        } else if (object instanceof Boolean b) {
-            return b ? "true" : "false";
-        } else {
-            return LogicalClassNode.getUncached().execute(object).fields.getName();
-        }
     }
 
     @TruffleBoundary
@@ -607,7 +596,7 @@ public final class CoreExceptions {
     @TruffleBoundary
     public RubyException typeErrorBadCoercion(Object from, String to, String coercionMethod, Object coercedTo,
             Node currentNode) {
-        String badClassName = LogicalClassNode.getUncached().execute(from).fields.getName();
+        String badClassName = getClassName(from);
         return typeError(
                 StringUtils.format(
                         "can't convert %s into %s (%s#%s gives %s)",
@@ -621,13 +610,13 @@ public final class CoreExceptions {
 
     @TruffleBoundary
     public RubyException typeErrorCantDump(Object object, Node currentNode) {
-        String logicalClass = LogicalClassNode.getUncached().execute(object).fields.getName();
+        String logicalClass = getClassName(object);
         return typeError(StringUtils.format("can't dump %s", logicalClass), currentNode);
     }
 
     @TruffleBoundary
     public RubyException typeErrorWrongArgumentType(Object object, String expectedType, Node currentNode) {
-        String badClassName = LogicalClassNode.getUncached().execute(object).fields.getName();
+        String badClassName = getClassName(object);
         return typeError(
                 StringUtils.format("wrong argument type %s (expected %s)", badClassName, expectedType),
                 currentNode);
@@ -650,7 +639,7 @@ public final class CoreExceptions {
 
     @TruffleBoundary
     public RubyException typeErrorSuperclassMustBeClass(Node currentNode, Object superclass) {
-        String given = LogicalClassNode.getUncached().execute(superclass).fields.getName();
+        String given = getClassName(superclass);
         return typeError(
                 StringUtils.format("superclass must be an instance of Class (given an instance of %s)", given),
                 currentNode);
@@ -668,7 +657,7 @@ public final class CoreExceptions {
 
     @TruffleBoundary
     public RubyException typeErrorExpectedProcOrMethodOrUnboundMethod(Object object, Node currentNode) {
-        String badClassName = LogicalClassNode.getUncached().execute(object).fields.getName();
+        String badClassName = getClassName(object);
         return typeError(
                 StringUtils.format("wrong argument type %s (expected Proc/Method/UnboundMethod)", badClassName),
                 currentNode);
@@ -765,7 +754,7 @@ public final class CoreExceptions {
 
     @TruffleBoundary
     public RubyNameError nameErrorUndefinedSingletonMethod(String name, Object receiver, Node currentNode) {
-        String className = LogicalClassNode.getUncached().execute(receiver).fields.getName();
+        String className = getClassName(receiver);
         return nameError(
                 StringUtils.format("undefined singleton method '%s' for %s", name, className),
                 receiver,
@@ -1301,6 +1290,22 @@ public final class CoreExceptions {
 
     private CoreStrings coreStrings() {
         return language.coreStrings;
+    }
+
+    // Like Truffle::Type.to_class_name
+    public static String toClassName(Object object) {
+        if (object == Nil.INSTANCE) {
+            return "nil";
+        } else if (object instanceof Boolean b) {
+            return b ? "true" : "false";
+        } else {
+            return getClassName(object);
+        }
+    }
+
+    /** In most cases {@link #toClassName(Object)} should be used instead */
+    private static String getClassName(Object from) {
+        return LogicalClassNode.getUncached().execute(from).fields.getName();
     }
 
     private Object nameForInspect(RubyEncoding encoding) {

--- a/src/main/java/org/truffleruby/core/exception/CoreExceptions.java
+++ b/src/main/java/org/truffleruby/core/exception/CoreExceptions.java
@@ -33,6 +33,7 @@ import org.truffleruby.core.string.StringUtils;
 import org.truffleruby.core.fiber.FiberNodes.FiberGetExceptionNode;
 import org.truffleruby.language.Nil;
 import org.truffleruby.language.RubyBaseNode;
+import org.truffleruby.language.RubyConstant;
 import org.truffleruby.language.backtrace.Backtrace;
 import org.truffleruby.language.backtrace.BacktraceFormatter;
 import org.truffleruby.language.backtrace.BacktraceFormatter.FormattingFlags;
@@ -578,7 +579,21 @@ public final class CoreExceptions {
 
     @TruffleBoundary
     public RubyException typeErrorIsNotAClassModule(Object value, Node currentNode) {
-        return typeError(inspectReceiver(value) + " is not a class/module", currentNode);
+        return typeErrorIsNotA(inspect(value), "class/module", currentNode);
+    }
+
+    @TruffleBoundary
+    public RubyException typeErrorIsNotAClassModule(RubyConstant existing, String type,
+            Node currentNode) {
+        final String name = existing.getName();
+        final SourceSection sourceSection = existing.getSourceSection();
+        if (sourceSection != null) {
+            return typeError(StringUtils.format(
+                    "%s is not a %s\n%s: previous definition of %s was here",
+                    name, type, language.fileLine(sourceSection), name), currentNode);
+        } else {
+            return typeError(name + " is not a " + type, currentNode);
+        }
     }
 
     @TruffleBoundary
@@ -634,8 +649,11 @@ public final class CoreExceptions {
     }
 
     @TruffleBoundary
-    public RubyException typeErrorSuperclassMustBeClass(Node currentNode) {
-        return typeError("superclass must be a Class", currentNode);
+    public RubyException typeErrorSuperclassMustBeClass(Node currentNode, Object superclass) {
+        String given = LogicalClassNode.getUncached().execute(superclass).fields.getName();
+        return typeError(
+                StringUtils.format("superclass must be an instance of Class (given an instance of %s)", given),
+                currentNode);
     }
 
     @TruffleBoundary

--- a/src/main/java/org/truffleruby/core/klass/ClassNodes.java
+++ b/src/main/java/org/truffleruby/core/klass/ClassNodes.java
@@ -246,7 +246,7 @@ public abstract class ClassNodes {
 
         @Specialization(guards = "!isRubyClass(superclass)")
         RubyClass newClass(Object superclass, boolean callInherited, Object maybeBlock) {
-            throw new RaiseException(getContext(), coreExceptions().typeErrorSuperclassMustBeClass(this));
+            throw new RaiseException(getContext(), coreExceptions().typeErrorSuperclassMustBeClass(this, superclass));
         }
     }
 

--- a/src/main/java/org/truffleruby/language/constants/GetConstantNode.java
+++ b/src/main/java/org/truffleruby/language/constants/GetConstantNode.java
@@ -30,19 +30,9 @@ import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.source.SourceSection;
+import org.truffleruby.language.objects.LookupForExistingModuleNode.ConstantAndResolvedValue;
 
 public abstract class GetConstantNode extends RubyBaseNode {
-
-    public final class ConstantAndResolvedValue {
-
-        public final RubyConstant constant;
-        public final Object value;
-
-        public ConstantAndResolvedValue(RubyConstant constant, Object value) {
-            this.constant = constant;
-            this.value = value;
-        }
-    }
 
     @NeverDefault
     public static GetConstantNode create() {

--- a/src/main/java/org/truffleruby/language/constants/GetConstantNode.java
+++ b/src/main/java/org/truffleruby/language/constants/GetConstantNode.java
@@ -33,10 +33,28 @@ import com.oracle.truffle.api.source.SourceSection;
 
 public abstract class GetConstantNode extends RubyBaseNode {
 
+    public final class ConstantAndResolvedValue {
+
+        public final RubyConstant constant;
+        public final Object value;
+
+        public ConstantAndResolvedValue(RubyConstant constant, Object value) {
+            this.constant = constant;
+            this.value = value;
+        }
+    }
 
     @NeverDefault
     public static GetConstantNode create() {
         return GetConstantNodeGen.create();
+    }
+
+    public ConstantAndResolvedValue constantAndResolvedValue(LexicalScope lexicalScope, RubyModule module, String name,
+            LookupConstantInterface lookupConstantNode, boolean callConstMissing) {
+        final RubyConstant constant = lookupConstantNode.lookupConstant(this, lexicalScope, module, name, true);
+        final Object value = executeGetConstant(lexicalScope, module, name, constant, lookupConstantNode,
+                callConstMissing);
+        return new ConstantAndResolvedValue(constant, value);
     }
 
     public Object lookupAndResolveConstant(LexicalScope lexicalScope, RubyModule module, String name,

--- a/src/main/java/org/truffleruby/language/objects/DefineClassNode.java
+++ b/src/main/java/org/truffleruby/language/objects/DefineClassNode.java
@@ -16,6 +16,7 @@ import org.truffleruby.core.module.RubyModule;
 import org.truffleruby.language.RubyContextSourceNode;
 import org.truffleruby.language.RubyNode;
 import org.truffleruby.language.control.RaiseException;
+import org.truffleruby.language.constants.GetConstantNode.ConstantAndResolvedValue;
 import org.truffleruby.language.dispatch.DispatchNode;
 
 import com.oracle.truffle.api.CompilerDirectives;
@@ -54,16 +55,16 @@ public final class DefineClassNode extends RubyContextSourceNode {
             errorProfile.enter();
             throw new RaiseException(
                     getContext(),
-                    coreExceptions().typeErrorIsNotA(lexicalParentObject, "module", this));
+                    coreExceptions().typeErrorIsNotAClassModule(lexicalParentObject, this));
         }
 
         final RubyModule lexicalParentModule = (RubyModule) lexicalParentObject;
         final RubyClass suppliedSuperClass = executeSuperClass(frame);
-        final Object existing = lookupForExistingModule(frame, name, lexicalParentModule);
+        final ConstantAndResolvedValue existing = lookupForExistingModule(frame, name, lexicalParentModule);
 
         final RubyClass definedClass;
 
-        if (needToDefineProfile.profile(existing == null)) {
+        if (needToDefineProfile.profile(existing.value == null)) {
             final RubyClass superClass;
             if (noSuperClassSupplied.profile(suppliedSuperClass == null)) {
                 superClass = getContext().getCoreLibrary().objectClass;
@@ -79,18 +80,19 @@ public final class DefineClassNode extends RubyContextSourceNode {
                     this);
             callInherited(frame, superClass, definedClass);
         } else {
-            if (!(existing instanceof RubyClass)) {
+            if (!(existing.value instanceof RubyClass)) {
                 errorProfile.enter();
-                throw new RaiseException(getContext(), coreExceptions().typeErrorIsNotA(existing, "class", this));
+                throw new RaiseException(getContext(),
+                        coreExceptions().typeErrorIsNotAClassModule(existing.constant, "class", this));
             }
 
-            definedClass = (RubyClass) existing;
+            definedClass = (RubyClass) existing.value;
 
             final Object currentSuperClass = definedClass.superclass;
-            if (suppliedSuperClass != null && currentSuperClass != suppliedSuperClass) { // bug-compat with MRI https://bugs.ruby-lang.org/issues/12367
+            if (suppliedSuperClass != null && currentSuperClass != suppliedSuperClass) {
                 errorProfile.enter();
                 throw new RaiseException(getContext(), coreExceptions().superclassMismatch(
-                        definedClass.fields.getName(),
+                        definedClass.fields.getSimpleName(),
                         this));
             }
         }
@@ -106,16 +108,15 @@ public final class DefineClassNode extends RubyContextSourceNode {
 
         if (!(superClassObject instanceof RubyClass)) {
             errorProfile.enter();
-            throw new RaiseException(getContext(), coreExceptions().typeError("superclass must be a Class", this));
+            throw new RaiseException(getContext(),
+                    coreExceptions().typeErrorSuperclassMustBeClass(this, superClassObject));
         }
 
         final RubyClass superClass = (RubyClass) superClassObject;
 
         if (superClass.isSingleton) {
             errorProfile.enter();
-            throw new RaiseException(
-                    getContext(),
-                    coreExceptions().typeError("can't make subclass of virtual class", this));
+            throw new RaiseException(getContext(), coreExceptions().typeErrorSubclassSingletonClass(this));
         }
 
         return superClass;
@@ -129,7 +130,8 @@ public final class DefineClassNode extends RubyContextSourceNode {
         inheritedNode.call(superClass, "inherited", childClass);
     }
 
-    private Object lookupForExistingModule(VirtualFrame frame, String name, RubyModule lexicalParent) {
+    private ConstantAndResolvedValue lookupForExistingModule(VirtualFrame frame, String name,
+            RubyModule lexicalParent) {
         if (lookupForExistingModuleNode == null) {
             CompilerDirectives.transferToInterpreterAndInvalidate();
             lookupForExistingModuleNode = insert(new LookupForExistingModuleNode());

--- a/src/main/java/org/truffleruby/language/objects/DefineClassNode.java
+++ b/src/main/java/org/truffleruby/language/objects/DefineClassNode.java
@@ -16,7 +16,6 @@ import org.truffleruby.core.module.RubyModule;
 import org.truffleruby.language.RubyContextSourceNode;
 import org.truffleruby.language.RubyNode;
 import org.truffleruby.language.control.RaiseException;
-import org.truffleruby.language.constants.GetConstantNode.ConstantAndResolvedValue;
 import org.truffleruby.language.dispatch.DispatchNode;
 
 import com.oracle.truffle.api.CompilerDirectives;
@@ -60,11 +59,13 @@ public final class DefineClassNode extends RubyContextSourceNode {
 
         final RubyModule lexicalParentModule = (RubyModule) lexicalParentObject;
         final RubyClass suppliedSuperClass = executeSuperClass(frame);
-        final ConstantAndResolvedValue existing = lookupForExistingModule(frame, name, lexicalParentModule);
+        final LookupForExistingModuleNode.ConstantAndResolvedValue existingPair = lookupForExistingModule(frame, name,
+                lexicalParentModule);
+        final Object existing = existingPair.value();
 
         final RubyClass definedClass;
 
-        if (needToDefineProfile.profile(existing.value == null)) {
+        if (needToDefineProfile.profile(existing == null)) {
             final RubyClass superClass;
             if (noSuperClassSupplied.profile(suppliedSuperClass == null)) {
                 superClass = getContext().getCoreLibrary().objectClass;
@@ -80,13 +81,13 @@ public final class DefineClassNode extends RubyContextSourceNode {
                     this);
             callInherited(frame, superClass, definedClass);
         } else {
-            if (!(existing.value instanceof RubyClass)) {
+            if (!(existing instanceof RubyClass)) {
                 errorProfile.enter();
                 throw new RaiseException(getContext(),
-                        coreExceptions().typeErrorIsNotAClassModule(existing.constant, "class", this));
+                        coreExceptions().typeErrorIsNotAClassModule(existingPair.constant(), "class", this));
             }
 
-            definedClass = (RubyClass) existing.value;
+            definedClass = (RubyClass) existing;
 
             final Object currentSuperClass = definedClass.superclass;
             if (suppliedSuperClass != null && currentSuperClass != suppliedSuperClass) {
@@ -130,8 +131,8 @@ public final class DefineClassNode extends RubyContextSourceNode {
         inheritedNode.call(superClass, "inherited", childClass);
     }
 
-    private ConstantAndResolvedValue lookupForExistingModule(VirtualFrame frame, String name,
-            RubyModule lexicalParent) {
+    private LookupForExistingModuleNode.ConstantAndResolvedValue lookupForExistingModule(VirtualFrame frame,
+            String name, RubyModule lexicalParent) {
         if (lookupForExistingModuleNode == null) {
             CompilerDirectives.transferToInterpreterAndInvalidate();
             lookupForExistingModuleNode = insert(new LookupForExistingModuleNode());

--- a/src/main/java/org/truffleruby/language/objects/DefineModuleNode.java
+++ b/src/main/java/org/truffleruby/language/objects/DefineModuleNode.java
@@ -14,6 +14,7 @@ import org.truffleruby.core.klass.RubyClass;
 import org.truffleruby.core.module.ModuleNodes;
 import org.truffleruby.core.module.RubyModule;
 import org.truffleruby.language.RubyContextSourceNode;
+import org.truffleruby.language.constants.GetConstantNode.ConstantAndResolvedValue;
 import org.truffleruby.language.RubyNode;
 import org.truffleruby.language.control.RaiseException;
 
@@ -41,11 +42,11 @@ public abstract class DefineModuleNode extends RubyContextSourceNode {
 
     @Specialization
     RubyModule defineModule(VirtualFrame frame, RubyModule lexicalParentModule) {
-        final Object existing = lookupForExistingModule(frame, name, lexicalParentModule);
+        final ConstantAndResolvedValue existing = lookupForExistingModule(frame, name, lexicalParentModule);
 
         final RubyModule definingModule;
 
-        if (needToDefineProfile.profile(existing == null)) {
+        if (needToDefineProfile.profile(existing.value == null)) {
             definingModule = ModuleNodes.createModule(
                     getContext(),
                     getEncapsulatingSourceSection(),
@@ -54,12 +55,13 @@ public abstract class DefineModuleNode extends RubyContextSourceNode {
                     name,
                     this);
         } else {
-            if (!(existing instanceof RubyModule) || existing instanceof RubyClass) {
+            if (!(existing.value instanceof RubyModule) || existing.value instanceof RubyClass) {
                 errorProfile.enter();
-                throw new RaiseException(getContext(), coreExceptions().typeErrorIsNotA(name, "module", this));
+                throw new RaiseException(getContext(),
+                        coreExceptions().typeErrorIsNotAClassModule(existing.constant, "module", this));
             }
 
-            definingModule = (RubyModule) existing;
+            definingModule = (RubyModule) existing.value;
         }
 
         return definingModule;
@@ -67,10 +69,11 @@ public abstract class DefineModuleNode extends RubyContextSourceNode {
 
     @Specialization(guards = "!isRubyModule(lexicalParentObject)")
     RubyModule defineModuleWrongParent(VirtualFrame frame, Object lexicalParentObject) {
-        throw new RaiseException(getContext(), coreExceptions().typeErrorIsNotA(lexicalParentObject, "module", this));
+        throw new RaiseException(getContext(), coreExceptions().typeErrorIsNotAClassModule(lexicalParentObject, this));
     }
 
-    private Object lookupForExistingModule(VirtualFrame frame, String name, RubyModule lexicalParent) {
+    private ConstantAndResolvedValue lookupForExistingModule(VirtualFrame frame, String name,
+            RubyModule lexicalParent) {
         if (lookupForExistingModuleNode == null) {
             CompilerDirectives.transferToInterpreterAndInvalidate();
             lookupForExistingModuleNode = insert(new LookupForExistingModuleNode());

--- a/src/main/java/org/truffleruby/language/objects/DefineModuleNode.java
+++ b/src/main/java/org/truffleruby/language/objects/DefineModuleNode.java
@@ -14,7 +14,6 @@ import org.truffleruby.core.klass.RubyClass;
 import org.truffleruby.core.module.ModuleNodes;
 import org.truffleruby.core.module.RubyModule;
 import org.truffleruby.language.RubyContextSourceNode;
-import org.truffleruby.language.constants.GetConstantNode.ConstantAndResolvedValue;
 import org.truffleruby.language.RubyNode;
 import org.truffleruby.language.control.RaiseException;
 
@@ -42,11 +41,13 @@ public abstract class DefineModuleNode extends RubyContextSourceNode {
 
     @Specialization
     RubyModule defineModule(VirtualFrame frame, RubyModule lexicalParentModule) {
-        final ConstantAndResolvedValue existing = lookupForExistingModule(frame, name, lexicalParentModule);
+        final LookupForExistingModuleNode.ConstantAndResolvedValue existingPair = lookupForExistingModule(frame, name,
+                lexicalParentModule);
+        final Object existing = existingPair.value();
 
         final RubyModule definingModule;
 
-        if (needToDefineProfile.profile(existing.value == null)) {
+        if (needToDefineProfile.profile(existing == null)) {
             definingModule = ModuleNodes.createModule(
                     getContext(),
                     getEncapsulatingSourceSection(),
@@ -55,13 +56,13 @@ public abstract class DefineModuleNode extends RubyContextSourceNode {
                     name,
                     this);
         } else {
-            if (!(existing.value instanceof RubyModule) || existing.value instanceof RubyClass) {
+            if (!(existing instanceof RubyModule) || existing instanceof RubyClass) {
                 errorProfile.enter();
                 throw new RaiseException(getContext(),
-                        coreExceptions().typeErrorIsNotAClassModule(existing.constant, "module", this));
+                        coreExceptions().typeErrorIsNotAClassModule(existingPair.constant(), "module", this));
             }
 
-            definingModule = (RubyModule) existing.value;
+            definingModule = (RubyModule) existing;
         }
 
         return definingModule;
@@ -72,8 +73,8 @@ public abstract class DefineModuleNode extends RubyContextSourceNode {
         throw new RaiseException(getContext(), coreExceptions().typeErrorIsNotAClassModule(lexicalParentObject, this));
     }
 
-    private ConstantAndResolvedValue lookupForExistingModule(VirtualFrame frame, String name,
-            RubyModule lexicalParent) {
+    private LookupForExistingModuleNode.ConstantAndResolvedValue lookupForExistingModule(VirtualFrame frame,
+            String name, RubyModule lexicalParent) {
         if (lookupForExistingModuleNode == null) {
             CompilerDirectives.transferToInterpreterAndInvalidate();
             lookupForExistingModuleNode = insert(new LookupForExistingModuleNode());

--- a/src/main/java/org/truffleruby/language/objects/LookupForExistingModuleNode.java
+++ b/src/main/java/org/truffleruby/language/objects/LookupForExistingModuleNode.java
@@ -10,6 +10,7 @@
  */
 package org.truffleruby.language.objects;
 
+import com.oracle.truffle.api.CompilerDirectives.ValueType;
 import com.oracle.truffle.api.nodes.Node;
 import org.truffleruby.core.klass.RubyClass;
 import org.truffleruby.core.module.ModuleOperations;
@@ -18,7 +19,6 @@ import org.truffleruby.language.LexicalScope;
 import org.truffleruby.language.RubyConstant;
 import org.truffleruby.language.arguments.RubyArguments;
 import org.truffleruby.language.constants.GetConstantNode;
-import org.truffleruby.language.constants.GetConstantNode.ConstantAndResolvedValue;
 import org.truffleruby.language.constants.LookupConstantBaseNode;
 import org.truffleruby.language.constants.LookupConstantInterface;
 import org.truffleruby.language.control.RaiseException;
@@ -27,6 +27,10 @@ import com.oracle.truffle.api.CompilerDirectives.TruffleBoundary;
 import com.oracle.truffle.api.frame.VirtualFrame;
 
 public final class LookupForExistingModuleNode extends LookupConstantBaseNode implements LookupConstantInterface {
+
+    @ValueType
+    public record ConstantAndResolvedValue(RubyConstant constant, Object value) {
+    }
 
     @Child GetConstantNode getConstantNode = GetConstantNode.create();
 

--- a/src/main/java/org/truffleruby/language/objects/LookupForExistingModuleNode.java
+++ b/src/main/java/org/truffleruby/language/objects/LookupForExistingModuleNode.java
@@ -18,6 +18,7 @@ import org.truffleruby.language.LexicalScope;
 import org.truffleruby.language.RubyConstant;
 import org.truffleruby.language.arguments.RubyArguments;
 import org.truffleruby.language.constants.GetConstantNode;
+import org.truffleruby.language.constants.GetConstantNode.ConstantAndResolvedValue;
 import org.truffleruby.language.constants.LookupConstantBaseNode;
 import org.truffleruby.language.constants.LookupConstantInterface;
 import org.truffleruby.language.control.RaiseException;
@@ -29,9 +30,9 @@ public final class LookupForExistingModuleNode extends LookupConstantBaseNode im
 
     @Child GetConstantNode getConstantNode = GetConstantNode.create();
 
-    public Object lookupForExistingModule(VirtualFrame frame, String name, RubyModule lexicalParent) {
+    public ConstantAndResolvedValue lookupForExistingModule(VirtualFrame frame, String name, RubyModule lexicalParent) {
         final LexicalScope lexicalScope = RubyArguments.getMethod(frame).getLexicalScope();
-        return getConstantNode.lookupAndResolveConstant(lexicalScope, lexicalParent, name, this, false);
+        return getConstantNode.constantAndResolvedValue(lexicalScope, lexicalParent, name, this, false);
     }
 
     @Override


### PR DESCRIPTION
Mostly just small tweaks. There are different messages depending on wether or not the reopened class is wrong at the end of that path or not:

```rb
ClassSpecsNumber = 123
begin
  class ClassSpecsNumber; end
rescue => e
  puts e.message # ClassSpecsNumber is not a class ...
end

begin
  class ClassSpecsNumber::Bar; end
rescue => e
  puts e.message # 123 is not a class/module
end
```

For the first case, it also shows the previous source location.

- [ ] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
