### PR TITLE
Raise `TypeError` for `Hash#transform_keys` with `nil`

### DIFF
--- a/spec/ruby/core/hash/transform_keys_spec.rb
+++ b/spec/ruby/core/hash/transform_keys_spec.rb
@@ -55,6 +55,10 @@ describe "Hash#transform_keys" do
     @hash.transform_keys({ a: :A }, &:to_s).should == { A: 1, 'b' => 2, 'c' => 3 }
   end
 
+  it "raises TypeError when the given mapping is nil" do
+    -> { @hash.transform_keys(nil) }.should.raise(TypeError)
+  end
+
   it "does not retain the default value" do
     h = Hash.new(1)
     h.transform_keys(&:succ).default.should == nil
@@ -121,6 +125,10 @@ describe "Hash#transform_keys!" do
   it "allows a hash argument" do
     @hash.transform_keys!({ a: :A, b: :B, c: :C, d: :D })
     @hash.should == { A: 1, B: 2, C: 3, D: 4 }
+  end
+
+  it "raises TypeError when the given mapping is nil" do
+    -> { @hash.transform_keys!(nil) }.should.raise(TypeError)
   end
 
   describe "on frozen instance" do

--- a/src/main/ruby/truffleruby/core/hash.rb
+++ b/src/main/ruby/truffleruby/core/hash.rb
@@ -563,46 +563,46 @@ class Hash
     self
   end
 
-  def transform_keys(mapping = nil)
+  def transform_keys(mapping = undefined)
     has_block = block_given?
     h = {}
 
-    if mapping
+    if Primitive.undefined?(mapping)
+      return to_enum(:transform_keys) { size } unless has_block
+
+      each_pair do |key, value|
+        h[yield(key)] = value
+      end
+    else
       mapping = Primitive.convert_with_to_hash(mapping)
       each_pair do |key, value|
         k = Primitive.hash_get_or_undefined(mapping, key)
         k = has_block ? yield(key) : key if Primitive.undefined?(k)
         h[k] = value
       end
-    else
-      return to_enum(:transform_keys) { size } unless has_block
-
-      each_pair do |key, value|
-        h[yield(key)] = value
-      end
     end
 
     h
   end
 
-  def transform_keys!(mapping = nil)
+  def transform_keys!(mapping = undefined)
     has_block = block_given?
-    return to_enum(:transform_keys!) { size } unless mapping || has_block
+    return to_enum(:transform_keys!) { size } if Primitive.undefined?(mapping) && !has_block
 
     Primitive.check_frozen self
     h = {}
 
     begin
-      if mapping
+      if Primitive.undefined?(mapping)
+        each_pair do |key, value|
+          h[yield(key)] = value
+        end
+      else
         mapping = Primitive.convert_with_to_hash(mapping)
         each_pair do |key, value|
           k = Primitive.hash_get_or_undefined(mapping, key)
           k = has_block ? yield(key) : key if Primitive.undefined?(k)
           h[k] = value
-        end
-      else
-        each_pair do |key, value|
-          h[yield(key)] = value
         end
       end
     ensure


### PR DESCRIPTION
Should be treated as a given mapping and fail to convert to a hash. There's a rails test about their hash with indifferent access that hits this.

- [ ] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
