### PR TITLE
Show Native Image progress and colors in mx interactive status line

### DIFF
--- a/mx.truffleruby/suite.py
+++ b/mx.truffleruby/suite.py
@@ -21,7 +21,7 @@ suite = {
             {
                 "name": "regex",
                 "subdir": True,
-                "version": "b9ebb50a4caee1312f0b2cbf68348a98094437c5",
+                "version": "197eb76bf0e8af210db708288dfa4179fb4eddba",
                 "urls": [
                     {"url": "https://github.com/truffleruby/graal.git", "kind": "git"},
                     {"url": "https://curio.ssw.jku.at/nexus/content/repositories/snapshots", "kind": "binary"},
@@ -30,7 +30,7 @@ suite = {
             {
                 "name": "sulong",
                 "subdir": True,
-                "version": "b9ebb50a4caee1312f0b2cbf68348a98094437c5",
+                "version": "197eb76bf0e8af210db708288dfa4179fb4eddba",
                 "urls": [
                     {"url": "https://github.com/truffleruby/graal.git", "kind": "git"},
                     {"url": "https://curio.ssw.jku.at/nexus/content/repositories/snapshots", "kind": "binary"},


### PR DESCRIPTION
* See truffleruby/graal@197eb76bf0e8af210db708288dfa4179fb4eddba

Before:
<img width="1000" height="104" alt="Screenshot From 2026-07-28 23-49-05" src="https://github.com/user-attachments/assets/dd3efc12-eb17-4f01-94c3-70d1323be2b9" />
(would only show once the line is completed so after a full step is done, and no color)

After:
<img width="881" height="122" alt="Screenshot From 2026-07-28 23-46-30" src="https://github.com/user-attachments/assets/2e4cac15-3555-452c-87a3-83b6685ec551" />
(how it should be, progress is shown with `*` as when running Native Image directly without `mx`)