### PR TITLE
Add some more glob specs

### DIFF
--- a/spec/ruby/core/dir/shared/glob.rb
+++ b/spec/ruby/core/dir/shared/glob.rb
@@ -321,6 +321,21 @@ describe :dir_glob, shared: true do
          subdir_two/nondotfile.ext]
   end
 
+  it "matches when ** is at start of pattern and next segment is at the base of the current directory" do
+    Dir.send(@method, "**/subdir_one/nondotfile").should == ["subdir_one/nondotfile"]
+    Dir.send(@method, "**/subdir_{one,two}/nondotfile").should == ["subdir_one/nondotfile", "subdir_two/nondotfile"]
+  end
+
+  it "matches when ** is at start of pattern and following segments are at different depths in the directory structure" do
+    Dir.send(@method, "**/{structure,subdir_one}/{bar,nondotfile}").should == ["deeply/nested/directory/structure/bar", "subdir_one/nondotfile"]
+  end
+
+  it "matches when ** is at start of pattern and followed by non-glob segments" do
+    Dir.send(@method, "**/deeply").should == ["deeply"]
+    Dir.send(@method, "**/deeply/nested").should == ["deeply/nested"]
+    Dir.send(@method, "**/deeply/nested/.dotfile.ext").should == ["deeply/nested/.dotfile.ext"]
+  end
+
   it "ignores matching through directories that doesn't exist" do
     Dir.send(@method, "deeply/notthere/blah*/whatever").should == []
   end
@@ -412,8 +427,12 @@ describe :dir_glob_recursive, shared: true do
     @mock_dir = File.expand_path tmp('dir_glob_mock')
 
     %w[
-      a/x/b/y/e
-      a/x/b/y/b/z/e
+      a/file.txt
+      a/1/file.txt
+      a/1/b/file.txt
+      a/1/b/2/file.txt
+      a/1/b/2/b/file.txt
+      a/1/b/2/b/3/file.txt
     ].each do |path|
       file = File.join @mock_dir, path
       mkdir_p File.dirname(file)
@@ -430,28 +449,53 @@ describe :dir_glob_recursive, shared: true do
 
   it "matches multiple recursives" do
     expected = %w[
-      a/x/b/y/b/z/e
-      a/x/b/y/e
+      a/1/b/2/b/3/file.txt
+      a/1/b/2/b/file.txt
+      a/1/b/2/file.txt
+      a/1/b/file.txt
     ]
 
-    Dir.send(@method, 'a/**/b/**/e').uniq.sort.should == expected
+    Dir.send(@method, 'a/**/b/**/file.txt').uniq.sort.should == expected
+  end
+
+  it "matches multiple recursives when a recursive is at start of pattern" do
+    expected = %w[
+      a/1/b/2/b/3/file.txt
+      a/1/b/2/b/file.txt
+      a/1/b/2/file.txt
+      a/1/b/file.txt
+      a/1/file.txt
+      a/file.txt
+    ]
+
+    Dir.send(@method, '**/a/**/file.txt').uniq.sort.should == expected
+
+    expected.pop
+    Dir.send(@method, '**/1/**/file.txt').uniq.sort.should == expected
+
+    expected.pop
+    Dir.send(@method, '**/b/**/file.txt').uniq.sort.should == expected
   end
 
   platform_is_not :windows do
     it "ignores symlinks" do
-      file = File.join @mock_dir, 'b/z/e'
-      link = File.join @mock_dir, 'a/y'
+      file = File.join @mock_dir, 'b/3/file.txt'
+      link = File.join @mock_dir, 'a/2'
 
       mkdir_p File.dirname(file)
       touch file
       File.symlink(File.dirname(file), link)
 
       expected = %w[
-        a/x/b/y/b/z/e
-        a/x/b/y/e
+        a/1/b/2/b/3/file.txt
+        a/1/b/2/b/file.txt
+        a/1/b/2/file.txt
+        a/1/b/file.txt
+        a/1/file.txt
+        a/file.txt
       ]
 
-      Dir.send(@method, 'a/**/e').uniq.sort.should == expected
+      Dir.send(@method, 'a/**/file.txt').uniq.sort.should == expected
     end
   end
 end

--- a/spec/tags/core/dir/element_reference_tags.txt
+++ b/spec/tags/core/dir/element_reference_tags.txt
@@ -1,0 +1,4 @@
+fails:Dir.[] matches when ** is at start of pattern and next segment is at the base of the current directory
+fails:Dir.[] matches when ** is at start of pattern and following segments are at different depths in the directory structure
+fails:Dir.[] matches when ** is at start of pattern and followed by non-glob segments
+fails:Dir.[] matches multiple recursives when a recursive is at start of pattern

--- a/spec/tags/core/dir/glob_tags.txt
+++ b/spec/tags/core/dir/glob_tags.txt
@@ -1,0 +1,4 @@
+fails:Dir.glob matches when ** is at start of pattern and next segment is at the base of the current directory
+fails:Dir.glob matches when ** is at start of pattern and following segments are at different depths in the directory structure
+fails:Dir.glob matches when ** is at start of pattern and followed by non-glob segments
+fails:Dir.glob matches multiple recursives when a recursive is at start of pattern

--- a/src/main/ruby/truffleruby/core/dir_glob.rb
+++ b/src/main/ruby/truffleruby/core/dir_glob.rb
@@ -66,7 +66,7 @@ class Dir
         raise 'invalid call to Node base method'
       end
 
-      def process_entry(entry, entry_type, matches, parent, glob_base_dir)
+      def process_entry(matches, parent, entry, entry_type, glob_base_dir)
         # Process an entry within a directory. This differs from
         # process_directory in that in many cases only this entry need
         # be examined. For example a file name matching node need only
@@ -137,7 +137,7 @@ class Dir
         @next.process_directory matches, path_join(parent, entry), @dir, glob_base_dir
       end
 
-      def process_entry(entry, entry_type, matches, parent, glob_base_dir)
+      def process_entry(matches, parent, entry, entry_type, glob_base_dir)
         #Check an entry with the guarantee that the previous node has checked it exists.
         @next.process_directory matches, path_join(parent, entry), @dir, glob_base_dir
       end
@@ -158,7 +158,7 @@ class Dir
         end
       end
 
-      def process_entry(entry, entry_type, matches, parent, glob_base_dir)
+      def process_entry(matches, parent, entry, entry_type, glob_base_dir)
         if entry == @name
           matches << path_join(parent, entry)
         end
@@ -170,7 +170,7 @@ class Dir
         @next.process_directory matches, nil, '/', glob_base_dir
       end
 
-      def process_entry(entry, entry_type, matches, parent, glob_base_dir)
+      def process_entry(matches, parent, entry, entry_type, glob_base_dir)
         @next.process_directory matches, nil, '/', glob_base_dir
       end
     end
@@ -184,9 +184,9 @@ class Dir
         matched.separator = @separator
         case @next
         when Match
-          matched.process_entry('.', Truffle::DirOperations::DT_DIR, matches, start, glob_base_dir)
+          matched.process_entry(matches, start, '.', Truffle::DirOperations::DT_DIR, glob_base_dir)
         else
-          matched.process_entry(entry, Truffle::DirOperations::DT_DIR, matches, parent, glob_base_dir)
+          matched.process_entry(matches, parent, entry, Truffle::DirOperations::DT_DIR, glob_base_dir)
         end
 
         stack = [[matched, start, separator, subdir_entries(glob_base_dir, start)]]
@@ -201,7 +201,7 @@ class Dir
 
             full = Dir::Glob.path_join(path, ent, sep)
             if (type == Truffle::DirOperations::DT_DIR) and (allow_dots or ent.getbyte(0) != 46) # ?.
-              matched.process_entry ent, type, matches, path, glob_base_dir
+              matched.process_entry matches, path, ent, type, glob_base_dir
               stack << [matched, path, sep, dir_entries]
               path = full
               sep = '/'
@@ -209,13 +209,13 @@ class Dir
               matched.separator = sep
               dir_entries = subdir_entries(glob_base_dir, full)
             elsif (allow_dots or ent.getbyte(0) != 46) # ?.
-              matched.process_entry ent, type, matches, path, glob_base_dir
+              matched.process_entry matches, path, ent, type, glob_base_dir
             end
           end
         end
       end
 
-      def process_entry(entry, entry_type, matches, parent, glob_base_dir)
+      def process_entry(matches, parent, entry, entry_type, glob_base_dir)
         process_directory(matches, parent, entry, glob_base_dir) if is_directory(glob_base_dir, parent, entry, entry_type)
       end
     end
@@ -230,9 +230,9 @@ class Dir
 
         if glob_base_dir
           if Primitive.is_a?(@next, DirectoriesOnly)
-            @next.process_entry '', Truffle::DirOperations::DT_DIR, matches, parent, glob_base_dir
+            @next.process_entry matches, parent, '', Truffle::DirOperations::DT_DIR, glob_base_dir
           else
-            @next.process_entry '.', Truffle::DirOperations::DT_DIR, matches, parent, glob_base_dir if allow_dots
+            @next.process_entry matches, parent, '.', Truffle::DirOperations::DT_DIR, glob_base_dir if allow_dots
           end
         end
 
@@ -246,20 +246,20 @@ class Dir
             full = path_join(path, ent)
             if (type == Truffle::DirOperations::DT_DIR)
               if (allow_dots or ent.getbyte(0) != 46) # ?.
-                @next.process_entry ent, type, matches, path, glob_base_dir
+                @next.process_entry matches, path, ent, type, glob_base_dir
 
                 stack << [path, dir_entries]
                 path = full
                 dir_entries = subdir_entries(glob_base_dir, full)
               end
             else
-              @next.process_entry ent, type, matches, path, glob_base_dir
+              @next.process_entry matches, path, ent, type, glob_base_dir
             end
           end
         end
       end
 
-      def process_entry(entry, entry_type, matches, parent, glob_base_dir)
+      def process_entry(matches, parent, entry, entry_type, glob_base_dir)
         raise 'Invalid usage'
       end
     end
@@ -296,7 +296,7 @@ class Dir
         end
       end
 
-      def process_entry(entry, entry_type, matches, parent, glob_base_dir)
+      def process_entry(matches, parent, entry, entry_type, glob_base_dir)
         @next.process_directory matches, parent, entry, glob_base_dir if is_directory(glob_base_dir, parent, entry, entry_type) && match?(entry)
       end
     end
@@ -315,7 +315,7 @@ class Dir
         end
       end
 
-      def process_entry(entry, entry_type, matches, parent, glob_base_dir)
+      def process_entry(matches, parent, entry, entry_type, glob_base_dir)
         matches << path_join(parent, entry) if match? entry
       end
     end
@@ -347,7 +347,7 @@ class Dir
         end
       end
 
-      def process_entry(entry, entry_type, matches, parent, glob_base_dir)
+      def process_entry(matches, parent, entry, entry_type, glob_base_dir)
         matches << "#{path_join(parent, entry)}/" if entry_type == Truffle::DirOperations::DT_DIR
       end
     end


### PR DESCRIPTION
The changed function doesn't seem to be called very often. If I stub it out, there's only one failing glob spec.

My understanding is that `process_entry` should just pass things along when it matches (like in `ConstantEntry`)
But currently it joins some paths together, which ends up in it checking for
`foo/foo/test.html.erb` and `foo/test.html.erb/foo/test.txt` in the following example:

```rb
require "tmpdir"

Dir.mktmpdir do |tmpdir|
  Dir.mkdir("#{tmpdir}/foo")
  FileUtils.touch("#{tmpdir}/foo/test.txt")

  Dir.chdir(tmpdir)

  puts Dir.glob("**/foo/test.txt").inspect
end
```

Obviously these are both incorrect. Now it only checks once for `foo/test.txt`.
I guess this might also manifest in a different ways, but if so it's not clear to me how exactly.

Tweaked some existing specs to have easier to grep file structure.

First commit is just some cleanup. I stared at this for way too long to find this, and having the params switch around didn't make it easier.

- [x] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
