### PR TITLE
Do not print commands and which Ruby is used from jt by default, only with -v/--verbose

### DIFF
--- a/tool/jt.rb
+++ b/tool/jt.rb
@@ -294,7 +294,7 @@ module Utilities
     @ruby_launcher = ruby_launcher
     @ruby_launcher_realpath = File.realpath(ruby_launcher)
 
-    unless @silent
+    if @verbose
       shortened_path = @ruby_launcher.sub(%r[^#{Regexp.escape TRUFFLERUBY_DIR}/], '')
       shortened_path = shortened_path.sub(%r[/bin/(ruby|truffleruby)$], '')
       tags = [*('Interpreted' if truffleruby? && !truffleruby_compiler?),
@@ -492,7 +492,7 @@ module Utilities
     use_exec = options.delete :use_exec
     timeout = options.delete :timeout
     capture = options.delete :capture
-    no_print_cmd = options.delete(:no_print_cmd) || @silent
+    no_print_cmd = options.delete(:no_print_cmd) || !@verbose
 
     unless no_print_cmd
       STDERR.puts bold "$ #{printable_cmd(args)}"
@@ -777,8 +777,7 @@ module Commands
                                     * 'ruby' which uses the current Ruby executable in the PATH
                                     Default value is --use jvm, therefore all commands run on truffleruby-jvm by default.
                                     The default can be changed with `export RUBY_BIN=RUBY_SELECTOR`
-          --silent|-q               Does not print the command and which Ruby is used
-          --verbose|-v              Print more details and commands
+          --verbose|-v              Print which Ruby is used and commands
           --jdk                     Specifies which version of the JDK should be used: #{JDK_VERSIONS.join(' or ')} (default: #{DEFAULT_JDK_VERSION})
 
       jt build [graalvm|options|core-symbols] ...   by default it builds graalvm
@@ -931,7 +930,6 @@ module Commands
 
   # Not `def ruby_home` because calls to `ruby_home` would then unintentionally print
   define_method(:'ruby-home') do
-    @silent = true
     puts ruby_home
   end
 
@@ -3359,7 +3357,6 @@ class JT
   end
 
   def initialize
-    @silent = false
     @verbose = false
     @jdk_version = ENV['JT_JDK'] || DEFAULT_JDK_VERSION
     @ruby_name = ENV['RUBY_BIN'] || ENV['JT_ENV'] || 'jvm'
@@ -3380,7 +3377,7 @@ class JT
       when '-u', '--use'
         @ruby_name = args.shift
       when '-q', '--silent'
-        @silent = true
+        @verbose = false # the default
       when '-v', '--verbose'
         @verbose = true
       when '--jdk'


### PR DESCRIPTION
The defaults were too noisy, e.g. for `jt test fast`
before:
```
$ jt test fast
Using TruffleRuby with Graal: mxbuild/truffleruby-jvm
$ /home/eregon/code/trws/truffleruby/mxbuild/truffleruby-jvm/bin/ruby \
  --vm.ea \
  --vm.esa \
  --experimental-options \
  --core-load-path=/home/eregon/code/trws/truffleruby/src/main/ruby/truffleruby \
  spec/mspec/bin/mspec \
  run \
  --config \
  spec/truffleruby.mspec \
  -t \
  /home/eregon/code/trws/truffleruby/mxbuild/truffleruby-jvm/bin/ruby \
  --excl-tag \
  fails \
  --excl-tag \
  slow \
  -T--vm.ea \
  -T--vm.esa \
  -T--experimental-options \
  -T--core-load-path=/home/eregon/code/trws/truffleruby/src/main/ruby/truffleruby
$ /home/eregon/code/trws/truffleruby/mxbuild/truffleruby-jvm/bin/ruby --vm.ea --vm.esa --experimental-options --core-load-path=/home/eregon/code/trws/truffleruby/src/main/ruby/truffleruby /home/eregon/code/trws/truffleruby/spec/mspec/bin/mspec-run -B spec/truffleruby.mspec --excl-tag fails --excl-tag slow
truffleruby 40.0.0-dev-82b4329c (2026-07-29), like ruby 4.0.2, Interpreted JVM [x86_64-linux]
[\ |                   0%                     | 00:00:00]      0F      0E ^C
```
after:
```
$ jt test fast   
$ /home/eregon/code/trws/truffleruby/mxbuild/truffleruby-jvm/bin/ruby --vm.ea --vm.esa --experimental-options --core-load-path=/home/eregon/code/trws/truffleruby/src/main/ruby/truffleruby /home/eregon/code/trws/truffleruby/spec/mspec/bin/mspec-run -B spec/truffleruby.mspec --excl-tag fails --excl-tag slow
truffleruby 40.0.0-dev-82b4329c (2026-07-29), like ruby 4.0.2, Interpreted JVM [x86_64-linux]
[- |                   0%                     | 00:00:00]      0F      0E ^C
```