### PR TITLE
Accept `flags` keyword argument in `Dir.glob`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ Compatibility:
 * Fix `rb_get_kwargs` for nil `keyword_hash` with required keywords. (#4376, @earlopain)
 * Run a signal handler immediately when `Process.kill(signal, Process.pid)` is called on the main Thread (#4383, @eregon).
 * Fix `Module#module_function` and keep new Module methods public created from implicitly private callbacks (#4388, @andrykonchin).
+* Add `flags` keyword argument to `Dir.glob` as an alternative to the positional argument (#4394, @earlopain).
 
 Performance:
 

--- a/spec/ruby/core/dir/glob_spec.rb
+++ b/spec/ruby/core/dir/glob_spec.rb
@@ -67,6 +67,14 @@ describe "Dir.glob" do
     Dir.glob('**', File::FNM_DOTMATCH).sort.should == DirSpecs.expected_glob_paths
   end
 
+  it "accepts the flags keyword argument as an alternative to the positional argument" do
+    Dir.glob('**', flags: File::FNM_DOTMATCH).sort.should == DirSpecs.expected_glob_paths
+  end
+
+  it "prefers the keyword argument over the positional flag argument" do
+    Dir.glob('**', :ignored, flags: File::FNM_DOTMATCH).sort.should == DirSpecs.expected_glob_paths
+  end
+
   it "recursively matches any subdirectories except './' or '../' with '**/' from the current directory and option File::FNM_DOTMATCH" do
     expected = %w[
       .dotsubdir/

--- a/src/main/ruby/truffleruby/core/dir.rb
+++ b/src/main/ruby/truffleruby/core/dir.rb
@@ -273,7 +273,7 @@ class Dir
       glob patterns, base: base, sort: sort
     end
 
-    def glob(pattern, flags = 0, base: nil, sort: true, &block)
+    def glob(pattern, flags_positional = 0, flags: flags_positional, base: nil, sort: true, &block)
       if Primitive.is_a?(pattern, Array)
         patterns = pattern
       else


### PR DESCRIPTION
The positional one isn't even documented anymore: https://docs.ruby-lang.org/en/4.0/Dir.html#method-c-glob

Ruby has the method definition in ruby, so it's easy to see how they handle when both are given https://github.com/ruby/ruby/blob/7a4de4748a11c380323d9c5f52b7f9d44b5d2f6b/dir.rb#L239

- [x] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
