### PR TITLE
Fix `Array#pack` with nil argument and hex format

### DIFF
--- a/spec/ruby/core/array/pack/shared/encodings.rb
+++ b/spec/ruby/core/array/pack/shared/encodings.rb
@@ -13,4 +13,8 @@ describe :array_pack_hex, shared: true do
     obj.should_receive(:to_str).and_return(1)
     -> { [obj].pack(pack_format) }.should.raise(TypeError)
   end
+
+  it "accepts nil" do
+    [nil].pack(pack_format).should == "\x00"
+  end
 end

--- a/spec/ruby/core/array/pack/shared/unicode.rb
+++ b/spec/ruby/core/array/pack/shared/unicode.rb
@@ -93,4 +93,8 @@ describe :array_pack_unicode, shared: true do
       [[0x10FFFF].pack("U"), Encoding::UTF_8]
     ].should be_computed_by(:encoding)
   end
+
+  it "raises a TypeError when passed nil" do
+    -> { [nil].pack("U") }.should.raise(TypeError)
+  end
 end

--- a/src/main/java/org/truffleruby/core/format/convert/ToStringOrDefaultValueNode.java
+++ b/src/main/java/org/truffleruby/core/format/convert/ToStringOrDefaultValueNode.java
@@ -23,7 +23,6 @@ public abstract class ToStringOrDefaultValueNode extends FormatNode {
     protected final boolean convertNumbersToStrings;
     private final String conversionMethod;
     private final boolean inspectOnConversionFailure;
-    private final Object valueOnNil;
     protected final boolean specialClassBehaviour;
 
     @Child private ToStringNode toStringNode;
@@ -31,22 +30,19 @@ public abstract class ToStringOrDefaultValueNode extends FormatNode {
     public ToStringOrDefaultValueNode(
             boolean convertNumbersToStrings,
             String conversionMethod,
-            boolean inspectOnConversionFailure,
-            Object valueOnNil) {
-        this(convertNumbersToStrings, conversionMethod, inspectOnConversionFailure, valueOnNil, false);
+            boolean inspectOnConversionFailure) {
+        this(convertNumbersToStrings, conversionMethod, inspectOnConversionFailure, false);
     }
 
     public ToStringOrDefaultValueNode(
             boolean convertNumbersToStrings,
             String conversionMethod,
             boolean inspectOnConversionFailure,
-            Object valueOnNil,
             boolean specialClassBehaviour) {
         this.convertNumbersToStrings = convertNumbersToStrings;
         this.conversionMethod = conversionMethod;
         this.inspectOnConversionFailure = inspectOnConversionFailure;
 
-        this.valueOnNil = valueOnNil;
         this.specialClassBehaviour = specialClassBehaviour;
     }
 
@@ -54,7 +50,7 @@ public abstract class ToStringOrDefaultValueNode extends FormatNode {
 
     @Specialization
     Object toStringNil(Nil nil) {
-        return valueOnNil;
+        return nil;
     }
 
     @Specialization(guards = "!isNil(value)")

--- a/src/main/java/org/truffleruby/core/format/pack/SimplePackTreeBuilder.java
+++ b/src/main/java/org/truffleruby/core/format/pack/SimplePackTreeBuilder.java
@@ -49,13 +49,10 @@ import org.truffleruby.core.format.write.bytes.WriteHexStringNodeGen;
 import org.truffleruby.core.format.write.bytes.WriteMIMEStringNodeGen;
 import org.truffleruby.core.format.write.bytes.WriteUTF8CharacterNodeGen;
 import org.truffleruby.core.format.write.bytes.WriteUUStringNodeGen;
-import org.truffleruby.language.Nil;
 import org.truffleruby.language.WarningNode;
 import org.truffleruby.language.control.DeferredRaiseException;
 
 import com.oracle.truffle.api.nodes.Node;
-
-import static org.truffleruby.language.RubyBaseNode.nil;
 
 public final class SimplePackTreeBuilder implements SimplePackListener {
 
@@ -159,7 +156,6 @@ public final class SimplePackTreeBuilder implements SimplePackListener {
                         false,
                         "to_str",
                         false,
-                        Nil.INSTANCE,
                         new SourceNode())));
     }
 
@@ -185,7 +181,6 @@ public final class SimplePackTreeBuilder implements SimplePackListener {
                         true,
                         "to_s",
                         true,
-                        nil,
                         new SourceNode())));
     }
 
@@ -202,7 +197,6 @@ public final class SimplePackTreeBuilder implements SimplePackListener {
                         false,
                         "to_str",
                         false,
-                        Nil.INSTANCE,
                         new SourceNode())));
     }
 
@@ -388,7 +382,6 @@ public final class SimplePackTreeBuilder implements SimplePackListener {
                         false,
                         "to_str",
                         false,
-                        Nil.INSTANCE,
                         new SourceNode())));
 
     }
@@ -404,7 +397,6 @@ public final class SimplePackTreeBuilder implements SimplePackListener {
                         false,
                         "to_str",
                         false,
-                        Nil.INSTANCE,
                         new SourceNode())));
     }
 
@@ -426,7 +418,6 @@ public final class SimplePackTreeBuilder implements SimplePackListener {
                         false,
                         "to_str",
                         false,
-                        Nil.INSTANCE,
                         new SourceNode())));
 
     }

--- a/src/main/java/org/truffleruby/core/format/read/array/ReadStringOrDefaultValueNode.java
+++ b/src/main/java/org/truffleruby/core/format/read/array/ReadStringOrDefaultValueNode.java
@@ -31,7 +31,6 @@ public abstract class ReadStringOrDefaultValueNode extends FormatNode {
     private final boolean convertNumbersToStrings;
     private final String conversionMethod;
     private final boolean inspectOnConversionFailure;
-    private final Object valueOnNil;
     private final boolean specialClassBehaviour;
 
     @Child private ToStringOrDefaultValueNode toStringOrDefaultValueNode;
@@ -39,21 +38,18 @@ public abstract class ReadStringOrDefaultValueNode extends FormatNode {
     public ReadStringOrDefaultValueNode(
             boolean convertNumbersToStrings,
             String conversionMethod,
-            boolean inspectOnConversionFailure,
-            Object valueOnNil) {
-        this(convertNumbersToStrings, conversionMethod, inspectOnConversionFailure, valueOnNil, false);
+            boolean inspectOnConversionFailure) {
+        this(convertNumbersToStrings, conversionMethod, inspectOnConversionFailure, false);
     }
 
     public ReadStringOrDefaultValueNode(
             boolean convertNumbersToStrings,
             String conversionMethod,
             boolean inspectOnConversionFailure,
-            Object valueOnNil,
             boolean specialClassBehaviour) {
         this.convertNumbersToStrings = convertNumbersToStrings;
         this.conversionMethod = conversionMethod;
         this.inspectOnConversionFailure = inspectOnConversionFailure;
-        this.valueOnNil = valueOnNil;
         this.specialClassBehaviour = specialClassBehaviour;
     }
 
@@ -70,7 +66,6 @@ public abstract class ReadStringOrDefaultValueNode extends FormatNode {
                     convertNumbersToStrings,
                     conversionMethod,
                     inspectOnConversionFailure,
-                    valueOnNil,
                     specialClassBehaviour,
                     null));
         }

--- a/src/main/java/org/truffleruby/core/format/write/bytes/WriteBitStringNode.java
+++ b/src/main/java/org/truffleruby/core/format/write/bytes/WriteBitStringNode.java
@@ -58,6 +58,8 @@ import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.NodeChild;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
+import org.truffleruby.core.string.TStringConstants;
+import org.truffleruby.language.Nil;
 import org.truffleruby.language.library.RubyStringLibrary;
 
 @NodeChild("value")
@@ -74,6 +76,11 @@ public abstract class WriteBitStringNode extends FormatNode {
     }
 
     @Specialization
+    Object write(VirtualFrame frame, Nil nil) {
+        return write(frame, TStringConstants.EMPTY_INTERNAL_BYTE_ARRAY);
+    }
+
+    @Specialization(guards = "!isNil(string)")
     Object write(VirtualFrame frame, Object string,
             @Bind Node node,
             @Cached RubyStringLibrary libString,

--- a/src/main/java/org/truffleruby/core/format/write/bytes/WriteHexStringNode.java
+++ b/src/main/java/org/truffleruby/core/format/write/bytes/WriteHexStringNode.java
@@ -58,7 +58,9 @@ import com.oracle.truffle.api.dsl.Cached;
 import com.oracle.truffle.api.dsl.NodeChild;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.frame.VirtualFrame;
+import org.truffleruby.core.string.TStringConstants;
 import org.truffleruby.language.library.RubyStringLibrary;
+import org.truffleruby.language.Nil;
 
 @NodeChild("value")
 public abstract class WriteHexStringNode extends FormatNode {
@@ -72,6 +74,11 @@ public abstract class WriteHexStringNode extends FormatNode {
     }
 
     @Specialization
+    Object write(VirtualFrame frame, Nil nil) {
+        return write(frame, TStringConstants.EMPTY_INTERNAL_BYTE_ARRAY);
+    }
+
+    @Specialization(guards = "!isNil(string)")
     Object write(VirtualFrame frame, Object string,
             @Bind Node node,
             @Cached RubyStringLibrary libString,

--- a/src/main/java/org/truffleruby/core/string/TStringConstants.java
+++ b/src/main/java/org/truffleruby/core/string/TStringConstants.java
@@ -11,6 +11,7 @@
 package org.truffleruby.core.string;
 
 import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
+import com.oracle.truffle.api.strings.InternalByteArray;
 import com.oracle.truffle.api.strings.TruffleString;
 import org.truffleruby.core.encoding.TStringUtils;
 
@@ -25,6 +26,9 @@ public final class TStringConstants {
     public static final TruffleString EMPTY_BINARY = TruffleString.Encoding.BYTES.getEmpty();
     public static final TruffleString EMPTY_US_ASCII = TruffleString.Encoding.US_ASCII.getEmpty();
     public static final TruffleString EMPTY_UTF8 = TruffleString.Encoding.UTF_8.getEmpty();
+
+    public static final InternalByteArray EMPTY_INTERNAL_BYTE_ARRAY = EMPTY_US_ASCII
+            .getInternalByteArrayUncached(TruffleString.Encoding.US_ASCII);
 
     @CompilationFinal(dimensions = 1) public static final byte[] EMPTY_BYTES = new byte[0];
     @CompilationFinal(dimensions = 1) public static final byte[] NEWLINE_BYTE_ARRAY = new byte[]{ '\n' };


### PR DESCRIPTION
In that case, it should not try to convert nil with the conversion method.

I've removed `valueOnNil` since they all pass `nil` anyways and that's only used to eventually raise the correct error. In cases where no error should be raised like here (or for `a`/`A`/`Z`, etc.), a specialization in the specific node makes more sense.

- [ ] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
